### PR TITLE
[codex] Wrap browser_eval snippets in IIFE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
   now scoped to each individual snippet. Migrate persistent state to `window.myVar = …` or
   `globalThis.myVar = …`.
 
-
+## [0.14.0] - 2026-04-18 — Background Input (WM_CHAR) + SetValue Chain + Terminal BG Fast-Path
 
 ### Added
 - **Background input engine** (`src/engine/bg-input.ts`): WM_CHAR/WM_KEYDOWN injection via

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Changelog
 
-## [0.14.0] - 2026-04-18 — Background Input (WM_CHAR) + SetValue Chain + Terminal BG Fast-Path
+## [Unreleased] — browser_eval IIFE wrapping
+
+### Added
+- **`browser_eval` IIFE auto-wrapping**: snippets are now automatically wrapped in an async IIFE
+  before CDP evaluation. This prevents `const`/`let` redeclaration errors when calling
+  `browser_eval` multiple times in the same tab with identical variable names.
+- Expression-shaped snippets are wrapped as `;(async () => (expr))()` to preserve the return
+  value without requiring an explicit `return`.
+- Statement-shaped snippets fall back to an `eval()`-based wrapper that preserves completion
+  values (e.g. `const x = 1; x` still returns `1`). On pages with CSP that blocks `unsafe-eval`,
+  the wrapper automatically falls back to a plain IIFE block so the snippet still runs (completion
+  value may be lost but no error is thrown).
+- Explicitly-wrapped IIFE expressions are passed through unchanged.
+
+### Changed
+- **`browser_eval` schema description** updated to document the IIFE wrapping behavior and
+  note that `window.*` / `globalThis.*` should be used when state must persist across calls.
+
+### Breaking Changes
+- **Variable declarations do not persist across `browser_eval` calls.** Previously, `var`
+  declarations evaluated in the same CDP session were visible in subsequent calls; they are
+  now scoped to each individual snippet. Migrate persistent state to `window.myVar = …` or
+  `globalThis.myVar = …`.
+
+
 
 ### Added
 - **Background input engine** (`src/engine/bg-input.ts`): WM_CHAR/WM_KEYDOWN injection via

--- a/docs/browser-eval-iife-roadmap.md
+++ b/docs/browser-eval-iife-roadmap.md
@@ -1,0 +1,55 @@
+# browser_eval IIFE wrapping roadmap
+
+Issue: https://github.com/Harusame64/desktop-touch-mcp/issues/21
+
+Goal: make repeated `browser_eval` calls safe in the same tab by preventing
+global `const` / `let` redeclaration collisions.
+
+## Scope
+
+- Add an automatic IIFE wrapping step in `browserEvalHandler`.
+- Preserve explicitly wrapped user expressions.
+- Keep raw text and `withPerception` result formatting unchanged.
+- Add regression coverage for repeated declarations in the same tab.
+- Update tool guidance so agents know multi-statement snippets should use
+  `return` for the final value.
+
+## Checklist
+
+- [x] Confirm current `browserEvalHandler` passes `expression` directly to `evaluateInTab`.
+- [x] Confirm browser e2e tests already launch Chrome and call `browserEvalHandler`.
+- [x] Add a helper that prepares `browser_eval` expressions before CDP evaluation.
+- [x] Skip wrapping when the user already passes a common IIFE form.
+- [x] Wrap expression-shaped snippets as `;(async () => (...))()`.
+- [x] Wrap statement-shaped snippets as `;(async () => { ... })()`.
+- [x] Route `browserEvalHandler` through the helper.
+- [x] Update `browserEvalSchema.expression` description.
+- [x] Regenerate `src/stub-tool-catalog.ts`.
+- [x] Add e2e coverage for repeated `const` declarations.
+- [x] Add e2e coverage for multi-statement snippets with explicit `return`.
+- [x] Run targeted browser e2e test.
+- [x] Run `npm run build`.
+
+## Implementation Notes
+
+- Candidate file: `src/tools/browser.ts`
+- Candidate test file: `tests/e2e/browser-tab-context.test.ts`
+- `evaluateInTab` in `src/engine/cdp-bridge.ts` already uses
+  `awaitPromise: true`, so an async IIFE result should be awaited by CDP.
+- If the expression is a multi-statement snippet, the wrapper will not infer a
+  final return value. Callers should write `return value` explicitly.
+
+## Handoff State
+
+- Started on 2026-04-20.
+- `npm run build` passed.
+- `npx vitest run --project=e2e tests/e2e/browser-tab-context.test.ts` passed
+  with 11 tests.
+- `npm run generate:stub-catalog` updated the browser_eval schema description in
+  `src/stub-tool-catalog.ts`.
+- The first sandboxed Vitest attempt failed before tests with `spawn EPERM`;
+  rerunning the same targeted test outside the sandbox succeeded.
+- Existing dirty files before this work: `.gitignore`,
+  `docs/Anti-Fukuwarai-V2.md`, `docs/anti-Fukuwarai-V2-design.md`,
+  `docs/tool-descriptions.md`.
+- Do not revert those existing changes.

--- a/docs/browser-eval-iife-roadmap.md
+++ b/docs/browser-eval-iife-roadmap.md
@@ -29,6 +29,8 @@ global `const` / `let` redeclaration collisions.
 - [x] Add e2e coverage for multi-statement snippets with explicit `return`.
 - [x] Run targeted browser e2e test.
 - [x] Run `npm run build`.
+- [x] Address Copilot review: preserve statement completion values.
+- [x] Address Copilot review: only skip wrapping for standalone IIFE expressions.
 
 ## Implementation Notes
 
@@ -47,6 +49,8 @@ global `const` / `let` redeclaration collisions.
   with 11 tests.
 - `npm run generate:stub-catalog` updated the browser_eval schema description in
   `src/stub-tool-catalog.ts`.
+- Copilot review follow-up tightened IIFE detection and preserved completion
+  values for statement snippets such as `const x = 1; x`.
 - The first sandboxed Vitest attempt failed before tests with `spawn EPERM`;
   rerunning the same targeted test outside the sandbox succeeded.
 - Existing dirty files before this work: `.gitignore`,

--- a/src/stub-tool-catalog.ts
+++ b/src/stub-tool-catalog.ts
@@ -106,7 +106,7 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
       "type": "object",
       "properties": {
         "expression": {
-          "description": "JavaScript expression to evaluate in the browser tab",
+          "description": "JavaScript expression to evaluate in the browser tab. The server automatically wraps snippets in an async IIFE to avoid repeated const/let name collisions. For multi-statement snippets, use an explicit final return value.",
           "type": "string"
         },
         "tabId": {

--- a/src/stub-tool-catalog.ts
+++ b/src/stub-tool-catalog.ts
@@ -106,7 +106,7 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
       "type": "object",
       "properties": {
         "expression": {
-          "description": "JavaScript expression to evaluate in the browser tab. The server automatically wraps snippets in an async IIFE to avoid repeated const/let name collisions. For multi-statement snippets, use an explicit final return value.",
+          "description": "JavaScript expression to evaluate in the browser tab. The server automatically wraps snippets in an async IIFE to avoid repeated const/let name collisions. For multi-statement snippets, use an explicit final return value. Declarations (const/let/var) are scoped to each snippet and will not persist across repeated browser_eval calls; use window.* or globalThis.* for persistence.",
           "type": "string"
         },
         "tabId": {

--- a/src/tools/browser-eval-helpers.ts
+++ b/src/tools/browser-eval-helpers.ts
@@ -1,0 +1,55 @@
+/**
+ * Pure helpers for browser_eval IIFE wrapping.
+ * No side-effectful imports — importable from tests without mocks.
+ */
+
+type AsyncFunctionConstructor = new (...args: string[]) => (...args: unknown[]) => Promise<unknown>;
+const AsyncFunction = Object.getPrototypeOf(async function () { /* constructor only */ }).constructor as AsyncFunctionConstructor;
+
+export function canParseAsExpression(expression: string): boolean {
+  try {
+    new AsyncFunction(`return (\n${expression}\n);`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function isAlreadyWrappedIife(expression: string): boolean {
+  const normalized = expression
+    .trim()
+    .replace(/^;/, "")
+    .replace(/;+\s*$/, "");
+
+  if (!/^\s*\(\s*(?:async\s+function\b|function\b|async\s*\([^)]*\)\s*=>|\([^)]*\)\s*=>)/.test(normalized)) {
+    return false;
+  }
+
+  return canParseAsExpression(normalized);
+}
+
+export function prepareBrowserEvalExpression(expression: string): string {
+  if (isAlreadyWrappedIife(expression)) return expression;
+
+  if (canParseAsExpression(expression)) {
+    return `;(async () => (\n${expression}\n))()`;
+  }
+
+  const serializedExpression = JSON.stringify(expression);
+  return `;(async () => {
+  const __mcpExpression = ${serializedExpression};
+  try {
+    return eval(__mcpExpression);
+  } catch (__mcpEvalError) {
+    if (
+      __mcpEvalError instanceof SyntaxError ||
+      (__mcpEvalError instanceof Error && __mcpEvalError.name === "EvalError")
+    ) {
+      return (async () => {
+${expression}
+      })();
+    }
+    throw __mcpEvalError;
+  }
+})()`;
+}

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -28,6 +28,7 @@ import { narrateParam } from "./_narration.js";
 import type { RichBlock } from "../engine/uia-diff.js";
 import { evaluatePreToolGuards, buildEnvelopeFor } from "../engine/perception/registry.js";
 import { runActionGuard, isAutoGuardEnabled, validateAndPrepareFix, consumeFix } from "./_action-guard.js";
+import { canParseAsExpression, isAlreadyWrappedIife, prepareBrowserEvalExpression } from "./browser-eval-helpers.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Schemas
@@ -826,57 +827,6 @@ function safeStringifyEval(value: unknown): string {
 function safeCloneForTransport(value: unknown): unknown {
   try { return JSON.parse(safeStringifyEval(value)); }
   catch { return "[Unserializable]"; }
-}
-
-type AsyncFunctionConstructor = new (...args: string[]) => (...args: unknown[]) => Promise<unknown>;
-const AsyncFunction = Object.getPrototypeOf(async function () { /* constructor only */ }).constructor as AsyncFunctionConstructor;
-
-function isAlreadyWrappedIife(expression: string): boolean {
-  const normalized = expression
-    .trim()
-    .replace(/^;/, "")
-    .replace(/;+\s*$/, "");
-
-  if (!/^\s*\(\s*(?:async\s+function\b|function\b|async\s*\([^)]*\)\s*=>|\([^)]*\)\s*=>)/.test(normalized)) {
-    return false;
-  }
-
-  return canParseAsExpression(normalized);
-}
-
-function canParseAsExpression(expression: string): boolean {
-  try {
-    new AsyncFunction(`return (\n${expression}\n);`);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function prepareBrowserEvalExpression(expression: string): string {
-  if (isAlreadyWrappedIife(expression)) return expression;
-
-  if (canParseAsExpression(expression)) {
-    return `;(async () => (\n${expression}\n))()`;
-  }
-
-  const serializedExpression = JSON.stringify(expression);
-  return `;(async () => {
-  const __mcpExpression = ${serializedExpression};
-  try {
-    return eval(__mcpExpression);
-  } catch (__mcpEvalError) {
-    if (
-      __mcpEvalError instanceof SyntaxError ||
-      (__mcpEvalError instanceof Error && __mcpEvalError.name === "EvalError")
-    ) {
-      return (async () => {
-${expression}
-      })();
-    }
-    throw __mcpEvalError;
-  }
-})()`;
 }
 
 export const browserEvalHandler = async ({

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -84,7 +84,11 @@ export const browserClickElementSchema = {
 };
 
 export const browserEvalSchema = {
-  expression: z.string().describe("JavaScript expression to evaluate in the browser tab"),
+  expression: z.string().describe(
+    "JavaScript expression to evaluate in the browser tab. " +
+    "The server automatically wraps snippets in an async IIFE to avoid repeated const/let name collisions. " +
+    "For multi-statement snippets, use an explicit final return value."
+  ),
   tabId: tabIdParam,
   port: portParam,
   includeContext: includeContextParam,
@@ -822,6 +826,32 @@ function safeCloneForTransport(value: unknown): unknown {
   catch { return "[Unserializable]"; }
 }
 
+type AsyncFunctionConstructor = new (...args: string[]) => (...args: unknown[]) => Promise<unknown>;
+const AsyncFunction = Object.getPrototypeOf(async function () { /* constructor only */ }).constructor as AsyncFunctionConstructor;
+
+function isAlreadyWrappedIife(expression: string): boolean {
+  return /^\s*;?\s*\(\s*(?:async\s+function\b|function\b|async\s*\([^)]*\)\s*=>|\([^)]*\)\s*=>)/.test(expression);
+}
+
+function canParseAsExpression(expression: string): boolean {
+  try {
+    new AsyncFunction(`return (\n${expression}\n);`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function prepareBrowserEvalExpression(expression: string): string {
+  if (isAlreadyWrappedIife(expression)) return expression;
+
+  if (canParseAsExpression(expression)) {
+    return `;(async () => (\n${expression}\n))()`;
+  }
+
+  return `;(async () => {\n${expression}\n})()`;
+}
+
 export const browserEvalHandler = async ({
   expression,
   tabId,
@@ -866,7 +896,8 @@ export const browserEvalHandler = async ({
       perceptionEnv = ag.summary;
     }
 
-    const rawResult = await evaluateInTab(expression, tabId ?? null, port);
+    const preparedExpression = prepareBrowserEvalExpression(expression);
+    const rawResult = await evaluateInTab(preparedExpression, tabId ?? null, port);
 
     if (withPerception) {
       // Phase J: structured response mode — safeClone to avoid circular ref in transport

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -830,7 +830,16 @@ type AsyncFunctionConstructor = new (...args: string[]) => (...args: unknown[]) 
 const AsyncFunction = Object.getPrototypeOf(async function () { /* constructor only */ }).constructor as AsyncFunctionConstructor;
 
 function isAlreadyWrappedIife(expression: string): boolean {
-  return /^\s*;?\s*\(\s*(?:async\s+function\b|function\b|async\s*\([^)]*\)\s*=>|\([^)]*\)\s*=>)/.test(expression);
+  const normalized = expression
+    .trim()
+    .replace(/^;/, "")
+    .replace(/;+\s*$/, "");
+
+  if (!/^\s*\(\s*(?:async\s+function\b|function\b|async\s*\([^)]*\)\s*=>|\([^)]*\)\s*=>)/.test(normalized)) {
+    return false;
+  }
+
+  return canParseAsExpression(normalized);
 }
 
 function canParseAsExpression(expression: string): boolean {
@@ -849,7 +858,20 @@ function prepareBrowserEvalExpression(expression: string): string {
     return `;(async () => (\n${expression}\n))()`;
   }
 
-  return `;(async () => {\n${expression}\n})()`;
+  const serializedExpression = JSON.stringify(expression);
+  return `;(async () => {
+  const __mcpExpression = ${serializedExpression};
+  try {
+    return eval(__mcpExpression);
+  } catch (__mcpEvalError) {
+    if (__mcpEvalError instanceof SyntaxError) {
+      return (async () => {
+${expression}
+      })();
+    }
+    throw __mcpEvalError;
+  }
+})()`;
 }
 
 export const browserEvalHandler = async ({

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -28,7 +28,7 @@ import { narrateParam } from "./_narration.js";
 import type { RichBlock } from "../engine/uia-diff.js";
 import { evaluatePreToolGuards, buildEnvelopeFor } from "../engine/perception/registry.js";
 import { runActionGuard, isAutoGuardEnabled, validateAndPrepareFix, consumeFix } from "./_action-guard.js";
-import { canParseAsExpression, isAlreadyWrappedIife, prepareBrowserEvalExpression } from "./browser-eval-helpers.js";
+import { prepareBrowserEvalExpression } from "./browser-eval-helpers.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Schemas

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -87,7 +87,9 @@ export const browserEvalSchema = {
   expression: z.string().describe(
     "JavaScript expression to evaluate in the browser tab. " +
     "The server automatically wraps snippets in an async IIFE to avoid repeated const/let name collisions. " +
-    "For multi-statement snippets, use an explicit final return value."
+    "For multi-statement snippets, use an explicit final return value. " +
+    "Declarations (const/let/var) are scoped to each snippet and will not persist across repeated browser_eval calls; " +
+    "use window.* or globalThis.* for persistence."
   ),
   tabId: tabIdParam,
   port: portParam,
@@ -864,7 +866,10 @@ function prepareBrowserEvalExpression(expression: string): string {
   try {
     return eval(__mcpExpression);
   } catch (__mcpEvalError) {
-    if (__mcpEvalError instanceof SyntaxError) {
+    if (
+      __mcpEvalError instanceof SyntaxError ||
+      (__mcpEvalError instanceof Error && __mcpEvalError.name === "EvalError")
+    ) {
       return (async () => {
 ${expression}
       })();

--- a/tests/e2e/browser-tab-context.test.ts
+++ b/tests/e2e/browser-tab-context.test.ts
@@ -100,6 +100,32 @@ describe.skipIf(!CHROME_AVAILABLE)("browser_eval — activeTab/readyState annota
     // Should be a failure JSON, not have activeTab
     expect(text).not.toMatch(/activeTab:/);
   });
+
+  it("allows repeated const declarations in the same tab", async () => {
+    const first = await browserEvalHandler({
+      expression: "const items = document.querySelectorAll('button'); return items.length;",
+      port: TEST_PORT,
+      includeContext: false,
+    });
+    const second = await browserEvalHandler({
+      expression: "const items = document.querySelectorAll('a'); return items.length;",
+      port: TEST_PORT,
+      includeContext: false,
+    });
+
+    expect((first.content[0] as { text: string }).text.trim()).toMatch(/^\d+$/);
+    expect((second.content[0] as { text: string }).text.trim()).toMatch(/^\d+$/);
+  });
+
+  it("returns explicit values from multi-statement snippets", async () => {
+    const result = await browserEvalHandler({
+      expression: "const value = 20 + 22; return value;",
+      port: TEST_PORT,
+      includeContext: false,
+    });
+
+    expect((result.content[0] as { text: string }).text.trim()).toBe("42");
+  });
 });
 
 describe.skipIf(!CHROME_AVAILABLE)("browser_find_element — activeTab/readyState annotation", () => {

--- a/tests/e2e/browser-tab-context.test.ts
+++ b/tests/e2e/browser-tab-context.test.ts
@@ -126,6 +126,38 @@ describe.skipIf(!CHROME_AVAILABLE)("browser_eval — activeTab/readyState annota
 
     expect((result.content[0] as { text: string }).text.trim()).toBe("42");
   });
+
+  it("preserves completion values from multi-statement snippets", async () => {
+    const first = await browserEvalHandler({
+      expression: "const completionValue = 20 + 22; completionValue",
+      port: TEST_PORT,
+      includeContext: false,
+    });
+    const second = await browserEvalHandler({
+      expression: "const completionValue = 30 + 12; completionValue",
+      port: TEST_PORT,
+      includeContext: false,
+    });
+
+    expect((first.content[0] as { text: string }).text.trim()).toBe("42");
+    expect((second.content[0] as { text: string }).text.trim()).toBe("42");
+  });
+
+  it("wraps IIFE-prefixed snippets that include trailing top-level declarations", async () => {
+    const first = await browserEvalHandler({
+      expression: "(() => 1)(); const iifePrefixedValue = 20 + 22; iifePrefixedValue",
+      port: TEST_PORT,
+      includeContext: false,
+    });
+    const second = await browserEvalHandler({
+      expression: "(() => 2)(); const iifePrefixedValue = 30 + 12; iifePrefixedValue",
+      port: TEST_PORT,
+      includeContext: false,
+    });
+
+    expect((first.content[0] as { text: string }).text.trim()).toBe("42");
+    expect((second.content[0] as { text: string }).text.trim()).toBe("42");
+  });
 });
 
 describe.skipIf(!CHROME_AVAILABLE)("browser_find_element — activeTab/readyState annotation", () => {

--- a/tests/unit/browser-eval-iife.test.ts
+++ b/tests/unit/browser-eval-iife.test.ts
@@ -1,0 +1,196 @@
+/**
+ * tests/unit/browser-eval-iife.test.ts
+ *
+ * Unit tests for prepareBrowserEvalExpression, isAlreadyWrappedIife, and
+ * canParseAsExpression. No browser or CDP connection required.
+ */
+
+import { describe, it, expect } from "vitest";
+
+// ── Import internal helpers via module augmentation trick ─────────────────────
+// The three helpers are not exported, so we re-implement them here using the
+// same logic so we can test the logic in isolation. If the implementation in
+// browser.ts changes, these shadows must be updated in lock-step.
+// Alternatively, export them with an `@internal` JSDoc tag and import directly.
+
+type AsyncFunctionConstructor = new (...args: string[]) => (...args: unknown[]) => Promise<unknown>;
+const AsyncFunction = Object.getPrototypeOf(async function () {
+  /* constructor only */
+}).constructor as AsyncFunctionConstructor;
+
+function canParseAsExpression(expression: string): boolean {
+  try {
+    new AsyncFunction(`return (\n${expression}\n);`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isAlreadyWrappedIife(expression: string): boolean {
+  const normalized = expression
+    .trim()
+    .replace(/^;/, "")
+    .replace(/;+\s*$/, "");
+
+  if (
+    !/^\s*\(\s*(?:async\s+function\b|function\b|async\s*\([^)]*\)\s*=>|\([^)]*\)\s*=>)/.test(
+      normalized
+    )
+  ) {
+    return false;
+  }
+
+  return canParseAsExpression(normalized);
+}
+
+function prepareBrowserEvalExpression(expression: string): string {
+  if (isAlreadyWrappedIife(expression)) return expression;
+
+  if (canParseAsExpression(expression)) {
+    return `;(async () => (\n${expression}\n))()`;
+  }
+
+  const serializedExpression = JSON.stringify(expression);
+  return `;(async () => {
+  const __mcpExpression = ${serializedExpression};
+  try {
+    return eval(__mcpExpression);
+  } catch (__mcpEvalError) {
+    if (
+      __mcpEvalError instanceof SyntaxError ||
+      (__mcpEvalError instanceof Error && __mcpEvalError.name === "EvalError")
+    ) {
+      return (async () => {
+${expression}
+      })();
+    }
+    throw __mcpEvalError;
+  }
+})()`;
+}
+
+// ── canParseAsExpression ──────────────────────────────────────────────────────
+
+describe("canParseAsExpression", () => {
+  it("returns true for a simple expression", () => {
+    expect(canParseAsExpression("document.title")).toBe(true);
+  });
+
+  it("returns true for a numeric literal", () => {
+    expect(canParseAsExpression("42")).toBe(true);
+  });
+
+  it("returns true for an IIFE expression", () => {
+    expect(canParseAsExpression("(() => 1)()")).toBe(true);
+  });
+
+  it("returns false for a statement with const declaration", () => {
+    expect(canParseAsExpression("const x = 1; x")).toBe(false);
+  });
+
+  it("returns false for a statement with return", () => {
+    expect(canParseAsExpression("const x = 1; return x;")).toBe(false);
+  });
+
+  it("returns false for a multi-statement block", () => {
+    expect(canParseAsExpression("let a = 1; let b = 2; a + b")).toBe(false);
+  });
+});
+
+// ── isAlreadyWrappedIife ──────────────────────────────────────────────────────
+
+describe("isAlreadyWrappedIife", () => {
+  it("returns true for a standalone arrow IIFE", () => {
+    expect(isAlreadyWrappedIife("(() => 1)()")).toBe(true);
+  });
+
+  it("returns true for a standalone async arrow IIFE", () => {
+    expect(isAlreadyWrappedIife("(async () => 1)()")).toBe(true);
+  });
+
+  it("returns true for a standalone async function IIFE", () => {
+    expect(isAlreadyWrappedIife("(async function() { return 1; })()")).toBe(true);
+  });
+
+  it("returns true for a standalone function IIFE", () => {
+    expect(isAlreadyWrappedIife("(function() { return 1; })()")).toBe(true);
+  });
+
+  it("returns true for an IIFE with leading semicolon", () => {
+    expect(isAlreadyWrappedIife(";(() => 1)()")).toBe(true);
+  });
+
+  it("returns true for an IIFE with trailing semicolon", () => {
+    expect(isAlreadyWrappedIife("(() => 1)();")).toBe(true);
+  });
+
+  it("returns false for a plain expression", () => {
+    expect(isAlreadyWrappedIife("document.title")).toBe(false);
+  });
+
+  it("returns false for an IIFE followed by top-level const (not standalone)", () => {
+    expect(isAlreadyWrappedIife("(() => 1)(); const x = 2; x")).toBe(false);
+  });
+
+  it("returns false for a statement-shaped snippet", () => {
+    expect(isAlreadyWrappedIife("const x = 1; x")).toBe(false);
+  });
+});
+
+// ── prepareBrowserEvalExpression ──────────────────────────────────────────────
+
+describe("prepareBrowserEvalExpression", () => {
+  it("passes through a standalone IIFE unchanged", () => {
+    const expr = "(() => 42)()";
+    expect(prepareBrowserEvalExpression(expr)).toBe(expr);
+  });
+
+  it("wraps a simple expression in expression-form IIFE", () => {
+    const result = prepareBrowserEvalExpression("document.title");
+    expect(result).toBe(`;(async () => (\ndocument.title\n))()`);
+  });
+
+  it("wraps a numeric literal in expression-form IIFE", () => {
+    const result = prepareBrowserEvalExpression("42");
+    expect(result).toBe(`;(async () => (\n42\n))()`);
+  });
+
+  it("wraps a statement-shaped snippet with eval-based wrapper", () => {
+    const result = prepareBrowserEvalExpression("const x = 1; x");
+    expect(result).toContain("eval(");
+    expect(result).toContain(JSON.stringify("const x = 1; x"));
+  });
+
+  it("eval-based wrapper includes EvalError in catch condition", () => {
+    const result = prepareBrowserEvalExpression("const x = 1; x");
+    expect(result).toContain('__mcpEvalError.name === "EvalError"');
+  });
+
+  it("eval-based wrapper includes SyntaxError in catch condition", () => {
+    const result = prepareBrowserEvalExpression("const x = 1; x");
+    expect(result).toContain("__mcpEvalError instanceof SyntaxError");
+  });
+
+  it("wraps a snippet with explicit return in eval-based wrapper", () => {
+    const result = prepareBrowserEvalExpression("const x = 42; return x;");
+    expect(result).toContain("eval(");
+  });
+
+  it("does not double-wrap an IIFE followed by top-level declarations", () => {
+    const snippet = "(() => 1)(); const v = 42; v";
+    const result = prepareBrowserEvalExpression(snippet);
+    // Must be wrapped (not passed through), so eval or IIFE block path
+    expect(result).not.toBe(snippet);
+    expect(result).toContain("async");
+  });
+
+  it("eval-based wrapper contains the fallback IIFE block for CSP environments", () => {
+    const expr = "const x = 1; x";
+    const result = prepareBrowserEvalExpression(expr);
+    // The fallback IIFE block should embed the original expression
+    expect(result).toContain(expr);
+    // The outer wrapper should be there
+    expect(result).toMatch(/\(async \(\) => \{/);
+  });
+});

--- a/tests/unit/browser-eval-iife.test.ts
+++ b/tests/unit/browser-eval-iife.test.ts
@@ -6,69 +6,11 @@
  */
 
 import { describe, it, expect } from "vitest";
-
-// ── Import internal helpers via module augmentation trick ─────────────────────
-// The three helpers are not exported, so we re-implement them here using the
-// same logic so we can test the logic in isolation. If the implementation in
-// browser.ts changes, these shadows must be updated in lock-step.
-// Alternatively, export them with an `@internal` JSDoc tag and import directly.
-
-type AsyncFunctionConstructor = new (...args: string[]) => (...args: unknown[]) => Promise<unknown>;
-const AsyncFunction = Object.getPrototypeOf(async function () {
-  /* constructor only */
-}).constructor as AsyncFunctionConstructor;
-
-function canParseAsExpression(expression: string): boolean {
-  try {
-    new AsyncFunction(`return (\n${expression}\n);`);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function isAlreadyWrappedIife(expression: string): boolean {
-  const normalized = expression
-    .trim()
-    .replace(/^;/, "")
-    .replace(/;+\s*$/, "");
-
-  if (
-    !/^\s*\(\s*(?:async\s+function\b|function\b|async\s*\([^)]*\)\s*=>|\([^)]*\)\s*=>)/.test(
-      normalized
-    )
-  ) {
-    return false;
-  }
-
-  return canParseAsExpression(normalized);
-}
-
-function prepareBrowserEvalExpression(expression: string): string {
-  if (isAlreadyWrappedIife(expression)) return expression;
-
-  if (canParseAsExpression(expression)) {
-    return `;(async () => (\n${expression}\n))()`;
-  }
-
-  const serializedExpression = JSON.stringify(expression);
-  return `;(async () => {
-  const __mcpExpression = ${serializedExpression};
-  try {
-    return eval(__mcpExpression);
-  } catch (__mcpEvalError) {
-    if (
-      __mcpEvalError instanceof SyntaxError ||
-      (__mcpEvalError instanceof Error && __mcpEvalError.name === "EvalError")
-    ) {
-      return (async () => {
-${expression}
-      })();
-    }
-    throw __mcpEvalError;
-  }
-})()`;
-}
+import {
+  canParseAsExpression,
+  isAlreadyWrappedIife,
+  prepareBrowserEvalExpression,
+} from "../../src/tools/browser-eval-helpers.js";
 
 // ── canParseAsExpression ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Wrap browser_eval snippets in an async IIFE before CDP evaluation to avoid repeated const/let redeclaration collisions in the same tab.
- Preserve common already-wrapped IIFE inputs and document the explicit return expectation for multi-statement snippets.
- Add a handoff roadmap and e2e regression coverage, then regenerate the stub tool catalog.

## Validation
- npm run build
- npx vitest run --project=e2e tests/e2e/browser-tab-context.test.ts