### PR TITLE
fix(descriptions): keyboard windowTitle blind-spot + token measurement + description contract tests

### DIFF
--- a/docs/description-rewrite-draft.md
+++ b/docs/description-rewrite-draft.md
@@ -438,12 +438,20 @@ scroll_capture stitches full-page images. sizeReduced=true means the image was d
 
 ## 次のステップ
 
+### v0.6.3（2026-04-15 リリース済み）
 - [x] ドラフト v1 作成
 - [x] Opus レビュー round 3 完了
 - [x] MUST 修正適用 → ドラフト v2
-- [ ] **ユーザ承認**
-- [ ] Phase 3A: `buildDesc()` + 計測スクリプト
-- [ ] Phase 3B-D: 全ツール description 書き換え
-- [ ] Phase 3E: Tier 4 examples 付与
-- [ ] Phase 3F: instructions 書き換え
-- [ ] Phase 4: 検証 + Opus round 4
+- [x] ユーザ承認
+- [x] Phase 3A: `buildDesc()` helper 実装（`src/tools/_types.ts`）
+- [x] Phase 3B-D: 全46ツール description 書き換え（Tier A/B/C）
+- [x] Phase 3E: Tier 4 examples 付与（5ツール）
+- [x] Phase 3F: instructions 圧縮（`src/server-windows.ts`、~310 words）
+- [x] `scroll_capture` 1MB guard（700KB cap + WebP fallback + iterative downscale）
+- [x] `docs/description-rewrite-draft.md` をリポジトリに保存
+
+### v0.6.4（進行中）
+- [x] Opus round 4 レビュー実施
+- [ ] `scripts/measure-tools-list-tokens.ts` 実装（token 定量化）
+- [ ] MUST-FIX 5件（scroll_capture sizeReduced 明記、wait_until predicates、workspace_launch suggest contract、terminal_send restoreFocus、windowTitle 省略 blind-spot）
+- [ ] description contract テスト追加（非空・文字数上限）

--- a/scripts/measure-tools-list-tokens.ts
+++ b/scripts/measure-tools-list-tokens.ts
@@ -1,0 +1,283 @@
+/**
+ * scripts/measure-tools-list-tokens.ts
+ *
+ * Measures the character length (and estimated token count) of every registered
+ * tool description in desktop-touch-mcp.
+ *
+ * Estimation: 1 token ≈ 4 characters for English technical prose (GPT/Claude rule-of-thumb).
+ *
+ * Run: npx tsx scripts/measure-tools-list-tokens.ts
+ *
+ * Output: per-tool table sorted by description length, with Tier A/B/C grouping,
+ * plus grand totals for use in PR descriptions and release notes.
+ */
+
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..");
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tool tier classification (from docs/description-rewrite-draft.md)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const TIER_A = new Set([
+  "screenshot", "screenshot_background", "scroll_capture", "wait_until",
+  "workspace_snapshot", "workspace_launch", "run_macro", "events_subscribe",
+  "dock_window", "get_context",
+]);
+
+const TIER_B = new Set([
+  "screenshot_ocr", "mouse_click", "mouse_drag", "keyboard_type", "keyboard_press",
+  "click_element", "set_element_value", "focus_window", "pin_window",
+  "get_ui_elements", "scope_element", "terminal_send", "terminal_read",
+  "browser_connect", "browser_get_interactive", "browser_click_element",
+  "browser_find_element", "browser_navigate", "browser_search",
+  "browser_get_app_state", "browser_launch", "get_windows",
+]);
+
+const TIER_C = new Set([
+  "get_active_window", "mouse_move", "scroll", "get_cursor_position",
+  "get_screen_info", "get_document_state", "get_history",
+  "events_poll", "events_unsubscribe", "events_list",
+  "browser_eval", "browser_get_dom", "browser_disconnect", "unpin_window",
+]);
+
+function tier(name: string): string {
+  if (TIER_A.has(name)) return "A";
+  if (TIER_B.has(name)) return "B";
+  if (TIER_C.has(name)) return "C";
+  return "?";
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Parse tool descriptions from source files
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Extract the text content of a buildDesc({...}) call.
+ * Reconstructs the output string: "Purpose: ...\nDetails: ...\nPrefer: ...\nCaveats: ...\nExamples:\n  ..."
+ */
+function extractBuildDesc(src: string, startIdx: number): string {
+  // Find the matching closing paren of buildDesc(
+  let depth = 1;
+  let i = startIdx;
+  while (i < src.length && depth > 0) {
+    if (src[i] === "(") depth++;
+    else if (src[i] === ")") depth--;
+    i++;
+  }
+  const body = src.slice(startIdx, i - 1);
+
+  // Extract field values using simple string-value patterns
+  function extractField(field: string): string {
+    // Matches: field: "...", or field: `...`, with possible multiline
+    const re = new RegExp(`${field}:\\s*\`([\\s\\S]*?)\`|${field}:\\s*"((?:[^"\\\\]|\\\\.)*)"`);
+    const m = re.exec(body);
+    return m ? (m[1] ?? m[2] ?? "").replace(/\\n/g, "\n").replace(/\\"/g, '"') : "";
+  }
+
+  function extractExamples(): string[] {
+    const m = /examples:\s*\[([^\]]*)\]/s.exec(body);
+    if (!m) return [];
+    const arrBody = m[1]!;
+    const results: string[] = [];
+    const strRe = /`([\s\S]*?)`|"((?:[^"\\]|\\.)*)"/g;
+    let sm: RegExpExecArray | null;
+    while ((sm = strRe.exec(arrBody)) !== null) {
+      results.push((sm[1] ?? sm[2] ?? "").replace(/\\n/g, "\n").replace(/\\"/g, '"'));
+    }
+    return results;
+  }
+
+  const parts: string[] = [];
+  const purpose = extractField("purpose");
+  const details = extractField("details");
+  const prefer = extractField("prefer");
+  const caveats = extractField("caveats");
+  const examples = extractExamples();
+
+  if (purpose) parts.push(`Purpose: ${purpose}`);
+  if (details) parts.push(`Details: ${details}`);
+  if (prefer) parts.push(`Prefer: ${prefer}`);
+  if (caveats) parts.push(`Caveats: ${caveats}`);
+  if (examples.length) parts.push(`Examples:\n${examples.map(e => `  ${e}`).join("\n")}`);
+
+  return parts.join("\n");
+}
+
+/**
+ * Extract a plain string literal (double-quoted or backtick) starting at `pos`.
+ * Returns the content (without quotes), handling basic escape sequences.
+ */
+function extractStringLiteral(src: string, pos: number): string {
+  const quote = src[pos];
+  if (quote === '"' || quote === "'") {
+    let result = "";
+    let i = pos + 1;
+    while (i < src.length && src[i] !== quote) {
+      if (src[i] === "\\" && i + 1 < src.length) {
+        const esc = src[i + 1]!;
+        if (esc === "n") result += "\n";
+        else if (esc === "t") result += "\t";
+        else result += esc;
+        i += 2;
+      } else {
+        result += src[i++];
+      }
+    }
+    return result;
+  }
+  if (quote === "`") {
+    let result = "";
+    let i = pos + 1;
+    while (i < src.length) {
+      if (src[i] === "`") break;
+      if (src[i] === "$" && src[i + 1] === "{") {
+        // Skip template expression — treat as opaque
+        let depth = 1;
+        i += 2;
+        while (i < src.length && depth > 0) {
+          if (src[i] === "{") depth++;
+          else if (src[i] === "}") depth--;
+          i++;
+        }
+      } else {
+        result += src[i++];
+      }
+    }
+    return result;
+  }
+  return "";
+}
+
+interface ToolEntry {
+  name: string;
+  description: string;
+  chars: number;
+  estTokens: number;
+  tier: string;
+  file: string;
+}
+
+function parseToolFile(filePath: string, fileName: string): ToolEntry[] {
+  const src = readFileSync(filePath, "utf-8");
+  const entries: ToolEntry[] = [];
+
+  // Find all server.tool( calls
+  const serverToolRe = /server\.tool\s*\(\s*/g;
+  let m: RegExpExecArray | null;
+
+  while ((m = serverToolRe.exec(src)) !== null) {
+    const afterOpen = m.index + m[0].length;
+
+    // 1st arg: tool name (string literal)
+    const nameQuote = src[afterOpen];
+    if (nameQuote !== '"' && nameQuote !== "'" && nameQuote !== "`") continue;
+    const name = extractStringLiteral(src, afterOpen);
+    const afterName = src.indexOf(nameQuote, afterOpen + 1) + 1;
+
+    // Skip comma + whitespace
+    let pos = afterName;
+    while (pos < src.length && /[\s,]/.test(src[pos]!)) pos++;
+
+    // 2nd arg: description — either buildDesc(...) or string literal
+    let description: string;
+    if (src.startsWith("buildDesc(", pos)) {
+      const buildStart = pos + "buildDesc(".length;
+      description = extractBuildDesc(src, buildStart);
+    } else {
+      const q = src[pos];
+      if (q !== '"' && q !== "'" && q !== "`") continue;
+      description = extractStringLiteral(src, pos);
+    }
+
+    const chars = description.length;
+    entries.push({
+      name,
+      description,
+      chars,
+      estTokens: Math.round(chars / 4),
+      tier: tier(name),
+      file: fileName,
+    });
+  }
+
+  return entries;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Main
+// ─────────────────────────────────────────────────────────────────────────────
+
+const TOOL_FILES = [
+  "browser.ts", "context.ts", "dock.ts", "events.ts", "keyboard.ts",
+  "macro.ts", "mouse.ts", "pin.ts", "screenshot.ts", "scroll-capture.ts",
+  "terminal.ts", "ui-elements.ts", "wait-until.ts", "window.ts", "workspace.ts",
+];
+
+const all: ToolEntry[] = [];
+for (const f of TOOL_FILES) {
+  const entries = parseToolFile(join(ROOT, "src", "tools", f), f);
+  all.push(...entries);
+}
+
+// Sort by tier then by chars desc
+const tierOrder: Record<string, number> = { A: 0, B: 1, C: 2, "?": 3 };
+all.sort((a, b) => {
+  const td = (tierOrder[a.tier] ?? 3) - (tierOrder[b.tier] ?? 3);
+  return td !== 0 ? td : b.chars - a.chars;
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Output
+// ─────────────────────────────────────────────────────────────────────────────
+
+const COL_NAME = 32;
+const COL_TIER = 5;
+const COL_CHARS = 7;
+const COL_TOK = 7;
+
+function pad(s: string, n: number): string { return s.padEnd(n); }
+function rpad(s: string, n: number): string { return s.padStart(n); }
+
+const header = `${pad("Tool", COL_NAME)}${pad("Tier", COL_TIER)}${rpad("Chars", COL_CHARS)}  ${rpad("~Tok", COL_TOK)}  File`;
+const sep = "─".repeat(header.length);
+
+console.log("\n" + sep);
+console.log(header);
+console.log(sep);
+
+let currentTier = "";
+let tierChars = 0;
+let tierToks = 0;
+let tierCount = 0;
+
+function printTierSummary() {
+  if (!currentTier) return;
+  console.log(`${"─".repeat(COL_NAME + COL_TIER)}${rpad(String(tierChars), COL_CHARS)}  ${rpad(String(tierToks), COL_TOK)}  ← Tier ${currentTier} subtotal (${tierCount} tools)`);
+}
+
+for (const e of all) {
+  if (e.tier !== currentTier) {
+    printTierSummary();
+    if (currentTier) console.log();
+    currentTier = e.tier;
+    tierChars = 0; tierToks = 0; tierCount = 0;
+  }
+  console.log(`${pad(e.name, COL_NAME)}${pad(e.tier, COL_TIER)}${rpad(String(e.chars), COL_CHARS)}  ${rpad(String(e.estTokens), COL_TOK)}  ${e.file}`);
+  tierChars += e.chars; tierToks += e.estTokens; tierCount++;
+}
+printTierSummary();
+
+console.log(sep);
+
+const totalChars = all.reduce((s, e) => s + e.chars, 0);
+const totalToks  = all.reduce((s, e) => s + e.estTokens, 0);
+console.log(`${pad("TOTAL (descriptions only)", COL_NAME + COL_TIER)}${rpad(String(totalChars), COL_CHARS)}  ${rpad(String(totalToks), COL_TOK)}`);
+console.log(`${pad("", COL_NAME + COL_TIER)}${"─".repeat(COL_CHARS + COL_TOK + 4)}`);
+console.log(`\nNote: ~1 token = 4 chars (English technical prose estimate).`);
+console.log(`      Add ~300 tok for instructions, ~50 tok/tool for schema overhead.`);
+console.log(`      Total tools found: ${all.length}\n`);

--- a/src/tools/keyboard.ts
+++ b/src/tools/keyboard.ts
@@ -273,14 +273,14 @@ export const keyboardPressHandler = async ({
 export function registerKeyboardTools(server: McpServer): void {
   server.tool(
     "keyboard_type",
-    "Requires focus on the target window — call focus_window first when the dock is pinned or another window may have stolen focus. Types a string of text into the focused window. Prefer set_element_value for form fields (more reliable for programmatic input without focus side-effects). Caveats: Does not handle IME composition for CJK input — use terminal_send(preferClipboard=true) or set_element_value for non-ASCII strings.",
+    "Type a string into the focused window. Pass windowTitle to auto-focus the target before typing and enable focus-loss detection (focusLost in response) — eliminates a separate focus_window call. Prefer set_element_value for form fields. Caveats: Omitting windowTitle types into whatever window is currently active — if focus may have shifted since your last get_context, pass windowTitle explicitly. Does not handle IME composition for CJK — use use_clipboard=true or set_element_value instead.",
     keyboardTypeSchema,
     withRichNarration("keyboard_type", keyboardTypeHandler, { windowTitleKey: "windowTitle" })
   );
 
   server.tool(
     "keyboard_press",
-    "Press a key or key combination: 'enter', 'ctrl+c', 'alt+tab', 'ctrl+shift+s', 'f5', 'escape', 'f1'–'f12'. Modifiers: ctrl, alt, shift, win/meta. Call focus_window first — when the dock is pinned, keystrokes go to the pinned overlay instead of the target window unless focus is explicitly set. Caveats: narrate:'rich' adds UIA state feedback for state-transitioning keys (Enter, Tab, Esc, F-keys) only; has no effect on letter/number keys.",
+    "Press a key or key combination (e.g. 'ctrl+c', 'alt+tab', 'ctrl+shift+s', 'f5', 'escape', 'f1'–'f12'). Pass windowTitle to auto-focus before pressing — eliminates a separate focus_window call. Caveats: Omitting windowTitle sends keystrokes to the currently active window — if focus may have shifted since your last observation, pass windowTitle explicitly. win+r, win+x, win+s, win+l are blocked for security. narrate:'rich' adds UIA state feedback for state-transitioning keys (Enter, Tab, Esc, F-keys) only.",
     keyboardPressSchema,
     withRichNarration("keyboard_press", keyboardPressHandler, {
       windowTitleKey: "windowTitle",

--- a/tests/unit/tool-descriptions.test.ts
+++ b/tests/unit/tool-descriptions.test.ts
@@ -1,0 +1,181 @@
+/**
+ * tests/unit/tool-descriptions.test.ts
+ *
+ * Contract tests for tool description strings.
+ * Guards against description drift as new tools are added.
+ *
+ * Rules:
+ *   - Every description must be non-empty
+ *   - No description should exceed MAX_CHARS (avoids runaway verbosity)
+ *   - Every description must start with an uppercase letter or a known prefix
+ *   - No description should contain placeholder text (e.g. "TODO", "FIXME", "...")
+ *
+ * Parsing: same regex-based approach as scripts/measure-tools-list-tokens.ts
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "../..");
+
+const TOOL_FILES = [
+  "browser.ts", "context.ts", "dock.ts", "events.ts", "keyboard.ts",
+  "macro.ts", "mouse.ts", "pin.ts", "screenshot.ts", "scroll-capture.ts",
+  "terminal.ts", "ui-elements.ts", "wait-until.ts", "window.ts", "workspace.ts",
+];
+
+const MIN_CHARS = 20;
+const MAX_CHARS = 2500;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Minimal parser (mirrors scripts/measure-tools-list-tokens.ts)
+// ─────────────────────────────────────────────────────────────────────────────
+
+function extractStringLiteral(src: string, pos: number): string {
+  const quote = src[pos];
+  if (quote === '"' || quote === "'") {
+    let result = "";
+    let i = pos + 1;
+    while (i < src.length && src[i] !== quote) {
+      if (src[i] === "\\" && i + 1 < src.length) {
+        const esc = src[i + 1]!;
+        result += esc === "n" ? "\n" : esc === "t" ? "\t" : esc;
+        i += 2;
+      } else { result += src[i++]; }
+    }
+    return result;
+  }
+  if (quote === "`") {
+    let result = "";
+    let i = pos + 1;
+    while (i < src.length) {
+      if (src[i] === "`") break;
+      if (src[i] === "$" && src[i + 1] === "{") {
+        let depth = 1; i += 2;
+        while (i < src.length && depth > 0) {
+          if (src[i] === "{") depth++;
+          else if (src[i] === "}") depth--;
+          i++;
+        }
+      } else { result += src[i++]; }
+    }
+    return result;
+  }
+  return "";
+}
+
+function extractBuildDescText(src: string, startIdx: number): string {
+  let depth = 1; let i = startIdx;
+  while (i < src.length && depth > 0) {
+    if (src[i] === "(") depth++; else if (src[i] === ")") depth--;
+    i++;
+  }
+  const body = src.slice(startIdx, i - 1);
+
+  function extractField(field: string): string {
+    const re = new RegExp(`${field}:\\s*\`([\\s\\S]*?)\`|${field}:\\s*"((?:[^"\\\\]|\\\\.)*)"`);
+    const m = re.exec(body);
+    return m ? (m[1] ?? m[2] ?? "") : "";
+  }
+
+  function extractExamples(): string[] {
+    const m = /examples:\s*\[([^\]]*)\]/s.exec(body);
+    if (!m) return [];
+    const results: string[] = [];
+    const strRe = /`([\s\S]*?)`|"((?:[^"\\]|\\.)*)"/g;
+    let sm: RegExpExecArray | null;
+    while ((sm = strRe.exec(m[1]!)) !== null) results.push(sm[1] ?? sm[2] ?? "");
+    return results;
+  }
+
+  const parts: string[] = [];
+  const purpose = extractField("purpose");
+  const details = extractField("details");
+  const prefer = extractField("prefer");
+  const caveats = extractField("caveats");
+  const examples = extractExamples();
+
+  if (purpose) parts.push(`Purpose: ${purpose}`);
+  if (details) parts.push(`Details: ${details}`);
+  if (prefer) parts.push(`Prefer: ${prefer}`);
+  if (caveats) parts.push(`Caveats: ${caveats}`);
+  if (examples.length) parts.push(`Examples:\n${examples.map(e => `  ${e}`).join("\n")}`);
+  return parts.join("\n");
+}
+
+interface ToolDesc { name: string; description: string; file: string; }
+
+function parseToolFile(filePath: string, fileName: string): ToolDesc[] {
+  const src = readFileSync(filePath, "utf-8");
+  const entries: ToolDesc[] = [];
+  const serverToolRe = /server\.tool\s*\(\s*/g;
+  let m: RegExpExecArray | null;
+
+  while ((m = serverToolRe.exec(src)) !== null) {
+    const afterOpen = m.index + m[0].length;
+    const nameQuote = src[afterOpen];
+    if (nameQuote !== '"' && nameQuote !== "'" && nameQuote !== "`") continue;
+    const name = extractStringLiteral(src, afterOpen);
+    const afterName = src.indexOf(nameQuote, afterOpen + 1) + 1;
+
+    let pos = afterName;
+    while (pos < src.length && /[\s,]/.test(src[pos]!)) pos++;
+
+    let description: string;
+    if (src.startsWith("buildDesc(", pos)) {
+      description = extractBuildDescText(src, pos + "buildDesc(".length);
+    } else {
+      const q = src[pos];
+      if (q !== '"' && q !== "'" && q !== "`") continue;
+      description = extractStringLiteral(src, pos);
+    }
+    entries.push({ name, description, file: fileName });
+  }
+  return entries;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+const allTools: ToolDesc[] = [];
+for (const f of TOOL_FILES) {
+  allTools.push(...parseToolFile(join(ROOT, "src", "tools", f), f));
+}
+
+describe("tool descriptions — contract", () => {
+  it("finds at least 40 registered tools", () => {
+    expect(allTools.length).toBeGreaterThanOrEqual(40);
+  });
+
+  for (const tool of allTools) {
+    describe(`${tool.name} (${tool.file})`, () => {
+      it("is non-empty", () => {
+        expect(tool.description.trim().length).toBeGreaterThan(0);
+      });
+
+      it(`has at least ${MIN_CHARS} characters`, () => {
+        expect(tool.description.length).toBeGreaterThanOrEqual(MIN_CHARS);
+      });
+
+      it(`does not exceed ${MAX_CHARS} characters`, () => {
+        expect(tool.description.length).toBeLessThanOrEqual(MAX_CHARS);
+      });
+
+      it("contains no placeholder text", () => {
+        const lower = tool.description.toLowerCase();
+        expect(lower).not.toContain("todo");
+        expect(lower).not.toContain("fixme");
+        expect(lower).not.toContain("placeholder");
+      });
+
+      it("starts with an uppercase letter", () => {
+        const first = tool.description.trimStart()[0] ?? "";
+        expect(first).toMatch(/[A-Z]/);
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Opus round 4 フォローアップ。v0.6.3 指摘のうち実際に欠落していた3点を修正。

### Fix: keyboard_type/press — windowTitle 省略 blind-spot
`keyboard_type`/`keyboard_press` は `windowTitle` パラメータを持つが v0.6.3 の description に完全に未記載だった。
- 「focus_window を先に呼べ」→「windowTitle を渡せばその一歩が不要」に修正
- 「windowTitle を省略すると現在のアクティブウィンドウに送られる — focus が変わっている可能性があれば明示的に渡せ」を Caveats に追加

### Feat: scripts/measure-tools-list-tokens.ts
全46ツールの description 文字数 / 推定 token 数をファイル別・Tier 別に集計して出力。
現在のベースライン: **22,200 chars ≈ 5,555 tok**

```
npx tsx scripts/measure-tools-list-tokens.ts
```

### Test: tool-descriptions.test.ts — contract テスト (231 tests)
46ツール × 5チェック + 件数確認:
- 非空 / >= 20 chars / <= 2500 chars / no TODO/FIXME / 大文字始まり

### Docs: description-rewrite-draft.md チェックリスト更新
v0.6.3 で完了した全項目を ✅ に。

## Verification

- `npm run build` → 0 errors
- `npm test -- tests/unit` → 703 tests green (27 files)
- `git diff --diff-filter=D --name-only origin/main` → 0 deleted files