### PR TITLE
feat: v0.10.0 — Phase 4+5+6 Reactive Perception Graph (watermarks, native events, MCP resources)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start": "node dist/index.js",
     "dev": "tsc --watch",
     "test": "vitest run",
-    "test:capture": "vitest run --reporter=json --outputFile=.vitest-out.json --reporter=default",
+    "test:capture": "node scripts/test-capture.mjs",
     "test:e2e": "vitest run tests/e2e",
     "test:headed": "HEADED=1 vitest run tests/e2e",
     "test:watch": "vitest",

--- a/scripts/test-capture.mjs
+++ b/scripts/test-capture.mjs
@@ -1,83 +1,132 @@
 /**
  * test-capture.mjs — Run vitest and capture output to .vitest-out.txt
  *
- * Unlike shell redirection (`> .vitest-out.txt`), this script uses
- * Node's fs.createWriteStream so the output file is written reliably
- * even when the npm script is launched via `run_in_background`.
+ * Structural guards against duplicate runs:
+ *   A. Lock file (.vitest-running): prevents concurrent executions.
+ *   B. Fresh-output check: if .vitest-out.txt was written within the last
+ *      120 seconds, refuse to re-run and tell the caller to read it first.
  *
- * Usage:  node scripts/test-capture.mjs [extra vitest args...]
+ * Both guards can be bypassed with --force.
+ *
+ * Usage:
+ *   node scripts/test-capture.mjs [--force] [extra vitest args...]
  *
  * Outputs:
- *   .vitest-out.json  — JSON reporter (machine-readable)
- *   .vitest-out.txt   — default reporter (human-readable)
+ *   .vitest-out.json  — JSON reporter (machine-readable, use Grep)
+ *   .vitest-out.txt   — default reporter (human-readable, use Read)
  *
  * Exit codes:
  *   0  — tests passed AND output files are non-empty
- *   1  — tests failed OR output files are empty/missing
+ *   1  — guard blocked / tests failed / output files empty or missing
  */
 
 import { spawn } from "node:child_process";
-import { createWriteStream, existsSync, statSync } from "node:fs";
+import {
+  createWriteStream,
+  existsSync,
+  statSync,
+  writeFileSync,
+  unlinkSync,
+} from "node:fs";
 import { resolve } from "node:path";
 
-const root = resolve(import.meta.dirname, "..");
-const txtPath = resolve(root, ".vitest-out.txt");
+const root    = resolve(import.meta.dirname, "..");
+const txtPath  = resolve(root, ".vitest-out.txt");
 const jsonPath = resolve(root, ".vitest-out.json");
+const lockPath = resolve(root, ".vitest-running");
 
-// Extra args passed after `node scripts/test-capture.mjs`
-const extraArgs = process.argv.slice(2);
+const FRESH_WINDOW_MS = 120_000; // 2 minutes
+
+// ── Parse args ────────────────────────────────────────────────────────────────
+
+const args      = process.argv.slice(2);
+const forceIdx  = args.indexOf("--force");
+const force     = forceIdx !== -1;
+if (force) args.splice(forceIdx, 1);   // remove --force before passing to vitest
+
+// ── Guard A: lock file ────────────────────────────────────────────────────────
+
+if (!force && existsSync(lockPath)) {
+  const lockAge = Date.now() - statSync(lockPath).mtimeMs;
+  // Stale lock (> 10 min) is silently removed to handle crash recovery
+  if (lockAge < 600_000) {
+    console.error("\n========================================");
+    console.error("  test:capture BLOCKED — already running");
+    console.error("========================================");
+    console.error(`Lock file: ${lockPath}`);
+    console.error("Another test run is in progress. Wait for it to complete.");
+    console.error("Use --force to bypass this check if the lock is stale.");
+    process.exit(1);
+  }
+  unlinkSync(lockPath);
+}
+
+// ── Guard B: fresh output ─────────────────────────────────────────────────────
+
+if (!force && existsSync(txtPath)) {
+  const ageMs = Date.now() - statSync(txtPath).mtimeMs;
+  if (ageMs < FRESH_WINDOW_MS) {
+    const ageSec = Math.round(ageMs / 1000);
+    console.error("\n========================================");
+    console.error("  test:capture BLOCKED — fresh output exists");
+    console.error("========================================");
+    console.error(`Output written ${ageSec}s ago: ${txtPath}`);
+    console.error("Read the existing output before running tests again:");
+    console.error("  Read tool  →  .vitest-out.txt");
+    console.error("  Grep tool  →  .vitest-out.json  (search for failures)");
+    console.error("Use --force to re-run anyway.");
+    process.exit(1);
+  }
+}
+
+// ── Acquire lock ──────────────────────────────────────────────────────────────
+
+writeFileSync(lockPath, String(process.pid), "utf-8");
+
+function releaseLock() {
+  try { unlinkSync(lockPath); } catch { /* already gone */ }
+}
+process.on("exit",    releaseLock);
+process.on("SIGINT",  () => { releaseLock(); process.exit(130); });
+process.on("SIGTERM", () => { releaseLock(); process.exit(143); });
+
+// ── Spawn vitest ──────────────────────────────────────────────────────────────
 
 const vitestArgs = [
   "run",
   "--reporter=json",
   `--outputFile=${jsonPath}`,
   "--reporter=default",
-  ...extraArgs,
+  ...args,
 ];
 
-// Resolve vitest binary from node_modules.
-// On Windows the .cmd shim must be used; spawn with shell:true
-// but pass the full command as a single string to avoid DEP0190.
-const isWin = process.platform === "win32";
-const vitestBin = resolve(
-  root,
-  "node_modules",
-  ".bin",
-  isWin ? "vitest.cmd" : "vitest",
-);
+const isWin    = process.platform === "win32";
+const vitestBin = resolve(root, "node_modules", ".bin", isWin ? "vitest.cmd" : "vitest");
+const cmdStr   = [JSON.stringify(vitestBin), ...vitestArgs.map((a) => JSON.stringify(a))].join(" ");
 
 const txtStream = createWriteStream(txtPath, { encoding: "utf-8" });
 
-// Build a single command string for shell mode (avoids DEP0190 warning)
-const cmdStr = [JSON.stringify(vitestBin), ...vitestArgs.map((a) => JSON.stringify(a))].join(" ");
-
 const child = spawn(cmdStr, [], {
-  cwd: root,
+  cwd:   root,
   stdio: ["ignore", "pipe", "pipe"],
-  env: { ...process.env, FORCE_COLOR: "0" },
+  env:   { ...process.env, FORCE_COLOR: "0" },
   shell: true,
 });
 
 child.stdout.pipe(txtStream, { end: false });
 child.stderr.pipe(txtStream, { end: false });
-
-// Also mirror to this process's stdout/stderr so the caller can see progress
 child.stdout.pipe(process.stdout);
 child.stderr.pipe(process.stderr);
 
 child.on("close", (code) => {
   txtStream.end(() => {
-    // Validate output files exist and are non-empty
+    releaseLock();
+
+    // ── Validate output files ──────────────────────────────────────────────
     const errors = [];
-    for (const [label, p] of [
-      [".vitest-out.txt", txtPath],
-      [".vitest-out.json", jsonPath],
-    ]) {
-      if (!existsSync(p)) {
-        errors.push(`ERROR: ${label} was not created.`);
-      } else if (statSync(p).size === 0) {
-        errors.push(`ERROR: ${label} is empty (0 bytes).`);
-      }
+    for (const [label, p] of [[".vitest-out.txt", txtPath], [".vitest-out.json", jsonPath]]) {
+      if (!existsSync(p))              errors.push(`ERROR: ${label} was not created.`);
+      else if (statSync(p).size === 0) errors.push(`ERROR: ${label} is empty (0 bytes).`);
     }
 
     if (errors.length > 0) {
@@ -85,18 +134,16 @@ child.on("close", (code) => {
       console.error("  test:capture output validation FAILED");
       console.error("========================================");
       errors.forEach((e) => console.error(e));
-      console.error(
-        "Hint: vitest may have crashed before producing output.",
-      );
+      console.error("Hint: vitest may have crashed before producing output.");
       process.exit(1);
     }
 
-    // Propagate vitest's exit code
     process.exit(code ?? 1);
   });
 });
 
 child.on("error", (err) => {
+  releaseLock();
   console.error(`ERROR: Failed to start vitest: ${err.message}`);
   process.exit(1);
 });

--- a/scripts/test-capture.mjs
+++ b/scripts/test-capture.mjs
@@ -1,0 +1,102 @@
+/**
+ * test-capture.mjs — Run vitest and capture output to .vitest-out.txt
+ *
+ * Unlike shell redirection (`> .vitest-out.txt`), this script uses
+ * Node's fs.createWriteStream so the output file is written reliably
+ * even when the npm script is launched via `run_in_background`.
+ *
+ * Usage:  node scripts/test-capture.mjs [extra vitest args...]
+ *
+ * Outputs:
+ *   .vitest-out.json  — JSON reporter (machine-readable)
+ *   .vitest-out.txt   — default reporter (human-readable)
+ *
+ * Exit codes:
+ *   0  — tests passed AND output files are non-empty
+ *   1  — tests failed OR output files are empty/missing
+ */
+
+import { spawn } from "node:child_process";
+import { createWriteStream, existsSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+
+const root = resolve(import.meta.dirname, "..");
+const txtPath = resolve(root, ".vitest-out.txt");
+const jsonPath = resolve(root, ".vitest-out.json");
+
+// Extra args passed after `node scripts/test-capture.mjs`
+const extraArgs = process.argv.slice(2);
+
+const vitestArgs = [
+  "run",
+  "--reporter=json",
+  `--outputFile=${jsonPath}`,
+  "--reporter=default",
+  ...extraArgs,
+];
+
+// Resolve vitest binary from node_modules.
+// On Windows the .cmd shim must be used; spawn with shell:true
+// but pass the full command as a single string to avoid DEP0190.
+const isWin = process.platform === "win32";
+const vitestBin = resolve(
+  root,
+  "node_modules",
+  ".bin",
+  isWin ? "vitest.cmd" : "vitest",
+);
+
+const txtStream = createWriteStream(txtPath, { encoding: "utf-8" });
+
+// Build a single command string for shell mode (avoids DEP0190 warning)
+const cmdStr = [JSON.stringify(vitestBin), ...vitestArgs.map((a) => JSON.stringify(a))].join(" ");
+
+const child = spawn(cmdStr, [], {
+  cwd: root,
+  stdio: ["ignore", "pipe", "pipe"],
+  env: { ...process.env, FORCE_COLOR: "0" },
+  shell: true,
+});
+
+child.stdout.pipe(txtStream, { end: false });
+child.stderr.pipe(txtStream, { end: false });
+
+// Also mirror to this process's stdout/stderr so the caller can see progress
+child.stdout.pipe(process.stdout);
+child.stderr.pipe(process.stderr);
+
+child.on("close", (code) => {
+  txtStream.end(() => {
+    // Validate output files exist and are non-empty
+    const errors = [];
+    for (const [label, p] of [
+      [".vitest-out.txt", txtPath],
+      [".vitest-out.json", jsonPath],
+    ]) {
+      if (!existsSync(p)) {
+        errors.push(`ERROR: ${label} was not created.`);
+      } else if (statSync(p).size === 0) {
+        errors.push(`ERROR: ${label} is empty (0 bytes).`);
+      }
+    }
+
+    if (errors.length > 0) {
+      console.error("\n========================================");
+      console.error("  test:capture output validation FAILED");
+      console.error("========================================");
+      errors.forEach((e) => console.error(e));
+      console.error(
+        "Hint: vitest may have crashed before producing output.",
+      );
+      process.exit(1);
+    }
+
+    // Propagate vitest's exit code
+    process.exit(code ?? 1);
+  });
+});
+
+child.on("error", (err) => {
+  console.error(`ERROR: Failed to start vitest: ${err.message}`);
+  process.exit(1);
+});

--- a/src/engine/perception/dirty-journal.ts
+++ b/src/engine/perception/dirty-journal.ts
@@ -1,0 +1,203 @@
+/**
+ * DirtyJournal — records uncertainty about fluent state.
+ *
+ * Native WinEvents and queue-overflow conditions write to this journal.
+ * The journal does NOT write fluent values. It records that something
+ * MIGHT have changed so that a subsequent sensor refresh can resolve the truth.
+ *
+ * Pure class — no OS imports.
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Semantic property names that native events can dirty.
+ * The set is deliberately small: only properties trackable by WinEvent without
+ * a full EnumWindows scan.
+ */
+export type DirtyProp =
+  | "target.exists"
+  | "target.identity"
+  | "target.title"
+  | "target.rect"
+  | "target.zOrder"
+  | "target.foreground"
+  | "modal.above"
+  | "stable.rect";
+
+/**
+ * Severity tiers for dirty entries.
+ *
+ * - `hint`: a single low-confidence event; cheap Win32 read likely sufficient.
+ * - `structural`: show/hide/destroy; identity or existence may have changed.
+ * - `identityRisk`: destroy + show same hwnd; re-verify identity before acting.
+ * - `global`: queue overflow; all tracked lenses are affected; EnumWindows needed.
+ */
+export type DirtySeverity = "hint" | "structural" | "identityRisk" | "global";
+
+export interface DirtyEntry {
+  /** Fluent store entity key prefix, e.g. `window:12345` or `browserTab:tab-1`. */
+  entityKey: string;
+  /** Properties that are dirty for this entity. */
+  props: Set<DirtyProp | string>;
+  /** Human-readable causes that contributed to this entry (coalesced). */
+  causes: string[];
+  /** Monotonic time of the first event that created this entry. */
+  firstEventAtMonoMs: number;
+  /** Monotonic time of the most recent event that touched this entry. */
+  lastEventAtMonoMs: number;
+  /** Total number of raw events coalesced into this entry. */
+  eventCount: number;
+  /** Severity of the most-severe event seen. */
+  severity: DirtySeverity;
+  /** Source event timestamp range (diagnostic only, not comparable to monotonic). */
+  sourceEventTimeMinMs?: number;
+  sourceEventTimeMaxMs?: number;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Severity ordering
+// ─────────────────────────────────────────────────────────────────────────────
+
+const SEVERITY_ORDER: Record<DirtySeverity, number> = {
+  hint: 0,
+  structural: 1,
+  identityRisk: 2,
+  global: 3,
+};
+
+function maxSeverity(a: DirtySeverity, b: DirtySeverity): DirtySeverity {
+  return SEVERITY_ORDER[a] >= SEVERITY_ORDER[b] ? a : b;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DirtyJournal
+// ─────────────────────────────────────────────────────────────────────────────
+
+export class DirtyJournal {
+  private _entries = new Map<string, DirtyEntry>();
+  private _globalDirty = false;
+  private _globalDirtyAtMonoMs = 0;
+  private _globalDirtyCause = "";
+
+  /**
+   * Mark one or more properties of an entity as dirty.
+   * Coalesces with any existing entry for the same entity.
+   */
+  mark(params: {
+    entityKey: string;
+    props: (DirtyProp | string)[];
+    cause: string;
+    monoMs: number;
+    severity?: DirtySeverity;
+    sourceEventTimeMs?: number;
+  }): void {
+    const { entityKey, props, cause, monoMs, severity = "hint", sourceEventTimeMs } = params;
+    const existing = this._entries.get(entityKey);
+
+    if (existing) {
+      for (const p of props) existing.props.add(p);
+      if (!existing.causes.includes(cause)) existing.causes.push(cause);
+      existing.lastEventAtMonoMs = monoMs;
+      existing.eventCount++;
+      existing.severity = maxSeverity(existing.severity, severity);
+      if (sourceEventTimeMs != null) {
+        existing.sourceEventTimeMinMs = Math.min(existing.sourceEventTimeMinMs ?? sourceEventTimeMs, sourceEventTimeMs);
+        existing.sourceEventTimeMaxMs = Math.max(existing.sourceEventTimeMaxMs ?? sourceEventTimeMs, sourceEventTimeMs);
+      }
+    } else {
+      const entry: DirtyEntry = {
+        entityKey,
+        props: new Set(props),
+        causes: [cause],
+        firstEventAtMonoMs: monoMs,
+        lastEventAtMonoMs: monoMs,
+        eventCount: 1,
+        severity,
+        ...(sourceEventTimeMs != null && {
+          sourceEventTimeMinMs: sourceEventTimeMs,
+          sourceEventTimeMaxMs: sourceEventTimeMs,
+        }),
+      };
+      this._entries.set(entityKey, entry);
+    }
+  }
+
+  /** Mark all tracked entities as dirty (used on raw event queue overflow). */
+  markGlobal(cause: string, monoMs: number): void {
+    this._globalDirty = true;
+    this._globalDirtyCause = cause;
+    this._globalDirtyAtMonoMs = Math.max(this._globalDirtyAtMonoMs, monoMs);
+    // Also mark the per-entity entries if present
+    for (const entry of this._entries.values()) {
+      entry.severity = "global";
+      if (!entry.causes.includes(cause)) entry.causes.push(cause);
+      entry.lastEventAtMonoMs = monoMs;
+      entry.eventCount++;
+    }
+  }
+
+  /** Whether a global dirty mark is currently active. */
+  isGlobalDirty(): boolean {
+    return this._globalDirty;
+  }
+
+  /** Monotonic timestamp of the global dirty mark, or 0 if not dirty. */
+  globalDirtyAtMonoMs(): number {
+    return this._globalDirtyAtMonoMs;
+  }
+
+  /** Clear the global dirty flag (call after a reconciliation sweep). */
+  clearGlobal(): void {
+    this._globalDirty = false;
+    this._globalDirtyAtMonoMs = 0;
+    this._globalDirtyCause = "";
+  }
+
+  /**
+   * Clear dirty marks for specific props of an entity, but only if the provided
+   * observation monotonic timestamp is NEWER than the last event that set those props.
+   *
+   * This preserves the invariant: "an observation clears dirty only if it was
+   * taken AFTER the event that caused the invalidation."
+   */
+  clearFor(entityKey: string, props: (DirtyProp | string)[], observedAtMonoMs: number): void {
+    const entry = this._entries.get(entityKey);
+    if (!entry) return;
+
+    if (observedAtMonoMs > entry.lastEventAtMonoMs) {
+      // Observation is newer — remove the cleared props
+      for (const p of props) entry.props.delete(p);
+      if (entry.props.size === 0) {
+        this._entries.delete(entityKey);
+      }
+    }
+    // If observedAtMonoMs <= lastEventAtMonoMs, the observation predates the
+    // most recent event — keep the entry unchanged.
+  }
+
+  /** Read-only snapshot of all per-entity dirty entries. */
+  entries(): Map<string, DirtyEntry> {
+    return this._entries;
+  }
+
+  /** Whether there are any dirty entries (including global). */
+  hasDirty(): boolean {
+    return this._globalDirty || this._entries.size > 0;
+  }
+
+  /** All entity keys that have at least one dirty prop. */
+  dirtyEntityKeys(): string[] {
+    return [...this._entries.keys()];
+  }
+
+  /** Reset all state. Only for tests. */
+  __resetForTests(): void {
+    this._entries.clear();
+    this._globalDirty = false;
+    this._globalDirtyAtMonoMs = 0;
+    this._globalDirtyCause = "";
+  }
+}

--- a/src/engine/perception/envelope.ts
+++ b/src/engine/perception/envelope.ts
@@ -21,9 +21,13 @@ export interface ProjectEnvelopeOptions {
 function deriveAttention(
   guardResult: GuardEvalResult,
   changedKeys: Set<string>,
+  hasDirty: boolean,
+  hasSettling: boolean,
   hasStale: boolean
 ): AttentionState {
   if (!guardResult.ok) return "guard_failed";
+  if (hasDirty) return "dirty";
+  if (hasSettling) return "settling";
   if (changedKeys.size > 0) return "changed";
   if (hasStale) return "stale";
   return "ok";
@@ -93,11 +97,13 @@ export function projectEnvelope(
     const bTitleFluent    = read("browser.title");
     const readyStateFluent = read("browser.readyState");
 
-    const hasStale = [urlFluent, bTitleFluent, readyStateFluent]
-      .some(f => f?.status === "stale" || f?.status === "dirty");
-    envelope.attention = deriveAttention(guardResult, changedKeys, hasStale);
+    const bFluentsAll = [urlFluent, bTitleFluent, readyStateFluent];
+    const hasDirty    = bFluentsAll.some(f => f?.status === "dirty");
+    const hasSettling = bFluentsAll.some(f => f?.status === "settling");
+    const hasStale    = bFluentsAll.some(f => f?.status === "stale");
+    envelope.attention = deriveAttention(guardResult, changedKeys, hasDirty, hasSettling, hasStale);
 
-    const bFluents = [urlFluent, bTitleFluent, readyStateFluent].filter(Boolean);
+    const bFluents = bFluentsAll.filter(Boolean);
     const avgConf = bFluents.length > 0
       ? bFluents.reduce((s, f) => s + (f?.support[0] ? confidenceFor(f.support[0], nowMs) : f?.confidence ?? 0), 0) / bFluents.length
       : 0;
@@ -118,9 +124,11 @@ export function projectEnvelope(
     const modalFluent   = read("modal.above");
     const feFluent      = read("target.focusedElement");
 
-    const hasStale = [existsFluent, titleFluent, rectFluent, fgFluent, modalFluent]
-      .some(f => f?.status === "stale" || f?.status === "dirty");
-    envelope.attention = deriveAttention(guardResult, changedKeys, hasStale);
+    const windowFluentsAll = [existsFluent, titleFluent, rectFluent, fgFluent, modalFluent];
+    const hasDirty    = windowFluentsAll.some(f => f?.status === "dirty");
+    const hasSettling = windowFluentsAll.some(f => f?.status === "settling");
+    const hasStale    = windowFluentsAll.some(f => f?.status === "stale");
+    envelope.attention = deriveAttention(guardResult, changedKeys, hasDirty, hasSettling, hasStale);
 
     const fluents = [existsFluent, titleFluent, rectFluent, fgFluent, zOrderFluent, modalFluent, feFluent].filter(Boolean);
     const avgConf = fluents.length > 0

--- a/src/engine/perception/fluent-store.ts
+++ b/src/engine/perception/fluent-store.ts
@@ -29,6 +29,11 @@ export class FluentStore {
       // TMS-lite: reject if observation is older than current
       if (existing && obs.seq < existing.validFromSeq) continue;
 
+      // Watermark check: if the observation's monotonic timestamp is NOT newer than
+      // the last dirty-mark, the evidence predates the invalidation hint — keep dirty.
+      const obsMonoMs = obs.monoMs ?? performance.now();
+      if (existing?.lastDirtyAtMonoMs != null && obsMonoMs <= existing.lastDirtyAtMonoMs) continue;
+
       // Same source: newer overrides
       // Different source: higher confidence replaces lower
       if (existing && obs.seq === existing.validFromSeq) {
@@ -47,10 +52,13 @@ export class FluentStore {
         property: obs.property,
         value: obs.value,
         validFromSeq: obs.seq,
+        validFromMonoMs: obsMonoMs,
         confidence: obs.confidence,
         support: [obs.evidence],
         contradictions: existing?.contradictions ?? [],
         status: "observed",
+        // Preserve generation across updates (cleared only on identity change)
+        ...(existing?.generation != null && { generation: existing.generation }),
       };
       this.store.set(key, updated);
       changed.add(key);
@@ -76,6 +84,39 @@ export class FluentStore {
     for (const k of keys) {
       const f = this.store.get(k);
       if (f) f.status = "dirty";
+    }
+  }
+
+  /**
+   * Mark fluents dirty with a cause and monotonic timestamp.
+   * The monoMs watermark is used by apply() to decide whether subsequent observations
+   * are newer than this invalidation hint.
+   */
+  markDirtyWithCause(keys: string[], cause: string, monoMs: number, seq?: number): void {
+    for (const k of keys) {
+      const f = this.store.get(k);
+      if (f) {
+        f.status = "dirty";
+        f.lastDirtyCause = cause;
+        f.lastDirtyAtMonoMs = monoMs;
+        if (seq != null) f.lastDirtySeq = seq;
+      }
+    }
+  }
+
+  /**
+   * Mark fluents as "settling" — used when a move/resize starts.
+   * Settling is a soft dirty: the value is becoming invalid due to an in-progress
+   * animation or drag. Guards should block on settling rects.
+   */
+  markSettling(keys: string[], monoMs: number): void {
+    for (const k of keys) {
+      const f = this.store.get(k);
+      if (f) {
+        f.status = "settling";
+        f.lastDirtyAtMonoMs = monoMs;
+        f.lastDirtyCause = "settling";
+      }
     }
   }
 

--- a/src/engine/perception/flush-scheduler.ts
+++ b/src/engine/perception/flush-scheduler.ts
@@ -1,0 +1,169 @@
+/**
+ * FlushScheduler — debounces and coalesces dirty marks before sensor refresh.
+ *
+ * High-frequency events (e.g. EVENT_OBJECT_LOCATIONCHANGE during a drag) can
+ * fire hundreds of times per second. The FlushScheduler ensures that only one
+ * refresh call is made per debounce window for each property class, using
+ * monotonic timestamps for deadline calculations.
+ *
+ * Pure class — no OS imports. Uses performance.now() for monotonic time.
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Property classes that drive different debounce windows.
+ *
+ * Debounce defaults (ms):
+ * - foreground   100  Include sidecar IPC jitter. Sync refresh still happens inside guards.
+ * - show_hide    100  Let z-order settle after show/hide animation.
+ * - title        100  Avoid typing-update spam from name-change events.
+ * - move_start     0  Set `settling` immediately; no refresh needed yet.
+ * - move_end      50  Refresh rect after MOVESIZEEND.
+ * - location     150  Coalesce drag/animation bursts.
+ * - reorder      100  Recompute modal after z-order settles.
+ * - overflow       0  Immediate: global dirty + reconciliation.
+ */
+export type PropertyClass =
+  | "foreground"
+  | "show_hide"
+  | "title"
+  | "move_start"
+  | "move_end"
+  | "location"
+  | "reorder"
+  | "overflow";
+
+export const DEFAULT_DEBOUNCE_MS: Record<PropertyClass, number> = {
+  foreground: 100,
+  show_hide:  100,
+  title:      100,
+  move_start:   0,
+  move_end:    50,
+  location:   150,
+  reorder:    100,
+  overflow:     0,
+};
+
+export interface FlushSchedulerOptions {
+  /** Override debounce windows. Partial: only specified classes are overridden. */
+  debounceMs?: Partial<Record<PropertyClass, number>>;
+  /** Called when a flush is due. The `reason` string describes what triggered it. */
+  onFlush: (reason: string) => void | Promise<void>;
+  /**
+   * Clock function for monotonic time. Defaults to performance.now().
+   * Injected for test determinism (fake timers replace setTimeout but tests
+   * can also override the clock to control debounce deadline comparisons).
+   */
+  clock?: () => number;
+  /**
+   * Timer factory. Defaults to setTimeout. Injected for tests with fake timers.
+   */
+  setTimeout?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  clearTimeout?: (id: ReturnType<typeof setTimeout>) => void;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FlushScheduler
+// ─────────────────────────────────────────────────────────────────────────────
+
+export class FlushScheduler {
+  private readonly _debounce: Record<PropertyClass, number>;
+  private readonly _onFlush: (reason: string) => void | Promise<void>;
+  private readonly _clock: () => number;
+  private readonly _setTimeout: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  private readonly _clearTimeout: (id: ReturnType<typeof setTimeout>) => void;
+
+  /** Pending timer handle per property class. */
+  private _timers = new Map<PropertyClass, ReturnType<typeof setTimeout>>();
+  /** Pending reasons to include when the timer fires. */
+  private _pendingReasons = new Map<PropertyClass, Set<string>>();
+
+  private _disposed = false;
+
+  constructor(opts: FlushSchedulerOptions) {
+    this._debounce = { ...DEFAULT_DEBOUNCE_MS, ...opts.debounceMs };
+    this._onFlush = opts.onFlush;
+    this._clock = opts.clock ?? (() => performance.now());
+    this._setTimeout = opts.setTimeout ?? setTimeout;
+    this._clearTimeout = opts.clearTimeout ?? clearTimeout;
+  }
+
+  /**
+   * Schedule a flush for the given property class.
+   * If a timer is already pending for this class, it is reset (leading-debounce NOT used;
+   * this is trailing-debounce: the flush fires after `debounceMs` of quiet time).
+   */
+  schedule(propertyClass: PropertyClass, reason?: string): void {
+    if (this._disposed) return;
+
+    const debounceMs = this._debounce[propertyClass];
+    const effectiveReason = reason ?? propertyClass;
+
+    // Accumulate reasons
+    let reasons = this._pendingReasons.get(propertyClass);
+    if (!reasons) { reasons = new Set(); this._pendingReasons.set(propertyClass, reasons); }
+    reasons.add(effectiveReason);
+
+    if (debounceMs === 0) {
+      // Immediate flush: fire synchronously (within the same microtask)
+      this._firePendingFor(propertyClass);
+      return;
+    }
+
+    // Reset the timer (trailing debounce)
+    const existing = this._timers.get(propertyClass);
+    if (existing != null) this._clearTimeout(existing);
+
+    const handle = this._setTimeout(() => {
+      this._timers.delete(propertyClass);
+      this._firePendingFor(propertyClass);
+    }, debounceMs);
+    this._timers.set(propertyClass, handle);
+  }
+
+  /** Force an immediate flush without waiting for the debounce window. */
+  scheduleImmediate(reason: string): void {
+    if (this._disposed) return;
+    // Cancel all pending timers and fire one consolidated flush
+    for (const [cls, handle] of this._timers) {
+      this._clearTimeout(handle);
+      this._timers.delete(cls);
+    }
+    const combinedReasons = new Set<string>([reason]);
+    for (const reasons of this._pendingReasons.values()) {
+      for (const r of reasons) combinedReasons.add(r);
+    }
+    this._pendingReasons.clear();
+    void this._onFlush([...combinedReasons].join(","));
+  }
+
+  /** Cancel all pending timers and stop accepting new work. */
+  dispose(): void {
+    this._disposed = true;
+    for (const handle of this._timers.values()) {
+      this._clearTimeout(handle);
+    }
+    this._timers.clear();
+    this._pendingReasons.clear();
+  }
+
+  /** Reset state for tests (does not dispose — the instance is reusable). */
+  __resetForTests(): void {
+    for (const handle of this._timers.values()) {
+      this._clearTimeout(handle);
+    }
+    this._timers.clear();
+    this._pendingReasons.clear();
+    this._disposed = false;
+  }
+
+  private _firePendingFor(propertyClass: PropertyClass): void {
+    const reasons = this._pendingReasons.get(propertyClass);
+    this._pendingReasons.delete(propertyClass);
+    const reasonStr = reasons ? [...reasons].join(",") : propertyClass;
+    void this._onFlush(reasonStr);
+  }
+}

--- a/src/engine/perception/guards.ts
+++ b/src/engine/perception/guards.ts
@@ -33,13 +33,21 @@ function readValue(store: FluentStore, lens: PerceptionLens, property: string): 
   value: unknown;
   confidence: number;
   status: string;
+  validFromMonoMs: number;
+  lastDirtyAtMonoMs: number | undefined;
 } | null {
   const key = entityKey(lens, property);
   const fluent = store.read(key);
   if (!fluent) return null;
   const nowMs = Date.now();
   const conf = fluent.support[0] ? confidenceFor(fluent.support[0], nowMs) : fluent.confidence;
-  return { value: fluent.value, confidence: conf, status: fluent.status };
+  return {
+    value: fluent.value,
+    confidence: conf,
+    status: fluent.status,
+    validFromMonoMs: fluent.validFromMonoMs,
+    lastDirtyAtMonoMs: fluent.lastDirtyAtMonoMs,
+  };
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -135,6 +143,29 @@ function evalKeyboardTarget(lens: PerceptionLens, store: FluentStore, nowMs: num
     };
   }
 
+  // Dirty/settling watermark gate: block if foreground evidence is stale w.r.t. dirty mark.
+  if (foreground.status === "dirty" || foreground.status === "settling") {
+    return {
+      kind: "safe.keyboardTarget",
+      ok: false,
+      confidence: foreground.confidence * 0.5,
+      reason: `Foreground state is ${foreground.status} — cannot confirm safe keyboard target`,
+      suggestedAction: "Call perception_read to get a fresh foreground observation",
+    };
+  }
+  if (
+    foreground.lastDirtyAtMonoMs != null &&
+    foreground.validFromMonoMs <= foreground.lastDirtyAtMonoMs
+  ) {
+    return {
+      kind: "safe.keyboardTarget",
+      ok: false,
+      confidence: foreground.confidence * 0.5,
+      reason: "Foreground evidence predates last dirty mark — window focus may have changed",
+      suggestedAction: "Call perception_read to refresh foreground state",
+    };
+  }
+
   // Additive focused-element gate (only when fluent is present — requires salience:"critical").
   // Absent fluent: passes silently, preserving backward compat for normal/background lenses.
   const fe = readValue(store, lens, "target.focusedElement");
@@ -200,6 +231,29 @@ function evalClickCoordinates(
     };
   }
 
+  // Dirty/settling watermark gate: block if rect is in motion or evidence is pre-dirty.
+  if (rectFluent.status === "dirty" || rectFluent.status === "settling") {
+    return {
+      kind: "safe.clickCoordinates",
+      ok: false,
+      confidence: rectFluent.confidence * 0.5,
+      reason: `Rect is ${rectFluent.status} — window may be moving or animating`,
+      suggestedAction: "Wait for the window to settle, then call perception_read",
+    };
+  }
+  if (
+    rectFluent.lastDirtyAtMonoMs != null &&
+    rectFluent.validFromMonoMs <= rectFluent.lastDirtyAtMonoMs
+  ) {
+    return {
+      kind: "safe.clickCoordinates",
+      ok: false,
+      confidence: rectFluent.confidence * 0.5,
+      reason: "Rect evidence predates last dirty mark — window may have moved since last observation",
+      suggestedAction: "Take a new screenshot and call perception_read to get updated coordinates",
+    };
+  }
+
   // Point-in-rect check (if coords provided)
   if (clickX != null && clickY != null) {
     const rect = rectFluent.value as { x: number; y: number; width: number; height: number } | null;
@@ -228,11 +282,12 @@ function evalStableRect(lens: PerceptionLens, store: FluentStore, nowMs: number)
   }
 
   /**
-   * MVP: fixed 250ms stability window.
-   * Pass when the rect evidence age >= 250ms AND status is "observed" (not dirty/stale).
-   * First-sample case (only one observation, <250ms old): pass with confidence 0.6.
-   * Note: confidence 0.6 is below the click/keyboard threshold (0.90), so this guard alone
-   * won't block — other guards (foreground, identity) will catch problems first.
+   * Quiet-window rule (watermark-based):
+   * 1. Block if status is dirty/settling/stale/invalidated — window in motion.
+   * 2. Block if validFromMonoMs <= lastDirtyAtMonoMs — evidence predates the last invalidation.
+   * 3. Wait (pass with low confidence) if evidence is very fresh (< 250ms) and there's no
+   *    prior dirty mark to anchor against.
+   * 4. Pass once we have post-dirty evidence that is >=250ms old.
    */
   const STABLE_MS = 250;
   const rectFluent = store.read(entityKey(lens, "target.rect"));
@@ -247,7 +302,13 @@ function evalStableRect(lens: PerceptionLens, store: FluentStore, nowMs: number)
     };
   }
 
-  if (rectFluent.status === "dirty" || rectFluent.status === "stale" || rectFluent.status === "invalidated") {
+  // Rule 1: dirty/settling/stale/invalidated — rect is in motion or evidence is unreliable.
+  if (
+    rectFluent.status === "dirty" ||
+    rectFluent.status === "settling" ||
+    rectFluent.status === "stale" ||
+    rectFluent.status === "invalidated"
+  ) {
     return {
       kind: "stable.rect",
       ok: false,
@@ -257,14 +318,33 @@ function evalStableRect(lens: PerceptionLens, store: FluentStore, nowMs: number)
     };
   }
 
-  const ev = rectFluent.support[0];
-  if (!ev) {
-    return { kind: "stable.rect", ok: true, confidence: 0.6 }; // first sample
+  // Rule 2: evidence predates the dirty mark — stale observation snuck through before watermark.
+  if (
+    rectFluent.lastDirtyAtMonoMs != null &&
+    rectFluent.validFromMonoMs <= rectFluent.lastDirtyAtMonoMs
+  ) {
+    return {
+      kind: "stable.rect",
+      ok: false,
+      confidence: 0.3,
+      reason: "Rect evidence predates last move/resize event — window position may have changed",
+      suggestedAction: "Call perception_read to capture post-move rect",
+    };
   }
 
-  const age = nowMs - ev.observedAtMs;
-  if (age < STABLE_MS) {
-    // First measurement or very fresh — pass with lower confidence
+  const ev = rectFluent.support[0];
+  if (!ev) {
+    // No evidence support record yet — first sample, treat as marginally stable.
+    return { kind: "stable.rect", ok: true, confidence: 0.6 };
+  }
+
+  // Rule 3/4: quiet-window check using monoMs-relative age.
+  // If we have a dirty mark, measure age from that mark (post-dirty observation).
+  // Otherwise fall back to evidence observation age.
+  const anchorMs = rectFluent.lastDirtyAtMonoMs ?? ev.observedAtMs;
+  const quietMs = rectFluent.validFromMonoMs - anchorMs;
+  if (quietMs < STABLE_MS) {
+    // Very fresh post-dirty observation — pass with lower confidence (guard alone won't block).
     return { kind: "stable.rect", ok: true, confidence: 0.6 };
   }
 

--- a/src/engine/perception/lens-event-index.ts
+++ b/src/engine/perception/lens-event-index.ts
@@ -1,0 +1,135 @@
+/**
+ * LensEventIndex — routes WinEvents to only the affected perception lenses.
+ *
+ * Without this index, every event would trigger a refresh of all lenses
+ * (the current polling behavior). The index makes Phase 5 efficient:
+ * a foreground event on hwnd X refreshes only lenses tracking X (or
+ * all foreground-sensitive lenses, for the foreground notification case).
+ *
+ * Pure module — no OS imports.
+ */
+
+import type { PerceptionLens, WindowIdentity } from "./types.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Index type
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface LensEventIndex {
+  /** hwnd string → Set of lensIds tracking that specific window. */
+  byHwnd: Map<string, Set<string>>;
+  /** pid number → Set of lensIds tracking a window owned by that process. */
+  byPid: Map<number, Set<string>>;
+  /** lensIds that maintain `target.foreground` and must be notified on foreground events. */
+  foregroundSensitive: Set<string>;
+  /** lensIds that maintain `modal.above` and must be notified on z-order/modal events. */
+  modalSensitive: Set<string>;
+  /** lensIds that maintain `target.zOrder` and must be notified on reorder events. */
+  zOrderSensitive: Set<string>;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function addToSet<K>(map: Map<K, Set<string>>, key: K, lensId: string): void {
+  let s = map.get(key);
+  if (!s) { s = new Set(); map.set(key, s); }
+  s.add(lensId);
+}
+
+function removeFromSet<K>(map: Map<K, Set<string>>, key: K, lensId: string): void {
+  const s = map.get(key);
+  if (!s) return;
+  s.delete(lensId);
+  if (s.size === 0) map.delete(key);
+}
+
+function isWindowIdentity(id: unknown): id is WindowIdentity {
+  return typeof id === "object" && id !== null && "pid" in id && "hwnd" in id;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Create an empty index. */
+export function createLensEventIndex(): LensEventIndex {
+  return {
+    byHwnd: new Map(),
+    byPid: new Map(),
+    foregroundSensitive: new Set(),
+    modalSensitive: new Set(),
+    zOrderSensitive: new Set(),
+  };
+}
+
+/** Add a lens to the index. */
+export function addLensToIndex(index: LensEventIndex, lens: PerceptionLens): void {
+  const { lensId } = lens;
+  const hwnd = lens.binding.hwnd;
+
+  // All lenses go into byHwnd
+  addToSet(index.byHwnd, hwnd, lensId);
+
+  // Window lenses also indexed by pid
+  if (isWindowIdentity(lens.boundIdentity)) {
+    addToSet(index.byPid, lens.boundIdentity.pid, lensId);
+  }
+
+  // Sensitivity flags based on maintained fluents
+  const maintained = new Set(lens.spec.maintain);
+  if (maintained.has("target.foreground")) index.foregroundSensitive.add(lensId);
+  if (maintained.has("modal.above"))       index.modalSensitive.add(lensId);
+  if (maintained.has("target.zOrder"))     index.zOrderSensitive.add(lensId);
+}
+
+/** Remove a lens from the index. */
+export function removeLensFromIndex(index: LensEventIndex, lens: PerceptionLens): void {
+  const { lensId } = lens;
+  const hwnd = lens.binding.hwnd;
+
+  removeFromSet(index.byHwnd, hwnd, lensId);
+
+  if (isWindowIdentity(lens.boundIdentity)) {
+    removeFromSet(index.byPid, lens.boundIdentity.pid, lensId);
+  }
+
+  index.foregroundSensitive.delete(lensId);
+  index.modalSensitive.delete(lensId);
+  index.zOrderSensitive.delete(lensId);
+}
+
+/** Rebuild the entire index from the current lens collection. */
+export function rebuildLensEventIndex(lenses: Iterable<PerceptionLens>): LensEventIndex {
+  const index = createLensEventIndex();
+  for (const lens of lenses) {
+    addLensToIndex(index, lens);
+  }
+  return index;
+}
+
+/**
+ * Look up all lensIds that should be refreshed for a hwnd-specific event.
+ * Returns lenses bound to the given hwnd.
+ */
+export function lensesForHwnd(index: LensEventIndex, hwnd: string): Set<string> {
+  return index.byHwnd.get(hwnd) ?? new Set();
+}
+
+/**
+ * Look up all lensIds that should be notified for a foreground change.
+ * Includes both the specific hwnd's lenses and all foreground-sensitive lenses
+ * (because a foreground change to ANY window affects every lens's `foreground` fluent).
+ */
+export function lensesForForegroundEvent(
+  index: LensEventIndex,
+  hwnd: string
+): Set<string> {
+  const result = new Set<string>();
+  // Direct hwnd matches
+  for (const id of (index.byHwnd.get(hwnd) ?? [])) result.add(id);
+  // All foreground-sensitive lenses (their own foreground state may have changed)
+  for (const id of index.foregroundSensitive) result.add(id);
+  return result;
+}

--- a/src/engine/perception/lens-event-index.ts
+++ b/src/engine/perception/lens-event-index.ts
@@ -20,6 +20,8 @@ export interface LensEventIndex {
   byHwnd: Map<string, Set<string>>;
   /** pid number → Set of lensIds tracking a window owned by that process. */
   byPid: Map<number, Set<string>>;
+  /** lensId → hwnd — reverse lookup to find which window a lens tracks. */
+  lensToHwnd: Map<string, string>;
   /** lensIds that maintain `target.foreground` and must be notified on foreground events. */
   foregroundSensitive: Set<string>;
   /** lensIds that maintain `modal.above` and must be notified on z-order/modal events. */
@@ -58,6 +60,7 @@ export function createLensEventIndex(): LensEventIndex {
   return {
     byHwnd: new Map(),
     byPid: new Map(),
+    lensToHwnd: new Map(),
     foregroundSensitive: new Set(),
     modalSensitive: new Set(),
     zOrderSensitive: new Set(),
@@ -69,8 +72,9 @@ export function addLensToIndex(index: LensEventIndex, lens: PerceptionLens): voi
   const { lensId } = lens;
   const hwnd = lens.binding.hwnd;
 
-  // All lenses go into byHwnd
+  // All lenses go into byHwnd and reverse map
   addToSet(index.byHwnd, hwnd, lensId);
+  index.lensToHwnd.set(lensId, hwnd);
 
   // Window lenses also indexed by pid
   if (isWindowIdentity(lens.boundIdentity)) {
@@ -90,6 +94,7 @@ export function removeLensFromIndex(index: LensEventIndex, lens: PerceptionLens)
   const hwnd = lens.binding.hwnd;
 
   removeFromSet(index.byHwnd, hwnd, lensId);
+  index.lensToHwnd.delete(lensId);
 
   if (isWindowIdentity(lens.boundIdentity)) {
     removeFromSet(index.byPid, lens.boundIdentity.pid, lensId);

--- a/src/engine/perception/raw-event-queue.ts
+++ b/src/engine/perception/raw-event-queue.ts
@@ -1,0 +1,113 @@
+/**
+ * raw-event-queue.ts
+ *
+ * Bounded ring-buffer for raw WinEvent records emitted by the native sidecar.
+ * Overflow drops oldest entries and flags a global dirty signal so the
+ * reconciliation loop can recover. Pure data structure — no OS imports.
+ */
+
+export interface RawWinEvent {
+  /** WinEvent constant (e.g. EVENT_SYSTEM_FOREGROUND = 3) */
+  event: number;
+  /** Target window handle as decimal string */
+  hwnd: string;
+  /** OBJID_* constant (0 = OBJID_WINDOW) */
+  idObject: number;
+  /** Child object id */
+  idChild: number;
+  /** Thread that owns the target window */
+  eventThread: number;
+  /**
+   * Timestamp from the sidecar's side (milliseconds, epoch).
+   * Use for diagnostics / ordering hints only — never compare to Node clocks.
+   */
+  sourceEventTimeMs: number;
+  /** Monotonically incrementing counter assigned by the sidecar */
+  sidecarSeq: number;
+  /** Monotonic ms (performance.now()) captured in Node when the event was received */
+  receivedAtMonoMs: number;
+  /** Wall-clock ms (Date.now()) captured in Node when the event was received */
+  receivedAtUnixMs: number;
+  /** Global sequence assigned by the Node receiver */
+  globalSeq: number;
+}
+
+export interface RawEventQueueDiagnostics {
+  totalEnqueued: number;
+  totalDropped: number;
+  totalDrained: number;
+  overflowCount: number;
+  pendingCount: number;
+}
+
+const DEFAULT_MAX_SIZE  = 1024;
+const DEFAULT_BATCH_MAX = 256;
+
+export class RawEventQueue {
+  private readonly maxSize: number;
+  private readonly batchMax: number;
+  private buffer: RawWinEvent[] = [];
+  private _totalEnqueued = 0;
+  private _totalDropped  = 0;
+  private _totalDrained  = 0;
+  private _overflowCount = 0;
+
+  /** Set by the queue when overflow occurs; cleared by the drain consumer. */
+  overflowPending = false;
+
+  constructor(opts?: { maxSize?: number; batchMax?: number }) {
+    this.maxSize  = opts?.maxSize  ?? DEFAULT_MAX_SIZE;
+    this.batchMax = opts?.batchMax ?? DEFAULT_BATCH_MAX;
+  }
+
+  /** Enqueue a single raw event. Returns true if accepted, false if overflow drop. */
+  enqueue(event: RawWinEvent): boolean {
+    if (this.buffer.length >= this.maxSize) {
+      // Drop oldest (front of ring) — keep newest
+      this.buffer.shift();
+      this._totalDropped++;
+      this._overflowCount++;
+      this.overflowPending = true;
+    }
+    this.buffer.push(event);
+    this._totalEnqueued++;
+    return true;
+  }
+
+  /**
+   * Drain up to batchMax events and return them.
+   * Clears overflowPending flag on first drain after overflow.
+   */
+  drain(): RawWinEvent[] {
+    const count = Math.min(this.buffer.length, this.batchMax);
+    if (count === 0) return [];
+    const batch = this.buffer.splice(0, count);
+    this._totalDrained += batch.length;
+    this.overflowPending = false;
+    return batch;
+  }
+
+  /** Number of events currently buffered. */
+  get pendingCount(): number {
+    return this.buffer.length;
+  }
+
+  diagnostics(): RawEventQueueDiagnostics {
+    return {
+      totalEnqueued:  this._totalEnqueued,
+      totalDropped:   this._totalDropped,
+      totalDrained:   this._totalDrained,
+      overflowCount:  this._overflowCount,
+      pendingCount:   this.buffer.length,
+    };
+  }
+
+  __resetForTests(): void {
+    this.buffer          = [];
+    this._totalEnqueued  = 0;
+    this._totalDropped   = 0;
+    this._totalDrained   = 0;
+    this._overflowCount  = 0;
+    this.overflowPending = false;
+  }
+}

--- a/src/engine/perception/reconciliation.ts
+++ b/src/engine/perception/reconciliation.ts
@@ -1,0 +1,106 @@
+/**
+ * reconciliation.ts
+ *
+ * Periodic full-reconciliation sweep for the Reactive Perception Graph.
+ * Runs every RECONCILE_INTERVAL_MS to catch anything the event-driven path misses,
+ * and also fires immediately on overflow signals from the raw event queue.
+ *
+ * This module holds the sweep timer and exposes startReconciliation / stopReconciliation.
+ * It does NOT replace the 250ms polling sensor loop — both run in parallel until the
+ * native events path is proven stable (Milestone 3 completion criterion).
+ */
+
+import type { PerceptionLens } from "./types.js";
+import type { DirtyJournal } from "./dirty-journal.js";
+import { buildRefreshPlan } from "./refresh-plan.js";
+import type { LensEventIndex } from "./lens-event-index.js";
+
+export interface ReconciliationCallbacks {
+  /**
+   * Called when the reconciler has determined which hwnds need full refresh.
+   * The caller (registry) performs the actual sensor calls.
+   */
+  onReconcile(opts: {
+    rectHwnds: Set<string>;
+    identityHwnds: Set<string>;
+    titleHwnds: Set<string>;
+    needsEnumWindows: boolean;
+    foreground: boolean;
+    modalForLensIds: Set<string>;
+    reason: string[];
+    trigger: "sweep" | "overflow";
+  }): void;
+}
+
+const RECONCILE_INTERVAL_MS = 5_000;
+
+export class ReconciliationScheduler {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private disposed = false;
+
+  constructor(
+    private readonly getLenses: () => PerceptionLens[],
+    private readonly getJournal: () => DirtyJournal,
+    private readonly getIndex: () => LensEventIndex,
+    private readonly getAllHwnds: () => Set<string>,
+    private readonly cbs: ReconciliationCallbacks,
+  ) {}
+
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => {
+      if (!this.disposed) this.sweep("sweep");
+    }, RECONCILE_INTERVAL_MS);
+    // Allow the Node process to exit even if timer is running
+    if (this.timer.unref) this.timer.unref();
+  }
+
+  /** Trigger an immediate reconciliation (e.g. on queue overflow). */
+  triggerImmediate(): void {
+    if (!this.disposed) this.sweep("overflow");
+  }
+
+  stop(): void {
+    this.disposed = true;
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private sweep(trigger: "sweep" | "overflow"): void {
+    const journal  = this.getJournal();
+    const index    = this.getIndex();
+    const allHwnds = this.getAllHwnds();
+    const plan     = buildRefreshPlan(journal, index, allHwnds);
+
+    if (
+      !plan.needsEnumWindows &&
+      plan.rectHwnds.size === 0 &&
+      plan.identityHwnds.size === 0 &&
+      plan.titleHwnds.size === 0 &&
+      !plan.foreground &&
+      plan.modalForLensIds.size === 0 &&
+      trigger === "sweep"
+    ) {
+      // Nothing dirty — skip this sweep tick
+      return;
+    }
+
+    this.cbs.onReconcile({
+      rectHwnds:       plan.rectHwnds,
+      identityHwnds:   plan.identityHwnds,
+      titleHwnds:      plan.titleHwnds,
+      needsEnumWindows: plan.needsEnumWindows,
+      foreground:      plan.foreground,
+      modalForLensIds: plan.modalForLensIds,
+      reason:          plan.reason.length > 0 ? plan.reason : [`${trigger}_sweep`],
+      trigger,
+    });
+  }
+
+  __resetForTests(): void {
+    this.stop();
+    this.disposed = false;
+  }
+}

--- a/src/engine/perception/refresh-plan.ts
+++ b/src/engine/perception/refresh-plan.ts
@@ -1,0 +1,156 @@
+/**
+ * RefreshPlan — batches dirty marks into the cheapest required sensor calls.
+ *
+ * Instead of calling refreshWin32Fluents() for every lens on every event,
+ * buildRefreshPlan() analyses the DirtyJournal and produces a minimal plan
+ * describing exactly which data needs to be fetched.
+ *
+ * Pure module — no OS imports.
+ */
+
+import type { DirtyJournal } from "./dirty-journal.js";
+import type { LensEventIndex } from "./lens-event-index.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface RefreshPlan {
+  /**
+   * If true, a full EnumWindows is required.
+   * Needed for z-order changes, modal recomputation, or global-dirty events.
+   */
+  needsEnumWindows: boolean;
+
+  /** HWNDs whose target.rect needs a cheap GetWindowRect() refresh. */
+  rectHwnds: Set<string>;
+
+  /** HWNDs whose target.identity needs re-verification. */
+  identityHwnds: Set<string>;
+
+  /** HWNDs whose target.title needs a cheap GetWindowText() refresh. */
+  titleHwnds: Set<string>;
+
+  /**
+   * If true, a GetForegroundWindow() + identity comparison is needed.
+   * Cheaper than a full EnumWindows for the foreground-only case.
+   */
+  foreground: boolean;
+
+  /** LensIds that need modal.above recomputed (requires z-order snapshot). */
+  modalForLensIds: Set<string>;
+
+  /** Human-readable reasons that contributed to this plan (for diagnostics). */
+  reason: string[];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Plan builder
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Build a minimal refresh plan from the current DirtyJournal state.
+ *
+ * @param journal  - Current dirty state.
+ * @param index    - Lens-event routing index (used to scope modal recompute).
+ * @param allHwnds - All HWNDs currently tracked (used for global-dirty expansion).
+ */
+export function buildRefreshPlan(
+  journal: DirtyJournal,
+  index: LensEventIndex,
+  allHwnds: Set<string> = new Set()
+): RefreshPlan {
+  const plan: RefreshPlan = {
+    needsEnumWindows: false,
+    rectHwnds: new Set(),
+    identityHwnds: new Set(),
+    titleHwnds: new Set(),
+    foreground: false,
+    modalForLensIds: new Set(),
+    reason: [],
+  };
+
+  if (!journal.hasDirty()) return plan;
+
+  // Global dirty: full scan required
+  if (journal.isGlobalDirty()) {
+    plan.needsEnumWindows = true;
+    plan.foreground = true;
+    for (const hwnd of allHwnds) {
+      plan.rectHwnds.add(hwnd);
+      plan.identityHwnds.add(hwnd);
+      plan.titleHwnds.add(hwnd);
+    }
+    for (const lensId of index.modalSensitive) plan.modalForLensIds.add(lensId);
+    plan.reason.push("global_dirty");
+    return plan;
+  }
+
+  // Per-entity entries
+  for (const [entityKey, entry] of journal.entries()) {
+    // Extract hwnd from entityKey format "window:12345" or "browserTab:tab-1"
+    const colonIdx = entityKey.indexOf(":");
+    const hwnd = colonIdx >= 0 ? entityKey.slice(colonIdx + 1) : entityKey;
+
+    for (const prop of entry.props) {
+      switch (prop) {
+        case "target.rect":
+          plan.rectHwnds.add(hwnd);
+          plan.reason.push(`rect_dirty:${hwnd}`);
+          break;
+
+        case "target.identity":
+          plan.identityHwnds.add(hwnd);
+          plan.reason.push(`identity_dirty:${hwnd}`);
+          break;
+
+        case "target.title":
+          plan.titleHwnds.add(hwnd);
+          plan.reason.push(`title_dirty:${hwnd}`);
+          break;
+
+        case "target.foreground":
+          plan.foreground = true;
+          plan.reason.push("foreground_dirty");
+          break;
+
+        case "target.zOrder":
+          plan.needsEnumWindows = true;
+          plan.reason.push(`zorder_dirty:${hwnd}`);
+          break;
+
+        case "modal.above":
+          // Modal recompute for all lenses that track modal.above
+          for (const lensId of (index.byHwnd.get(hwnd) ?? [])) {
+            if (index.modalSensitive.has(lensId)) plan.modalForLensIds.add(lensId);
+          }
+          // Also all modal-sensitive lenses (modal can come from any z-order change)
+          for (const lensId of index.modalSensitive) plan.modalForLensIds.add(lensId);
+          plan.reason.push(`modal_dirty:${hwnd}`);
+          break;
+
+        case "stable.rect":
+          // stable.rect dirty just means a quiet-window check is needed; no extra sensor call
+          plan.reason.push(`stable_rect_dirty:${hwnd}`);
+          break;
+
+        case "target.exists":
+          plan.identityHwnds.add(hwnd);
+          plan.reason.push(`exists_dirty:${hwnd}`);
+          break;
+      }
+    }
+
+    // Structural/identityRisk entries escalate to EnumWindows
+    if (entry.severity === "structural" || entry.severity === "identityRisk") {
+      plan.needsEnumWindows = true;
+    }
+  }
+
+  // If modal recompute is needed, we need z-order (requires EnumWindows)
+  if (plan.modalForLensIds.size > 0) {
+    plan.needsEnumWindows = true;
+  }
+
+  return plan;
+}

--- a/src/engine/perception/registry.ts
+++ b/src/engine/perception/registry.ts
@@ -11,7 +11,9 @@ import type {
   LensSpec,
   Observation,
   PerceptionEnvelope,
+  PerceptionLens,
 } from "./types.js";
+import { DirtyJournal } from "./dirty-journal.js";
 import { FluentStore } from "./fluent-store.js";
 import { DependencyGraph } from "./dependency-graph.js";
 import {
@@ -21,7 +23,6 @@ import {
   buildBrowserTabIdentity,
   resetLensCounter,
 } from "./lens.js";
-import type { PerceptionLens } from "./types.js";
 import { evaluateGuards } from "./guards.js";
 import type { GuardContext } from "./guards.js";
 import { projectEnvelope } from "./envelope.js";
@@ -46,8 +47,9 @@ import { enumWindowsInZOrder } from "../win32.js";
 
 const MAX_LENSES = 16;
 
-const store = new FluentStore();
-const graph = new DependencyGraph();
+const store  = new FluentStore();
+const graph  = new DependencyGraph();
+const _journal = new DirtyJournal();
 const lenses = new Map<string, PerceptionLens>();
 /** Insertion order for FIFO eviction */
 const lensOrder: string[] = [];
@@ -402,8 +404,18 @@ export function __resetForTests(): void {
   if (_disposeCdpLoop)    { _disposeCdpLoop();    _disposeCdpLoop = null;    }
   store.__resetForTests();
   graph.__resetForTests();
+  _journal.__resetForTests();
   __resetSensorForTests();
   __resetUiaSensorForTests();
   __resetCdpSensorForTests();
   resetLensCounter();
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Accessors for resource model and tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function getStore(): FluentStore { return store; }
+export function getDirtyJournal(): DirtyJournal { return _journal; }
+export function getLens(lensId: string): PerceptionLens | undefined { return lenses.get(lensId); }
+export function getAllLenses(): PerceptionLens[] { return [...lenses.values()]; }

--- a/src/engine/perception/resource-model.ts
+++ b/src/engine/perception/resource-model.ts
@@ -1,0 +1,276 @@
+/**
+ * resource-model.ts
+ *
+ * Projection functions for per-lens MCP resources.
+ * Pure functions — no OS imports. All inputs injected.
+ *
+ * Views:
+ *   summary  — attention, watermark, canAct, guards summary, target/browser state
+ *   guards   — full GuardResult list
+ *   debug    — all fluents, dirty journal, diagnostics (gated behind DEBUG_RESOURCES)
+ */
+
+import type {
+  AttentionState,
+  Fluent,
+  GuardEvalResult,
+  GuardResult,
+  PerceptionLens,
+} from "./types.js";
+import type { FluentStore } from "./fluent-store.js";
+import type { DirtyJournal } from "./dirty-journal.js";
+import { evaluateGuards } from "./guards.js";
+import { confidenceFor } from "./evidence.js";
+
+// ── canAct helper ─────────────────────────────────────────────────────────────
+
+export interface CanAct {
+  keyboard: boolean;
+  mouse: boolean;
+}
+
+export function computeCanAct(guardResult: GuardEvalResult): CanAct {
+  if (!guardResult.ok) {
+    return { keyboard: false, mouse: false };
+  }
+  return { keyboard: true, mouse: true };
+}
+
+// ── formatGuardSummary ────────────────────────────────────────────────────────
+
+/** Shared guard failure message template for envelope and resources. */
+export function formatGuardSummary(r: GuardResult): string {
+  if (r.ok) return `${r.kind}: ok (confidence=${r.confidence.toFixed(2)})`;
+  const parts = [`${r.kind}: FAILED`];
+  if (r.reason) parts.push(`reason="${r.reason}"`);
+  if (r.suggestedAction) parts.push(`action="${r.suggestedAction}"`);
+  return parts.join(" | ");
+}
+
+// ── LensSnapshot ─────────────────────────────────────────────────────────────
+
+export interface LensSnapshot {
+  lens: PerceptionLens;
+  guardResult: GuardEvalResult;
+  canAct: CanAct;
+  attention: AttentionState;
+  fluents: Map<string, Fluent>;
+  hasDirty: boolean;
+  hasSettling: boolean;
+  hasStale: boolean;
+  nowMs: number;
+  seq: number;
+}
+
+export function buildLensSnapshot(
+  lens: PerceptionLens,
+  store: FluentStore,
+  _journal: DirtyJournal,
+): LensSnapshot {
+  const nowMs = Date.now();
+  const guardResult = evaluateGuards(lens, store, lens.spec.guardPolicy ?? "block");
+  const canAct = computeCanAct(guardResult);
+
+  const fluents = new Map<string, Fluent>();
+  for (const key of lens.fluentKeys) {
+    const f = store.read(key);
+    if (f) fluents.set(key, f);
+  }
+
+  const hasDirty    = [...fluents.values()].some(f => f.status === "dirty");
+  const hasSettling = [...fluents.values()].some(f => f.status === "settling");
+  const hasStale    = [...fluents.values()].some(f => f.status === "stale");
+
+  // Derive attention with full priority chain (mirrors envelope.ts deriveAttention)
+  let attention: AttentionState;
+  if (!guardResult.ok) {
+    attention = "guard_failed";
+  } else if (hasDirty) {
+    attention = "dirty";
+  } else if (hasSettling) {
+    attention = "settling";
+  } else if (hasStale) {
+    attention = "stale";
+  } else {
+    attention = "ok";
+  }
+
+  return {
+    lens,
+    guardResult,
+    canAct,
+    attention,
+    fluents,
+    hasDirty,
+    hasSettling,
+    hasStale,
+    nowMs,
+    seq: store.currentSeq(),
+  };
+}
+
+// ── Resource projections ──────────────────────────────────────────────────────
+
+export interface SummaryResource {
+  lensId: string;
+  seq: number;
+  attention: AttentionState;
+  watermark: {
+    hasDirty: boolean;
+    hasSettling: boolean;
+    hasStale: boolean;
+  };
+  target?: Record<string, unknown>;
+  browser?: Record<string, unknown>;
+  guards: Record<string, { ok: boolean; confidence: number }>;
+  changed: string[];
+  canAct: CanAct;
+  suggestedNext?: string;
+}
+
+export function projectResourceSummary(snapshot: LensSnapshot): SummaryResource {
+  const { lens, guardResult, canAct, attention, fluents, hasDirty, hasSettling, hasStale, nowMs, seq } = snapshot;
+  const entityKind = lens.spec.target.kind;
+  const entityId   = lens.binding.hwnd;
+
+  function read(property: string): Fluent | undefined {
+    return fluents.get(`${entityKind}:${entityId}.${property}`);
+  }
+
+  const guardsOut: Record<string, { ok: boolean; confidence: number }> = {};
+  for (const r of guardResult.results) {
+    guardsOut[r.kind] = { ok: r.ok, confidence: Math.round(r.confidence * 100) / 100 };
+  }
+
+  const summary: SummaryResource = {
+    lensId: lens.lensId,
+    seq,
+    attention,
+    watermark: { hasDirty, hasSettling, hasStale },
+    guards: guardsOut,
+    changed: [],
+    canAct,
+  };
+
+  // Suggest next action based on attention
+  if (!guardResult.ok && guardResult.failedGuard) {
+    summary.suggestedNext = guardResult.failedGuard.suggestedAction;
+  } else if (hasDirty || hasSettling) {
+    summary.suggestedNext = "Call perception_read to get fresh observations";
+  } else if (attention === "ok") {
+    summary.suggestedNext = "Ready to act";
+  }
+
+  if (entityKind === "browserTab") {
+    const url       = read("browser.url");
+    const title     = read("browser.title");
+    const readyState = read("browser.readyState");
+    summary.browser = {
+      ...(url        && { url: url.value }),
+      ...(title      && { title: title.value }),
+      ...(readyState && { readyState: readyState.value }),
+      confidence: computeAvgConf([url, title, readyState], nowMs),
+    };
+  } else {
+    const exists  = read("target.exists");
+    const titleF  = read("target.title");
+    const rect    = read("target.rect");
+    const fg      = read("target.foreground");
+    const modal   = read("modal.above");
+    summary.target = {
+      ...(exists  && { exists: exists.value }),
+      ...(titleF  && { title: titleF.value }),
+      ...(rect    && { rect: rect.value }),
+      ...(fg      && { foreground: fg.value }),
+      ...(modal   && { modalAbove: modal.value }),
+      confidence: computeAvgConf([exists, titleF, rect, fg, modal], nowMs),
+    };
+  }
+
+  return summary;
+}
+
+export interface GuardsResource {
+  lensId: string;
+  seq: number;
+  policy: string;
+  ok: boolean;
+  guards: Array<GuardResult & { summary: string }>;
+}
+
+export function projectResourceGuards(snapshot: LensSnapshot): GuardsResource {
+  const { lens, guardResult, seq } = snapshot;
+  return {
+    lensId: lens.lensId,
+    seq,
+    policy: lens.spec.guardPolicy ?? "block",
+    ok: guardResult.ok,
+    guards: guardResult.results.map(r => ({
+      ...r,
+      summary: formatGuardSummary(r),
+    })),
+  };
+}
+
+export interface DebugResource {
+  lensId: string;
+  seq: number;
+  fluents: Array<{
+    key: string;
+    value: unknown;
+    status: string;
+    confidence: number;
+    validFromMonoMs: number;
+    lastDirtyAtMonoMs: number | undefined;
+    lastDirtyCause: string | undefined;
+  }>;
+  diagnostics: {
+    hasDirty: boolean;
+    hasSettling: boolean;
+    hasStale: boolean;
+    guardOk: boolean;
+    attention: AttentionState;
+  };
+  warnings: string[];
+}
+
+export function projectResourceDebug(snapshot: LensSnapshot): DebugResource {
+  const { lens, guardResult, fluents, hasDirty, hasSettling, hasStale, attention, seq, nowMs } = snapshot;
+
+  const warnings: string[] = [];
+  if (hasDirty)    warnings.push("has_dirty_fluents");
+  if (hasSettling) warnings.push("has_settling_fluents");
+  if (hasStale)    warnings.push("has_stale_fluents");
+  if (!guardResult.ok) warnings.push(`guard_failed:${guardResult.failedGuard?.kind}`);
+
+  return {
+    lensId: lens.lensId,
+    seq,
+    fluents: [...fluents.entries()].map(([key, f]) => ({
+      key,
+      value: f.value,
+      status: f.status,
+      confidence: Math.round((f.support[0] ? confidenceFor(f.support[0], nowMs) : f.confidence) * 100) / 100,
+      validFromMonoMs: f.validFromMonoMs,
+      lastDirtyAtMonoMs: f.lastDirtyAtMonoMs,
+      lastDirtyCause: f.lastDirtyCause,
+    })),
+    diagnostics: {
+      hasDirty,
+      hasSettling,
+      hasStale,
+      guardOk: guardResult.ok,
+      attention,
+    },
+    warnings,
+  };
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function computeAvgConf(fluents: (Fluent | undefined)[], nowMs: number): number {
+  const valid = fluents.filter(Boolean) as Fluent[];
+  if (valid.length === 0) return 0;
+  const total = valid.reduce((s, f) => s + (f.support[0] ? confidenceFor(f.support[0], nowMs) : f.confidence), 0);
+  return Math.round((total / valid.length) * 100) / 100;
+}

--- a/src/engine/perception/resource-notifications.ts
+++ b/src/engine/perception/resource-notifications.ts
@@ -1,0 +1,129 @@
+/**
+ * resource-notifications.ts
+ *
+ * Coalesced resource update notifications for the Reactive Perception Graph.
+ * Fires at most once per lens per debounce window, and only on attention transitions.
+ *
+ * Attention transitions that trigger notifications:
+ *   ok → guard_failed / dirty / settling / stale    (degradation)
+ *   guard_failed / dirty / settling / stale → ok    (recovery)
+ * Non-transitions (value unchanged) do NOT fire.
+ * "changed" alone does NOT fire — too noisy for minor value updates.
+ */
+
+import type { AttentionState } from "./types.js";
+
+export type NotificationTrigger = "attention_change" | "guard_transition" | "identity_changed";
+
+/** "ok" and "changed" are "good" — everything else is "degraded". */
+function isDegraded(attention: AttentionState | undefined): boolean {
+  return attention !== undefined && attention !== "ok" && attention !== "changed";
+}
+
+const DEFAULT_DEBOUNCE_MS = 500;
+
+interface LensNotificationState {
+  lastAttention: AttentionState | undefined;
+  timer: ReturnType<typeof setTimeout> | null;
+  pendingUris: Set<string>;
+}
+
+export interface ResourceNotificationCallbacks {
+  onNotify(uris: Set<string>): void;
+}
+
+export class ResourceNotificationScheduler {
+  private readonly states = new Map<string, LensNotificationState>();
+  private readonly debounceMs: number;
+  private disposed = false;
+
+  constructor(
+    private readonly getUrisForLens: (lensId: string) => string[],
+    private readonly getAttention: (lensId: string) => AttentionState | undefined,
+    private readonly cbs: ResourceNotificationCallbacks,
+    debounceMs = DEFAULT_DEBOUNCE_MS,
+  ) {
+    this.debounceMs = debounceMs;
+  }
+
+  /**
+   * Call after sensor observations are ingested for affected lenses.
+   * Schedules notifications only for lenses whose attention has meaningfully transitioned.
+   *
+   * Policy:
+   *   - "ok" and "changed" are both "good" states — transitions between them do NOT notify.
+   *   - Transitions between "good" and "degraded" (guard_failed/dirty/settling/stale) DO notify.
+   *   - First observation in a degraded state notifies; first observation in a good state does not.
+   */
+  maybeNotify(lensIds: Set<string>, _trigger: NotificationTrigger): void {
+    if (this.disposed) return;
+
+    for (const lensId of lensIds) {
+      const newAttention = this.getAttention(lensId);
+      if (newAttention === undefined) continue;
+
+      const state = this.getOrCreateState(lensId);
+
+      // No change — skip
+      if (state.lastAttention === newAttention) continue;
+
+      const wasDegraded = isDegraded(state.lastAttention);
+      const nowDegraded = isDegraded(newAttention);
+
+      // Only notify on good↔degraded transitions
+      // (includes first-observation-in-degraded: undefined treated as "good")
+      const isMeaningfulTransition = wasDegraded !== nowDegraded;
+
+      state.lastAttention = newAttention;
+
+      if (!isMeaningfulTransition) continue;
+
+      // Add URIs to pending set and debounce
+      const uris = this.getUrisForLens(lensId);
+      for (const uri of uris) state.pendingUris.add(uri);
+
+      if (!state.timer) {
+        state.timer = setTimeout(() => {
+          if (!this.disposed) this.flush(lensId);
+        }, this.debounceMs);
+        if (state.timer.unref) state.timer.unref();
+      }
+    }
+  }
+
+  private flush(lensId: string): void {
+    const state = this.states.get(lensId);
+    if (!state) return;
+    state.timer = null;
+
+    if (state.pendingUris.size > 0) {
+      this.cbs.onNotify(new Set(state.pendingUris));
+      state.pendingUris.clear();
+    }
+  }
+
+  private getOrCreateState(lensId: string): LensNotificationState {
+    let state = this.states.get(lensId);
+    if (!state) {
+      state = { lastAttention: undefined, timer: null, pendingUris: new Set() };
+      this.states.set(lensId, state);
+    }
+    return state;
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    for (const state of this.states.values()) {
+      if (state.timer) { clearTimeout(state.timer); state.timer = null; }
+    }
+    this.states.clear();
+  }
+
+  __resetForTests(): void {
+    for (const state of this.states.values()) {
+      if (state.timer) { clearTimeout(state.timer); state.timer = null; }
+    }
+    this.states.clear();
+    this.disposed = false;
+  }
+}

--- a/src/engine/perception/resource-registry.ts
+++ b/src/engine/perception/resource-registry.ts
@@ -1,0 +1,142 @@
+/**
+ * resource-registry.ts
+ *
+ * Maps lens IDs to MCP resource URIs and manages tombstones (30s TTL).
+ * Pure state machine — no MCP server imports.
+ */
+
+import type { PerceptionLens } from "./types.js";
+
+const TOMBSTONE_TTL_MS  = 30_000;
+const MAX_TOMBSTONES    = 128;
+
+export interface ResourceUri {
+  lensId: string;
+  uri: string;
+  view: "summary" | "guards" | "debug" | "events";
+}
+
+export interface TombstoneEntry {
+  lensId: string;
+  uri: string;
+  removedAtMs: number;
+  message: string;
+}
+
+/** Callback invoked when the list of resources changes (add/remove). */
+export type OnResourceListChanged = () => void;
+
+export class ResourceRegistry {
+  private readonly lensUris = new Map<string, string[]>(); // lensId → [uri, ...]
+  private readonly uriToLensId = new Map<string, string>();
+  private readonly tombstones  = new Map<string, TombstoneEntry>(); // uri → tombstone
+  private tombstoneTimers      = new Map<string, ReturnType<typeof setTimeout>>();
+
+  private onListChanged?: OnResourceListChanged;
+
+  setOnListChanged(cb: OnResourceListChanged): void {
+    this.onListChanged = cb;
+  }
+
+  onLensRegistered(lens: PerceptionLens): string[] {
+    const uris: string[] = [];
+    for (const view of ["summary", "guards"] as const) {
+      const uri = `perception://lens/${lens.lensId}/${view}`;
+      uris.push(uri);
+      this.uriToLensId.set(uri, lens.lensId);
+    }
+
+    // Debug/events only if debug resources flag is enabled
+    if (process.env.DESKTOP_TOUCH_PERCEPTION_DEBUG_RESOURCES === "1") {
+      for (const view of ["debug", "events"] as const) {
+        const uri = `perception://lens/${lens.lensId}/${view}`;
+        uris.push(uri);
+        this.uriToLensId.set(uri, lens.lensId);
+      }
+    }
+
+    this.lensUris.set(lens.lensId, uris);
+
+    // Clear any tombstone for this lens (re-registered)
+    for (const uri of uris) {
+      if (this.tombstones.has(uri)) {
+        this.clearTombstone(uri);
+      }
+    }
+
+    this.onListChanged?.();
+    return uris;
+  }
+
+  onLensForgotten(lensId: string): void {
+    const uris = this.lensUris.get(lensId) ?? [];
+    this.lensUris.delete(lensId);
+    for (const uri of uris) {
+      this.uriToLensId.delete(uri);
+      this.addTombstone(uri, lensId);
+    }
+    this.onListChanged?.();
+  }
+
+  getLensId(uri: string): string | undefined {
+    return this.uriToLensId.get(uri);
+  }
+
+  getTombstone(uri: string): TombstoneEntry | undefined {
+    return this.tombstones.get(uri);
+  }
+
+  /** All active (non-tombstone) resource URIs. */
+  listUris(): string[] {
+    const all: string[] = [];
+    for (const uris of this.lensUris.values()) all.push(...uris);
+    return all;
+  }
+
+  listForClient(): Array<{ uri: string; name: string; mimeType: string }> {
+    return this.listUris().map(uri => ({
+      uri,
+      name: uri.split("/").slice(-2).join("/"),
+      mimeType: "application/json",
+    }));
+  }
+
+  // ── Tombstone helpers ────────────────────────────────────────────────────────
+
+  private addTombstone(uri: string, lensId: string): void {
+    // Evict oldest tombstone if over limit
+    if (this.tombstones.size >= MAX_TOMBSTONES) {
+      const oldest = this.tombstones.keys().next().value;
+      if (oldest) this.clearTombstone(oldest);
+    }
+
+    const entry: TombstoneEntry = {
+      lensId,
+      uri,
+      removedAtMs: Date.now(),
+      message: `Lens ${lensId} was forgotten. Resource URI is no longer active.`,
+    };
+    this.tombstones.set(uri, entry);
+
+    const timer = setTimeout(() => {
+      this.clearTombstone(uri);
+      this.onListChanged?.();
+    }, TOMBSTONE_TTL_MS);
+    if (timer.unref) timer.unref();
+    this.tombstoneTimers.set(uri, timer);
+  }
+
+  private clearTombstone(uri: string): void {
+    const timer = this.tombstoneTimers.get(uri);
+    if (timer) { clearTimeout(timer); this.tombstoneTimers.delete(uri); }
+    this.tombstones.delete(uri);
+  }
+
+  __resetForTests(): void {
+    for (const t of this.tombstoneTimers.values()) clearTimeout(t);
+    this.lensUris.clear();
+    this.uriToLensId.clear();
+    this.tombstones.clear();
+    this.tombstoneTimers.clear();
+  }
+}

--- a/src/engine/perception/sensors-native-win32.ts
+++ b/src/engine/perception/sensors-native-win32.ts
@@ -1,0 +1,171 @@
+/**
+ * sensors-native-win32.ts
+ *
+ * Bridge between the raw WinEvent queue and the DirtyJournal / FlushScheduler.
+ * Consumes batches of raw events, maps each event code to dirty properties,
+ * dispatches only to lenses affected via LensEventIndex, and schedules refreshes.
+ *
+ * Pure mapping logic — no direct Win32 imports. All side effects go through
+ * the injected callbacks (onDirty, onSchedule).
+ */
+
+import type { RawWinEvent } from "./raw-event-queue.js";
+import type { DirtyJournal } from "./dirty-journal.js";
+import type { FlushScheduler, PropertyClass } from "./flush-scheduler.js";
+import type { LensEventIndex } from "./lens-event-index.js";
+import { lensesForHwnd, lensesForForegroundEvent } from "./lens-event-index.js";
+
+// ── WinEvent constants ────────────────────────────────────────────────────────
+
+export const EVENT_SYSTEM_FOREGROUND        = 0x0003;
+export const EVENT_SYSTEM_MOVESIZESTART     = 0x000A;
+export const EVENT_SYSTEM_MOVESIZEEND       = 0x000B;
+export const EVENT_OBJECT_SHOW              = 0x8002;
+export const EVENT_OBJECT_HIDE              = 0x8003;
+export const EVENT_OBJECT_DESTROY          = 0x8001;
+export const EVENT_OBJECT_NAMECHANGE        = 0x800C;
+export const EVENT_OBJECT_LOCATIONCHANGE    = 0x800B;
+export const EVENT_OBJECT_REORDER          = 0x8004;
+
+// OBJID_WINDOW — events with idObject !== 0 are sub-objects we generally ignore
+const OBJID_WINDOW = 0;
+
+// ── Mapping table: event → { dirtyProps, severity, propertyClass } ───────────
+
+interface EventMapping {
+  dirtyProps: string[];
+  severity?: "hint" | "structural" | "identityRisk";
+  propertyClass: PropertyClass;
+  /** If true, fan out to all foreground-sensitive lenses, not just byHwnd */
+  foregroundFanout?: boolean;
+  /** If true, trigger EnumWindows (needsEnumWindows in RefreshPlan) */
+  needsEnumWindows?: boolean;
+}
+
+// Phase 5-A events only (location/reorder in Milestone 4 behind LOCATION_EVENTS flag)
+const PHASE5A_EVENT_MAP: Map<number, EventMapping> = new Map([
+  [EVENT_SYSTEM_FOREGROUND, {
+    dirtyProps: ["target.foreground"],
+    propertyClass: "foreground",
+    foregroundFanout: true,
+  }],
+  [EVENT_OBJECT_SHOW, {
+    dirtyProps: ["target.exists"],
+    severity: "structural",
+    propertyClass: "show_hide",
+    needsEnumWindows: true,
+  }],
+  [EVENT_OBJECT_HIDE, {
+    dirtyProps: ["target.exists"],
+    severity: "structural",
+    propertyClass: "show_hide",
+    needsEnumWindows: true,
+  }],
+  [EVENT_OBJECT_DESTROY, {
+    dirtyProps: ["target.exists"],
+    severity: "structural",
+    propertyClass: "show_hide",
+    needsEnumWindows: true,
+  }],
+  [EVENT_OBJECT_NAMECHANGE, {
+    dirtyProps: ["target.title"],
+    propertyClass: "title",
+  }],
+]);
+
+// Milestone 4 events (location/reorder) — added when LOCATION_EVENTS=1
+const LOCATION_EVENT_MAP: Map<number, EventMapping> = new Map([
+  [EVENT_SYSTEM_MOVESIZESTART, {
+    dirtyProps: ["target.rect", "stable.rect"],
+    propertyClass: "move_start",
+  }],
+  [EVENT_SYSTEM_MOVESIZEEND, {
+    dirtyProps: ["target.rect"],
+    propertyClass: "move_end",
+  }],
+  [EVENT_OBJECT_LOCATIONCHANGE, {
+    dirtyProps: ["target.rect"],
+    propertyClass: "location",
+  }],
+  [EVENT_OBJECT_REORDER, {
+    dirtyProps: ["target.zOrder", "modal.above"],
+    propertyClass: "reorder",
+    needsEnumWindows: true,
+  }],
+]);
+
+// ── NativeSensorBridge ────────────────────────────────────────────────────────
+
+export interface NativeSensorBridgeCallbacks {
+  /** Called when events need to be dispatched to the DirtyJournal. */
+  onDirty(entityKey: string, props: string[], cause: string, monoMs: number, severity?: "hint" | "structural" | "identityRisk"): void;
+  /** Called when a global dirty (overflow) should be emitted. */
+  onGlobalDirty(cause: string, monoMs: number): void;
+  /** Called to schedule a refresh flush. */
+  onSchedule(propertyClass: PropertyClass, reason?: string): void;
+  /** Called when needsEnumWindows is required by the event. */
+  onEnumWindowsNeeded(reason: string): void;
+}
+
+export class NativeSensorBridge {
+  private readonly locationEventsEnabled: boolean;
+
+  constructor(private readonly cbs: NativeSensorBridgeCallbacks) {
+    this.locationEventsEnabled = process.env.DESKTOP_TOUCH_PERCEPTION_LOCATION_EVENTS === "1";
+  }
+
+  /**
+   * Process a batch of raw events from the queue.
+   * All lensId lookups go through LensEventIndex for subset dispatch.
+   */
+  processBatch(events: RawWinEvent[], index: LensEventIndex, _journal: DirtyJournal): void {
+    for (const ev of events) {
+      // Only process OBJID_WINDOW events for window handle targeting
+      if (ev.idObject !== OBJID_WINDOW) continue;
+      if (ev.hwnd === "0") continue;
+
+      const mapping = this.resolveMapping(ev.event);
+      if (!mapping) continue;
+
+      // Determine which lens IDs are affected
+      const affectedLensIds = mapping.foregroundFanout
+        ? lensesForForegroundEvent(index, ev.hwnd)
+        : lensesForHwnd(index, ev.hwnd);
+
+      const entityKey = `window:${ev.hwnd}`;
+      const cause     = `winevent_0x${ev.event.toString(16).padStart(4, "0")}`;
+
+      // Mark dirty for the window entity
+      this.cbs.onDirty(entityKey, mapping.dirtyProps, cause, ev.receivedAtMonoMs, mapping.severity);
+
+      // For foreground fanout, also mark all other foreground-sensitive windows dirty
+      if (mapping.foregroundFanout && affectedLensIds.size > 0) {
+        // The journal coalesces per entityKey — other affected lenses have their own hwnd
+        // Their updates are handled by the reconciliation RefreshPlan (foreground=true → all)
+      }
+
+      // Schedule flush
+      this.cbs.onSchedule(mapping.propertyClass, `${cause}:hwnd=${ev.hwnd}`);
+
+      // Trigger EnumWindows if needed
+      if (mapping.needsEnumWindows) {
+        this.cbs.onEnumWindowsNeeded(cause);
+      }
+    }
+  }
+
+  /** Handle a queue overflow — emit global dirty and schedule immediate flush. */
+  processOverflow(monoMs: number): void {
+    this.cbs.onGlobalDirty("queue_overflow", monoMs);
+    this.cbs.onSchedule("overflow", "queue_overflow");
+  }
+
+  private resolveMapping(eventCode: number): EventMapping | undefined {
+    const phase5a = PHASE5A_EVENT_MAP.get(eventCode);
+    if (phase5a) return phase5a;
+    if (this.locationEventsEnabled) {
+      return LOCATION_EVENT_MAP.get(eventCode);
+    }
+    return undefined;
+  }
+}

--- a/src/engine/perception/sensors-native-win32.ts
+++ b/src/engine/perception/sensors-native-win32.ts
@@ -135,13 +135,19 @@ export class NativeSensorBridge {
       const entityKey = `window:${ev.hwnd}`;
       const cause     = `winevent_0x${ev.event.toString(16).padStart(4, "0")}`;
 
-      // Mark dirty for the window entity
+      // Mark dirty for the event source window
       this.cbs.onDirty(entityKey, mapping.dirtyProps, cause, ev.receivedAtMonoMs, mapping.severity);
 
-      // For foreground fanout, also mark all other foreground-sensitive windows dirty
+      // For foreground fanout, also mark ALL foreground-sensitive lens windows as dirty.
+      // A foreground event on hwnd X means every other window lost foreground — their
+      // target.foreground fluents are now stale regardless of which hwnd gained focus.
       if (mapping.foregroundFanout && affectedLensIds.size > 0) {
-        // The journal coalesces per entityKey — other affected lenses have their own hwnd
-        // Their updates are handled by the reconciliation RefreshPlan (foreground=true → all)
+        for (const lensId of affectedLensIds) {
+          const lensHwnd = index.lensToHwnd.get(lensId);
+          if (lensHwnd && lensHwnd !== ev.hwnd) {
+            this.cbs.onDirty(`window:${lensHwnd}`, mapping.dirtyProps, cause, ev.receivedAtMonoMs, mapping.severity);
+          }
+        }
       }
 
       // Schedule flush

--- a/src/engine/perception/types.ts
+++ b/src/engine/perception/types.ts
@@ -58,6 +58,13 @@ export interface Observation {
   value: unknown;
   confidence: number;
   evidence: Evidence;
+  /**
+   * Monotonic timestamp (performance.now()) recorded at the START of the sensor read
+   * that produced this observation. Used to compare against lastDirtyAtMonoMs in FluentStore
+   * to determine whether the evidence is newer than the last invalidation hint.
+   * Optional: sensors that do not support monotonic timestamps omit this field.
+   */
+  monoMs?: number;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -68,6 +75,7 @@ export type FluentStatus =
   | "observed"
   | "inferred"
   | "dirty"
+  | "settling"
   | "stale"
   | "contradicted"
   | "invalidated";
@@ -77,10 +85,23 @@ export interface Fluent {
   property: string;
   value: unknown;
   validFromSeq: number;
+  /** Monotonic timestamp (performance.now()) when this fluent was last written by apply(). */
+  validFromMonoMs: number;
   confidence: number;
   support: Evidence[];
   contradictions: Evidence[];
   status: FluentStatus;
+  /** Sequence number of the last dirty-mark applied to this fluent. */
+  lastDirtySeq?: number;
+  /** Monotonic timestamp of the last dirty-mark applied to this fluent. */
+  lastDirtyAtMonoMs?: number;
+  /** Human-readable cause string for the last dirty-mark. */
+  lastDirtyCause?: string;
+  /**
+   * Generation token — changes when target identity changes.
+   * Coordinates derived under generation G1 must not be used after the target becomes G2.
+   */
+  generation?: string;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -190,6 +211,7 @@ export type AttentionState =
   | "ok"
   | "changed"
   | "dirty"
+  | "settling"
   | "stale"
   | "guard_failed"
   | "identity_changed"

--- a/src/engine/winevent-source.ts
+++ b/src/engine/winevent-source.ts
@@ -1,0 +1,305 @@
+/**
+ * winevent-source.ts
+ *
+ * Lifecycle manager for the native WinEvent sidecar process.
+ * Strategy B: native sidecar communicates via stdio newline-delimited JSON.
+ *
+ * Sidecar contract: one JSON object per line on stdout:
+ *   {"event":3,"hwnd":"123456","idObject":0,"idChild":0,"eventThread":9988,
+ *    "sourceEventTimeMs":1234567,"sidecarSeq":42}
+ *
+ * Node side adds receivedAtMonoMs (performance.now()) and receivedAtUnixMs (Date.now())
+ * at parse time. sourceEventTimeMs is for diagnostics / ordering hints only — never
+ * compare to Node clocks.
+ */
+
+import { spawn, ChildProcess } from "node:child_process";
+import { performance } from "node:perf_hooks";
+import * as path from "node:path";
+import * as url from "node:url";
+import type { RawWinEvent } from "./perception/raw-event-queue.js";
+
+// ── State machine ─────────────────────────────────────────────────────────────
+
+export type WinEventSourceState =
+  | "disabled"
+  | "starting"
+  | "live"
+  | "degraded"
+  | "restarting"
+  | "stopped";
+
+// ── Backoff configuration ─────────────────────────────────────────────────────
+
+const BACKOFF_INITIAL_MS  = 500;
+const BACKOFF_MULTIPLIER  = 2;
+const BACKOFF_MAX_MS      = 30_000;
+const MAX_RESTART_CYCLES  = 10; // after which we stay degraded
+
+// ── WinEventSource ────────────────────────────────────────────────────────────
+
+export interface WinEventSourceOptions {
+  /** Override the sidecar binary path (defaults to DESKTOP_TOUCH_SIDECAR_PATH env or built-in bin/) */
+  sidecarPath?: string;
+  /** Additional arguments to pass to the sidecar process (useful for testing: node mock-sidecar.js) */
+  sidecarArgs?: string[];
+  /** Called for each parsed raw event */
+  onRawEvent: (event: RawWinEvent) => void;
+  /** Called when a line cannot be parsed (malformed JSON) */
+  onMalformedLine?: (line: string) => void;
+  /** Called when the state changes */
+  onStateChange?: (state: WinEventSourceState) => void;
+}
+
+export interface WinEventSourceDiagnostics {
+  state: WinEventSourceState;
+  startCount: number;
+  restartCount: number;
+  malformedLines: number;
+  lastRestartReasonMs: number | undefined;
+}
+
+export class WinEventSource {
+  private state: WinEventSourceState = "disabled";
+  private process: ChildProcess | null = null;
+  private lineBuffer = "";
+  private globalSeq  = 0;
+
+  private backoffMs    = BACKOFF_INITIAL_MS;
+  private restartCount = 0;
+  private startCount   = 0;
+
+  private _malformedLines = 0;
+  private _lastRestartAtMs: number | undefined;
+
+  private restartTimer: ReturnType<typeof setTimeout> | null = null;
+  private disposed = false;
+
+  constructor(private readonly opts: WinEventSourceOptions) {}
+
+  start(): void {
+    if (this.disposed) return;
+    if (this.state !== "disabled" && this.state !== "stopped") return;
+    this.spawn();
+  }
+
+  stop(): void {
+    this.disposed = true;
+    this.clearRestartTimer();
+    this.killProcess();
+    this.setState("stopped");
+  }
+
+  getState(): WinEventSourceState {
+    return this.state;
+  }
+
+  diagnostics(): WinEventSourceDiagnostics {
+    return {
+      state:              this.state,
+      startCount:         this.startCount,
+      restartCount:       this.restartCount,
+      malformedLines:     this._malformedLines,
+      lastRestartReasonMs: this._lastRestartAtMs,
+    };
+  }
+
+  // ── Private ─────────────────────────────────────────────────────────────────
+
+  private spawn(): void {
+    if (this.disposed) return;
+
+    const sidecarPath = this.opts.sidecarPath
+      ?? process.env.DESKTOP_TOUCH_SIDECAR_PATH
+      ?? this.defaultSidecarPath();
+
+    this.setState("starting");
+    this.startCount++;
+
+    let proc: ChildProcess;
+    try {
+      proc = spawn(sidecarPath, this.opts.sidecarArgs ?? [], {
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+      });
+    } catch (err) {
+      console.error(`[winevent-source] Failed to spawn sidecar: ${String(err)}`);
+      this.scheduleRestart();
+      return;
+    }
+
+    this.process = proc;
+
+    proc.stdout?.setEncoding("utf8");
+    proc.stdout?.on("data", (chunk: string) => {
+      this.handleData(chunk);
+    });
+
+    proc.stderr?.setEncoding("utf8");
+    proc.stderr?.on("data", (chunk: string) => {
+      const trimmed = chunk.trim();
+      if (trimmed) console.error(`[winevent-source:stderr] ${trimmed}`);
+    });
+
+    proc.once("spawn", () => {
+      if (!this.disposed && this.state === "starting") {
+        this.setState("live");
+        this.backoffMs    = BACKOFF_INITIAL_MS; // reset on successful start
+        this.lineBuffer   = "";
+      }
+    });
+
+    proc.once("error", (err) => {
+      console.error(`[winevent-source] Sidecar process error: ${err.message}`);
+      if (!this.disposed) this.scheduleRestart();
+    });
+
+    proc.once("exit", (code) => {
+      if (!this.disposed) {
+        console.error(`[winevent-source] Sidecar exited (code ${code})`);
+        this.process = null;
+        this.scheduleRestart();
+      }
+    });
+  }
+
+  private handleData(chunk: string): void {
+    this.lineBuffer += chunk;
+    const lines = this.lineBuffer.split("\n");
+    this.lineBuffer = lines.pop() ?? "";
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      this.parseLine(trimmed);
+    }
+  }
+
+  private parseLine(line: string): void {
+    try {
+      const raw = JSON.parse(line) as {
+        event: number;
+        hwnd: string;
+        idObject: number;
+        idChild: number;
+        eventThread: number;
+        sourceEventTimeMs: number;
+        sidecarSeq: number;
+      };
+
+      const receivedAtMonoMs = performance.now();
+      const receivedAtUnixMs = Date.now();
+
+      const ev: RawWinEvent = {
+        event:              raw.event,
+        hwnd:               String(raw.hwnd),
+        idObject:           raw.idObject,
+        idChild:            raw.idChild,
+        eventThread:        raw.eventThread,
+        sourceEventTimeMs:  raw.sourceEventTimeMs,
+        sidecarSeq:         raw.sidecarSeq,
+        receivedAtMonoMs,
+        receivedAtUnixMs,
+        globalSeq:          ++this.globalSeq,
+      };
+
+      this.opts.onRawEvent(ev);
+    } catch {
+      this._malformedLines++;
+      this.opts.onMalformedLine?.(line);
+    }
+  }
+
+  private scheduleRestart(): void {
+    if (this.disposed) return;
+    if (this.restartCount >= MAX_RESTART_CYCLES) {
+      console.error("[winevent-source] Max restart cycles reached — staying degraded");
+      this.setState("degraded");
+      return;
+    }
+
+    this.setState("restarting");
+    this.restartCount++;
+    this._lastRestartAtMs = Date.now();
+
+    const delay = this.backoffMs;
+    this.backoffMs = Math.min(this.backoffMs * BACKOFF_MULTIPLIER, BACKOFF_MAX_MS);
+
+    console.error(`[winevent-source] Restarting in ${delay}ms (attempt ${this.restartCount})`);
+    this.restartTimer = setTimeout(() => {
+      if (!this.disposed) this.spawn();
+    }, delay);
+  }
+
+  private clearRestartTimer(): void {
+    if (this.restartTimer) {
+      clearTimeout(this.restartTimer);
+      this.restartTimer = null;
+    }
+  }
+
+  private killProcess(): void {
+    if (this.process && !this.process.killed) {
+      try { this.process.kill("SIGTERM"); } catch { /* ignore */ }
+      this.process = null;
+    }
+  }
+
+  private setState(next: WinEventSourceState): void {
+    if (this.state === next) return;
+    this.state = next;
+    this.opts.onStateChange?.(next);
+  }
+
+  private defaultSidecarPath(): string {
+    // Resolve relative to this file's location
+    const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+    return path.join(__dirname, "..", "..", "bin", "dt-winevent-sidecar.exe");
+  }
+
+  __resetForTests(): void {
+    this.clearRestartTimer();
+    this.killProcess();
+    this.state         = "disabled";
+    this.lineBuffer    = "";
+    this.globalSeq     = 0;
+    this.backoffMs     = BACKOFF_INITIAL_MS;
+    this.restartCount  = 0;
+    this.startCount    = 0;
+    this._malformedLines      = 0;
+    this._lastRestartAtMs     = undefined;
+    this.disposed      = false;
+  }
+}
+
+// ── Module-level singleton ────────────────────────────────────────────────────
+
+let _source: WinEventSource | null = null;
+
+export function startWinEventSource(
+  onRawEvent: (event: RawWinEvent) => void,
+  opts?: { sidecarPath?: string; onStateChange?: (s: WinEventSourceState) => void }
+): WinEventSource {
+  stopWinEventSource();
+  _source = new WinEventSource({
+    onRawEvent,
+    onMalformedLine: (line) => {
+      console.error(`[winevent-source] Malformed sidecar line: ${line.slice(0, 200)}`);
+    },
+    onStateChange: opts?.onStateChange,
+    sidecarPath: opts?.sidecarPath,
+  });
+  _source.start();
+  return _source;
+}
+
+export function stopWinEventSource(): void {
+  if (_source) {
+    _source.stop();
+    _source = null;
+  }
+}
+
+export function getWinEventSourceState(): WinEventSourceState {
+  return _source?.getState() ?? "disabled";
+}

--- a/src/engine/winevent-source.ts
+++ b/src/engine/winevent-source.ts
@@ -151,6 +151,7 @@ export class WinEventSource {
 
     proc.once("error", (err) => {
       console.error(`[winevent-source] Sidecar process error: ${err.message}`);
+      this.process = null;
       if (!this.disposed) this.scheduleRestart();
     });
 
@@ -212,12 +213,16 @@ export class WinEventSource {
 
   private scheduleRestart(): void {
     if (this.disposed) return;
+    // Guard against double-fire from both "error" and "exit" events on the same crash.
+    if (this.state === "restarting" || this.state === "degraded") return;
+
     if (this.restartCount >= MAX_RESTART_CYCLES) {
       console.error("[winevent-source] Max restart cycles reached — staying degraded");
       this.setState("degraded");
       return;
     }
 
+    this.clearRestartTimer(); // clear any prior timer before setting a new one
     this.setState("restarting");
     this.restartCount++;
     this._lastRestartAtMs = Date.now();
@@ -229,6 +234,7 @@ export class WinEventSource {
     this.restartTimer = setTimeout(() => {
       if (!this.disposed) this.spawn();
     }, delay);
+    if (this.restartTimer.unref) this.restartTimer.unref();
   }
 
   private clearRestartTimer(): void {

--- a/src/server-windows.ts
+++ b/src/server-windows.ts
@@ -21,6 +21,7 @@ import { registerNotificationTools } from "./tools/notification.js";
 import { registerScrollToElementTools } from "./tools/scroll-to-element.js";
 import { registerSmartScrollTools } from "./tools/smart-scroll.js";
 import { registerPerceptionTools } from "./tools/perception.js";
+import { registerPerceptionResources, resourceRegistry } from "./tools/perception-resources.js";
 import { startTray, stopTray } from "./utils/tray.js";
 import { checkFailsafe, FailsafeError } from "./utils/failsafe.js";
 import { SERVER_VERSION } from "./version.js";
@@ -79,6 +80,25 @@ const server = new McpServer(
       "",
       "## Emergency stop (Failsafe)",
       "Move mouse to the top-left corner of the screen (within 10px of 0,0) to immediately terminate the MCP server.",
+      "",
+      "## Reactive Perception (lensId-based workflow)",
+      "For repeated interactions with the same window or browser tab, use the perception workflow:",
+      "1. perception_register(spec) — bind a lens to a window/tab; receive lensId",
+      "2. Pass lensId to action tools (mouse_click, keyboard_type, etc.) — the server evaluates safety guards before acting",
+      "3. Check post.perception in the tool response — attention/guards/changed summarize what happened",
+      "4. Use perception_read(lensId) to force a full refresh and get a fresh envelope",
+      "5. perception_forget(lensId) when done",
+      "",
+      "Attention values and recommended actions:",
+      "  ok           — safe to act",
+      "  changed      — state updated; verify before acting",
+      "  dirty        — evidence pending; call perception_read first",
+      "  settling     — window in motion; wait then call perception_read",
+      "  stale        — evidence may be old; call perception_read to refresh",
+      "  guard_failed — unsafe; read failedGuard.suggestedAction before proceeding",
+      "  identity_changed — window was replaced; re-register the lens",
+      "",
+      "Screenshots are a fallback — use perception_read for structured state.",
     ].join("\n"),
   }
 );
@@ -119,6 +139,11 @@ registerNotificationTools(server);
 registerScrollToElementTools(server);
 registerSmartScrollTools(server);
 registerPerceptionTools(server);
+
+// ─── Perception resources (opt-in: DESKTOP_TOUCH_PERCEPTION_RESOURCES=1) ──────
+if (process.env.DESKTOP_TOUCH_PERCEPTION_RESOURCES === "1") {
+  registerPerceptionResources(server);
+}
 
 // ─── Failsafe background monitor (backup for long-running operations) ─────────
 // Primary check: per-tool call via the wrapper above.

--- a/src/server-windows.ts
+++ b/src/server-windows.ts
@@ -21,7 +21,7 @@ import { registerNotificationTools } from "./tools/notification.js";
 import { registerScrollToElementTools } from "./tools/scroll-to-element.js";
 import { registerSmartScrollTools } from "./tools/smart-scroll.js";
 import { registerPerceptionTools } from "./tools/perception.js";
-import { registerPerceptionResources, resourceRegistry } from "./tools/perception-resources.js";
+import { registerPerceptionResources } from "./tools/perception-resources.js";
 import { startTray, stopTray } from "./utils/tray.js";
 import { checkFailsafe, FailsafeError } from "./utils/failsafe.js";
 import { SERVER_VERSION } from "./version.js";

--- a/src/tools/perception-resources.ts
+++ b/src/tools/perception-resources.ts
@@ -1,0 +1,137 @@
+/**
+ * perception-resources.ts
+ *
+ * MCP resource registration for per-lens Reactive Perception Graph state.
+ * Gated behind DESKTOP_TOUCH_PERCEPTION_RESOURCES=1.
+ *
+ * Views:
+ *   perception://lens/{lensId}/summary  — attention, canAct, guards, target/browser
+ *   perception://lens/{lensId}/guards   — full guard result list
+ *   perception://lens/{lensId}/debug    — all fluents + diagnostics (DEBUG_RESOURCES=1 only)
+ *   perception://lens/{lensId}/events   — reserved (DEBUG_RESOURCES=1 only)
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  buildLensSnapshot,
+  projectResourceSummary,
+  projectResourceGuards,
+  projectResourceDebug,
+} from "../engine/perception/resource-model.js";
+import { ResourceRegistry } from "../engine/perception/resource-registry.js";
+import { getStore, getLens, getAllLenses } from "../engine/perception/registry.js";
+import { getDirtyJournal } from "../engine/perception/registry.js";
+
+export const resourceRegistry = new ResourceRegistry();
+
+/** Called once at server start to register the perception resource template. */
+export function registerPerceptionResources(server: McpServer): void {
+  resourceRegistry.setOnListChanged(() => {
+    server.sendResourceListChanged();
+  });
+
+  // Dynamic template: perception://lens/{lensId}/{view}
+  const template = new ResourceTemplate(
+    "perception://lens/{lensId}/{view}",
+    {
+      list: async () => {
+        return { resources: resourceRegistry.listForClient() };
+      },
+      complete: {
+        lensId: async (_value) => {
+          return getAllLenses().map(l => l.lensId);
+        },
+        view: async (_value) => {
+          const views = ["summary", "guards"];
+          if (process.env.DESKTOP_TOUCH_PERCEPTION_DEBUG_RESOURCES === "1") {
+            views.push("debug", "events");
+          }
+          return views;
+        },
+      },
+    }
+  );
+
+  server.registerResource(
+    "perception-lens",
+    template,
+    {
+      title: "Perception Lens State",
+      description: "Read-only per-lens state for the Reactive Perception Graph. Views: summary, guards, debug (flag-gated).",
+      mimeType: "application/json",
+    },
+    async (uri, { lensId, view }) => {
+      const resolvedLensId = Array.isArray(lensId) ? lensId[0] : lensId;
+      const resolvedView   = Array.isArray(view)   ? view[0]   : view;
+
+      // Check for tombstone first
+      const tombstone = resourceRegistry.getTombstone(uri.href);
+      if (tombstone) {
+        return {
+          contents: [{
+            uri: uri.href,
+            mimeType: "application/json",
+            text: JSON.stringify({
+              attention: "tombstone",
+              lensId: tombstone.lensId,
+              removedAtMs: tombstone.removedAtMs,
+              message: tombstone.message,
+            }, null, 2),
+          }],
+        };
+      }
+
+      // Debug/events views are restricted
+      if ((resolvedView === "debug" || resolvedView === "events") &&
+          process.env.DESKTOP_TOUCH_PERCEPTION_DEBUG_RESOURCES !== "1") {
+        return {
+          contents: [{
+            uri: uri.href,
+            mimeType: "application/json",
+            text: JSON.stringify({
+              error: "not_found",
+              message: `View '${resolvedView}' requires DESKTOP_TOUCH_PERCEPTION_DEBUG_RESOURCES=1`,
+            }, null, 2),
+          }],
+        };
+      }
+
+      const lens = getLens(resolvedLensId);
+      if (!lens) {
+        return {
+          contents: [{
+            uri: uri.href,
+            mimeType: "application/json",
+            text: JSON.stringify({
+              error: "not_found",
+              message: `Lens '${resolvedLensId}' not found. Register it first with perception_register.`,
+            }, null, 2),
+          }],
+        };
+      }
+
+      const store   = getStore();
+      const journal = getDirtyJournal();
+      const snapshot = buildLensSnapshot(lens, store, journal);
+
+      let body: unknown;
+      switch (resolvedView) {
+        case "summary": body = projectResourceSummary(snapshot); break;
+        case "guards":  body = projectResourceGuards(snapshot);  break;
+        case "debug":   body = projectResourceDebug(snapshot);   break;
+        case "events":  body = { lensId: lens.lensId, message: "events view not yet implemented" }; break;
+        default:
+          body = { error: "unknown_view", view: resolvedView };
+      }
+
+      return {
+        contents: [{
+          uri: uri.href,
+          mimeType: "application/json",
+          text: JSON.stringify(body, null, 2),
+        }],
+      };
+    }
+  );
+}

--- a/tests/fixtures/mock-sidecar.js
+++ b/tests/fixtures/mock-sidecar.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * tests/fixtures/mock-sidecar.js
+ *
+ * Mock WinEvent sidecar for unit/integration testing.
+ * Reads JSON commands from stdin and emits synthetic WinEvent lines on stdout.
+ *
+ * Command format (one JSON object per line on stdin):
+ *   {"cmd":"emit","event":{"event":3,"hwnd":"100","idObject":0,"idChild":0,
+ *     "eventThread":1234,"sourceEventTimeMs":0,"sidecarSeq":1}}
+ *   {"cmd":"emit_many","events":[...]}
+ *   {"cmd":"exit","code":0}
+ *   {"cmd":"crash"}   — exits with non-zero to test restart logic
+ *
+ * The sidecar emits each event as a JSON line on stdout.
+ */
+
+import * as readline from "node:readline";
+
+let seq = 0;
+
+const rl = readline.createInterface({ input: process.stdin, terminal: false });
+
+rl.on("line", (line) => {
+  const trimmed = line.trim();
+  if (!trimmed) return;
+
+  let cmd;
+  try {
+    cmd = JSON.parse(trimmed);
+  } catch {
+    process.stderr.write(`[mock-sidecar] malformed command: ${trimmed}\n`);
+    return;
+  }
+
+  switch (cmd.cmd) {
+    case "emit": {
+      const ev = { ...cmd.event, sidecarSeq: ++seq };
+      process.stdout.write(JSON.stringify(ev) + "\n");
+      break;
+    }
+    case "emit_many": {
+      for (const e of cmd.events) {
+        const ev = { ...e, sidecarSeq: ++seq };
+        process.stdout.write(JSON.stringify(ev) + "\n");
+      }
+      break;
+    }
+    case "malformed": {
+      // Emit an unparseable line to test malformed-line handling
+      process.stdout.write("NOT_JSON_LINE\n");
+      break;
+    }
+    case "exit": {
+      process.exit(cmd.code ?? 0);
+      break;
+    }
+    case "crash": {
+      process.exit(1);
+      break;
+    }
+    default: {
+      process.stderr.write(`[mock-sidecar] unknown command: ${cmd.cmd}\n`);
+    }
+  }
+});
+
+rl.on("close", () => {
+  process.exit(0);
+});
+
+// Signal readiness
+process.stderr.write("[mock-sidecar] ready\n");

--- a/tests/unit/dirty-journal.test.ts
+++ b/tests/unit/dirty-journal.test.ts
@@ -1,0 +1,171 @@
+/**
+ * tests/unit/dirty-journal.test.ts
+ *
+ * Unit tests for DirtyJournal — uncertainty recording without sensor reads.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { DirtyJournal } from "../../src/engine/perception/dirty-journal.js";
+
+describe("DirtyJournal", () => {
+  let journal: DirtyJournal;
+
+  beforeEach(() => {
+    journal = new DirtyJournal();
+    journal.__resetForTests();
+  });
+
+  // ── mark / basic coalescing ──────────────────────────────────────────────
+
+  it("starts empty", () => {
+    expect(journal.hasDirty()).toBe(false);
+    expect(journal.entries().size).toBe(0);
+  });
+
+  it("mark creates an entry", () => {
+    journal.mark({ entityKey: "window:100", props: ["target.foreground"], cause: "EVENT_SYSTEM_FOREGROUND", monoMs: 1000 });
+    expect(journal.hasDirty()).toBe(true);
+    expect(journal.entries().size).toBe(1);
+    const entry = journal.entries().get("window:100")!;
+    expect(entry).toBeDefined();
+    expect(entry.props.has("target.foreground")).toBe(true);
+    expect(entry.eventCount).toBe(1);
+  });
+
+  it("coalesces multiple marks for the same entity into one entry", () => {
+    journal.mark({ entityKey: "window:100", props: ["target.foreground"], cause: "fg1", monoMs: 1000 });
+    journal.mark({ entityKey: "window:100", props: ["target.foreground"], cause: "fg2", monoMs: 1050 });
+    journal.mark({ entityKey: "window:100", props: ["target.foreground"], cause: "fg3", monoMs: 1100 });
+    expect(journal.entries().size).toBe(1);
+    const entry = journal.entries().get("window:100")!;
+    expect(entry.eventCount).toBe(3);
+    expect(entry.firstEventAtMonoMs).toBe(1000);
+    expect(entry.lastEventAtMonoMs).toBe(1100);
+  });
+
+  it("coalesces foreground A→B→C into one dirty entry", () => {
+    journal.mark({ entityKey: "window:100", props: ["target.foreground"], cause: "A", monoMs: 100 });
+    journal.mark({ entityKey: "window:200", props: ["target.foreground"], cause: "B", monoMs: 110 });
+    journal.mark({ entityKey: "window:100", props: ["target.foreground"], cause: "C", monoMs: 120 });
+    // Two different entities
+    expect(journal.entries().size).toBe(2);
+    const entry100 = journal.entries().get("window:100")!;
+    expect(entry100.eventCount).toBe(2);
+    expect(entry100.lastEventAtMonoMs).toBe(120);
+  });
+
+  it("merges different props for the same entity", () => {
+    journal.mark({ entityKey: "window:100", props: ["target.foreground"], cause: "fg", monoMs: 1000 });
+    journal.mark({ entityKey: "window:100", props: ["target.title"], cause: "name", monoMs: 1001 });
+    const entry = journal.entries().get("window:100")!;
+    expect(entry.props.has("target.foreground")).toBe(true);
+    expect(entry.props.has("target.title")).toBe(true);
+    expect(entry.eventCount).toBe(2);
+  });
+
+  it("accumulates unique causes only", () => {
+    journal.mark({ entityKey: "window:100", props: ["target.foreground"], cause: "same", monoMs: 1000 });
+    journal.mark({ entityKey: "window:100", props: ["target.foreground"], cause: "same", monoMs: 1001 });
+    const entry = journal.entries().get("window:100")!;
+    expect(entry.causes).toHaveLength(1);
+  });
+
+  // ── severity precedence ──────────────────────────────────────────────────
+
+  it("severity escalates to the highest seen", () => {
+    journal.mark({ entityKey: "window:100", props: ["target.foreground"], cause: "hint", monoMs: 100, severity: "hint" });
+    journal.mark({ entityKey: "window:100", props: ["target.exists"], cause: "show", monoMs: 110, severity: "structural" });
+    const entry = journal.entries().get("window:100")!;
+    expect(entry.severity).toBe("structural");
+  });
+
+  it("identityRisk beats structural", () => {
+    journal.mark({ entityKey: "window:100", props: ["target.exists"], cause: "destroy", monoMs: 100, severity: "structural" });
+    journal.mark({ entityKey: "window:100", props: ["target.identity"], cause: "reuse", monoMs: 110, severity: "identityRisk" });
+    journal.mark({ entityKey: "window:100", props: ["target.exists"], cause: "show", monoMs: 120, severity: "structural" });
+    const entry = journal.entries().get("window:100")!;
+    expect(entry.severity).toBe("identityRisk");
+  });
+
+  // ── clearFor / watermark correctness ──────────────────────────────────────
+
+  it("clearFor removes props when observation is newer than the last event", () => {
+    journal.mark({ entityKey: "window:100", props: ["target.foreground", "target.zOrder"], cause: "fg", monoMs: 1000 });
+    // Observation timestamp 1001 > lastEventAtMonoMs 1000 → clears
+    journal.clearFor("window:100", ["target.foreground"], 1001);
+    const entry = journal.entries().get("window:100")!;
+    expect(entry.props.has("target.foreground")).toBe(false);
+    expect(entry.props.has("target.zOrder")).toBe(true);
+  });
+
+  it("clearFor removes the entry when all props are cleared", () => {
+    journal.mark({ entityKey: "window:100", props: ["target.foreground"], cause: "fg", monoMs: 1000 });
+    journal.clearFor("window:100", ["target.foreground"], 1001);
+    expect(journal.entries().has("window:100")).toBe(false);
+    expect(journal.hasDirty()).toBe(false);
+  });
+
+  it("clearFor does NOT clear when observation is same age as last event", () => {
+    journal.mark({ entityKey: "window:100", props: ["target.foreground"], cause: "fg", monoMs: 1000 });
+    journal.clearFor("window:100", ["target.foreground"], 1000); // equal, not newer
+    const entry = journal.entries().get("window:100")!;
+    expect(entry.props.has("target.foreground")).toBe(true);
+  });
+
+  it("clearFor does NOT clear when observation is older than last event", () => {
+    journal.mark({ entityKey: "window:100", props: ["target.foreground"], cause: "fg1", monoMs: 1000 });
+    journal.mark({ entityKey: "window:100", props: ["target.foreground"], cause: "fg2", monoMs: 1100 }); // newer event
+    journal.clearFor("window:100", ["target.foreground"], 1050); // 1050 < lastEvent 1100
+    const entry = journal.entries().get("window:100")!;
+    expect(entry.props.has("target.foreground")).toBe(true);
+  });
+
+  it("clearFor on non-existent entity is a no-op", () => {
+    expect(() => journal.clearFor("window:999", ["target.foreground"], 9999)).not.toThrow();
+  });
+
+  // ── global dirty ──────────────────────────────────────────────────────────
+
+  it("markGlobal sets globalDirty flag", () => {
+    expect(journal.isGlobalDirty()).toBe(false);
+    journal.markGlobal("overflow", 5000);
+    expect(journal.isGlobalDirty()).toBe(true);
+    expect(journal.globalDirtyAtMonoMs()).toBe(5000);
+  });
+
+  it("clearGlobal removes globalDirty flag", () => {
+    journal.markGlobal("overflow", 5000);
+    journal.clearGlobal();
+    expect(journal.isGlobalDirty()).toBe(false);
+    expect(journal.globalDirtyAtMonoMs()).toBe(0);
+  });
+
+  it("markGlobal also updates existing per-entity entries to 'global' severity", () => {
+    journal.mark({ entityKey: "window:100", props: ["target.foreground"], cause: "fg", monoMs: 1000, severity: "hint" });
+    journal.markGlobal("overflow", 2000);
+    const entry = journal.entries().get("window:100")!;
+    expect(entry.severity).toBe("global");
+  });
+
+  // ── dirtyEntityKeys ────────────────────────────────────────────────────────
+
+  it("dirtyEntityKeys returns all entity keys with dirty props", () => {
+    journal.mark({ entityKey: "window:100", props: ["target.foreground"], cause: "fg", monoMs: 100 });
+    journal.mark({ entityKey: "window:200", props: ["target.title"],      cause: "name", monoMs: 200 });
+    const keys = journal.dirtyEntityKeys();
+    expect(keys).toContain("window:100");
+    expect(keys).toContain("window:200");
+    expect(keys).toHaveLength(2);
+  });
+
+  // ── __resetForTests ────────────────────────────────────────────────────────
+
+  it("__resetForTests clears all state", () => {
+    journal.mark({ entityKey: "window:100", props: ["target.foreground"], cause: "fg", monoMs: 100 });
+    journal.markGlobal("overflow", 200);
+    journal.__resetForTests();
+    expect(journal.hasDirty()).toBe(false);
+    expect(journal.isGlobalDirty()).toBe(false);
+    expect(journal.entries().size).toBe(0);
+  });
+});

--- a/tests/unit/fluent-store.test.ts
+++ b/tests/unit/fluent-store.test.ts
@@ -160,6 +160,75 @@ describe("FluentStore", () => {
     expect(obs.confidence).toBe(0.98);
   });
 
+  // ── validFromMonoMs ───────────────────────────────────────────────────────
+
+  it("apply sets validFromMonoMs on new fluent", () => {
+    store.apply([makeObs(1, "100", "target.title", "A")]);
+    const f = store.read("window:100.target.title");
+    expect(f?.validFromMonoMs).toBeTypeOf("number");
+    expect(f!.validFromMonoMs).toBeGreaterThan(0);
+  });
+
+  it("apply uses obs.monoMs when provided", () => {
+    const obs = { ...makeObs(1, "100", "target.title", "A"), monoMs: 12345 };
+    store.apply([obs]);
+    expect(store.read("window:100.target.title")?.validFromMonoMs).toBe(12345);
+  });
+
+  // ── markDirtyWithCause / watermark ────────────────────────────────────────
+
+  it("markDirtyWithCause sets status, cause, and monoMs", () => {
+    store.apply([makeObs(1, "100", "target.rect", { x: 0, y: 0, width: 800, height: 600 })]);
+    store.markDirtyWithCause(["window:100.target.rect"], "MOVESIZEEND", 9999);
+    const f = store.read("window:100.target.rect")!;
+    expect(f.status).toBe("dirty");
+    expect(f.lastDirtyCause).toBe("MOVESIZEEND");
+    expect(f.lastDirtyAtMonoMs).toBe(9999);
+  });
+
+  it("watermark rule: observation older than lastDirtyAtMonoMs does NOT clear dirty", () => {
+    store.apply([makeObs(1, "100", "target.rect", { x: 0, y: 0, width: 800, height: 600 })]);
+    store.markDirtyWithCause(["window:100.target.rect"], "move", 5000);
+
+    // Apply an observation with monoMs=4999 (BEFORE the dirty mark at 5000)
+    const staleObs = { ...makeObs(2, "100", "target.rect", { x: 10, y: 0, width: 800, height: 600 }), monoMs: 4999 };
+    const { changed } = store.apply([staleObs]);
+    expect(changed.size).toBe(0); // skipped
+    expect(store.read("window:100.target.rect")?.status).toBe("dirty"); // still dirty
+    expect(store.read("window:100.target.rect")?.value).toEqual({ x: 0, y: 0, width: 800, height: 600 }); // old value preserved
+  });
+
+  it("observation EQUAL to lastDirtyAtMonoMs does NOT clear dirty (boundary)", () => {
+    store.apply([makeObs(1, "100", "target.rect", { x: 0, y: 0, width: 800, height: 600 })]);
+    store.markDirtyWithCause(["window:100.target.rect"], "move", 5000);
+
+    const equalObs = { ...makeObs(2, "100", "target.rect", { x: 10, y: 0, width: 800, height: 600 }), monoMs: 5000 };
+    store.apply([equalObs]);
+    expect(store.read("window:100.target.rect")?.status).toBe("dirty");
+  });
+
+  it("observation NEWER than lastDirtyAtMonoMs DOES clear dirty and updates fluent", () => {
+    store.apply([makeObs(1, "100", "target.rect", { x: 0, y: 0, width: 800, height: 600 })]);
+    store.markDirtyWithCause(["window:100.target.rect"], "move", 5000);
+
+    const freshObs = { ...makeObs(2, "100", "target.rect", { x: 20, y: 0, width: 800, height: 600 }), monoMs: 5001 };
+    const { changed } = store.apply([freshObs]);
+    expect(changed.size).toBe(1);
+    expect(store.read("window:100.target.rect")?.status).toBe("observed");
+    expect((store.read("window:100.target.rect")?.value as { x: number }).x).toBe(20);
+  });
+
+  // ── markSettling ──────────────────────────────────────────────────────────
+
+  it("markSettling sets status to settling", () => {
+    store.apply([makeObs(1, "100", "target.rect", { x: 0, y: 0, width: 800, height: 600 })]);
+    store.markSettling(["window:100.target.rect"], 7000);
+    const f = store.read("window:100.target.rect")!;
+    expect(f.status).toBe("settling");
+    expect(f.lastDirtyAtMonoMs).toBe(7000);
+    expect(f.lastDirtyCause).toBe("settling");
+  });
+
   // ── __resetForTests ───────────────────────────────────────────────────────
 
   it("__resetForTests clears state", () => {

--- a/tests/unit/flush-scheduler.test.ts
+++ b/tests/unit/flush-scheduler.test.ts
@@ -1,0 +1,165 @@
+/**
+ * tests/unit/flush-scheduler.test.ts
+ *
+ * Unit tests for FlushScheduler — debounced sensor refresh scheduling.
+ * Uses vitest fake timers for deterministic timer control.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { FlushScheduler, DEFAULT_DEBOUNCE_MS } from "../../src/engine/perception/flush-scheduler.js";
+
+describe("FlushScheduler — default debounce", () => {
+  it("DEFAULT_DEBOUNCE_MS exports expected values", () => {
+    expect(DEFAULT_DEBOUNCE_MS.foreground).toBe(100);
+    expect(DEFAULT_DEBOUNCE_MS.location).toBe(150);
+    expect(DEFAULT_DEBOUNCE_MS.overflow).toBe(0);
+    expect(DEFAULT_DEBOUNCE_MS.move_end).toBe(50);
+  });
+});
+
+describe("FlushScheduler — trailing debounce", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fires once after the debounce window for a single schedule call", () => {
+    const calls: string[] = [];
+    const scheduler = new FlushScheduler({ onFlush: (r) => { calls.push(r); } });
+
+    scheduler.schedule("foreground", "fg1");
+    expect(calls).toHaveLength(0); // not fired yet
+
+    vi.advanceTimersByTime(DEFAULT_DEBOUNCE_MS.foreground);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain("fg1");
+
+    scheduler.dispose();
+  });
+
+  it("coalesces multiple schedule calls into one flush (trailing)", () => {
+    const calls: string[] = [];
+    const scheduler = new FlushScheduler({ onFlush: (r) => { calls.push(r); } });
+
+    // 50 location events within 150ms → only one flush
+    for (let i = 0; i < 50; i++) {
+      scheduler.schedule("location", `loc${i}`);
+      vi.advanceTimersByTime(2); // 2ms per event, 100ms total (< 150ms debounce)
+    }
+    expect(calls).toHaveLength(0); // still pending
+
+    vi.advanceTimersByTime(DEFAULT_DEBOUNCE_MS.location);
+    expect(calls).toHaveLength(1);
+
+    scheduler.dispose();
+  });
+
+  it("fires again after quiet window reset", () => {
+    const calls: string[] = [];
+    const scheduler = new FlushScheduler({ onFlush: (r) => { calls.push(r); } });
+
+    scheduler.schedule("foreground", "fg1");
+    vi.advanceTimersByTime(DEFAULT_DEBOUNCE_MS.foreground);
+    expect(calls).toHaveLength(1);
+
+    // Second batch
+    scheduler.schedule("foreground", "fg2");
+    vi.advanceTimersByTime(DEFAULT_DEBOUNCE_MS.foreground);
+    expect(calls).toHaveLength(2);
+
+    scheduler.dispose();
+  });
+
+  it("fires synchronously for overflow (debounce=0)", () => {
+    const calls: string[] = [];
+    const scheduler = new FlushScheduler({ onFlush: (r) => { calls.push(r); } });
+
+    scheduler.schedule("overflow", "queue_overflow");
+    // No timer advance needed — debounce=0 fires synchronously
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain("queue_overflow");
+
+    scheduler.dispose();
+  });
+
+  it("fires synchronously for move_start (debounce=0)", () => {
+    const calls: string[] = [];
+    const scheduler = new FlushScheduler({ onFlush: (r) => { calls.push(r); } });
+
+    scheduler.schedule("move_start", "drag_started");
+    expect(calls).toHaveLength(1);
+
+    scheduler.dispose();
+  });
+
+  it("custom debounce override is respected", () => {
+    const calls: string[] = [];
+    const scheduler = new FlushScheduler({
+      debounceMs: { foreground: 200 },
+      onFlush: (r) => { calls.push(r); },
+    });
+
+    scheduler.schedule("foreground", "fg");
+    vi.advanceTimersByTime(150); // less than 200ms
+    expect(calls).toHaveLength(0);
+
+    vi.advanceTimersByTime(60); // total 210ms > 200ms
+    expect(calls).toHaveLength(1);
+
+    scheduler.dispose();
+  });
+});
+
+describe("FlushScheduler — scheduleImmediate", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("cancels all pending timers and fires immediately", () => {
+    const calls: string[] = [];
+    const scheduler = new FlushScheduler({ onFlush: (r) => { calls.push(r); } });
+
+    // Queue several pending
+    scheduler.schedule("foreground", "fg");
+    scheduler.schedule("location", "loc");
+    expect(calls).toHaveLength(0);
+
+    scheduler.scheduleImmediate("forced");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain("forced");
+
+    // Advance timers — no extra calls from the cancelled timers
+    vi.advanceTimersByTime(500);
+    expect(calls).toHaveLength(1);
+
+    scheduler.dispose();
+  });
+});
+
+describe("FlushScheduler — dispose", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("dispose cancels pending timers and ignores future schedule calls", () => {
+    const calls: string[] = [];
+    const scheduler = new FlushScheduler({ onFlush: (r) => { calls.push(r); } });
+
+    scheduler.schedule("foreground", "fg");
+    scheduler.dispose();
+
+    vi.advanceTimersByTime(1000);
+    expect(calls).toHaveLength(0); // timer was cancelled
+  });
+});

--- a/tests/unit/flush-scheduler.test.ts
+++ b/tests/unit/flush-scheduler.test.ts
@@ -111,6 +111,39 @@ describe("FlushScheduler — trailing debounce", () => {
 
     scheduler.dispose();
   });
+
+  it("50 LOCATIONCHANGE events within 150ms coalesce into a single flush (Milestone 4)", () => {
+    const calls: string[] = [];
+    const scheduler = new FlushScheduler({ onFlush: (r) => { calls.push(r); } });
+
+    // 50 location events fired every 2ms = 100ms total (< 150ms debounce)
+    for (let i = 0; i < 50; i++) {
+      scheduler.schedule("location", `locationchange:hwnd=100:seq=${i}`);
+      vi.advanceTimersByTime(2);
+    }
+    expect(calls).toHaveLength(0); // still within debounce window
+
+    vi.advanceTimersByTime(DEFAULT_DEBOUNCE_MS.location);
+    expect(calls).toHaveLength(1); // single coalesced flush
+
+    scheduler.dispose();
+  });
+
+  it("MOVESIZESTART fires synchronously (debounce=0), MOVESIZEEND fires after 50ms", () => {
+    const calls: string[] = [];
+    const scheduler = new FlushScheduler({ onFlush: (r) => { calls.push(r); } });
+
+    scheduler.schedule("move_start", "movesizestart:hwnd=100");
+    expect(calls).toHaveLength(1); // synchronous
+
+    scheduler.schedule("move_end", "movesizeend:hwnd=100");
+    expect(calls).toHaveLength(1); // pending
+
+    vi.advanceTimersByTime(DEFAULT_DEBOUNCE_MS.move_end);
+    expect(calls).toHaveLength(2); // flushed after 50ms
+
+    scheduler.dispose();
+  });
 });
 
 describe("FlushScheduler — scheduleImmediate", () => {

--- a/tests/unit/guards-eval.test.ts
+++ b/tests/unit/guards-eval.test.ts
@@ -165,6 +165,49 @@ describe("safe.keyboardTarget", () => {
     expect(result.ok).toBe(false);
     expect(result.reason).toMatch(/confidence/i);
   });
+
+  it("fails when foreground status is dirty (watermark gate)", () => {
+    const store = makeStore();
+    populateStore(store, hwnd);
+    store.markDirtyWithCause([`window:${hwnd}.target.foreground`], "foreground_change", 9000);
+    const result = evaluateGuard("safe.keyboardTarget", makeLens(), store, Date.now());
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/dirty/i);
+  });
+
+  it("fails when foreground status is settling (watermark gate)", () => {
+    const store = makeStore();
+    populateStore(store, hwnd);
+    store.markSettling([`window:${hwnd}.target.foreground`], 9000);
+    const result = evaluateGuard("safe.keyboardTarget", makeLens(), store, Date.now());
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/settling/i);
+  });
+
+  it("fails when foreground evidence is older than dirty mark (watermark gate, status=dirty)", () => {
+    const store = makeStore();
+    // Apply observation with explicit early monoMs
+    const nowMs = Date.now();
+    const ev = makeEvidence("win32", 1, nowMs);
+    store.apply([{
+      seq: 1, tsMs: nowMs, source: "win32",
+      entity: { kind: "window", id: hwnd }, property: "target.identity",
+      value: { pid: 1234, processStartTimeMs: 1700000000000 }, confidence: 0.98, evidence: ev,
+    }]);
+    store.apply([{
+      seq: 2, tsMs: nowMs, source: "win32",
+      entity: { kind: "window", id: hwnd }, property: "target.foreground",
+      value: true, confidence: 0.98, evidence: ev,
+      monoMs: 1000,  // observation monoMs = 1000
+    }]);
+    // dirty mark at monoMs=2000 (AFTER the observation) → status becomes "dirty"
+    // old obs (monoMs=1000) cannot clear dirty (watermark prevents it)
+    store.markDirtyWithCause([`window:${hwnd}.target.foreground`], "fg_change", 2000);
+    const result = evaluateGuard("safe.keyboardTarget", makeLens(), store, Date.now());
+    expect(result.ok).toBe(false);
+    // dirty status check fires first (Rule 1) — confirms guard blocks
+    expect(result.reason).toMatch(/dirty/i);
+  });
 });
 
 describe("safe.clickCoordinates", () => {
@@ -198,6 +241,46 @@ describe("safe.clickCoordinates", () => {
     populateStore(store, hwnd);
     const result = evaluateGuard("safe.clickCoordinates", makeLens(), store, Date.now(), {});
     expect(result.ok).toBe(true);
+  });
+
+  it("fails when rect status is dirty (watermark gate)", () => {
+    const store = makeStore();
+    populateStore(store, hwnd);
+    store.markDirtyWithCause([`window:${hwnd}.target.rect`], "move", 9000);
+    const result = evaluateGuard("safe.clickCoordinates", makeLens(), store, Date.now(), { clickX: 100, clickY: 100 });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/dirty/i);
+  });
+
+  it("fails when rect status is settling (watermark gate)", () => {
+    const store = makeStore();
+    populateStore(store, hwnd);
+    store.markSettling([`window:${hwnd}.target.rect`], 9000);
+    const result = evaluateGuard("safe.clickCoordinates", makeLens(), store, Date.now(), { clickX: 100, clickY: 100 });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/settling/i);
+  });
+
+  it("fails when rect evidence is older than dirty mark (watermark gate, status=dirty)", () => {
+    const store = makeStore();
+    const nowMs = Date.now();
+    const ev = makeEvidence("win32", 1, nowMs);
+    store.apply([{
+      seq: 1, tsMs: nowMs, source: "win32",
+      entity: { kind: "window", id: hwnd }, property: "target.identity",
+      value: { pid: 1234, processStartTimeMs: 1700000000000 }, confidence: 0.98, evidence: ev,
+    }]);
+    store.apply([{
+      seq: 2, tsMs: nowMs, source: "win32",
+      entity: { kind: "window", id: hwnd }, property: "target.rect",
+      value: { x: 0, y: 0, width: 800, height: 600 }, confidence: 0.98, evidence: ev,
+      monoMs: 1000,  // observation monoMs = 1000
+    }]);
+    // dirty mark at monoMs=2000 (AFTER the observation) → status becomes "dirty"
+    store.markDirtyWithCause([`window:${hwnd}.target.rect`], "move", 2000);
+    const result = evaluateGuard("safe.clickCoordinates", makeLens(), store, Date.now(), { clickX: 100, clickY: 100 });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/dirty/i);
   });
 });
 
@@ -242,6 +325,58 @@ describe("stable.rect", () => {
     const result = evaluateGuard("stable.rect", makeLens(), store, Date.now());
     expect(result.ok).toBe(true);
     expect(result.confidence).toBe(0.6);
+  });
+
+  it("fails when rect status is settling", () => {
+    const store = makeStore();
+    populateStore(store, hwnd);
+    store.markSettling([`window:${hwnd}.target.rect`], 9000);
+    const result = evaluateGuard("stable.rect", makeLens(), store, Date.now());
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/settling/i);
+  });
+
+  it("fails when rect evidence is older than dirty mark (watermark rule, status=dirty)", () => {
+    const store = makeStore();
+    const nowMs = Date.now();
+    const ev = makeEvidence("win32", 1, nowMs);
+    store.apply([{
+      seq: 1, tsMs: nowMs, source: "win32",
+      entity: { kind: "window", id: hwnd }, property: "target.rect",
+      value: { x: 0, y: 0, width: 800, height: 600 }, confidence: 0.98, evidence: ev,
+      monoMs: 1000,  // observation before dirty mark
+    }]);
+    // dirty mark at monoMs=2000 → status="dirty"; old obs cannot clear it (watermark)
+    store.markDirtyWithCause([`window:${hwnd}.target.rect`], "move", 2000);
+    const result = evaluateGuard("stable.rect", makeLens(), store, Date.now());
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/dirty/i);
+  });
+
+  it("passes with confidence=0.6 for rect observed right after dirty mark (quiet window < 250ms)", () => {
+    const store = makeStore();
+    const nowMs = Date.now();
+    const ev = makeEvidence("win32", 1, nowMs);
+    // First apply to establish the fluent
+    store.apply([{
+      seq: 1, tsMs: nowMs, source: "win32",
+      entity: { kind: "window", id: hwnd }, property: "target.rect",
+      value: { x: 0, y: 0, width: 800, height: 600 }, confidence: 0.98, evidence: ev,
+      monoMs: 1000,
+    }]);
+    // Mark dirty at monoMs=2000
+    store.markDirtyWithCause([`window:${hwnd}.target.rect`], "move", 2000);
+    // Apply fresh observation at monoMs=2050 (just 50ms after dirty, < 250ms quiet window)
+    const ev2 = makeEvidence("win32", 2, nowMs);
+    store.apply([{
+      seq: 2, tsMs: nowMs, source: "win32",
+      entity: { kind: "window", id: hwnd }, property: "target.rect",
+      value: { x: 10, y: 0, width: 800, height: 600 }, confidence: 0.98, evidence: ev2,
+      monoMs: 2050,
+    }]);
+    const result = evaluateGuard("stable.rect", makeLens(), store, Date.now());
+    expect(result.ok).toBe(true);
+    expect(result.confidence).toBe(0.6); // quiet window not yet elapsed
   });
 });
 

--- a/tests/unit/lens-event-index.test.ts
+++ b/tests/unit/lens-event-index.test.ts
@@ -1,0 +1,167 @@
+/**
+ * tests/unit/lens-event-index.test.ts
+ *
+ * Unit tests for LensEventIndex — event-to-lens routing.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  createLensEventIndex,
+  addLensToIndex,
+  removeLensFromIndex,
+  rebuildLensEventIndex,
+  lensesForHwnd,
+  lensesForForegroundEvent,
+} from "../../src/engine/perception/lens-event-index.js";
+import type { PerceptionLens, WindowIdentity, LensSpec } from "../../src/engine/perception/types.js";
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const baseIdentity: WindowIdentity = {
+  hwnd: "100",
+  pid: 1234,
+  processName: "notepad.exe",
+  processStartTimeMs: 1700000000000,
+  titleResolved: "Untitled",
+};
+
+function makeLens(
+  lensId: string,
+  hwnd: string,
+  maintain: string[],
+  pid = 1234
+): PerceptionLens {
+  const identity: WindowIdentity = { ...baseIdentity, hwnd, pid };
+  return {
+    lensId,
+    spec: {
+      name: lensId,
+      target: { kind: "window", match: { titleIncludes: "test" } },
+      maintain: maintain as LensSpec["maintain"],
+      guards: [],
+      guardPolicy: "block",
+      maxEnvelopeTokens: 120,
+      salience: "normal",
+    },
+    binding: { hwnd, windowTitle: "Test" },
+    boundIdentity: identity,
+    fluentKeys: maintain.map(m => `window:${hwnd}.${m}`),
+    registeredAtSeq: 0,
+    registeredAtMs: Date.now(),
+  };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("LensEventIndex — add / remove", () => {
+  it("adds a lens to byHwnd", () => {
+    const index = createLensEventIndex();
+    const lens = makeLens("perc-1", "100", ["target.foreground"]);
+    addLensToIndex(index, lens);
+    expect(index.byHwnd.get("100")?.has("perc-1")).toBe(true);
+  });
+
+  it("adds a lens to byPid", () => {
+    const index = createLensEventIndex();
+    const lens = makeLens("perc-1", "100", ["target.foreground"], 9999);
+    addLensToIndex(index, lens);
+    expect(index.byPid.get(9999)?.has("perc-1")).toBe(true);
+  });
+
+  it("marks foregroundSensitive when lens maintains target.foreground", () => {
+    const index = createLensEventIndex();
+    addLensToIndex(index, makeLens("perc-1", "100", ["target.foreground"]));
+    expect(index.foregroundSensitive.has("perc-1")).toBe(true);
+    expect(index.modalSensitive.has("perc-1")).toBe(false);
+  });
+
+  it("marks modalSensitive when lens maintains modal.above", () => {
+    const index = createLensEventIndex();
+    addLensToIndex(index, makeLens("perc-1", "100", ["modal.above"]));
+    expect(index.modalSensitive.has("perc-1")).toBe(true);
+  });
+
+  it("marks zOrderSensitive when lens maintains target.zOrder", () => {
+    const index = createLensEventIndex();
+    addLensToIndex(index, makeLens("perc-1", "100", ["target.zOrder"]));
+    expect(index.zOrderSensitive.has("perc-1")).toBe(true);
+  });
+
+  it("lens can be in multiple sensitivity sets", () => {
+    const index = createLensEventIndex();
+    addLensToIndex(index, makeLens("perc-1", "100", ["target.foreground", "modal.above", "target.zOrder"]));
+    expect(index.foregroundSensitive.has("perc-1")).toBe(true);
+    expect(index.modalSensitive.has("perc-1")).toBe(true);
+    expect(index.zOrderSensitive.has("perc-1")).toBe(true);
+  });
+
+  it("removes a lens from all buckets", () => {
+    const index = createLensEventIndex();
+    const lens = makeLens("perc-1", "100", ["target.foreground", "modal.above", "target.zOrder"], 1234);
+    addLensToIndex(index, lens);
+    removeLensFromIndex(index, lens);
+    expect(index.byHwnd.get("100")).toBeUndefined();
+    expect(index.byPid.get(1234)).toBeUndefined();
+    expect(index.foregroundSensitive.has("perc-1")).toBe(false);
+    expect(index.modalSensitive.has("perc-1")).toBe(false);
+    expect(index.zOrderSensitive.has("perc-1")).toBe(false);
+  });
+
+  it("removing one lens leaves others in the same hwnd bucket", () => {
+    const index = createLensEventIndex();
+    addLensToIndex(index, makeLens("perc-1", "100", ["target.foreground"]));
+    addLensToIndex(index, makeLens("perc-2", "100", ["target.title"]));
+    removeLensFromIndex(index, makeLens("perc-1", "100", ["target.foreground"]));
+    expect(index.byHwnd.get("100")?.has("perc-2")).toBe(true);
+    expect(index.byHwnd.get("100")?.has("perc-1")).toBe(false);
+  });
+});
+
+describe("LensEventIndex — rebuild", () => {
+  it("rebuilds from a collection of lenses", () => {
+    const lenses = [
+      makeLens("perc-1", "100", ["target.foreground", "modal.above"]),
+      makeLens("perc-2", "200", ["target.title"]),
+    ];
+    const index = rebuildLensEventIndex(lenses);
+    expect(index.byHwnd.get("100")?.has("perc-1")).toBe(true);
+    expect(index.byHwnd.get("200")?.has("perc-2")).toBe(true);
+    expect(index.foregroundSensitive.has("perc-1")).toBe(true);
+    expect(index.modalSensitive.has("perc-1")).toBe(true);
+    expect(index.foregroundSensitive.has("perc-2")).toBe(false);
+  });
+});
+
+describe("LensEventIndex — routing", () => {
+  it("lensesForHwnd returns only lenses bound to that hwnd", () => {
+    const index = createLensEventIndex();
+    addLensToIndex(index, makeLens("perc-1", "100", ["target.foreground"]));
+    addLensToIndex(index, makeLens("perc-2", "200", ["target.foreground"]));
+    const result = lensesForHwnd(index, "100");
+    expect(result.has("perc-1")).toBe(true);
+    expect(result.has("perc-2")).toBe(false);
+  });
+
+  it("lensesForHwnd returns empty set for unknown hwnd", () => {
+    const index = createLensEventIndex();
+    expect(lensesForHwnd(index, "999").size).toBe(0);
+  });
+
+  it("lensesForForegroundEvent includes direct hwnd match AND all foreground-sensitive lenses", () => {
+    const index = createLensEventIndex();
+    // perc-1 is bound to hwnd 100 and is foreground-sensitive
+    addLensToIndex(index, makeLens("perc-1", "100", ["target.foreground"]));
+    // perc-2 is bound to hwnd 200 and is foreground-sensitive (its window lost foreground)
+    addLensToIndex(index, makeLens("perc-2", "200", ["target.foreground"]));
+    // perc-3 is bound to hwnd 300 but NOT foreground-sensitive
+    addLensToIndex(index, makeLens("perc-3", "300", ["target.title"]));
+
+    const result = lensesForForegroundEvent(index, "100");
+    // perc-1: direct hwnd match
+    expect(result.has("perc-1")).toBe(true);
+    // perc-2: foreground-sensitive (needs to update its foreground=false)
+    expect(result.has("perc-2")).toBe(true);
+    // perc-3: not foreground-sensitive and not bound to hwnd 100
+    expect(result.has("perc-3")).toBe(false);
+  });
+});

--- a/tests/unit/raw-event-queue.test.ts
+++ b/tests/unit/raw-event-queue.test.ts
@@ -1,0 +1,133 @@
+/**
+ * tests/unit/raw-event-queue.test.ts
+ *
+ * Unit tests for RawEventQueue — bounded ring buffer for WinEvents.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { RawEventQueue } from "../../src/engine/perception/raw-event-queue.js";
+import type { RawWinEvent } from "../../src/engine/perception/raw-event-queue.js";
+
+function makeEvent(seq: number, hwnd = "100"): RawWinEvent {
+  return {
+    event: 0x0003, // EVENT_SYSTEM_FOREGROUND
+    hwnd,
+    idObject: 0,
+    idChild: 0,
+    eventThread: 1234,
+    sourceEventTimeMs: 0,
+    sidecarSeq: seq,
+    receivedAtMonoMs: seq * 10,
+    receivedAtUnixMs: 1700000000000 + seq,
+    globalSeq: seq,
+  };
+}
+
+describe("RawEventQueue — basic operations", () => {
+  let queue: RawEventQueue;
+
+  beforeEach(() => {
+    queue = new RawEventQueue({ maxSize: 8, batchMax: 4 });
+    queue.__resetForTests();
+  });
+
+  it("starts empty with zero diagnostics", () => {
+    const d = queue.diagnostics();
+    expect(d.pendingCount).toBe(0);
+    expect(d.totalEnqueued).toBe(0);
+    expect(d.totalDropped).toBe(0);
+    expect(queue.overflowPending).toBe(false);
+  });
+
+  it("enqueues events and returns them via drain", () => {
+    queue.enqueue(makeEvent(1));
+    queue.enqueue(makeEvent(2));
+    const batch = queue.drain();
+    expect(batch).toHaveLength(2);
+    expect(batch[0].sidecarSeq).toBe(1);
+    expect(batch[1].sidecarSeq).toBe(2);
+  });
+
+  it("drain returns at most batchMax events", () => {
+    for (let i = 1; i <= 6; i++) queue.enqueue(makeEvent(i));
+    const batch = queue.drain();
+    expect(batch).toHaveLength(4); // batchMax=4
+    expect(queue.pendingCount).toBe(2);
+  });
+
+  it("drain returns empty array when queue is empty", () => {
+    expect(queue.drain()).toHaveLength(0);
+  });
+
+  it("drain clears overflowPending", () => {
+    // Fill to overflow
+    for (let i = 1; i <= 9; i++) queue.enqueue(makeEvent(i));
+    expect(queue.overflowPending).toBe(true);
+    queue.drain();
+    expect(queue.overflowPending).toBe(false);
+  });
+});
+
+describe("RawEventQueue — overflow behavior", () => {
+  it("drops oldest when maxSize is exceeded", () => {
+    const queue = new RawEventQueue({ maxSize: 3, batchMax: 10 });
+
+    queue.enqueue(makeEvent(1)); // will be dropped
+    queue.enqueue(makeEvent(2));
+    queue.enqueue(makeEvent(3));
+    queue.enqueue(makeEvent(4)); // triggers overflow, drops seq=1
+
+    const batch = queue.drain();
+    const seqs = batch.map(e => e.sidecarSeq);
+    expect(seqs).not.toContain(1); // oldest dropped
+    expect(seqs).toContain(4);
+    expect(queue.diagnostics().totalDropped).toBe(1);
+    expect(queue.diagnostics().overflowCount).toBe(1);
+  });
+
+  it("sets overflowPending on overflow", () => {
+    const queue = new RawEventQueue({ maxSize: 2, batchMax: 10 });
+    queue.enqueue(makeEvent(1));
+    queue.enqueue(makeEvent(2));
+    expect(queue.overflowPending).toBe(false);
+    queue.enqueue(makeEvent(3)); // overflow
+    expect(queue.overflowPending).toBe(true);
+  });
+
+  it("multiple overflows accumulate overflowCount", () => {
+    const queue = new RawEventQueue({ maxSize: 2, batchMax: 10 });
+    queue.enqueue(makeEvent(1));
+    queue.enqueue(makeEvent(2));
+    queue.enqueue(makeEvent(3)); // overflow 1
+    queue.enqueue(makeEvent(4)); // overflow 2
+    expect(queue.diagnostics().overflowCount).toBe(2);
+    expect(queue.diagnostics().totalDropped).toBe(2);
+  });
+
+  it("diagnostics track totalEnqueued and totalDrained accurately", () => {
+    const queue = new RawEventQueue({ maxSize: 10, batchMax: 4 });
+    for (let i = 1; i <= 6; i++) queue.enqueue(makeEvent(i));
+    queue.drain();
+    const d = queue.diagnostics();
+    expect(d.totalEnqueued).toBe(6);
+    expect(d.totalDrained).toBe(4);
+    expect(d.pendingCount).toBe(2);
+  });
+});
+
+describe("RawEventQueue — __resetForTests", () => {
+  it("clears all state", () => {
+    const queue = new RawEventQueue({ maxSize: 4, batchMax: 4 });
+    queue.enqueue(makeEvent(1));
+    queue.enqueue(makeEvent(2));
+    queue.enqueue(makeEvent(3));
+    queue.enqueue(makeEvent(4));
+    queue.enqueue(makeEvent(5)); // overflow
+    queue.__resetForTests();
+    const d = queue.diagnostics();
+    expect(d.pendingCount).toBe(0);
+    expect(d.totalEnqueued).toBe(0);
+    expect(d.overflowCount).toBe(0);
+    expect(queue.overflowPending).toBe(false);
+  });
+});

--- a/tests/unit/reconciliation.test.ts
+++ b/tests/unit/reconciliation.test.ts
@@ -1,0 +1,118 @@
+/**
+ * tests/unit/reconciliation.test.ts
+ *
+ * Unit tests for ReconciliationScheduler.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { ReconciliationScheduler } from "../../src/engine/perception/reconciliation.js";
+import { DirtyJournal } from "../../src/engine/perception/dirty-journal.js";
+import { createLensEventIndex } from "../../src/engine/perception/lens-event-index.js";
+import type { PerceptionLens } from "../../src/engine/perception/types.js";
+
+function makeScheduler(onReconcile: ConstructorParameters<typeof ReconciliationScheduler>[4]["onReconcile"]) {
+  const journal = new DirtyJournal();
+  journal.__resetForTests();
+  const index = createLensEventIndex();
+
+  return new ReconciliationScheduler(
+    () => [] as PerceptionLens[],
+    () => journal,
+    () => index,
+    () => new Set(["100", "200"]),
+    { onReconcile },
+  );
+}
+
+describe("ReconciliationScheduler — triggerImmediate", () => {
+  it("calls onReconcile immediately with overflow trigger when dirty", () => {
+    const calls: string[] = [];
+    const journal = new DirtyJournal();
+    journal.__resetForTests();
+    journal.mark({ entityKey: "window:100", props: ["target.rect"], cause: "move", monoMs: 100 });
+
+    const index = createLensEventIndex();
+    const scheduler = new ReconciliationScheduler(
+      () => [],
+      () => journal,
+      () => index,
+      () => new Set(["100"]),
+      {
+        onReconcile: (opts) => { calls.push(opts.trigger); },
+      }
+    );
+
+    scheduler.triggerImmediate();
+    expect(calls).toContain("overflow");
+    scheduler.stop();
+  });
+
+  it("calls onReconcile even when nothing is dirty (overflow forces full sweep)", () => {
+    const calls: unknown[] = [];
+    const scheduler = makeScheduler((opts) => calls.push(opts));
+    scheduler.triggerImmediate();
+    // overflow always reconciles regardless of dirty state
+    expect(calls).toHaveLength(1);
+    scheduler.stop();
+  });
+});
+
+describe("ReconciliationScheduler — sweep timer", () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it("does NOT fire sweep when nothing is dirty", () => {
+    const calls: unknown[] = [];
+    const scheduler = makeScheduler((opts) => calls.push(opts));
+    scheduler.start();
+
+    vi.advanceTimersByTime(5_001);
+    expect(calls).toHaveLength(0); // nothing dirty → skip
+
+    scheduler.stop();
+  });
+
+  it("fires sweep when there are dirty entries", () => {
+    const journal = new DirtyJournal();
+    journal.__resetForTests();
+    journal.mark({ entityKey: "window:100", props: ["target.foreground"], cause: "fg", monoMs: 100 });
+
+    const index = createLensEventIndex();
+    const calls: unknown[] = [];
+    const scheduler = new ReconciliationScheduler(
+      () => [],
+      () => journal,
+      () => index,
+      () => new Set(["100"]),
+      { onReconcile: (opts) => calls.push(opts) }
+    );
+    scheduler.start();
+
+    vi.advanceTimersByTime(5_001);
+    expect(calls).toHaveLength(1);
+    expect((calls[0] as { trigger: string }).trigger).toBe("sweep");
+
+    scheduler.stop();
+  });
+
+  it("stop() prevents future sweeps", () => {
+    const journal = new DirtyJournal();
+    journal.__resetForTests();
+    journal.mark({ entityKey: "window:100", props: ["target.foreground"], cause: "fg", monoMs: 100 });
+
+    const index = createLensEventIndex();
+    const calls: unknown[] = [];
+    const scheduler = new ReconciliationScheduler(
+      () => [],
+      () => journal,
+      () => index,
+      () => new Set(["100"]),
+      { onReconcile: (opts) => calls.push(opts) }
+    );
+    scheduler.start();
+    scheduler.stop();
+
+    vi.advanceTimersByTime(10_000);
+    expect(calls).toHaveLength(0); // stopped before any sweep
+  });
+});

--- a/tests/unit/refresh-plan.test.ts
+++ b/tests/unit/refresh-plan.test.ts
@@ -1,0 +1,151 @@
+/**
+ * tests/unit/refresh-plan.test.ts
+ *
+ * Unit tests for buildRefreshPlan — maps dirty journal state to sensor call plan.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { DirtyJournal } from "../../src/engine/perception/dirty-journal.js";
+import { buildRefreshPlan } from "../../src/engine/perception/refresh-plan.js";
+import {
+  createLensEventIndex,
+  addLensToIndex,
+} from "../../src/engine/perception/lens-event-index.js";
+import type { LensEventIndex } from "../../src/engine/perception/lens-event-index.js";
+import type { PerceptionLens, WindowIdentity, LensSpec } from "../../src/engine/perception/types.js";
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const identity: WindowIdentity = {
+  hwnd: "100", pid: 1234, processName: "notepad.exe",
+  processStartTimeMs: 1700000000000, titleResolved: "Untitled",
+};
+
+function makeLens(lensId: string, hwnd: string, maintain: string[]): PerceptionLens {
+  return {
+    lensId,
+    spec: {
+      name: lensId,
+      target: { kind: "window", match: { titleIncludes: "test" } },
+      maintain: maintain as LensSpec["maintain"],
+      guards: [],
+      guardPolicy: "block",
+      maxEnvelopeTokens: 120,
+      salience: "normal",
+    },
+    binding: { hwnd, windowTitle: "Test" },
+    boundIdentity: { ...identity, hwnd },
+    fluentKeys: maintain.map(m => `window:${hwnd}.${m}`),
+    registeredAtSeq: 0,
+    registeredAtMs: Date.now(),
+  };
+}
+
+function makeIndex(...lenses: PerceptionLens[]): LensEventIndex {
+  const idx = createLensEventIndex();
+  for (const l of lenses) addLensToIndex(idx, l);
+  return idx;
+}
+
+describe("buildRefreshPlan", () => {
+  let journal: DirtyJournal;
+
+  beforeEach(() => {
+    journal = new DirtyJournal();
+    journal.__resetForTests();
+  });
+
+  it("returns an empty plan when journal has no dirty entries", () => {
+    const idx = makeIndex();
+    const plan = buildRefreshPlan(journal, idx);
+    expect(plan.needsEnumWindows).toBe(false);
+    expect(plan.rectHwnds.size).toBe(0);
+    expect(plan.foreground).toBe(false);
+    expect(plan.reason).toHaveLength(0);
+  });
+
+  it("target.rect dirty → rectHwnds only (no EnumWindows)", () => {
+    journal.mark({ entityKey: "window:100", props: ["target.rect"], cause: "rect", monoMs: 100 });
+    const plan = buildRefreshPlan(journal, makeIndex());
+    expect(plan.rectHwnds.has("100")).toBe(true);
+    expect(plan.needsEnumWindows).toBe(false);
+    expect(plan.foreground).toBe(false);
+  });
+
+  it("target.foreground dirty → foreground=true, no EnumWindows", () => {
+    journal.mark({ entityKey: "window:100", props: ["target.foreground"], cause: "fg", monoMs: 100 });
+    const plan = buildRefreshPlan(journal, makeIndex());
+    expect(plan.foreground).toBe(true);
+    expect(plan.needsEnumWindows).toBe(false);
+  });
+
+  it("target.title dirty → titleHwnds", () => {
+    journal.mark({ entityKey: "window:100", props: ["target.title"], cause: "name", monoMs: 100 });
+    const plan = buildRefreshPlan(journal, makeIndex());
+    expect(plan.titleHwnds.has("100")).toBe(true);
+    expect(plan.needsEnumWindows).toBe(false);
+  });
+
+  it("target.identity dirty → identityHwnds", () => {
+    journal.mark({ entityKey: "window:100", props: ["target.identity"], cause: "identity", monoMs: 100 });
+    const plan = buildRefreshPlan(journal, makeIndex());
+    expect(plan.identityHwnds.has("100")).toBe(true);
+  });
+
+  it("target.zOrder dirty → needsEnumWindows", () => {
+    journal.mark({ entityKey: "window:100", props: ["target.zOrder"], cause: "reorder", monoMs: 100 });
+    const plan = buildRefreshPlan(journal, makeIndex());
+    expect(plan.needsEnumWindows).toBe(true);
+  });
+
+  it("modal.above dirty without rect dirty → modalForLensIds only, triggers EnumWindows", () => {
+    const lens = makeLens("perc-1", "100", ["modal.above"]);
+    journal.mark({ entityKey: "window:100", props: ["modal.above"], cause: "modal", monoMs: 100 });
+    const plan = buildRefreshPlan(journal, makeIndex(lens));
+    expect(plan.modalForLensIds.has("perc-1")).toBe(true);
+    expect(plan.rectHwnds.size).toBe(0);
+    expect(plan.needsEnumWindows).toBe(true); // modal requires z-order snapshot
+  });
+
+  it("structural severity entry → needsEnumWindows", () => {
+    journal.mark({ entityKey: "window:100", props: ["target.exists"], cause: "show", monoMs: 100, severity: "structural" });
+    const plan = buildRefreshPlan(journal, makeIndex());
+    expect(plan.needsEnumWindows).toBe(true);
+  });
+
+  it("identityRisk severity entry → needsEnumWindows", () => {
+    journal.mark({ entityKey: "window:100", props: ["target.identity"], cause: "reuse", monoMs: 100, severity: "identityRisk" });
+    const plan = buildRefreshPlan(journal, makeIndex());
+    expect(plan.needsEnumWindows).toBe(true);
+  });
+
+  it("stable.rect dirty adds a reason but no sensor call", () => {
+    journal.mark({ entityKey: "window:100", props: ["stable.rect"], cause: "move", monoMs: 100 });
+    const plan = buildRefreshPlan(journal, makeIndex());
+    expect(plan.reason.some(r => r.includes("stable_rect"))).toBe(true);
+    expect(plan.rectHwnds.size).toBe(0);
+    expect(plan.needsEnumWindows).toBe(false);
+  });
+
+  it("global dirty → all allHwnds get all ops", () => {
+    journal.markGlobal("overflow", 500);
+    const allHwnds = new Set(["100", "200", "300"]);
+    const lens1 = makeLens("perc-1", "100", ["modal.above"]);
+    const lens2 = makeLens("perc-2", "200", ["target.foreground"]);
+    const plan = buildRefreshPlan(journal, makeIndex(lens1, lens2), allHwnds);
+    expect(plan.needsEnumWindows).toBe(true);
+    expect(plan.foreground).toBe(true);
+    for (const h of ["100", "200", "300"]) {
+      expect(plan.rectHwnds.has(h)).toBe(true);
+      expect(plan.identityHwnds.has(h)).toBe(true);
+      expect(plan.titleHwnds.has(h)).toBe(true);
+    }
+    expect(plan.reason).toContain("global_dirty");
+  });
+
+  it("reason array is populated", () => {
+    journal.mark({ entityKey: "window:100", props: ["target.foreground", "target.rect"], cause: "multi", monoMs: 100 });
+    const plan = buildRefreshPlan(journal, makeIndex());
+    expect(plan.reason.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/resource-model.test.ts
+++ b/tests/unit/resource-model.test.ts
@@ -1,0 +1,246 @@
+/**
+ * tests/unit/resource-model.test.ts
+ *
+ * Unit tests for resource-model projections.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  buildLensSnapshot,
+  projectResourceSummary,
+  projectResourceGuards,
+  projectResourceDebug,
+  computeCanAct,
+  formatGuardSummary,
+} from "../../src/engine/perception/resource-model.js";
+import { FluentStore } from "../../src/engine/perception/fluent-store.js";
+import { DirtyJournal } from "../../src/engine/perception/dirty-journal.js";
+import { makeEvidence } from "../../src/engine/perception/evidence.js";
+import type { PerceptionLens, LensSpec, WindowIdentity } from "../../src/engine/perception/types.js";
+import { FLUENT_KINDS } from "../../src/engine/perception/types.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const hwnd = "100";
+
+const baseIdentity: WindowIdentity = {
+  hwnd, pid: 1234, processName: "notepad.exe",
+  processStartTimeMs: 1700000000000, titleResolved: "Notepad",
+};
+
+function makeStore(): FluentStore {
+  const s = new FluentStore();
+  s.__resetForTests();
+  return s;
+}
+
+function populateStore(store: FluentStore) {
+  const nowMs = Date.now();
+  const obs = (prop: string, value: unknown, seq: number) => ({
+    seq, tsMs: nowMs, source: "win32" as const,
+    entity: { kind: "window" as const, id: hwnd },
+    property: prop, value, confidence: 0.98,
+    evidence: makeEvidence("win32", seq, nowMs),
+  });
+  store.apply([
+    obs("target.exists",     true,  1),
+    obs("target.identity",   { pid: 1234, processStartTimeMs: 1700000000000 }, 2),
+    obs("target.title",      "Notepad", 3),
+    obs("target.rect",       { x: 0, y: 0, width: 800, height: 600 }, 4),
+    obs("target.foreground", true,  5),
+    obs("target.zOrder",     0,     6),
+    obs("modal.above",       false, 7),
+  ]);
+}
+
+const baseSpec: LensSpec = {
+  name: "test",
+  target: { kind: "window", match: { titleIncludes: "Notepad" } },
+  maintain: [...FLUENT_KINDS],
+  guards: ["target.identityStable", "safe.keyboardTarget", "safe.clickCoordinates", "stable.rect"],
+  guardPolicy: "block",
+  maxEnvelopeTokens: 120,
+  salience: "normal",
+};
+
+function makeLens(): PerceptionLens {
+  return {
+    lensId: "perc-1",
+    spec: baseSpec,
+    binding: { hwnd, windowTitle: "Notepad" },
+    boundIdentity: baseIdentity,
+    fluentKeys: FLUENT_KINDS.map(k => `window:${hwnd}.${k}`),
+    registeredAtSeq: 1,
+    registeredAtMs: Date.now(),
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("buildLensSnapshot", () => {
+  it("returns a snapshot with correct shape", () => {
+    const store   = makeStore();
+    const journal = new DirtyJournal();
+    journal.__resetForTests();
+    populateStore(store);
+
+    const snap = buildLensSnapshot(makeLens(), store, journal);
+    expect(snap.lens.lensId).toBe("perc-1");
+    expect(snap.seq).toBeGreaterThan(0);
+    expect(snap.fluents.size).toBeGreaterThan(0);
+    expect(typeof snap.hasDirty).toBe("boolean");
+    expect(typeof snap.hasSettling).toBe("boolean");
+    expect(typeof snap.hasStale).toBe("boolean");
+  });
+
+  it("hasDirty is true when a fluent is dirty", () => {
+    const store   = makeStore();
+    const journal = new DirtyJournal();
+    journal.__resetForTests();
+    populateStore(store);
+    store.markDirty([`window:${hwnd}.target.rect`]);
+    const snap = buildLensSnapshot(makeLens(), store, journal);
+    expect(snap.hasDirty).toBe(true);
+  });
+
+  it("attention is guard_failed when a guard fails", () => {
+    const store   = makeStore();
+    const journal = new DirtyJournal();
+    journal.__resetForTests();
+    populateStore(store);
+    store.markDirtyWithCause([`window:${hwnd}.target.foreground`], "fg_change", 9000);
+    const snap = buildLensSnapshot(makeLens(), store, journal);
+    expect(snap.attention).toBe("guard_failed");
+  });
+
+  it("attention is dirty when fluents are dirty but guards pass", () => {
+    const store   = makeStore();
+    const journal = new DirtyJournal();
+    journal.__resetForTests();
+    populateStore(store);
+    // Only mark a non-guarded fluent dirty (zOrder is not checked by any guard)
+    store.markDirty([`window:${hwnd}.target.zOrder`]);
+    const snap = buildLensSnapshot(makeLens(), store, journal);
+    expect(snap.hasDirty).toBe(true);
+    // guards pass (foreground/identity are clean)
+    if (snap.guardResult.ok) {
+      expect(snap.attention).toBe("dirty");
+    }
+  });
+});
+
+describe("projectResourceSummary", () => {
+  it("includes attention, watermark, guards, canAct", () => {
+    const store   = makeStore();
+    const journal = new DirtyJournal();
+    journal.__resetForTests();
+    populateStore(store);
+
+    const snap    = buildLensSnapshot(makeLens(), store, journal);
+    const summary = projectResourceSummary(snap);
+
+    expect(summary.lensId).toBe("perc-1");
+    expect(summary.seq).toBeGreaterThan(0);
+    expect(typeof summary.attention).toBe("string");
+    expect(summary.watermark).toHaveProperty("hasDirty");
+    expect(summary.watermark).toHaveProperty("hasSettling");
+    expect(summary.watermark).toHaveProperty("hasStale");
+    expect(typeof summary.canAct.keyboard).toBe("boolean");
+    expect(typeof summary.canAct.mouse).toBe("boolean");
+    expect(typeof summary.guards).toBe("object");
+  });
+
+  it("includes target block for window lens", () => {
+    const store   = makeStore();
+    const journal = new DirtyJournal();
+    journal.__resetForTests();
+    populateStore(store);
+    const snap    = buildLensSnapshot(makeLens(), store, journal);
+    const summary = projectResourceSummary(snap);
+    expect(summary.target).toBeDefined();
+    expect(summary.target!["title"]).toBe("Notepad");
+  });
+
+  it("dirty fluents are never reported with attention 'ok'", () => {
+    const store   = makeStore();
+    const journal = new DirtyJournal();
+    journal.__resetForTests();
+    populateStore(store);
+    store.markDirty([`window:${hwnd}.target.rect`]);
+    const snap    = buildLensSnapshot(makeLens(), store, journal);
+    const summary = projectResourceSummary(snap);
+    expect(summary.attention).not.toBe("ok");
+    expect(summary.canAct.mouse).toBe(false);
+  });
+});
+
+describe("projectResourceGuards", () => {
+  it("returns full guard list with summary strings", () => {
+    const store   = makeStore();
+    const journal = new DirtyJournal();
+    journal.__resetForTests();
+    populateStore(store);
+
+    const snap   = buildLensSnapshot(makeLens(), store, journal);
+    const guards = projectResourceGuards(snap);
+
+    expect(guards.lensId).toBe("perc-1");
+    expect(Array.isArray(guards.guards)).toBe(true);
+    expect(guards.guards.length).toBe(baseSpec.guards.length);
+    for (const g of guards.guards) {
+      expect(typeof g.summary).toBe("string");
+    }
+  });
+});
+
+describe("projectResourceDebug", () => {
+  it("returns fluents array and diagnostics", () => {
+    const store   = makeStore();
+    const journal = new DirtyJournal();
+    journal.__resetForTests();
+    populateStore(store);
+
+    const snap  = buildLensSnapshot(makeLens(), store, journal);
+    const debug = projectResourceDebug(snap);
+
+    expect(debug.lensId).toBe("perc-1");
+    expect(Array.isArray(debug.fluents)).toBe(true);
+    expect(debug.diagnostics).toHaveProperty("hasDirty");
+    expect(Array.isArray(debug.warnings)).toBe(true);
+  });
+});
+
+describe("computeCanAct", () => {
+  it("returns keyboard=true, mouse=true when guard passes", () => {
+    const ca = computeCanAct({ ok: true, policy: "block", attention: "ok", results: [] });
+    expect(ca.keyboard).toBe(true);
+    expect(ca.mouse).toBe(true);
+  });
+
+  it("returns keyboard=false, mouse=false when guard fails", () => {
+    const ca = computeCanAct({ ok: false, policy: "block", attention: "guard_failed", results: [] });
+    expect(ca.keyboard).toBe(false);
+    expect(ca.mouse).toBe(false);
+  });
+});
+
+describe("formatGuardSummary", () => {
+  it("formats passing guard", () => {
+    const s = formatGuardSummary({ kind: "stable.rect", ok: true, confidence: 0.98 });
+    expect(s).toContain("ok");
+    expect(s).toContain("stable.rect");
+  });
+
+  it("formats failing guard with reason and action", () => {
+    const s = formatGuardSummary({
+      kind: "safe.keyboardTarget",
+      ok: false,
+      confidence: 0.5,
+      reason: "Window not in foreground",
+      suggestedAction: "Call focus_window first",
+    });
+    expect(s).toContain("FAILED");
+    expect(s).toContain("not in foreground");
+    expect(s).toContain("focus_window");
+  });
+});

--- a/tests/unit/resource-model.test.ts
+++ b/tests/unit/resource-model.test.ts
@@ -4,7 +4,7 @@
  * Unit tests for resource-model projections.
  */
 
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   buildLensSnapshot,
   projectResourceSummary,

--- a/tests/unit/resource-notifications.test.ts
+++ b/tests/unit/resource-notifications.test.ts
@@ -1,0 +1,149 @@
+/**
+ * tests/unit/resource-notifications.test.ts
+ *
+ * Unit tests for ResourceNotificationScheduler — coalesced attention-change notifications.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { ResourceNotificationScheduler } from "../../src/engine/perception/resource-notifications.js";
+import type { AttentionState } from "../../src/engine/perception/types.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeScheduler(
+  attentionMap: Map<string, AttentionState>,
+  onNotify: (uris: Set<string>) => void,
+  debounceMs = 500
+): ResourceNotificationScheduler {
+  return new ResourceNotificationScheduler(
+    (lensId) => [`perception://lens/${lensId}/summary`, `perception://lens/${lensId}/guards`],
+    (lensId) => attentionMap.get(lensId),
+    { onNotify },
+    debounceMs,
+  );
+}
+
+describe("ResourceNotificationScheduler — coalescing", () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it("fires exactly once per debounce window for 100 attention changes", () => {
+    const attention = new Map<string, AttentionState>([["perc-1", "ok"]]);
+    const notifications: Set<string>[] = [];
+    const sched = makeScheduler(attention, (uris) => notifications.push(uris), 500);
+
+    // Simulate ok → dirty transition
+    attention.set("perc-1", "dirty");
+    for (let i = 0; i < 100; i++) {
+      sched.maybeNotify(new Set(["perc-1"]), "attention_change");
+    }
+
+    expect(notifications).toHaveLength(0); // pending
+
+    vi.advanceTimersByTime(500);
+    expect(notifications).toHaveLength(1); // coalesced into one
+
+    sched.dispose();
+  });
+
+  it("ok → dirty fires notification (degradation)", () => {
+    const attention = new Map<string, AttentionState>([["perc-1", "ok"]]);
+    const notifications: Set<string>[] = [];
+    const sched = makeScheduler(attention, (uris) => notifications.push(uris));
+
+    attention.set("perc-1", "dirty");
+    sched.maybeNotify(new Set(["perc-1"]), "attention_change");
+
+    vi.advanceTimersByTime(500);
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].has("perception://lens/perc-1/summary")).toBe(true);
+
+    sched.dispose();
+  });
+
+  it("ok → dirty → ok fires two notifications (degradation + recovery)", () => {
+    const attention = new Map<string, AttentionState>([["perc-1", "ok"]]);
+    const notifications: Set<string>[] = [];
+    const sched = makeScheduler(attention, (uris) => notifications.push(uris));
+
+    attention.set("perc-1", "dirty");
+    sched.maybeNotify(new Set(["perc-1"]), "attention_change");
+    vi.advanceTimersByTime(500); // fire first notification
+
+    attention.set("perc-1", "ok");
+    sched.maybeNotify(new Set(["perc-1"]), "attention_change");
+    vi.advanceTimersByTime(500); // fire second notification
+
+    expect(notifications).toHaveLength(2);
+
+    sched.dispose();
+  });
+
+  it("ok → changed does NOT fire (changed alone is too noisy)", () => {
+    const attention = new Map<string, AttentionState>([["perc-1", "ok"]]);
+    const notifications: Set<string>[] = [];
+    const sched = makeScheduler(attention, (uris) => notifications.push(uris));
+
+    // "changed" is not a degradation from "ok" — both are "good"
+    attention.set("perc-1", "changed" as AttentionState);
+    sched.maybeNotify(new Set(["perc-1"]), "attention_change");
+
+    vi.advanceTimersByTime(500);
+    // "changed" → no meaningful transition (both good)
+    expect(notifications).toHaveLength(0);
+
+    sched.dispose();
+  });
+
+  it("guard_failed → ok fires notification (recovery)", () => {
+    const attention = new Map<string, AttentionState>([["perc-1", "guard_failed"]]);
+    const notifications: Set<string>[] = [];
+    const sched = makeScheduler(attention, (uris) => notifications.push(uris));
+
+    // Prime state with guard_failed
+    sched.maybeNotify(new Set(["perc-1"]), "attention_change");
+    vi.advanceTimersByTime(500);
+
+    attention.set("perc-1", "ok");
+    sched.maybeNotify(new Set(["perc-1"]), "attention_change");
+    vi.advanceTimersByTime(500);
+
+    expect(notifications.length).toBeGreaterThanOrEqual(1);
+
+    sched.dispose();
+  });
+
+  it("no notification when attention stays the same", () => {
+    const attention = new Map<string, AttentionState>([["perc-1", "ok"]]);
+    const notifications: Set<string>[] = [];
+    const sched = makeScheduler(attention, (uris) => notifications.push(uris));
+
+    // Same attention over and over
+    for (let i = 0; i < 10; i++) {
+      sched.maybeNotify(new Set(["perc-1"]), "attention_change");
+      vi.advanceTimersByTime(100);
+    }
+
+    expect(notifications).toHaveLength(0);
+    sched.dispose();
+  });
+});
+
+describe("ResourceNotificationScheduler — dispose", () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it("dispose cancels pending timers", () => {
+    const attention = new Map<string, AttentionState>([["perc-1", "ok"]]);
+    const notifications: Set<string>[] = [];
+    const sched = makeScheduler(attention, (uris) => notifications.push(uris));
+
+    attention.set("perc-1", "dirty");
+    sched.maybeNotify(new Set(["perc-1"]), "attention_change");
+
+    sched.dispose();
+    vi.advanceTimersByTime(1000);
+
+    expect(notifications).toHaveLength(0); // cancelled
+  });
+});

--- a/tests/unit/resource-registry.test.ts
+++ b/tests/unit/resource-registry.test.ts
@@ -1,0 +1,151 @@
+/**
+ * tests/unit/resource-registry.test.ts
+ *
+ * Unit tests for ResourceRegistry — URI lifecycle management.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { ResourceRegistry } from "../../src/engine/perception/resource-registry.js";
+import type { PerceptionLens, LensSpec, WindowIdentity } from "../../src/engine/perception/types.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const baseIdentity: WindowIdentity = {
+  hwnd: "100", pid: 1234, processName: "notepad.exe",
+  processStartTimeMs: 1700000000000, titleResolved: "Notepad",
+};
+
+function makeLens(lensId: string, hwnd = "100"): PerceptionLens {
+  return {
+    lensId,
+    spec: {
+      name: lensId,
+      target: { kind: "window", match: { titleIncludes: "test" } },
+      maintain: ["target.foreground"],
+      guards: [],
+      guardPolicy: "block",
+      maxEnvelopeTokens: 120,
+      salience: "normal",
+    } satisfies LensSpec,
+    binding: { hwnd, windowTitle: "Test" },
+    boundIdentity: { ...baseIdentity, hwnd },
+    fluentKeys: [`window:${hwnd}.target.foreground`],
+    registeredAtSeq: 0,
+    registeredAtMs: Date.now(),
+  };
+}
+
+describe("ResourceRegistry — registration", () => {
+  let reg: ResourceRegistry;
+
+  beforeEach(() => {
+    reg = new ResourceRegistry();
+    reg.__resetForTests();
+  });
+
+  it("onLensRegistered returns summary and guards URIs", () => {
+    const uris = reg.onLensRegistered(makeLens("perc-1"));
+    expect(uris).toContain("perception://lens/perc-1/summary");
+    expect(uris).toContain("perception://lens/perc-1/guards");
+  });
+
+  it("debug/events URIs are not included without DEBUG_RESOURCES flag", () => {
+    delete process.env.DESKTOP_TOUCH_PERCEPTION_DEBUG_RESOURCES;
+    const uris = reg.onLensRegistered(makeLens("perc-1"));
+    expect(uris).not.toContain("perception://lens/perc-1/debug");
+    expect(uris).not.toContain("perception://lens/perc-1/events");
+  });
+
+  it("debug/events URIs are included with DEBUG_RESOURCES=1", () => {
+    vi.stubEnv("DESKTOP_TOUCH_PERCEPTION_DEBUG_RESOURCES", "1");
+    const uris = reg.onLensRegistered(makeLens("perc-2"));
+    expect(uris).toContain("perception://lens/perc-2/debug");
+    expect(uris).toContain("perception://lens/perc-2/events");
+    vi.unstubAllEnvs();
+  });
+
+  it("getLensId resolves URI to lensId", () => {
+    reg.onLensRegistered(makeLens("perc-1"));
+    expect(reg.getLensId("perception://lens/perc-1/summary")).toBe("perc-1");
+    expect(reg.getLensId("perception://lens/perc-1/guards")).toBe("perc-1");
+  });
+
+  it("listUris includes all registered URIs", () => {
+    reg.onLensRegistered(makeLens("perc-1"));
+    reg.onLensRegistered(makeLens("perc-2"));
+    const all = reg.listUris();
+    expect(all).toContain("perception://lens/perc-1/summary");
+    expect(all).toContain("perception://lens/perc-2/guards");
+  });
+
+  it("onListChanged callback fires on register", () => {
+    const changes: number[] = [];
+    reg.setOnListChanged(() => changes.push(1));
+    reg.onLensRegistered(makeLens("perc-1"));
+    expect(changes.length).toBeGreaterThan(0);
+  });
+});
+
+describe("ResourceRegistry — tombstone", () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it("onLensForgotten removes URIs from active list and creates tombstone", () => {
+    const reg = new ResourceRegistry();
+    reg.onLensRegistered(makeLens("perc-1"));
+    reg.onLensForgotten("perc-1");
+
+    expect(reg.listUris()).not.toContain("perception://lens/perc-1/summary");
+    expect(reg.getTombstone("perception://lens/perc-1/summary")).toBeDefined();
+    expect(reg.getTombstone("perception://lens/perc-1/guards")).toBeDefined();
+  });
+
+  it("tombstone disappears after 30s TTL", () => {
+    const reg = new ResourceRegistry();
+    reg.onLensRegistered(makeLens("perc-1"));
+    reg.onLensForgotten("perc-1");
+
+    vi.advanceTimersByTime(29_999);
+    expect(reg.getTombstone("perception://lens/perc-1/summary")).toBeDefined();
+
+    vi.advanceTimersByTime(2);
+    expect(reg.getTombstone("perception://lens/perc-1/summary")).toBeUndefined();
+  });
+
+  it("tombstone has lensId and removedAtMs", () => {
+    const reg = new ResourceRegistry();
+    reg.onLensRegistered(makeLens("perc-1"));
+    reg.onLensForgotten("perc-1");
+
+    const t = reg.getTombstone("perception://lens/perc-1/summary");
+    expect(t).toBeDefined();
+    expect(t!.lensId).toBe("perc-1");
+    expect(typeof t!.removedAtMs).toBe("number");
+    expect(typeof t!.message).toBe("string");
+  });
+
+  it("re-registering a lens clears its tombstone", () => {
+    const reg = new ResourceRegistry();
+    reg.onLensRegistered(makeLens("perc-1"));
+    reg.onLensForgotten("perc-1");
+    expect(reg.getTombstone("perception://lens/perc-1/summary")).toBeDefined();
+
+    reg.onLensRegistered(makeLens("perc-1")); // re-register
+    expect(reg.getTombstone("perception://lens/perc-1/summary")).toBeUndefined();
+    expect(reg.listUris()).toContain("perception://lens/perc-1/summary");
+  });
+
+  it("evicts oldest tombstone when 128 limit is reached", () => {
+    const reg = new ResourceRegistry();
+    // Fill 128 tombstones by registering/forgetting 64 lenses (2 URIs each)
+    for (let i = 0; i < 64; i++) {
+      reg.onLensRegistered(makeLens(`perc-${i}`));
+      reg.onLensForgotten(`perc-${i}`);
+    }
+    // The first tombstone (perc-0/summary) should have been evicted
+    // (we have 64*2=128 tombstones so exactly at limit — next add will evict oldest)
+    reg.onLensRegistered(makeLens("perc-overflow"));
+    reg.onLensForgotten("perc-overflow"); // adds 2 more (129th, 130th) → evicts 2 oldest
+    expect(reg.getTombstone("perception://lens/perc-0/summary")).toBeUndefined();
+  });
+});

--- a/tests/unit/sensors-native-win32.test.ts
+++ b/tests/unit/sensors-native-win32.test.ts
@@ -102,6 +102,21 @@ describe("NativeSensorBridge — Phase 5-A event mapping", () => {
     expect(cbs.onEnumWindowsNeeded).not.toHaveBeenCalled();
   });
 
+  it("EVENT_SYSTEM_FOREGROUND fanout — other foreground-sensitive windows also marked dirty", () => {
+    const cbs = makeCallbacks();
+    const bridge = new NativeSensorBridge(cbs);
+    // Add a second foreground-sensitive lens on a different hwnd
+    addLensToIndex(index, makeLens("perc-2", "200", ["target.foreground"]));
+
+    // Foreground event on hwnd 100 → hwnd 100 AND hwnd 200 should both be dirty
+    bridge.processBatch([makeEvent(EVENT_SYSTEM_FOREGROUND, "100")], index, journal);
+
+    const dirtyCalls = (cbs.onDirty as ReturnType<typeof vi.fn>).mock.calls;
+    const dirtyEntityKeys = dirtyCalls.map((c: unknown[]) => c[0]);
+    expect(dirtyEntityKeys).toContain("window:100"); // event source
+    expect(dirtyEntityKeys).toContain("window:200"); // foreground-sensitive fanout
+  });
+
   it("EVENT_OBJECT_SHOW → structural severity, EnumWindows needed", () => {
     const cbs = makeCallbacks();
     const bridge = new NativeSensorBridge(cbs);

--- a/tests/unit/sensors-native-win32.test.ts
+++ b/tests/unit/sensors-native-win32.test.ts
@@ -1,0 +1,240 @@
+/**
+ * tests/unit/sensors-native-win32.test.ts
+ *
+ * Unit tests for NativeSensorBridge — event-to-dirty mapping and dispatch.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  NativeSensorBridge,
+  EVENT_SYSTEM_FOREGROUND,
+  EVENT_OBJECT_SHOW,
+  EVENT_OBJECT_HIDE,
+  EVENT_OBJECT_DESTROY,
+  EVENT_OBJECT_NAMECHANGE,
+  EVENT_SYSTEM_MOVESIZESTART,
+  EVENT_SYSTEM_MOVESIZEEND,
+  EVENT_OBJECT_LOCATIONCHANGE,
+  EVENT_OBJECT_REORDER,
+} from "../../src/engine/perception/sensors-native-win32.js";
+import type { NativeSensorBridgeCallbacks } from "../../src/engine/perception/sensors-native-win32.js";
+import type { RawWinEvent } from "../../src/engine/perception/raw-event-queue.js";
+import { DirtyJournal } from "../../src/engine/perception/dirty-journal.js";
+import {
+  createLensEventIndex,
+  addLensToIndex,
+} from "../../src/engine/perception/lens-event-index.js";
+import type { LensEventIndex } from "../../src/engine/perception/lens-event-index.js";
+import type { PerceptionLens, LensSpec, WindowIdentity } from "../../src/engine/perception/types.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeEvent(eventCode: number, hwnd: string, idObject = 0): RawWinEvent {
+  return {
+    event: eventCode,
+    hwnd,
+    idObject,
+    idChild: 0,
+    eventThread: 1234,
+    sourceEventTimeMs: 0,
+    sidecarSeq: 1,
+    receivedAtMonoMs: 5000,
+    receivedAtUnixMs: 1700000000000,
+    globalSeq: 1,
+  };
+}
+
+const identity: WindowIdentity = {
+  hwnd: "100", pid: 1234, processName: "notepad.exe",
+  processStartTimeMs: 1700000000000, titleResolved: "Notepad",
+};
+
+function makeLens(lensId: string, hwnd: string, maintain: string[]): PerceptionLens {
+  return {
+    lensId,
+    spec: {
+      name: lensId,
+      target: { kind: "window", match: { titleIncludes: "test" } },
+      maintain: maintain as LensSpec["maintain"],
+      guards: [],
+      guardPolicy: "block",
+      maxEnvelopeTokens: 120,
+      salience: "normal",
+    },
+    binding: { hwnd, windowTitle: "Test" },
+    boundIdentity: { ...identity, hwnd },
+    fluentKeys: maintain.map(m => `window:${hwnd}.${m}`),
+    registeredAtSeq: 0,
+    registeredAtMs: Date.now(),
+  };
+}
+
+function makeCallbacks() {
+  return {
+    onDirty:            vi.fn(),
+    onGlobalDirty:      vi.fn(),
+    onSchedule:         vi.fn(),
+    onEnumWindowsNeeded: vi.fn(),
+  } satisfies NativeSensorBridgeCallbacks;
+}
+
+// ── Phase 5-A event mapping ───────────────────────────────────────────────────
+
+describe("NativeSensorBridge — Phase 5-A event mapping", () => {
+  let journal: DirtyJournal;
+  let index: LensEventIndex;
+
+  beforeEach(() => {
+    journal = new DirtyJournal();
+    journal.__resetForTests();
+    index = createLensEventIndex();
+    addLensToIndex(index, makeLens("perc-1", "100", ["target.foreground"]));
+  });
+
+  it("EVENT_SYSTEM_FOREGROUND → target.foreground dirty, foreground schedule", () => {
+    const cbs = makeCallbacks();
+    const bridge = new NativeSensorBridge(cbs);
+    bridge.processBatch([makeEvent(EVENT_SYSTEM_FOREGROUND, "100")], index, journal);
+    expect(cbs.onDirty).toHaveBeenCalledWith(
+      "window:100", ["target.foreground"], expect.stringContaining("0003"), 5000, undefined
+    );
+    expect(cbs.onSchedule).toHaveBeenCalledWith("foreground", expect.any(String));
+    expect(cbs.onEnumWindowsNeeded).not.toHaveBeenCalled();
+  });
+
+  it("EVENT_OBJECT_SHOW → structural severity, EnumWindows needed", () => {
+    const cbs = makeCallbacks();
+    const bridge = new NativeSensorBridge(cbs);
+    bridge.processBatch([makeEvent(EVENT_OBJECT_SHOW, "100")], index, journal);
+    expect(cbs.onDirty).toHaveBeenCalledWith(
+      "window:100", ["target.exists"], expect.any(String), 5000, "structural"
+    );
+    expect(cbs.onEnumWindowsNeeded).toHaveBeenCalled();
+  });
+
+  it("EVENT_OBJECT_HIDE → structural severity", () => {
+    const cbs = makeCallbacks();
+    const bridge = new NativeSensorBridge(cbs);
+    bridge.processBatch([makeEvent(EVENT_OBJECT_HIDE, "100")], index, journal);
+    expect(cbs.onDirty).toHaveBeenCalledWith(
+      "window:100", ["target.exists"], expect.any(String), 5000, "structural"
+    );
+  });
+
+  it("EVENT_OBJECT_DESTROY → structural severity", () => {
+    const cbs = makeCallbacks();
+    const bridge = new NativeSensorBridge(cbs);
+    bridge.processBatch([makeEvent(EVENT_OBJECT_DESTROY, "100")], index, journal);
+    expect(cbs.onDirty).toHaveBeenCalledWith(
+      "window:100", ["target.exists"], expect.any(String), 5000, "structural"
+    );
+  });
+
+  it("EVENT_OBJECT_NAMECHANGE → target.title dirty, title schedule", () => {
+    const cbs = makeCallbacks();
+    const bridge = new NativeSensorBridge(cbs);
+    bridge.processBatch([makeEvent(EVENT_OBJECT_NAMECHANGE, "100")], index, journal);
+    expect(cbs.onDirty).toHaveBeenCalledWith(
+      "window:100", ["target.title"], expect.any(String), 5000, undefined
+    );
+    expect(cbs.onSchedule).toHaveBeenCalledWith("title", expect.any(String));
+  });
+
+  it("skips events with idObject !== OBJID_WINDOW", () => {
+    const cbs = makeCallbacks();
+    const bridge = new NativeSensorBridge(cbs);
+    bridge.processBatch([makeEvent(EVENT_SYSTEM_FOREGROUND, "100", 1 /* not OBJID_WINDOW */)], index, journal);
+    expect(cbs.onDirty).not.toHaveBeenCalled();
+  });
+
+  it("skips events with hwnd='0'", () => {
+    const cbs = makeCallbacks();
+    const bridge = new NativeSensorBridge(cbs);
+    bridge.processBatch([makeEvent(EVENT_SYSTEM_FOREGROUND, "0")], index, journal);
+    expect(cbs.onDirty).not.toHaveBeenCalled();
+  });
+
+  it("unknown event codes are silently ignored", () => {
+    const cbs = makeCallbacks();
+    const bridge = new NativeSensorBridge(cbs);
+    bridge.processBatch([makeEvent(0xFFFF, "100")], index, journal);
+    expect(cbs.onDirty).not.toHaveBeenCalled();
+  });
+});
+
+// ── Overflow handling ─────────────────────────────────────────────────────────
+
+describe("NativeSensorBridge — overflow handling", () => {
+  it("processOverflow emits global dirty and overflow schedule", () => {
+    const cbs = makeCallbacks();
+    const bridge = new NativeSensorBridge(cbs);
+    bridge.processOverflow(9000);
+    expect(cbs.onGlobalDirty).toHaveBeenCalledWith("queue_overflow", 9000);
+    expect(cbs.onSchedule).toHaveBeenCalledWith("overflow", "queue_overflow");
+  });
+});
+
+// ── Location events (LOCATION_EVENTS=1) ───────────────────────────────────────
+
+describe("NativeSensorBridge — location events (flag gated)", () => {
+  it("MOVESIZESTART ignored when LOCATION_EVENTS is unset", () => {
+    delete process.env.DESKTOP_TOUCH_PERCEPTION_LOCATION_EVENTS;
+    const cbs = makeCallbacks();
+    const bridge = new NativeSensorBridge(cbs);
+    const index = createLensEventIndex();
+    bridge.processBatch([makeEvent(EVENT_SYSTEM_MOVESIZESTART, "100")], index, new DirtyJournal());
+    expect(cbs.onDirty).not.toHaveBeenCalled();
+  });
+
+  it("MOVESIZESTART → stable.rect dirty with move_start schedule when LOCATION_EVENTS=1", () => {
+    vi.stubEnv("DESKTOP_TOUCH_PERCEPTION_LOCATION_EVENTS", "1");
+    const cbs = makeCallbacks();
+    const bridge = new NativeSensorBridge(cbs);
+    const index = createLensEventIndex();
+    bridge.processBatch([makeEvent(EVENT_SYSTEM_MOVESIZESTART, "100")], index, new DirtyJournal());
+    expect(cbs.onDirty).toHaveBeenCalledWith(
+      "window:100", ["target.rect", "stable.rect"], expect.any(String), 5000, undefined
+    );
+    expect(cbs.onSchedule).toHaveBeenCalledWith("move_start", expect.any(String));
+    vi.unstubAllEnvs();
+  });
+
+  it("MOVESIZEEND → target.rect dirty with move_end schedule when LOCATION_EVENTS=1", () => {
+    vi.stubEnv("DESKTOP_TOUCH_PERCEPTION_LOCATION_EVENTS", "1");
+    const cbs = makeCallbacks();
+    const bridge = new NativeSensorBridge(cbs);
+    const index = createLensEventIndex();
+    bridge.processBatch([makeEvent(EVENT_SYSTEM_MOVESIZEEND, "100")], index, new DirtyJournal());
+    expect(cbs.onDirty).toHaveBeenCalledWith(
+      "window:100", ["target.rect"], expect.any(String), 5000, undefined
+    );
+    expect(cbs.onSchedule).toHaveBeenCalledWith("move_end", expect.any(String));
+    vi.unstubAllEnvs();
+  });
+
+  it("LOCATIONCHANGE → target.rect dirty with location schedule when LOCATION_EVENTS=1", () => {
+    vi.stubEnv("DESKTOP_TOUCH_PERCEPTION_LOCATION_EVENTS", "1");
+    const cbs = makeCallbacks();
+    const bridge = new NativeSensorBridge(cbs);
+    const index = createLensEventIndex();
+    bridge.processBatch([makeEvent(EVENT_OBJECT_LOCATIONCHANGE, "100")], index, new DirtyJournal());
+    expect(cbs.onDirty).toHaveBeenCalledWith(
+      "window:100", ["target.rect"], expect.any(String), 5000, undefined
+    );
+    expect(cbs.onSchedule).toHaveBeenCalledWith("location", expect.any(String));
+    vi.unstubAllEnvs();
+  });
+
+  it("REORDER → zOrder + modal dirty, EnumWindows needed when LOCATION_EVENTS=1", () => {
+    vi.stubEnv("DESKTOP_TOUCH_PERCEPTION_LOCATION_EVENTS", "1");
+    const cbs = makeCallbacks();
+    const bridge = new NativeSensorBridge(cbs);
+    const index = createLensEventIndex();
+    bridge.processBatch([makeEvent(EVENT_OBJECT_REORDER, "100")], index, new DirtyJournal());
+    expect(cbs.onDirty).toHaveBeenCalledWith(
+      "window:100", ["target.zOrder", "modal.above"], expect.any(String), 5000, undefined
+    );
+    expect(cbs.onEnumWindowsNeeded).toHaveBeenCalled();
+    vi.unstubAllEnvs();
+  });
+});

--- a/tests/unit/winevent-source.test.ts
+++ b/tests/unit/winevent-source.test.ts
@@ -1,0 +1,160 @@
+/**
+ * tests/unit/winevent-source.test.ts
+ *
+ * Unit tests for WinEventSource — sidecar lifecycle management.
+ * Uses the mock-sidecar.js fixture as a real child process via node <script>.
+ */
+
+import { describe, it, expect } from "vitest";
+import * as path from "node:path";
+import * as url from "node:url";
+import * as fs from "node:fs";
+import { WinEventSource } from "../../src/engine/winevent-source.js";
+import type { WinEventSourceState } from "../../src/engine/winevent-source.js";
+import type { RawWinEvent } from "../../src/engine/perception/raw-event-queue.js";
+
+const __dirname  = path.dirname(url.fileURLToPath(import.meta.url));
+const MOCK_SIDECAR = path.join(__dirname, "../fixtures/mock-sidecar.js");
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/** Spawn node <mock-sidecar.js> as the "sidecar" */
+function makeMockSource(
+  onEvent: (e: RawWinEvent) => void = () => {},
+  onState?: (s: WinEventSourceState) => void,
+  onMalformed?: (l: string) => void,
+): WinEventSource {
+  return new WinEventSource({
+    sidecarPath: process.execPath,
+    sidecarArgs: [MOCK_SIDECAR],
+    onRawEvent:  onEvent,
+    onStateChange: onState,
+    onMalformedLine: onMalformed,
+  });
+}
+
+// ── Lifecycle ─────────────────────────────────────────────────────────────────
+
+describe("WinEventSource — basic lifecycle", () => {
+  it("starts in 'disabled' state before start()", () => {
+    const src = new WinEventSource({
+      sidecarPath: "nonexistent.exe",
+      onRawEvent: () => {},
+    });
+    expect(src.getState()).toBe("disabled");
+  });
+
+  it("transitions to 'live' when mock sidecar spawns successfully", async () => {
+    const states: WinEventSourceState[] = [];
+    const src = makeMockSource(() => {}, (s) => states.push(s));
+    src.start();
+    await sleep(600);
+    src.stop();
+    expect(states).toContain("starting");
+    expect(states).toContain("live");
+  }, 5000);
+
+  it("transitions to 'stopped' on stop()", async () => {
+    const states: WinEventSourceState[] = [];
+    const src = makeMockSource(() => {}, (s) => states.push(s));
+    src.start();
+    await sleep(400);
+    src.stop();
+    expect(states[states.length - 1]).toBe("stopped");
+  }, 5000);
+});
+
+// ── Malformed line handling ───────────────────────────────────────────────────
+
+describe("WinEventSource — malformed line handling", () => {
+  it("counts malformed lines from a sidecar that emits bad JSON", async () => {
+    const malformed: string[] = [];
+
+    // Create a tiny inline sidecar that emits one bad line then stays alive
+    const scriptPath = path.join(__dirname, "../../.tmp-malformed-sidecar.mjs");
+    fs.writeFileSync(scriptPath,
+      `process.stdout.write("NOT_JSON_LINE\\n"); await new Promise(r => setTimeout(r, 30000));\n`
+    );
+
+    const src = new WinEventSource({
+      sidecarPath: process.execPath,
+      sidecarArgs: [scriptPath],
+      onRawEvent: () => {},
+      onMalformedLine: (l) => malformed.push(l),
+    });
+    src.start();
+    await sleep(600);
+    src.stop();
+
+    try { fs.unlinkSync(scriptPath); } catch { /* ignore */ }
+
+    expect(malformed.length).toBeGreaterThan(0);
+    expect(malformed[0]).toContain("NOT_JSON_LINE");
+    expect(src.diagnostics().malformedLines).toBeGreaterThan(0);
+  }, 5000);
+});
+
+// ── Crash and restart ─────────────────────────────────────────────────────────
+
+describe("WinEventSource — crash and restart", () => {
+  it("transitions to 'restarting' when sidecar crashes (exits non-zero)", async () => {
+    const states: WinEventSourceState[] = [];
+
+    // Inline sidecar that immediately exits with code 1
+    const scriptPath = path.join(__dirname, "../../.tmp-crash-sidecar.mjs");
+    fs.writeFileSync(scriptPath, `process.exit(1);\n`);
+
+    const src = new WinEventSource({
+      sidecarPath: process.execPath,
+      sidecarArgs: [scriptPath],
+      onRawEvent: () => {},
+      onStateChange: (s) => states.push(s),
+    });
+    src.start();
+    await sleep(800);
+    src.stop();
+
+    try { fs.unlinkSync(scriptPath); } catch { /* ignore */ }
+
+    expect(states).toContain("restarting");
+    expect(src.diagnostics().restartCount).toBeGreaterThan(0);
+  }, 6000);
+
+  it("resets backoff on successful restart after crash", async () => {
+    const src = new WinEventSource({
+      sidecarPath: process.execPath,
+      sidecarArgs: [MOCK_SIDECAR],
+      onRawEvent: () => {},
+    });
+    // __resetForTests resets backoffMs
+    src.__resetForTests();
+    expect(src.getState()).toBe("disabled");
+  }, 3000);
+});
+
+// ── Diagnostics ───────────────────────────────────────────────────────────────
+
+describe("WinEventSource — diagnostics", () => {
+  it("diagnostics() returns expected shape on a fresh instance", () => {
+    const src = new WinEventSource({
+      sidecarPath: "dummy.exe",
+      onRawEvent: () => {},
+    });
+    const d = src.diagnostics();
+    expect(d.state).toBe("disabled");
+    expect(d.startCount).toBe(0);
+    expect(d.restartCount).toBe(0);
+    expect(d.malformedLines).toBe(0);
+    expect(d.lastRestartReasonMs).toBeUndefined();
+  });
+
+  it("diagnostics() includes startCount after start()", async () => {
+    const src = makeMockSource();
+    src.start();
+    await sleep(300);
+    src.stop();
+    expect(src.diagnostics().startCount).toBe(1);
+  }, 5000);
+});


### PR DESCRIPTION
## Summary

Phase 4–6 の Reactive Perception Graph 完全実装。全変更を 1 PR にまとめてリリース（計画書通り）。

### Phase 4 — UIA / CDP / owner-chain modal（既存コミット）
- Phase 4-A: UIA focused-element push（critical lens）
- Phase 4-B: CDP browserTab エンティティ種別（browser.url/title/readyState fluent）
- Phase 4-C: owner-chain modal 検出（Z-order + ownerHwnd + `#32770` クラス）
- fix: browser.ready / Win32 guard の cross-kind vacuous-pass

### Phase 5 — DirtyJournal + watermark + native WinEvent pipeline
- **Milestone 1**: `DirtyJournal`、`FlushScheduler`、`LensEventIndex`、`RefreshPlan`、FluentStore watermark (`validFromMonoMs`, `lastDirtyAtMonoMs`)
- **Milestone 2**: guards が watermark を消費 — `evalKeyboardTarget`/`evalClickCoordinates`/`evalStableRect` に dirty/settling ステータスチェック追加
- **Milestone 3-4**: ネイティブ WinEvent パイプライン（Strategy B: stdio sidecar）  
  - `RawEventQueue`: bounded ring buffer（1024 cap、overflow → global dirty）  
  - `NativeSensorBridge`: event→dirty マッピング（Phase5-A + `LOCATION_EVENTS=1` 時は LOCATIONCHANGE/REORDER）  
  - `WinEventSource`: sidecar ライフサイクル管理（指数バックオフ再起動）  
  - `ReconciliationScheduler`: 5 秒 sweep + overflow 即時 reconcile  
  - `tests/fixtures/mock-sidecar.js`: Node モック sidecar

### Phase 6 — read-only per-lens MCP リソース（`RESOURCES=1` でオプトイン）
- `resource-model.ts`: `buildLensSnapshot`, `projectResourceSummary/Guards/Debug`, `computeCanAct`, `formatGuardSummary`
- `resource-registry.ts`: URI ライフサイクル、tombstone 30 秒 TTL、128 エントリ eviction
- `perception-resources.ts`: `ResourceTemplate("perception://lens/{lensId}/{view}")`
- `ResourceNotificationScheduler`: attention 遷移時のみ coalesced 通知（500ms debounce）
- `server-windows.ts`: Reactive Perception instructions 追加

### Feature flags（全てデフォルト off）
| フラグ | 効果 |
|--------|------|
| `DESKTOP_TOUCH_PERCEPTION_NATIVE_EVENTS=1` | WinEvent sidecar 起動（要 `bin/dt-winevent-sidecar.exe`） |
| `DESKTOP_TOUCH_PERCEPTION_LOCATION_EVENTS=1` | LOCATIONCHANGE/MOVESIZESTART/MOVESIZEEND/REORDER |
| `DESKTOP_TOUCH_PERCEPTION_RESOURCES=1` | per-lens MCP リソース公開 |
| `DESKTOP_TOUCH_PERCEPTION_DEBUG_RESOURCES=1` | debug/events ビュー追加 |

### Resolved caveats from v0.9.0
- `guards.ts` の watermark 未使用（Milestone 2 で解消）
- foreground guard は値の変化を検出できるが、観測が dirty mark より古い場合でもパスしていた（解消）

### Known follow-ups（本 PR 範囲外）
- ネイティブ sidecar バイナリ未同梱（`NATIVE_EVENTS=1` は現状 test-only）
- Linux stub パリティ（`server-linux-stub.ts` はリソース登録なし）
- Session 分離リソース URI（stdio 単一クライアント MVP には不要）

## Test plan

- [x] `npm run build` — TypeScript strict clean
- [x] `npx vitest run tests/unit/` — 850 件全グリーン（Phase 4+5+6 追加分込み）
- [x] Opus レビューループ完了 — 2 回目で指摘ゼロ（major #3/#13 修正済み）
- [ ] 手動スモーク: v0.9 相当動作をフラグ全 off で確認（既存ユーザーへの動作変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)