### PR TITLE
feat: browser CDP tools + mouse homing correction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,20 +12,46 @@
         "@nut-tree-fork/nut-js": "^4.2.6",
         "koffi": "^2.9.0",
         "sharp": "^0.34.5",
+        "ws": "^8.20.0",
         "zod": "^4.3.6"
       },
       "devDependencies": {
         "@types/node": "^25.6.0",
-        "typescript": "^6.0.2"
+        "@types/ws": "^8.18.1",
+        "typescript": "^6.0.2",
+        "vitest": "^4.1.4"
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
       "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -928,6 +954,13 @@
         "regenerator-runtime": "^0.13.3"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
@@ -966,6 +999,25 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
+      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@nut-tree-fork/default-clipboard-provider": {
@@ -1122,10 +1174,345 @@
         "node-abort-controller": "3.1.1"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tokenizer/token": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -1136,6 +1523,129 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/abort-controller": {
@@ -1221,6 +1731,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -1361,6 +1881,16 @@
         "follow-redirects": "^1.15.6"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/clipboardy": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-2.3.0.tgz",
@@ -1396,6 +1926,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -1542,6 +2079,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -1559,6 +2103,16 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -1698,6 +2252,16 @@
       "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
       "integrity": "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="
     },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/express": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
@@ -1781,6 +2345,24 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/file-type": {
       "version": "16.5.4",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
@@ -1861,6 +2443,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -2194,6 +2791,279 @@
         "url": "https://liberapay.com/Koromix"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/load-bmfont": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.2.tgz",
@@ -2208,6 +3078,16 @@
         "phin": "^3.7.1",
         "xhr": "^2.0.1",
         "xtend": "^4.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -2291,6 +3171,25 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
@@ -2381,6 +3280,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/omggif": {
       "version": "1.0.10",
@@ -2480,6 +3390,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/peek-readable": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
@@ -2504,6 +3421,26 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/pixelmatch": {
@@ -2543,6 +3480,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.13.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/process": {
@@ -2685,6 +3651,40 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.124.0",
+        "@rolldown/pluginutils": "1.0.0-rc.15"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
       }
     },
     "node_modules/router": {
@@ -2938,11 +3938,35 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",
@@ -2952,6 +3976,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -2994,11 +4025,55 @@
       "integrity": "sha512-IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
       "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
@@ -3101,6 +4176,174 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.15",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -3138,11 +4381,49 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xhr": {
       "version": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -10,17 +10,24 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "dev": "tsc --watch"
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "test:e2e": "vitest run tests/e2e",
+    "test:headed": "HEADED=1 vitest run tests/e2e",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.10.0",
     "@nut-tree-fork/nut-js": "^4.2.6",
     "koffi": "^2.9.0",
     "sharp": "^0.34.5",
+    "ws": "^8.20.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",
-    "typescript": "^6.0.2"
+    "@types/ws": "^8.18.1",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.4"
   }
 }

--- a/src/engine/cdp-bridge.ts
+++ b/src/engine/cdp-bridge.ts
@@ -1,0 +1,438 @@
+/**
+ * cdp-bridge.ts — Chrome DevTools Protocol (CDP) integration
+ *
+ * Provides WebSocket-based communication with Chrome/Edge running with
+ * --remote-debugging-port. Converts DOM element coordinates to physical
+ * screen pixels compatible with the rest of desktop-touch-mcp.
+ *
+ * Usage:
+ *   chrome.exe --remote-debugging-port=9222 --user-data-dir=C:\tmp\cdp
+ */
+
+import WebSocket from "ws";
+
+export const DEFAULT_CDP_PORT = 9222;
+const CMD_TIMEOUT_MS = 15_000;
+const CONNECT_TIMEOUT_MS = 5_000;
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface CdpTab {
+  id: string;
+  title: string;
+  url: string;
+  type: string;
+  webSocketDebuggerUrl?: string;
+}
+
+export interface ElementCoords {
+  /** Screen X of element center (physical pixels) */
+  x: number;
+  /** Screen Y of element center (physical pixels) */
+  y: number;
+  /** Screen X of element left edge (physical pixels) */
+  left: number;
+  /** Screen Y of element top edge (physical pixels) */
+  top: number;
+  /** Element width in physical pixels */
+  width: number;
+  /** Element height in physical pixels */
+  height: number;
+  /** Whether the element is fully within the viewport */
+  inViewport: boolean;
+}
+
+// ─── CDP Session ──────────────────────────────────────────────────────────────
+
+interface PendingCommand {
+  resolve: (result: unknown) => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+interface CdpResponse {
+  id?: number;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+interface RuntimeEvaluateResult {
+  result: { type: string; value?: unknown; description?: string };
+  exceptionDetails?: { text: string; exception?: { description?: string } };
+}
+
+class CdpSession {
+  private ws: WebSocket;
+  private nextId = 1;
+  private pending = new Map<number, PendingCommand>();
+  private _closed = false;
+
+  constructor(ws: WebSocket) {
+    this.ws = ws;
+
+    ws.on("message", (data: Buffer | string) => {
+      try {
+        const msg = JSON.parse(
+          typeof data === "string" ? data : data.toString()
+        ) as CdpResponse;
+        if (msg.id !== undefined) {
+          const cmd = this.pending.get(msg.id);
+          if (cmd) {
+            clearTimeout(cmd.timer);
+            this.pending.delete(msg.id);
+            if (msg.error) {
+              cmd.reject(new Error(`CDP: ${msg.error.message}`));
+            } else {
+              cmd.resolve(msg.result ?? null);
+            }
+          }
+        }
+      } catch {
+        // ignore malformed messages
+      }
+    });
+
+    ws.on("close", () => {
+      this._closed = true;
+      for (const [, cmd] of this.pending) {
+        clearTimeout(cmd.timer);
+        cmd.reject(new Error("CDP connection closed unexpectedly"));
+      }
+      this.pending.clear();
+    });
+
+    ws.on("error", (err) => {
+      // P1 fix: mark closed immediately on error so isOpen returns false
+      this._closed = true;
+      for (const [, cmd] of this.pending) {
+        clearTimeout(cmd.timer);
+        cmd.reject(err as Error);
+      }
+      this.pending.clear();
+    });
+  }
+
+  get isOpen(): boolean {
+    return !this._closed && this.ws.readyState === WebSocket.OPEN;
+  }
+
+  send(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
+    if (!this.isOpen) {
+      return Promise.reject(new Error("CDP session is not open"));
+    }
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(
+          new Error(
+            `CDP timeout: ${method} did not respond within ${CMD_TIMEOUT_MS}ms`
+          )
+        );
+      }, CMD_TIMEOUT_MS);
+      this.pending.set(id, { resolve, reject, timer });
+      this.ws.send(JSON.stringify({ id, method, params }));
+    });
+  }
+
+  close(): void {
+    if (!this._closed) {
+      this._closed = true;
+      this.ws.close();
+    }
+  }
+}
+
+// ─── Session cache ────────────────────────────────────────────────────────────
+
+// key: `${port}:${tabId}`
+const sessions = new Map<string, CdpSession>();
+// Deduplicates concurrent connection attempts for the same tab
+const connecting = new Map<string, Promise<CdpSession>>();
+
+function sessionKey(port: number, tabId: string): string {
+  return `${port}:${tabId}`;
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+async function fetchTabs(port: number): Promise<CdpTab[]> {
+  let res: Response;
+  try {
+    // P2 fix: add fetch timeout to avoid hanging indefinitely
+    res = await fetch(`http://127.0.0.1:${port}/json`, {
+      signal: AbortSignal.timeout(CONNECT_TIMEOUT_MS),
+    });
+  } catch (err) {
+    throw new Error(
+      `Cannot reach Chrome/Edge CDP at port ${port}. ` +
+        `Make sure the browser is running with --remote-debugging-port=${port}. ` +
+        `Original error: ${String(err)}`
+    );
+  }
+  if (!res.ok) {
+    throw new Error(`CDP /json returned HTTP ${res.status}`);
+  }
+  return (await res.json()) as CdpTab[];
+}
+
+async function resolveTab(
+  tabId: string | null,
+  port: number
+): Promise<CdpTab> {
+  const tabs = await fetchTabs(port);
+  if (tabs.length === 0) {
+    throw new Error(
+      "No tabs found in Chrome/Edge CDP. Is the browser running with --remote-debugging-port?"
+    );
+  }
+  if (tabId === null) {
+    const pageTab = tabs.find((t) => t.type === "page") ?? tabs[0];
+    return pageTab;
+  }
+  const tab = tabs.find((t) => t.id === tabId);
+  if (!tab) {
+    throw new Error(
+      `Tab "${tabId}" not found. Available tab IDs: ${tabs.map((t) => t.id).join(", ")}`
+    );
+  }
+  return tab;
+}
+
+async function doConnect(tab: CdpTab, port: number, key: string): Promise<CdpSession> {
+  if (!tab.webSocketDebuggerUrl) {
+    throw new Error(
+      `Tab "${tab.id}" (${tab.title}) has no webSocketDebuggerUrl. It may be a DevTools tab.`
+    );
+  }
+  const ws = await new Promise<WebSocket>((resolve, reject) => {
+    const socket = new WebSocket(tab.webSocketDebuggerUrl!);
+    const timer = setTimeout(() => {
+      socket.terminate();
+      reject(
+        new Error(
+          `CDP WebSocket connection timed out after ${CONNECT_TIMEOUT_MS}ms`
+        )
+      );
+    }, CONNECT_TIMEOUT_MS);
+    socket.once("open", () => {
+      clearTimeout(timer);
+      resolve(socket);
+    });
+    socket.once("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+
+  ws.on("close", () => sessions.delete(key));
+
+  const session = new CdpSession(ws);
+  sessions.set(key, session);
+  return session;
+}
+
+async function openSession(tab: CdpTab, port: number): Promise<CdpSession> {
+  const key = sessionKey(port, tab.id);
+  const existing = sessions.get(key);
+  if (existing?.isOpen) {
+    return existing;
+  }
+  // P1 fix: deduplicate concurrent connection attempts for the same tab
+  const inflight = connecting.get(key);
+  if (inflight) {
+    return inflight;
+  }
+  const promise = doConnect(tab, port, key);
+  connecting.set(key, promise);
+  try {
+    return await promise;
+  } finally {
+    connecting.delete(key);
+  }
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * List all tabs open in Chrome/Edge at the given CDP port.
+ */
+export async function listTabs(port = DEFAULT_CDP_PORT): Promise<CdpTab[]> {
+  return fetchTabs(port);
+}
+
+/**
+ * Evaluate a JavaScript expression in a browser tab.
+ *
+ * @param expression  JS expression string (may use `await`)
+ * @param tabId       Target tab ID (null = first page tab)
+ * @param port        CDP port (default 9222)
+ * @returns           The serializable return value of the expression
+ */
+export async function evaluateInTab(
+  expression: string,
+  tabId: string | null = null,
+  port = DEFAULT_CDP_PORT
+): Promise<unknown> {
+  const tab = await resolveTab(tabId, port);
+  const session = await openSession(tab, port);
+  const raw = (await session.send("Runtime.evaluate", {
+    expression,
+    returnByValue: true,
+    awaitPromise: true,
+  })) as RuntimeEvaluateResult;
+
+  if (raw.exceptionDetails) {
+    const msg =
+      raw.exceptionDetails.exception?.description ??
+      raw.exceptionDetails.text;
+    throw new Error(`JS exception in tab: ${msg}`);
+  }
+  return raw.result.value;
+}
+
+/**
+ * Get screen coordinates of a DOM element identified by a CSS selector.
+ * Coordinates are in physical pixels, compatible with mouse_click.
+ *
+ * Coordinate formula:
+ *   chromeH = outerHeight - innerHeight  (browser tab strip + address bar, in CSS px)
+ *   physX   = (window.screenX + chromeW/2 + rect.left) * devicePixelRatio
+ *   physY   = (window.screenY + chromeH   + rect.top)  * devicePixelRatio
+ *
+ * window.screenX/Y in Chrome on Windows is the outer window position in CSS pixels.
+ * getBoundingClientRect() is relative to the viewport (inner content area).
+ * The difference (the browser chrome height) must be added explicitly.
+ * Multiplying by devicePixelRatio converts CSS pixels to physical pixels,
+ * which matches Win32 DPI-aware coordinates used by nut-js mouse.
+ */
+export async function getElementScreenCoords(
+  selector: string,
+  tabId: string | null = null,
+  port = DEFAULT_CDP_PORT
+): Promise<ElementCoords> {
+  const expression = `
+(function() {
+  var sel = ${JSON.stringify(selector)};
+  var el = document.querySelector(sel);
+  if (!el) return JSON.stringify({ error: "Element not found: " + sel });
+  var rect = el.getBoundingClientRect();
+  if (rect.width === 0 && rect.height === 0) {
+    return JSON.stringify({ error: "Element has zero size (hidden or not rendered): " + sel });
+  }
+  var dpr     = window.devicePixelRatio || 1;
+  var sx      = window.screenX;
+  var sy      = window.screenY;
+  // Browser chrome offsets: outerHeight-innerHeight = tab strip + address bar height in CSS px.
+  // outerWidth-innerWidth = left+right frame (usually 0 on Chrome; scrollbar is inside innerWidth).
+  var chromeH = window.outerHeight - window.innerHeight;
+  var chromeW = Math.round((window.outerWidth - window.innerWidth) / 2);
+  var physLeft   = Math.round((sx + chromeW + rect.left)            * dpr);
+  var physTop    = Math.round((sy + chromeH + rect.top)             * dpr);
+  var physRight  = Math.round((sx + chromeW + rect.right)           * dpr);
+  var physBottom = Math.round((sy + chromeH + rect.bottom)          * dpr);
+  return JSON.stringify({
+    left:   physLeft,
+    top:    physTop,
+    width:  Math.round(rect.width  * dpr),
+    height: Math.round(rect.height * dpr),
+    x:      Math.round((physLeft + physRight)  / 2),
+    y:      Math.round((physTop  + physBottom) / 2),
+    inViewport: (function() {
+      var cx = rect.left + rect.width / 2;
+      var cy = rect.top  + rect.height / 2;
+      return cx >= 0 && cx < window.innerWidth && cy >= 0 && cy < window.innerHeight;
+    })(),
+  });
+})()`;
+
+  const raw = (await evaluateInTab(expression, tabId, port)) as string;
+  let parsed: ({ error: string } | (ElementCoords & { error?: undefined }));
+  try {
+    parsed = JSON.parse(raw) as typeof parsed;
+  } catch {
+    throw new Error(`Unexpected response from CDP: ${String(raw)}`);
+  }
+  if (parsed.error) {
+    throw new Error(parsed.error);
+  }
+  return parsed as ElementCoords;
+}
+
+/**
+ * Navigate the browser tab to a URL.
+ * Only http:// and https:// URLs are accepted; javascript: and file: are rejected.
+ */
+export async function navigateTo(
+  url: string,
+  tabId: string | null = null,
+  port = DEFAULT_CDP_PORT
+): Promise<void> {
+  // P2 fix: reject non-http(s) URLs to prevent javascript: injection and file: access
+  if (!/^https?:\/\//i.test(url)) {
+    throw new Error(
+      `browser_navigate only accepts http:// and https:// URLs. Got: ${url}`
+    );
+  }
+  const tab = await resolveTab(tabId, port);
+  const session = await openSession(tab, port);
+  await session.send("Page.navigate", { url });
+}
+
+/**
+ * Get the DOM of an element (or document.body) as an HTML string.
+ * Truncated to maxLength characters to avoid token overload.
+ * Throws if the selector is provided but the element is not found.
+ */
+export async function getDomHtml(
+  selector: string | null = null,
+  tabId: string | null = null,
+  port = DEFAULT_CDP_PORT,
+  maxLength = 10_000
+): Promise<string> {
+  let expr: string;
+  if (selector) {
+    // P2 fix: return structured error so caller can distinguish not-found from HTML content
+    expr = `(function(){
+      var el = document.querySelector(${JSON.stringify(selector)});
+      return el ? el.outerHTML : JSON.stringify({__cdpError: "Element not found: " + ${JSON.stringify(selector)}});
+    })()`;
+  } else {
+    expr = `document.body.outerHTML`;
+  }
+
+  const result = (await evaluateInTab(expr, tabId, port)) as string;
+  const str = String(result);
+
+  // Check for structured error response
+  if (str.startsWith('{"__cdpError"')) {
+    try {
+      const errObj = JSON.parse(str) as { __cdpError: string };
+      throw new Error(errObj.__cdpError);
+    } catch (e) {
+      if (e instanceof SyntaxError) {
+        // Not a structured error, treat as HTML
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  return str.length > maxLength
+    ? str.substring(0, maxLength) + `\n... [truncated at ${maxLength} chars, use a more specific selector]`
+    : str;
+}
+
+/**
+ * Close all cached CDP sessions for a given port.
+ */
+export function disconnectAll(port = DEFAULT_CDP_PORT): void {
+  const prefix = `${port}:`;
+  // P1 fix: collect entries before iterating to avoid mutation-during-iteration
+  // and prevent the ws "close" handler from double-deleting Map entries.
+  const toClose = [...sessions.entries()].filter(([k]) => k.startsWith(prefix));
+  for (const [key, session] of toClose) {
+    sessions.delete(key); // delete first so "close" handler finds nothing to delete
+    session.close();
+  }
+}

--- a/src/engine/win32.ts
+++ b/src/engine/win32.ts
@@ -284,6 +284,20 @@ export function getWindowTitleW(hwnd: unknown): string {
   return buf.slice(0, len * 2).toString("utf16le");
 }
 
+/**
+ * Get the current bounding rectangle of a window by its HWND.
+ * Returns null if the window no longer exists or the call fails.
+ */
+export function getWindowRectByHwnd(hwnd: unknown): { x: number; y: number; width: number; height: number } | null {
+  try {
+    const rect = { left: 0, top: 0, right: 0, bottom: 0 };
+    if (!GetWindowRect(hwnd, rect)) return null;
+    return { x: rect.left, y: rect.top, width: rect.right - rect.left, height: rect.bottom - rect.top };
+  } catch {
+    return null;
+  }
+}
+
 /** Restore a minimized window and bring it to the foreground.
  *  Returns the actual window rect after restoration. */
 export function restoreAndFocusWindow(hwnd: unknown): { x: number; y: number; width: number; height: number } {

--- a/src/engine/window-cache.ts
+++ b/src/engine/window-cache.ts
@@ -1,0 +1,122 @@
+/**
+ * window-cache.ts — Lightweight window position cache for homing correction
+ *
+ * Stores window positions as observed at the time of the last screenshot /
+ * get_windows / workspace_snapshot call. At mouse action time, the cache
+ * allows us to detect whether a window moved since the LLM last saw it and
+ * apply a simple (dx, dy) offset correction — sub-millisecond cost.
+ */
+
+import type { WindowZInfo } from "./win32.js";
+import { getWindowRectByHwnd } from "./win32.js";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface CachedWindow {
+  hwnd: bigint;
+  title: string;
+  region: { x: number; y: number; width: number; height: number };
+  zOrder: number;
+  timestamp: number;
+}
+
+export interface WindowDelta {
+  dx: number;
+  dy: number;
+  /** true if the window's size changed — simple offset correction is unreliable */
+  sizeChanged: boolean;
+}
+
+// ─── Cache store ──────────────────────────────────────────────────────────────
+
+// keyed by hwnd (as string, since Map<bigint> works but string avoids coercion issues)
+const cache = new Map<string, CachedWindow>();
+
+/** Cache entries older than this are treated as stale — HWND may have been recycled. */
+const CACHE_TTL_MS = 60_000;
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Update the cache with the current window list.
+ * Call this whenever any tool enumerates windows (screenshot, get_windows, etc.)
+ */
+export function updateWindowCache(windows: WindowZInfo[]): void {
+  // Remove windows that are no longer visible
+  const liveKeys = new Set(windows.map((w) => String(w.hwnd)));
+  for (const key of cache.keys()) {
+    if (!liveKeys.has(key)) cache.delete(key);
+  }
+  // Upsert live windows (skip minimized — their region is zeroed)
+  for (const w of windows) {
+    if (!w.isMinimized) {
+      cache.set(String(w.hwnd), {
+        hwnd: w.hwnd,
+        title: w.title,
+        region: { ...w.region },
+        zOrder: w.zOrder,
+        timestamp: Date.now(),
+      });
+    }
+  }
+}
+
+/**
+ * Find the cached window that contains the given screen coordinate.
+ * Searches in Z-order (lowest zOrder = frontmost) so overlapping windows
+ * resolve to the topmost one — matching what the LLM saw in the screenshot.
+ * Returns null if no cached window contains the point.
+ */
+export function findContainingWindow(x: number, y: number): CachedWindow | null {
+  let best: CachedWindow | null = null;
+  let bestZ = Infinity;
+  for (const w of cache.values()) {
+    const r = w.region;
+    if (x >= r.x && x < r.x + r.width && y >= r.y && y < r.y + r.height) {
+      if (w.zOrder < bestZ) {
+        best = w;
+        bestZ = w.zOrder;
+      }
+    }
+  }
+  return best;
+}
+
+/**
+ * Look up a cached window by partial title match (case-insensitive).
+ * Returns the frontmost match (lowest zOrder).
+ */
+export function getCachedWindowByTitle(title: string): CachedWindow | null {
+  const query = title.toLowerCase();
+  let best: CachedWindow | null = null;
+  let bestZ = Infinity;
+  for (const w of cache.values()) {
+    if (w.title.toLowerCase().includes(query) && w.zOrder < bestZ) {
+      best = w;
+      bestZ = w.zOrder;
+    }
+  }
+  return best;
+}
+
+/**
+ * Compute how much a window has moved since it was cached.
+ * Calls GetWindowRect (one Win32 call, <1ms) to get the current position.
+ * Returns null if the window no longer exists or the cache entry is stale.
+ * Stale entries (>60s) are skipped to guard against HWND recycling.
+ */
+export function computeWindowDelta(hwnd: bigint): WindowDelta | null {
+  const cached = cache.get(String(hwnd));
+  if (!cached) return null;
+  if (Date.now() - cached.timestamp > CACHE_TTL_MS) return null;
+
+  const current = getWindowRectByHwnd(hwnd);
+  if (!current) return null; // window closed
+
+  const dx = current.x - cached.region.x;
+  const dy = current.y - cached.region.y;
+  const sizeChanged =
+    current.width !== cached.region.width || current.height !== cached.region.height;
+
+  return { dx, dy, sizeChanged };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { registerWorkspaceTools } from "./tools/workspace.js";
 import { registerPinTools } from "./tools/pin.js";
 import { registerMacroTools } from "./tools/macro.js";
 import { registerScrollCaptureTools } from "./tools/scroll-capture.js";
+import { registerBrowserTools } from "./tools/browser.js";
 import { startTray, stopTray } from "./utils/tray.js";
 import { checkFailsafe, FailsafeError } from "./utils/failsafe.js";
 
@@ -65,6 +66,30 @@ const server = new McpServer(
       "  fullContent=true (default): PW_RENDERFULLCONTENT — works for Chrome/Electron/WinUI3.",
       "  fullContent=false: legacy flag — use if call hangs on games or video players.",
       "",
+      "## Browser automation via CDP (Chrome/Edge)",
+      "browser_connect(port?)          — Connect to Chrome/Edge; lists open tabs. Default port 9222.",
+      "browser_find_element(selector)  — CSS selector → exact screen coords (no SS scaling needed).",
+      "browser_click_element(selector) — find + click in one step.",
+      "browser_eval(expression)        — run JS in the page; returns result.",
+      "browser_get_dom(selector?)      — get outerHTML of element or body.",
+      "browser_navigate(url)           — CDP Page.navigate; no address bar interaction needed.",
+      "browser_disconnect(port?)       — close cached CDP WebSocket sessions.",
+      "",
+      "## CDP setup",
+      "Launch: chrome.exe --remote-debugging-port=9222 --user-data-dir=C:\\tmp\\cdp",
+      "Edge:   msedge.exe --remote-debugging-port=9222 --user-data-dir=C:\\tmp\\cdp",
+      "",
+      "## Virtual desktops (Windows 11)",
+      "get_windows() shows isOnCurrentDesktop per window.",
+      "Switch desktops: keyboard_press('ctrl+win+left') / keyboard_press('ctrl+win+right').",
+      "New desktop: keyboard_press('ctrl+win+d')  |  Close: keyboard_press('ctrl+win+f4').",
+      "",
+      "## Browser UI shortcuts (more reliable than finding UI elements)",
+      "Navigate:    browser_navigate(url)  — or: keyboard_press('ctrl+l') → keyboard_type(url) → keyboard_press('enter').",
+      "Back/Fwd:   keyboard_press('alt+left') / keyboard_press('alt+right').",
+      "New tab:    keyboard_press('ctrl+t').",
+      "DevTools:   keyboard_press('f12').",
+      "",
       "## Batching with run_macro",
       "Group sequential operations into a single run_macro call to eliminate API round-trips.",
       "Max 50 steps. Use sleep pseudo-command for waits (max 10000ms).",
@@ -100,6 +125,7 @@ registerWorkspaceTools(server);
 registerPinTools(server);
 registerMacroTools(server);
 registerScrollCaptureTools(server);
+registerBrowserTools(server);
 
 // ─── Failsafe background monitor (backup for long-running operations) ─────────
 // Primary check: per-tool call via the wrapper above.

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -1,0 +1,468 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { mouse, Button, Point, straightTo, DEFAULT_MOUSE_SPEED } from "../engine/nutjs.js";
+import { enumWindowsInZOrder, restoreAndFocusWindow } from "../engine/win32.js";
+import { updateWindowCache } from "../engine/window-cache.js";
+import type { ToolResult } from "./_types.js";
+import {
+  listTabs,
+  evaluateInTab,
+  getElementScreenCoords,
+  navigateTo,
+  getDomHtml,
+  disconnectAll,
+  DEFAULT_CDP_PORT,
+} from "../engine/cdp-bridge.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Schemas
+// ─────────────────────────────────────────────────────────────────────────────
+
+const portParam = z.coerce
+  .number()
+  .int()
+  .min(1)
+  .max(65535)
+  .default(DEFAULT_CDP_PORT)
+  .describe("Chrome/Edge CDP remote debugging port (default 9222)");
+
+const tabIdParam = z
+  .string()
+  .optional()
+  .describe("Tab ID from browser_connect. Omit to use the first page tab.");
+
+const selectorParam = z
+  .string()
+  .describe("CSS selector for the target element (e.g. '#submit', '.btn', 'button[type=submit]')");
+
+export const browserConnectSchema = {
+  port: portParam,
+};
+
+export const browserFindElementSchema = {
+  selector: selectorParam,
+  tabId: tabIdParam,
+  port: portParam,
+};
+
+export const browserClickElementSchema = {
+  selector: selectorParam,
+  tabId: tabIdParam,
+  port: portParam,
+};
+
+export const browserEvalSchema = {
+  expression: z.string().describe("JavaScript expression to evaluate in the browser tab"),
+  tabId: tabIdParam,
+  port: portParam,
+};
+
+export const browserGetDomSchema = {
+  selector: z
+    .string()
+    .optional()
+    .describe("CSS selector for root element. Omit for document.body."),
+  tabId: tabIdParam,
+  port: portParam,
+  maxLength: z.coerce
+    .number()
+    .int()
+    .min(100)
+    .max(100_000)
+    .default(10_000)
+    .describe("Maximum characters to return (default 10000)"),
+};
+
+export const browserNavigateSchema = {
+  url: z.string().describe("URL to navigate to"),
+  tabId: tabIdParam,
+  port: portParam,
+};
+
+export const browserDisconnectSchema = {
+  port: portParam,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internal helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Ensure a specific window is focused before sending mouse events.
+ * If the active window already matches titleHint, this is a no-op.
+ * Otherwise finds the window by title and brings it to the front.
+ * Updates the window cache after enumeration.
+ */
+async function ensureWindowFocused(titleHint: string): Promise<void> {
+  const windows = enumWindowsInZOrder();
+  updateWindowCache(windows);
+  const active = windows.find((w) => w.isActive);
+  if (active && active.title.toLowerCase().includes(titleHint.toLowerCase())) {
+    return; // already focused
+  }
+  const target = windows.find((w) =>
+    w.title.toLowerCase().includes(titleHint.toLowerCase())
+  );
+  if (target) {
+    restoreAndFocusWindow(target.hwnd);
+    await new Promise<void>((r) => setTimeout(r, 100));
+  }
+}
+
+/**
+ * Ensure a browser window is focused before sending mouse events.
+ * Falls back to generic Chrome/Edge title search when tab title cannot be resolved.
+ */
+async function ensureBrowserFocused(port: number): Promise<void> {
+  // Try to match by current tab title from CDP
+  let tabTitle: string | undefined;
+  try {
+    const tabs = await listTabs(port);
+    const pageTab = tabs.find((t) => t.type === "page");
+    tabTitle = pageTab?.title;
+  } catch {
+    // ignore — fall back to browser name search
+  }
+
+  if (tabTitle) {
+    await ensureWindowFocused(tabTitle);
+    return;
+  }
+
+  // Fall back to browser process name
+  const windows = enumWindowsInZOrder();
+  updateWindowCache(windows);
+  const active = windows.find((w) => w.isActive);
+  if (
+    active &&
+    (active.title.includes("Google Chrome") || active.title.includes("Microsoft Edge"))
+  ) {
+    return;
+  }
+  const browserWindow = windows.find((w) =>
+    w.title.includes("Google Chrome") || w.title.includes("Microsoft Edge")
+  );
+  if (browserWindow) {
+    restoreAndFocusWindow(browserWindow.hwnd);
+    await new Promise<void>((r) => setTimeout(r, 100));
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Handlers
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const browserConnectHandler = async ({
+  port,
+}: {
+  port: number;
+}): Promise<ToolResult> => {
+  try {
+    const tabs = await listTabs(port);
+    const pageTabs = tabs.filter((t) => t.type === "page");
+    const summary = pageTabs.map((t) => ({
+      id: t.id,
+      title: t.title,
+      url: t.url,
+    }));
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: [
+            `Connected to Chrome/Edge CDP at port ${port}.`,
+            `${pageTabs.length} page tab(s) found:`,
+            JSON.stringify(summary, null, 2),
+            "",
+            "Pass a tab's id to other browser_* tools to target it, or omit to use the first tab.",
+          ].join("\n"),
+        },
+      ],
+    };
+  } catch (err) {
+    return {
+      content: [{ type: "text" as const, text: `browser_connect failed: ${String(err)}` }],
+    };
+  }
+};
+
+export const browserFindElementHandler = async ({
+  selector,
+  tabId,
+  port,
+}: {
+  selector: string;
+  tabId?: string;
+  port: number;
+}): Promise<ToolResult> => {
+  try {
+    const coords = await getElementScreenCoords(
+      selector,
+      tabId ?? null,
+      port
+    );
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: [
+            `Element found: ${selector}`,
+            JSON.stringify({
+              center: { x: coords.x, y: coords.y },
+              topLeft: { x: coords.left, y: coords.top },
+              size: { width: coords.width, height: coords.height },
+              inViewport: coords.inViewport,
+              clickAt: { x: coords.x, y: coords.y },
+            }, null, 2),
+            "",
+            !coords.inViewport
+              ? "Warning: element is outside the visible viewport. Scroll into view before clicking."
+              : "Element is visible. Pass clickAt coords to mouse_click.",
+          ].join("\n"),
+        },
+      ],
+    };
+  } catch (err) {
+    return {
+      content: [{ type: "text" as const, text: `browser_find_element failed: ${String(err)}` }],
+    };
+  }
+};
+
+export const browserClickElementHandler = async ({
+  selector,
+  tabId,
+  port,
+}: {
+  selector: string;
+  tabId?: string;
+  port: number;
+}): Promise<ToolResult> => {
+  try {
+    const coords = await getElementScreenCoords(
+      selector,
+      tabId ?? null,
+      port
+    );
+    if (!coords.inViewport) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text:
+              `browser_click_element: element "${selector}" is outside the visible viewport. ` +
+              `Scroll it into view first: browser_eval("document.querySelector(${JSON.stringify(selector)}).scrollIntoView()")`,
+          },
+        ],
+      };
+    }
+    // Ensure browser window is focused so click events reach the page
+    await ensureBrowserFocused(port);
+    // Perform the actual mouse click using nut-js
+    const speed = DEFAULT_MOUSE_SPEED;
+    if (speed === 0) {
+      await mouse.setPosition(new Point(coords.x, coords.y));
+    } else {
+      const prev = mouse.config.mouseSpeed;
+      mouse.config.mouseSpeed = speed;
+      try {
+        await mouse.move(straightTo(new Point(coords.x, coords.y)));
+      } finally {
+        mouse.config.mouseSpeed = prev;
+      }
+    }
+    await mouse.click(Button.LEFT);
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Clicked "${selector}" at screen (${coords.x}, ${coords.y})`,
+        },
+      ],
+    };
+  } catch (err) {
+    return {
+      content: [{ type: "text" as const, text: `browser_click_element failed: ${String(err)}` }],
+    };
+  }
+};
+
+export const browserEvalHandler = async ({
+  expression,
+  tabId,
+  port,
+}: {
+  expression: string;
+  tabId?: string;
+  port: number;
+}): Promise<ToolResult> => {
+  try {
+    const result = await evaluateInTab(expression, tabId ?? null, port);
+    const text =
+      result === null || result === undefined
+        ? "(null)"
+        : typeof result === "string"
+          ? result
+          : JSON.stringify(result, null, 2);
+    return {
+      content: [{ type: "text" as const, text }],
+    };
+  } catch (err) {
+    return {
+      content: [{ type: "text" as const, text: `browser_eval failed: ${String(err)}` }],
+    };
+  }
+};
+
+export const browserGetDomHandler = async ({
+  selector,
+  tabId,
+  port,
+  maxLength,
+}: {
+  selector?: string;
+  tabId?: string;
+  port: number;
+  maxLength: number;
+}): Promise<ToolResult> => {
+  try {
+    const html = await getDomHtml(
+      selector ?? null,
+      tabId ?? null,
+      port,
+      maxLength
+    );
+    return {
+      content: [{ type: "text" as const, text: html }],
+    };
+  } catch (err) {
+    return {
+      content: [{ type: "text" as const, text: `browser_get_dom failed: ${String(err)}` }],
+    };
+  }
+};
+
+export const browserNavigateHandler = async ({
+  url,
+  tabId,
+  port,
+}: {
+  url: string;
+  tabId?: string;
+  port: number;
+}): Promise<ToolResult> => {
+  try {
+    await navigateTo(url, tabId ?? null, port);
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Navigating to: ${url}\nWait a moment, then use browser_eval("document.readyState") to check if the page has loaded.`,
+        },
+      ],
+    };
+  } catch (err) {
+    return {
+      content: [{ type: "text" as const, text: `browser_navigate failed: ${String(err)}` }],
+    };
+  }
+};
+
+export const browserDisconnectHandler = async ({
+  port,
+}: {
+  port: number;
+}): Promise<ToolResult> => {
+  try {
+    disconnectAll(port);
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Closed all cached CDP sessions for port ${port}.`,
+        },
+      ],
+    };
+  } catch (err) {
+    return {
+      content: [{ type: "text" as const, text: `browser_disconnect failed: ${String(err)}` }],
+    };
+  }
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Registration
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function registerBrowserTools(server: McpServer): void {
+  server.tool(
+    "browser_connect",
+    [
+      "Connect to Chrome or Edge running with --remote-debugging-port and list open tabs.",
+      "Launch with: chrome.exe --remote-debugging-port=9222 --user-data-dir=C:\\tmp\\cdp",
+      "Returns tab IDs needed for other browser_* tools.",
+    ].join("\n"),
+    browserConnectSchema,
+    browserConnectHandler
+  );
+
+  server.tool(
+    "browser_find_element",
+    [
+      "Find a DOM element by CSS selector and return its exact screen coordinates (physical pixels).",
+      "Coordinates are directly compatible with mouse_click — no manual scaling needed.",
+      "More accurate than screenshot-based coordinate estimation.",
+    ].join("\n"),
+    browserFindElementSchema,
+    browserFindElementHandler
+  );
+
+  server.tool(
+    "browser_click_element",
+    [
+      "Find a DOM element by CSS selector and click it. Combines browser_find_element + mouse_click in one step.",
+      "Fails if the element is outside the visible viewport — scroll into view first.",
+    ].join("\n"),
+    browserClickElementSchema,
+    browserClickElementHandler
+  );
+
+  server.tool(
+    "browser_eval",
+    [
+      "Evaluate a JavaScript expression in the browser tab and return the result.",
+      "Use for: reading text content, checking state, scrolling, filling inputs via JS.",
+      "Example: browser_eval(\"document.title\") → page title string.",
+    ].join("\n"),
+    browserEvalSchema,
+    browserEvalHandler
+  );
+
+  server.tool(
+    "browser_get_dom",
+    [
+      "Get the HTML of a DOM element (or document.body if no selector). Truncated to maxLength chars.",
+      "Useful for inspecting the page structure before deciding which selector to use.",
+    ].join("\n"),
+    browserGetDomSchema,
+    browserGetDomHandler
+  );
+
+  server.tool(
+    "browser_navigate",
+    [
+      "Navigate the browser tab to a URL using CDP Page.navigate.",
+      "More reliable than clicking the address bar — no need to find UI elements.",
+      "After calling, wait and check document.readyState via browser_eval.",
+    ].join("\n"),
+    browserNavigateSchema,
+    browserNavigateHandler
+  );
+
+  server.tool(
+    "browser_disconnect",
+    "Close cached CDP WebSocket sessions for a port. Call when done to release connections.",
+    browserDisconnectSchema,
+    browserDisconnectHandler
+  );
+}

--- a/src/tools/mouse.ts
+++ b/src/tools/mouse.ts
@@ -1,6 +1,14 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { mouse, Button, Point, straightTo, DEFAULT_MOUSE_SPEED } from "../engine/nutjs.js";
+import { enumWindowsInZOrder, restoreAndFocusWindow } from "../engine/win32.js";
+import {
+  updateWindowCache,
+  findContainingWindow,
+  getCachedWindowByTitle,
+  computeWindowDelta,
+} from "../engine/window-cache.js";
+import { getElementBounds } from "../engine/uia-bridge.js";
 import type { ToolResult } from "./_types.js";
 
 /**
@@ -33,6 +41,94 @@ function toButton(b: string): Button {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Homing helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Threshold: if delta exceeds this many pixels, treat as "significant movement". */
+const LARGE_DELTA_PX = 200;
+
+interface HomingResult {
+  x: number;
+  y: number;
+  notes: string[];
+}
+
+/**
+ * Apply homing correction to a target coordinate.
+ *
+ * Tier 1: Look up the window containing (x,y) in the cache and compute how far
+ *         it has moved since the last screenshot. Apply the (dx,dy) offset.
+ * Tier 2: If windowTitle is provided, ensure that window is focused first.
+ * Tier 3: If elementName/elementId are provided AND the window resized or moved
+ *         significantly, re-query via UIA to get fresh coordinates.
+ */
+async function applyHoming(
+  x: number,
+  y: number,
+  windowTitle?: string,
+  elementName?: string,
+  elementId?: string,
+): Promise<HomingResult> {
+  const notes: string[] = [];
+
+  // ── Tier 2: focus the target window if it went behind another ─────────────
+  if (windowTitle) {
+    const windows = enumWindowsInZOrder();
+    updateWindowCache(windows); // keep cache fresh before delta check below
+    const active = windows.find((w) => w.isActive);
+    if (!active || !active.title.toLowerCase().includes(windowTitle.toLowerCase())) {
+      const target = windows.find((w) =>
+        w.title.toLowerCase().includes(windowTitle.toLowerCase())
+      );
+      if (target) {
+        restoreAndFocusWindow(target.hwnd);
+        await new Promise<void>((r) => setTimeout(r, 100));
+        // Refresh cache again after restore: window may have moved/unminimized
+        updateWindowCache(enumWindowsInZOrder());
+        notes.push(`brought "${target.title}" to front`);
+      }
+    }
+  }
+
+  // ── Tier 1: window-delta correction ──────────────────────────────────────
+  const cached = windowTitle
+    ? getCachedWindowByTitle(windowTitle)
+    : findContainingWindow(x, y);
+
+  if (!cached) {
+    // No cache entry — nothing to correct
+    return { x, y, notes };
+  }
+
+  const delta = computeWindowDelta(cached.hwnd);
+  if (!delta) {
+    // Window no longer exists — leave coords as-is
+    return { x, y, notes };
+  }
+
+  // ── Tier 3: UIA re-query (window resized or moved dramatically) ──────────
+  if (
+    (elementName || elementId) &&
+    windowTitle &&
+    (delta.sizeChanged || Math.abs(delta.dx) > LARGE_DELTA_PX || Math.abs(delta.dy) > LARGE_DELTA_PX)
+  ) {
+    const bounds = await getElementBounds(windowTitle, elementName, elementId);
+    if (bounds?.boundingRect) {
+      const nx = Math.round(bounds.boundingRect.x + bounds.boundingRect.width / 2);
+      const ny = Math.round(bounds.boundingRect.y + bounds.boundingRect.height / 2);
+      notes.push(`re-queried "${elementName ?? elementId}" via UIA, window ${delta.sizeChanged ? "resized" : "moved far"}`);
+      return { x: nx, y: ny, notes };
+    }
+  }
+
+  // Simple offset correction
+  if (delta.dx !== 0 || delta.dy !== 0) {
+    notes.push(`window moved ${delta.dx > 0 ? "+" : ""}${delta.dx},${delta.dy > 0 ? "+" : ""}${delta.dy}`);
+  }
+  return { x: x + delta.dx, y: y + delta.dy, notes };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Schemas
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -41,10 +137,34 @@ const speedParam = z.coerce.number().int().min(0).optional().describe(
   "Omit to use the configured default (DESKTOP_TOUCH_MOUSE_SPEED env var, default 1500)."
 );
 
+const homingParam = z.boolean().default(true).describe(
+  "Enable homing correction (default true). " +
+  "When enabled, the MCP server corrects stale coordinates if the target window moved " +
+  "since the last screenshot. Set false to disable all correction (like traction control OFF)."
+);
+
+const windowTitleParam = z.string().optional().describe(
+  "Hint: partial title of the window being clicked. " +
+  "Enables window-delta correction and auto-focus if the window went behind another. " +
+  "Example: \"メモ帳\", \"Google Chrome\""
+);
+
+const elementNameParam = z.string().optional().describe(
+  "Hint: name/label of the UI element (from actionable[].name in screenshot(detail='text')). " +
+  "Requires windowTitle. Triggers UIA re-query to get fresh coordinates when the window resized or moved far."
+);
+
+const elementIdParam = z.string().optional().describe(
+  "Hint: automationId of the UI element (from actionable[].id). " +
+  "Requires windowTitle. Used with elementName for more precise UIA re-query."
+);
+
 export const mouseMoveSchema = {
   x: z.coerce.number().describe("X coordinate in virtual screen pixels"),
   y: z.coerce.number().describe("Y coordinate in virtual screen pixels"),
   speed: speedParam,
+  homing: homingParam,
+  windowTitle: windowTitleParam,
 };
 
 export const mouseClickSchema = {
@@ -53,6 +173,10 @@ export const mouseClickSchema = {
   button: z.enum(["left", "right", "middle"]).default("left").describe("Mouse button to click"),
   doubleClick: z.boolean().default(false).describe("Whether to double-click"),
   speed: speedParam,
+  homing: homingParam,
+  windowTitle: windowTitleParam,
+  elementName: elementNameParam,
+  elementId: elementIdParam,
 };
 
 export const mouseDragSchema = {
@@ -61,6 +185,8 @@ export const mouseDragSchema = {
   endX: z.coerce.number(),
   endY: z.coerce.number(),
   speed: speedParam,
+  homing: homingParam,
+  windowTitle: windowTitleParam,
 };
 
 export const scrollSchema = {
@@ -69,6 +195,8 @@ export const scrollSchema = {
   x: z.coerce.number().optional().describe("X coordinate to scroll at (moves cursor there first)"),
   y: z.coerce.number().optional().describe("Y coordinate to scroll at"),
   speed: speedParam,
+  homing: homingParam,
+  windowTitle: windowTitleParam,
 };
 
 export const getCursorPositionSchema = {};
@@ -77,20 +205,42 @@ export const getCursorPositionSchema = {};
 // Handlers
 // ─────────────────────────────────────────────────────────────────────────────
 
-export const mouseMoveHandler = async ({ x, y, speed }: { x: number; y: number; speed?: number }): Promise<ToolResult> => {
+export const mouseMoveHandler = async ({
+  x, y, speed, homing, windowTitle,
+}: {
+  x: number; y: number; speed?: number; homing: boolean; windowTitle?: string;
+}): Promise<ToolResult> => {
   try {
-    await moveTo(x, y, speed);
-    return { content: [{ type: "text" as const, text: `Mouse moved to (${x}, ${y})` }] };
+    let tx = x, ty = y;
+    const notes: string[] = [];
+    if (homing) {
+      const result = await applyHoming(x, y, windowTitle);
+      tx = result.x; ty = result.y;
+      notes.push(...result.notes);
+    }
+    await moveTo(tx, ty, speed);
+    const homingStr = !homing ? " [homing: off]" : notes.length ? ` [homing: ${notes.join(", ")}]` : "";
+    return { content: [{ type: "text" as const, text: `Mouse moved to (${tx}, ${ty})${homingStr}` }] };
   } catch (err) {
     return { content: [{ type: "text" as const, text: `mouse_move failed: ${String(err)}` }] };
   }
 };
 
 export const mouseClickHandler = async ({
-  x, y, button, doubleClick, speed,
-}: { x: number; y: number; button: "left" | "right" | "middle"; doubleClick: boolean; speed?: number }): Promise<ToolResult> => {
+  x, y, button, doubleClick, speed, homing, windowTitle, elementName, elementId,
+}: {
+  x: number; y: number; button: "left" | "right" | "middle"; doubleClick: boolean;
+  speed?: number; homing: boolean; windowTitle?: string; elementName?: string; elementId?: string;
+}): Promise<ToolResult> => {
   try {
-    await moveTo(x, y, speed);
+    let tx = x, ty = y;
+    const notes: string[] = [];
+    if (homing) {
+      const result = await applyHoming(x, y, windowTitle, elementName, elementId);
+      tx = result.x; ty = result.y;
+      notes.push(...result.notes);
+    }
+    await moveTo(tx, ty, speed);
     const btn = toButton(button);
     if (doubleClick) {
       await mouse.doubleClick(btn);
@@ -98,35 +248,51 @@ export const mouseClickHandler = async ({
       await mouse.click(btn);
     }
     const action = doubleClick ? "Double-clicked" : "Clicked";
-    return { content: [{ type: "text" as const, text: `${action} ${button} at (${x}, ${y})` }] };
+    const homingStr = !homing ? " [homing: off]" : notes.length ? ` [homing: ${notes.join(", ")}]` : "";
+    return { content: [{ type: "text" as const, text: `${action} ${button} at (${tx}, ${ty})${homingStr}` }] };
   } catch (err) {
     return { content: [{ type: "text" as const, text: `mouse_click failed: ${String(err)}` }] };
   }
 };
 
 export const mouseDragHandler = async ({
-  startX, startY, endX, endY, speed,
-}: { startX: number; startY: number; endX: number; endY: number; speed?: number }): Promise<ToolResult> => {
+  startX, startY, endX, endY, speed, homing, windowTitle,
+}: {
+  startX: number; startY: number; endX: number; endY: number;
+  speed?: number; homing: boolean; windowTitle?: string;
+}): Promise<ToolResult> => {
   try {
-    // Move to start instantly (or at speed), then drag to end at same speed
-    await moveTo(startX, startY, speed);
+    let tsx = startX, tsy = startY;
+    let tex = endX, tey = endY;
+    const notes: string[] = [];
+    if (homing) {
+      // Homing result gives us (correctedX, correctedY) and the underlying delta.
+      // Apply the same (dx, dy) to the end point so the drag vector is preserved.
+      const result = await applyHoming(startX, startY, windowTitle);
+      const dx = result.x - startX;
+      const dy = result.y - startY;
+      tsx = result.x; tsy = result.y;
+      tex = endX + dx; tey = endY + dy;
+      notes.push(...result.notes);
+    }
+    await moveTo(tsx, tsy, speed);
     const s = speed ?? DEFAULT_MOUSE_SPEED;
     if (s === 0) {
-      // Instant drag: setPosition to end (fast but no held-button animation)
       await mouse.pressButton(Button.LEFT);
-      await mouse.setPosition(new Point(endX, endY));
+      await mouse.setPosition(new Point(tex, tey));
       await mouse.releaseButton(Button.LEFT);
     } else {
       const prev = mouse.config.mouseSpeed;
       mouse.config.mouseSpeed = s;
       try {
-        await mouse.drag(straightTo(new Point(endX, endY)));
+        await mouse.drag(straightTo(new Point(tex, tey)));
       } finally {
         mouse.config.mouseSpeed = prev;
       }
     }
+    const homingStr = !homing ? " [homing: off]" : notes.length ? ` [homing: ${notes.join(", ")}]` : "";
     return {
-      content: [{ type: "text" as const, text: `Dragged from (${startX}, ${startY}) to (${endX}, ${endY})` }],
+      content: [{ type: "text" as const, text: `Dragged from (${tsx}, ${tsy}) to (${tex}, ${tey})${homingStr}` }],
     };
   } catch (err) {
     return { content: [{ type: "text" as const, text: `mouse_drag failed: ${String(err)}` }] };
@@ -134,11 +300,21 @@ export const mouseDragHandler = async ({
 };
 
 export const scrollHandler = async ({
-  direction, amount, x, y, speed,
-}: { direction: "up" | "down" | "left" | "right"; amount: number; x?: number; y?: number; speed?: number }): Promise<ToolResult> => {
+  direction, amount, x, y, speed, homing, windowTitle,
+}: {
+  direction: "up" | "down" | "left" | "right"; amount: number;
+  x?: number; y?: number; speed?: number; homing: boolean; windowTitle?: string;
+}): Promise<ToolResult> => {
   try {
-    if (x !== undefined && y !== undefined) {
-      await moveTo(x, y, speed);
+    let tx = x, ty = y;
+    const notes: string[] = [];
+    if (homing && x !== undefined && y !== undefined) {
+      const result = await applyHoming(x, y, windowTitle);
+      tx = result.x; ty = result.y;
+      notes.push(...result.notes);
+    }
+    if (tx !== undefined && ty !== undefined) {
+      await moveTo(tx, ty, speed);
     }
     const SCROLL_MULTIPLIER = 3;
     switch (direction) {
@@ -151,7 +327,8 @@ export const scrollHandler = async ({
         for (let i = 0; i < amount; i++) await mouse.scrollLeft(SCROLL_MULTIPLIER);
         break;
     }
-    return { content: [{ type: "text" as const, text: `Scrolled ${direction} by ${amount} steps` }] };
+    const homingStr = !homing ? " [homing: off]" : notes.length ? ` [homing: ${notes.join(", ")}]` : "";
+    return { content: [{ type: "text" as const, text: `Scrolled ${direction} by ${amount} steps${homingStr}` }] };
   } catch (err) {
     return { content: [{ type: "text" as const, text: `scroll failed: ${String(err)}` }] };
   }
@@ -172,7 +349,19 @@ export const getCursorPositionHandler = async (): Promise<ToolResult> => {
 
 export function registerMouseTools(server: McpServer): void {
   server.tool("mouse_move", "Move the mouse cursor to the specified screen coordinates.", mouseMoveSchema, mouseMoveHandler);
-  server.tool("mouse_click", "Click the mouse at the specified coordinates.", mouseClickSchema, mouseClickHandler);
+  server.tool(
+    "mouse_click",
+    [
+      "Click the mouse at the specified coordinates.",
+      "Pass windowTitle (and optionally elementName/elementId) as hints to enable homing correction:",
+      "  - Tier 1: auto-corrects (dx,dy) if the window moved since the last screenshot (<1ms overhead)",
+      "  - Tier 2: auto-focuses the window if it went behind another (~100ms overhead)",
+      "  - Tier 3: re-queries UIA for fresh coords if the window resized (1-3s, only when elementName/Id given)",
+      "Set homing=false to disable all correction (like traction control OFF).",
+    ].join("\n"),
+    mouseClickSchema,
+    mouseClickHandler
+  );
   server.tool("mouse_drag", "Click and drag from one position to another (left button hold).", mouseDragSchema, mouseDragHandler);
   server.tool("scroll", "Scroll at the current position or at specified coordinates.", scrollSchema, scrollHandler);
   server.tool("get_cursor_position", "Get the current mouse cursor position in virtual screen coordinates.", getCursorPositionSchema, getCursorPositionHandler);

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -6,6 +6,7 @@ import type { WindowInfo } from "../engine/layer-buffer.js";
 import { getWindows } from "../engine/nutjs.js";
 import { enumMonitors, getVirtualScreen, getWindowTitleW, enumWindowsInZOrder } from "../engine/win32.js";
 import { getUiElements, extractActionableElements } from "../engine/uia-bridge.js";
+import { updateWindowCache } from "../engine/window-cache.js";
 import type { ToolResult } from "./_types.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -166,6 +167,7 @@ export const screenshotHandler = async ({
     // ── diffMode: layer-based differential capture ───────────────────────────
     if (diffMode) {
       const windowInfos = await buildWindowInfoList();
+      updateWindowCache(enumWindowsInZOrder());
       const isFirstFrame = !hasBuffer();
       const diffs = isFirstFrame
         ? await captureAllLayers(windowInfos, webpQuality)
@@ -208,6 +210,7 @@ export const screenshotHandler = async ({
     // ── detail=meta: window positions only, no image ─────────────────────────
     if (detail === "meta") {
       const wins = enumWindowsInZOrder();
+      updateWindowCache(wins);
       const metaList = wins
         .filter((w) => w.region.width >= 50 && w.region.height >= 50)
         .map((w) => ({
@@ -233,15 +236,18 @@ export const screenshotHandler = async ({
     // ── detail=text: UIA element tree as JSON ────────────────────────────────
     if (detail === "text") {
       if (windowTitle) {
+        updateWindowCache(enumWindowsInZOrder());
         const uiaText = await buildUiaText(windowTitle);
         return { content: [{ type: "text" as const, text: uiaText }] };
       }
       // All visible windows
-      const wins = enumWindowsInZOrder()
+      const wins = enumWindowsInZOrder();
+      updateWindowCache(wins);
+      const filteredWins = wins
         .filter((w) => w.region.width >= 100 && w.region.height >= 50)
         .slice(0, 10);
       const results = await Promise.all(
-        wins.map(async (w) => {
+        filteredWins.map(async (w) => {
           try { return JSON.parse(await buildUiaText(w.title)); } catch { return { window: w.title, elements: [] }; }
         })
       );

--- a/src/tools/window.ts
+++ b/src/tools/window.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { getActiveWindow } from "../engine/nutjs.js";
 import { getWindowTitleW, enumWindowsInZOrder, restoreAndFocusWindow } from "../engine/win32.js";
 import { getVirtualDesktopStatus } from "../engine/uia-bridge.js";
+import { updateWindowCache } from "../engine/window-cache.js";
 import type { ToolResult } from "./_types.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -24,6 +25,7 @@ export const focusWindowSchema = {
 export const getWindowsHandler = async (): Promise<ToolResult> => {
   try {
     const wins = enumWindowsInZOrder();
+    updateWindowCache(wins);
     const hwndStrings = wins.map((w) => String(w.hwnd));
     const vdStatus = await getVirtualDesktopStatus(hwndStrings);
 
@@ -70,6 +72,7 @@ export const focusWindowHandler = async ({ title }: { title: string }): Promise<
   try {
     // Use enumWindowsInZOrder (Win32-based) so minimized windows are also included.
     const windows = enumWindowsInZOrder();
+    updateWindowCache(windows);
     const query = title.toLowerCase();
 
     for (const win of windows) {

--- a/src/tools/workspace.ts
+++ b/src/tools/workspace.ts
@@ -9,6 +9,7 @@ import { enumMonitors, getVirtualScreen, enumWindowsInZOrder, type WindowZInfo }
 import { captureScreen } from "../engine/image.js";
 import { clearLayers } from "../engine/layer-buffer.js";
 import { getUiElements, extractActionableElements } from "../engine/uia-bridge.js";
+import { updateWindowCache } from "../engine/window-cache.js";
 import type { ToolResult } from "./_types.js";
 
 /** Chromium-based browser windows — UIA traversal is prohibitively slow on these */
@@ -255,6 +256,7 @@ export const workspaceSnapshotHandler = async ({
     ]);
 
     const allWindows = enumWindowsInZOrder();
+    updateWindowCache(allWindows);
     // Compute virtualScreen from already-fetched monitors to avoid a second EnumDisplayMonitors sweep
     const mons = monitors.map(m => m.bounds);
     const virtualScreen = mons.length === 0

--- a/tests/e2e/browser-cdp.test.ts
+++ b/tests/e2e/browser-cdp.test.ts
@@ -1,0 +1,369 @@
+/**
+ * browser-cdp.test.ts — E2E tests for CDP browser integration
+ *
+ * Tests the cdp-bridge engine functions directly (no MCP server overhead).
+ * Requires Chrome/Edge with --remote-debugging-port; auto-launched per suite.
+ *
+ * Test categories:
+ *   - headless: connect, eval, DOM, navigate — runnable in CI
+ *   - headed:   coordinate precision + click — requires HEADED=1 env var
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+import { launchChrome, type ChromeInstance } from "./helpers/chrome-launcher.js";
+import {
+  listTabs,
+  evaluateInTab,
+  getElementScreenCoords,
+  navigateTo,
+  getDomHtml,
+  disconnectAll,
+} from "../../src/engine/cdp-bridge.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = join(__dirname, "fixtures", "test-page.html");
+const TEST_PORT = 9224; // Separate from dev port 9222 and other test suite 9223
+const IS_HEADED = Boolean(process.env.HEADED);
+
+// ─── Test fixture URL ─────────────────────────────────────────────────────────
+
+// Use file:// URL so no HTTP server is needed
+const FIXTURE_URL = `file:///${FIXTURE_PATH.replace(/\\/g, "/")}`;
+
+// ─── Suite setup ──────────────────────────────────────────────────────────────
+
+let chrome: ChromeInstance;
+
+beforeAll(async () => {
+  // Launch Chrome with the fixture page as initial URL (file:// bypasses the
+  // http-only restriction in navigateTo, which is correct for production use)
+  chrome = await launchChrome(TEST_PORT, !IS_HEADED, FIXTURE_URL);
+  await waitForLoad("desktop-touch CDP Test Page");
+});
+
+afterAll(() => {
+  disconnectAll(TEST_PORT);
+  chrome?.kill();
+});
+
+async function waitForLoad(expectedTitle?: string, maxMs = 8_000): Promise<void> {
+  const deadline = Date.now() + maxMs;
+  while (Date.now() < deadline) {
+    try {
+      const state = await evaluateInTab("document.readyState", null, TEST_PORT);
+      if (state === "complete") {
+        if (!expectedTitle) return;
+        const title = await evaluateInTab("document.title", null, TEST_PORT);
+        if (title === expectedTitle) return;
+      }
+    } catch {
+      // session may not be ready yet
+    }
+    await sleep(300);
+  }
+  throw new Error(
+    `Page did not finish loading${expectedTitle ? ` with title "${expectedTitle}"` : ""} within ${maxMs}ms`
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// browser_connect equivalent — listTabs
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("listTabs", () => {
+  it("returns at least one page tab", async () => {
+    const tabs = await listTabs(TEST_PORT);
+    expect(tabs.length).toBeGreaterThan(0);
+    const pageTabs = tabs.filter((t) => t.type === "page");
+    expect(pageTabs.length).toBeGreaterThan(0);
+  });
+
+  it("each tab has id, title, url, webSocketDebuggerUrl", async () => {
+    const tabs = await listTabs(TEST_PORT);
+    const page = tabs.find((t) => t.type === "page")!;
+    expect(page.id).toBeTruthy();
+    expect(page.webSocketDebuggerUrl).toMatch(/^ws:\/\//);
+  });
+
+  it("throws a descriptive error on wrong port", async () => {
+    await expect(listTabs(19999)).rejects.toThrow(/CDP|remote-debugging-port|Cannot reach/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// evaluateInTab — browser_eval
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("evaluateInTab", () => {
+  it("returns document.title of the test page", async () => {
+    const title = await evaluateInTab("document.title", null, TEST_PORT);
+    expect(title).toBe("desktop-touch CDP Test Page");
+  });
+
+  it("returns a number", async () => {
+    const val = await evaluateInTab("1 + 2 + 3", null, TEST_PORT);
+    expect(val).toBe(6);
+  });
+
+  it("returns null for void expressions", async () => {
+    const val = await evaluateInTab("void 0", null, TEST_PORT);
+    expect(val).toBeUndefined();
+  });
+
+  it("returns a JSON-serializable object", async () => {
+    const val = (await evaluateInTab(
+      "JSON.stringify({a: 1, b: 'hello'})",
+      null,
+      TEST_PORT
+    )) as string;
+    expect(JSON.parse(val)).toEqual({ a: 1, b: "hello" });
+  });
+
+  it("can read and set a DOM element's textContent", async () => {
+    // Set
+    await evaluateInTab(
+      "document.getElementById('text-result').textContent = 'test-marker-42'",
+      null,
+      TEST_PORT
+    );
+    // Read back
+    const text = await evaluateInTab(
+      "document.getElementById('text-result').textContent",
+      null,
+      TEST_PORT
+    );
+    expect(text).toBe("test-marker-42");
+  });
+
+  it("throws on syntax error", async () => {
+    await expect(
+      evaluateInTab("this is not valid JS !!!", null, TEST_PORT)
+    ).rejects.toThrow(/JS exception/);
+  });
+
+  it("throws when expression throws", async () => {
+    await expect(
+      evaluateInTab("throw new Error('intentional error')", null, TEST_PORT)
+    ).rejects.toThrow(/intentional error/);
+  });
+
+  it("can await async expressions", async () => {
+    const val = await evaluateInTab(
+      "new Promise(r => setTimeout(() => r('async-ok'), 100))",
+      null,
+      TEST_PORT
+    );
+    expect(val).toBe("async-ok");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getElementScreenCoords — browser_find_element
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("getElementScreenCoords", () => {
+  it("returns coords for #btn-submit", async () => {
+    const coords = await getElementScreenCoords("#btn-submit", null, TEST_PORT);
+    expect(coords.x).toBeGreaterThan(0);
+    expect(coords.y).toBeGreaterThan(0);
+    expect(coords.width).toBeGreaterThan(0);
+    expect(coords.height).toBeGreaterThan(0);
+  });
+
+  it("returns coords within reasonable screen bounds", async () => {
+    const coords = await getElementScreenCoords("#btn-submit", null, TEST_PORT);
+    // Screen should be at most 8K resolution
+    expect(coords.x).toBeLessThan(8000);
+    expect(coords.y).toBeLessThan(8000);
+    expect(coords.x).toBeGreaterThan(0);
+    expect(coords.y).toBeGreaterThan(0);
+  });
+
+  it("center = left + width/2 (roughly)", async () => {
+    const coords = await getElementScreenCoords("#btn-submit", null, TEST_PORT);
+    const expectedCenterX = coords.left + Math.round(coords.width / 2);
+    expect(Math.abs(coords.x - expectedCenterX)).toBeLessThanOrEqual(1);
+  });
+
+  it("center = top + height/2 (roughly)", async () => {
+    const coords = await getElementScreenCoords("#btn-submit", null, TEST_PORT);
+    const expectedCenterY = coords.top + Math.round(coords.height / 2);
+    expect(Math.abs(coords.y - expectedCenterY)).toBeLessThanOrEqual(1);
+  });
+
+  it("reports inViewport=true for visible element", async () => {
+    const coords = await getElementScreenCoords("#btn-submit", null, TEST_PORT);
+    expect(coords.inViewport).toBe(true);
+  });
+
+  it("reports inViewport=false for below-fold element (before scrolling)", async () => {
+    // Reset scroll to top
+    await evaluateInTab("window.scrollTo(0, 0)", null, TEST_PORT);
+    const coords = await getElementScreenCoords(
+      "#section-scroll",
+      null,
+      TEST_PORT
+    );
+    expect(coords.inViewport).toBe(false);
+  });
+
+  it("reports inViewport=true after scrolling element into view", async () => {
+    await evaluateInTab(
+      "document.getElementById('section-scroll').scrollIntoView()",
+      null,
+      TEST_PORT
+    );
+    await sleep(300); // give browser time to scroll
+    const coords = await getElementScreenCoords(
+      "#section-scroll",
+      null,
+      TEST_PORT
+    );
+    expect(coords.inViewport).toBe(true);
+    // Restore scroll
+    await evaluateInTab("window.scrollTo(0, 0)", null, TEST_PORT);
+  });
+
+  it("throws for non-existent selector", async () => {
+    await expect(
+      getElementScreenCoords("#does-not-exist-xyz", null, TEST_PORT)
+    ).rejects.toThrow(/not found/i);
+  });
+
+  it("throws for zero-size hidden element", async () => {
+    await expect(
+      getElementScreenCoords("#btn-hidden", null, TEST_PORT)
+    ).rejects.toThrow(/zero size|hidden/i);
+  });
+
+  it("two different elements have different coords", async () => {
+    const btn = await getElementScreenCoords("#btn-submit", null, TEST_PORT);
+    const input = await getElementScreenCoords("#input-name", null, TEST_PORT);
+    expect(btn.x).not.toBe(input.x);
+    expect(btn.y).not.toBe(input.y);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getDomHtml — browser_get_dom
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("getDomHtml", () => {
+  it("returns document.body HTML when no selector given", async () => {
+    const html = await getDomHtml(null, null, TEST_PORT);
+    expect(html).toContain("btn-submit");
+    expect(html).toContain("input-name");
+  });
+
+  it("returns element HTML for a valid selector", async () => {
+    const html = await getDomHtml("#btn-submit", null, TEST_PORT);
+    expect(html).toContain("btn-submit");
+    expect(html).not.toContain("input-name"); // different element
+  });
+
+  it("throws for missing selector", async () => {
+    await expect(
+      getDomHtml("#no-such-element", null, TEST_PORT)
+    ).rejects.toThrow(/Element not found/);
+  });
+
+  it("truncates at maxLength", async () => {
+    const html = await getDomHtml(null, null, TEST_PORT, 100);
+    expect(html.length).toBeLessThanOrEqual(200); // allow for truncation message
+    expect(html).toContain("truncated");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// navigateTo — browser_navigate
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("navigateTo", () => {
+  it("navigates to a new http page and title changes", async () => {
+    await navigateTo("https://example.com", null, TEST_PORT);
+    await sleep(2000);
+    const title = await evaluateInTab("document.title", null, TEST_PORT);
+    expect(typeof title).toBe("string");
+    expect((title as string).length).toBeGreaterThan(0);
+
+    // Restore fixture via browser history (file:// → https:// → file:// via back())
+    await evaluateInTab("window.history.back()", null, TEST_PORT);
+    await waitForLoad("desktop-touch CDP Test Page");
+  });
+
+  it("throws for non-http(s) URLs", async () => {
+    await expect(
+      navigateTo("javascript:alert(1)", null, TEST_PORT)
+    ).rejects.toThrow(/https?/);
+    await expect(
+      navigateTo("file:///C:/Windows/system.ini", null, TEST_PORT)
+    ).rejects.toThrow(/https?/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Coordinate precision — headed only (requires HEADED=1)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe.runIf(IS_HEADED)("coordinate precision (headed mode)", () => {
+  it("coords change consistently when page is scrolled", async () => {
+    await evaluateInTab("window.scrollTo(0, 0)", null, TEST_PORT);
+    const before = await getElementScreenCoords("#btn-submit", null, TEST_PORT);
+
+    const scrollAmount = 50; // px
+    await evaluateInTab(
+      `window.scrollTo(0, ${scrollAmount})`,
+      null,
+      TEST_PORT
+    );
+    await sleep(200);
+
+    const after = await getElementScreenCoords("#btn-submit", null, TEST_PORT);
+    // Y coordinate should decrease by ~scrollAmount * devicePixelRatio
+    const dpr = (await evaluateInTab(
+      "window.devicePixelRatio",
+      null,
+      TEST_PORT
+    )) as number;
+    const expectedDelta = scrollAmount * dpr;
+    const actualDelta = before.y - after.y;
+    expect(Math.abs(actualDelta - expectedDelta)).toBeLessThanOrEqual(
+      dpr + 1 // allow 1 CSS pixel rounding error
+    );
+
+    await evaluateInTab("window.scrollTo(0, 0)", null, TEST_PORT);
+  });
+
+  // This test requires physical mouse clicking, so only run headed and locally
+  it("find_element coords → mouse_click fires click event", async () => {
+    // Reset click log
+    await evaluateInTab("window._clickLog = []", null, TEST_PORT);
+
+    const coords = await getElementScreenCoords("#btn-submit", null, TEST_PORT);
+
+    // Dynamically import nut-js mouse here to avoid loading native module
+    // in headless/CI runs. This import only succeeds in headed mode with
+    // the native addon compiled.
+    const { mouse, Button, Point } = await import(
+      "../../src/engine/nutjs.js"
+    );
+    await mouse.setPosition(new Point(coords.x, coords.y));
+    await mouse.click(Button.LEFT);
+    await sleep(200);
+
+    const log = (await evaluateInTab(
+      "JSON.stringify(window._clickLog)",
+      null,
+      TEST_PORT
+    )) as string;
+    const events = JSON.parse(log) as Array<{ id: string }>;
+    expect(events.some((e) => e.id === "btn-submit")).toBe(true);
+  });
+});

--- a/tests/e2e/fixtures/test-page.html
+++ b/tests/e2e/fixtures/test-page.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>desktop-touch CDP Test Page</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: sans-serif; background: #f5f5f5; }
+    .container { position: relative; width: 800px; min-height: 600px; background: white; padding: 20px; }
+    #btn-submit {
+      position: absolute;
+      left: 100px; top: 200px;
+      width: 120px; height: 40px;
+      background: #4caf50; color: white;
+      border: none; border-radius: 4px;
+      cursor: pointer; font-size: 14px;
+    }
+    #btn-submit:hover { background: #43a047; }
+    #input-name {
+      position: absolute;
+      left: 100px; top: 300px;
+      width: 200px; height: 32px;
+      border: 1px solid #ccc; border-radius: 4px;
+      padding: 0 8px; font-size: 14px;
+    }
+    #link-next {
+      position: absolute;
+      left: 100px; top: 380px;
+      font-size: 16px;
+    }
+    #text-result {
+      position: absolute;
+      left: 100px; top: 260px;
+      font-size: 14px; color: #333;
+    }
+    #btn-hidden { display: none; }
+    #section-scroll {
+      position: absolute;
+      left: 100px; top: 1000px;
+      width: 200px; height: 50px;
+      background: #e3f2fd;
+      display: flex; align-items: center; justify-content: center;
+      font-size: 14px;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1 id="page-title" style="padding-top:20px;">CDP Test Page</h1>
+
+    <button id="btn-submit">Submit</button>
+
+    <div id="text-result"></div>
+
+    <input id="input-name" type="text" placeholder="Enter name...">
+
+    <a id="link-next" href="#next">Next Page</a>
+
+    <!-- Hidden element for testing -->
+    <button id="btn-hidden">Hidden Button</button>
+
+    <!-- Below-fold element for scroll testing -->
+    <div id="section-scroll">Below the fold</div>
+  </div>
+
+  <script>
+    // Track click events for test verification
+    window._clickLog = [];
+
+    document.getElementById('btn-submit').addEventListener('click', function() {
+      window._clickLog.push({ id: 'btn-submit', time: Date.now() });
+      document.getElementById('text-result').textContent = 'Clicked at ' + Date.now();
+    });
+
+    document.getElementById('input-name').addEventListener('input', function(e) {
+      window._clickLog.push({ id: 'input-name', value: e.target.value, time: Date.now() });
+    });
+  </script>
+</body>
+</html>

--- a/tests/e2e/helpers/chrome-launcher.ts
+++ b/tests/e2e/helpers/chrome-launcher.ts
@@ -1,0 +1,123 @@
+/**
+ * chrome-launcher.ts — Test helper to launch Chrome with CDP remote debugging
+ *
+ * Finds the Chrome executable, starts it with a temporary user-data-dir and
+ * --remote-debugging-port, waits for CDP to become available, and returns
+ * a cleanup function.
+ */
+
+import { spawn, type ChildProcess } from "child_process";
+import { existsSync, mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const CHROME_CANDIDATES: string[] = [
+  process.env.CHROME_PATH ?? "",
+  "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+  "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
+  process.env.LOCALAPPDATA
+    ? join(process.env.LOCALAPPDATA, "Google", "Chrome", "Application", "chrome.exe")
+    : "",
+  // Edge fallback
+  process.env.EDGE_PATH ?? "",
+  "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe",
+  "C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe",
+].filter(Boolean);
+
+export interface ChromeInstance {
+  port: number;
+  kill: () => void;
+}
+
+/**
+ * Launch Chrome with remote debugging enabled.
+ * @param port     CDP port (default 9223 — avoids conflict with dev Chrome on 9222)
+ * @param headless Run headless (default false; screen coordinate tests require headed)
+ */
+export async function launchChrome(
+  port = 9223,
+  headless = false,
+  initialUrl = "about:blank"
+): Promise<ChromeInstance> {
+  const chromePath = findChrome();
+  const userDataDir = mkdtempSync(join(tmpdir(), "cdp-test-"));
+
+  const args = [
+    `--remote-debugging-port=${port}`,
+    `--user-data-dir=${userDataDir}`,
+    "--no-first-run",
+    "--no-default-browser-check",
+    "--disable-default-apps",
+    "--disable-extensions",
+    "--disable-sync",
+    "--disable-translate",
+    "--disable-background-networking",
+    "--safebrowsing-disable-auto-update",
+    ...(headless ? ["--headless=new"] : []),
+    initialUrl,
+  ];
+
+  const proc: ChildProcess = spawn(chromePath, args, {
+    stdio: "ignore",
+    detached: false,
+  });
+
+  proc.on("error", (err) => {
+    console.error(`Chrome process error: ${err.message}`);
+  });
+
+  await waitForCdp(port);
+
+  return {
+    port,
+    kill: () => {
+      try {
+        proc.kill("SIGTERM");
+      } catch {
+        // ignore
+      }
+      try {
+        rmSync(userDataDir, { recursive: true, force: true });
+      } catch {
+        // ignore
+      }
+    },
+  };
+}
+
+/**
+ * Wait until the CDP endpoint at the given port accepts connections.
+ */
+export async function waitForCdp(
+  port: number,
+  timeoutMs = 10_000
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/json/version`);
+      if (res.ok) return;
+    } catch {
+      // not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error(
+    `Chrome CDP at port ${port} did not become available within ${timeoutMs}ms`
+  );
+}
+
+/** Returns the path to the first found Chrome/Edge executable */
+export function findChrome(): string {
+  for (const candidate of CHROME_CANDIDATES) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  throw new Error(
+    `Chrome/Edge executable not found. ` +
+      `Set CHROME_PATH or EDGE_PATH environment variable, ` +
+      `or install Chrome to a standard location.\n` +
+      `Checked: ${CHROME_CANDIDATES.join(", ")}`
+  );
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+    // Run test files serially to avoid CDP port conflicts
+    sequence: { concurrent: false },
+  },
+});


### PR DESCRIPTION
## Summary

- **7つの新規 MCP ツール** (browser_connect / find_element / click_element / eval / get_dom / navigate / disconnect) — Chrome DevTools Protocol 経由でDOM要素をCSS selectorで特定し、物理ピクセル座標に変換してマウス操作と連携
- **vitest E2E テストスイート** (29テスト) — 実Chrome を起動してCDP エンジン関数を直接検証、headless/headed モード対応
- **マウスホーミング補正** — スクリーンショット取得からクリック実行までの遅延中にウィンドウが移動した際に座標を自動補正（トラクションコントロール方式）

## Browser CDP Tools

Chrome/Edge を `--remote-debugging-port=9222` で起動すればそのまま使えます：

```
browser_connect(port=9222)           → タブ一覧 + tabId 取得
browser_find_element(selector, ...)  → CSS selector → 物理ピクセル座標
browser_click_element(selector, ...) → find + click を1ステップで
browser_eval(expression, ...)        → JS 式を評価して結果を返す
browser_get_dom(selector, ...)       → outerHTML 取得 (truncation付き)
browser_navigate(url, ...)           → CDP Page.navigate でURL遷移
browser_disconnect(port)             → WebSocketセッションをクリーンアップ
```

座標計算: `physX = (screenX + chromeW/2 + rect.left) * dpr` でブラウザUIのオフセットとDevicePixelRatioを考慮済み。スクリーンショットベースの座標推定より正確。

## Mouse Homing Correction

LLM がスクリーンショットで座標を取得 → 数秒後にクリック、この間にウィンドウが移動する「福笑い問題」を MCP サーバー側で補正：

| Tier | トリガー | レイテンシ | 効果 |
|------|---------|-----------|------|
| 1 | 常時 (cache あれば) | <1ms | ウィンドウ移動を (dx,dy) 補正 |
| 2 | `windowTitle` 指定時 | ~100ms | 裏に隠れたウィンドウを前面化 |
| 3 | `elementName/Id` + リサイズ検出 | 1-3s | UIA で最新座標を再クエリ |

```
mouse_click(x=500, y=300, windowTitle="メモ帳")         # Tier 1+2
mouse_click(x=500, y=300, homing=false)                 # OFF
```

## Test plan

- [x] `npm run build` — TypeScript コンパイル成功
- [x] `npm run test:e2e` — 27 tests passed (headless)
- [x] `HEADED=1 npm run test:e2e` — 29 tests passed (including coord precision + click)
- [x] 手動: ウィンドウ移動後のホーミング補正動作確認
- [x] 手動: `--remote-debugging-port=9222` で起動した Chrome への browser_* ツール動作確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)