### PR TITLE
Potential fix for code scanning alert no. 80: Unused variable, import, function or class

### DIFF
--- a/src/server-windows.ts
+++ b/src/server-windows.ts
@@ -1,5 +1,4 @@
 import { createServer, type Server as HttpServer } from "node:http";
-import { randomUUID } from "node:crypto";
 import { dirname, join } from "node:path";
 import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";


### PR DESCRIPTION
Potential fix for [https://github.com/Harusame64/desktop-touch-mcp/security/code-scanning/80](https://github.com/Harusame64/desktop-touch-mcp/security/code-scanning/80)

Remove the unused `randomUUID` import from `src/server-windows.ts`.

- **General fix**: delete imports that are not referenced anywhere in the file.
- **Best specific fix here**: remove `randomUUID` from `node:crypto` entirely, since it is a standalone import line and CodeQL identifies it as unused.
- **Where to change**: `src/server-windows.ts`, the import block at the top (line 2 in the provided snippet).
- **What is needed**: no new methods, definitions, or dependencies; just one import deletion.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
