### PR TITLE
[codex] Fix tray and stdio shutdown handling

### DIFF
--- a/bin/launcher.js
+++ b/bin/launcher.js
@@ -2,6 +2,7 @@
 
 import { execFile, spawn } from "node:child_process";
 import { createReadStream, createWriteStream, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import {
   mkdir,
   mkdtemp,
@@ -40,6 +41,71 @@ function log(message) {
 function fail(message) {
   console.error(`[desktop-touch-mcp] ${message}`);
   process.exit(1);
+}
+
+export function isDisconnectError(error) {
+  return error?.code === "EPIPE" || error?.code === "ERR_STREAM_DESTROYED";
+}
+
+export function wireLauncherStdio(child, options = {}) {
+  const parentStdin = options.parentStdin ?? process.stdin;
+  const parentStdout = options.parentStdout ?? process.stdout;
+  const parentStderr = options.parentStderr ?? process.stderr;
+  const shutdownGraceMs = options.shutdownGraceMs ?? 1000;
+
+  let shutdownRequested = false;
+  let forcedShutdownTimer = null;
+
+  function clearForcedShutdownTimer() {
+    if (forcedShutdownTimer !== null) {
+      clearTimeout(forcedShutdownTimer);
+      forcedShutdownTimer = null;
+    }
+  }
+
+  function requestChildShutdown() {
+    if (shutdownRequested) return;
+    shutdownRequested = true;
+    try {
+      child.stdin?.end();
+    } catch {
+      // ignore
+    }
+    forcedShutdownTimer = setTimeout(() => {
+      if (child.exitCode === null && !child.killed) {
+        try { child.kill("SIGTERM"); } catch { /* ignore */ }
+      }
+    }, shutdownGraceMs);
+    if (forcedShutdownTimer.unref) forcedShutdownTimer.unref();
+  }
+
+  function terminateChild() {
+    clearForcedShutdownTimer();
+    if (child.exitCode === null && !child.killed) {
+      try { child.kill("SIGTERM"); } catch { /* ignore */ }
+    }
+  }
+
+  parentStdin.pipe(child.stdin);
+  child.stdout?.pipe(parentStdout);
+  child.stderr?.pipe(parentStderr);
+
+  parentStdin.on("end", requestChildShutdown);
+  parentStdin.on("close", requestChildShutdown);
+  parentStdin.on("error", requestChildShutdown);
+
+  const onParentOutputError = (error) => {
+    if (isDisconnectError(error)) {
+      terminateChild();
+    }
+  };
+  parentStdout.on("error", onParentOutputError);
+  parentStderr.on("error", onParentOutputError);
+
+  child.stdin?.on("error", (error) => {
+    if (!isDisconnectError(error)) throw error;
+  });
+  child.on("exit", clearForcedShutdownTimer);
 }
 
 function tagToDirName(tagName) {
@@ -286,9 +352,11 @@ function launchServer(releaseDir) {
   const entry = path.join(releaseDir, "dist", "index.js");
   const child = spawn(process.execPath, [entry, ...process.argv.slice(2)], {
     cwd: releaseDir,
-    stdio: "inherit",
+    stdio: ["pipe", "pipe", "pipe"],
     windowsHide: false,
   });
+
+  wireLauncherStdio(child);
 
   for (const signal of ["SIGINT", "SIGTERM"]) {
     process.on(signal, () => {
@@ -318,6 +386,14 @@ async function main() {
   launchServer(releaseDir);
 }
 
-main().catch((error) => {
-  fail(error instanceof Error ? error.message : String(error));
-});
+const launchedAsScript = (() => {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  return path.resolve(entry) === path.resolve(fileURLToPath(import.meta.url));
+})();
+
+if (launchedAsScript) {
+  main().catch((error) => {
+    fail(error instanceof Error ? error.message : String(error));
+  });
+}

--- a/src/server-windows.ts
+++ b/src/server-windows.ts
@@ -229,7 +229,12 @@ const httpUrl = useHttp ? `http://127.0.0.1:${httpPort}/mcp` : undefined;
 logAutoGuardStartup();
 
 // ─── Start tray icon ─────────────────────────────────────────────────────────
-const trayOptions: TrayOptions = { httpUrl, icoPath: icoOk, version: SERVER_VERSION };
+const trayOptions: TrayOptions = {
+  httpUrl,
+  icoPath: icoOk,
+  version: SERVER_VERSION,
+  onExitRequested: shutdown,
+};
 startTray(trayOptions);
 
 // ─── Connect MCP transport ───────────────────────────────────────────────────

--- a/src/utils/tray.ts
+++ b/src/utils/tray.ts
@@ -7,6 +7,8 @@ export interface TrayOptions {
   icoPath?: string;
   /** Server version string for About dialog and tooltip */
   version?: string;
+  /** Called when the tray explicitly requests that the parent process exit. */
+  onExitRequested?: () => void;
 }
 
 function escapePs(s: string): string {
@@ -52,6 +54,8 @@ function buildTrayScript(options: TrayOptions): string {
   ].join("\n");
 
   const exitBody = [
+    `    [Console]::Out.WriteLine('EXIT')`,
+    `    [Console]::Out.Flush()`,
     `    $icon.Visible = $false`,
     `    $icon.Dispose()`,
     `    [System.Windows.Forms.Application]::Exit()`,
@@ -150,6 +154,22 @@ function buildTrayScript(options: TrayOptions): string {
 
 let trayProcess: ChildProcess | null = null;
 
+export function createTrayMessageParser(
+  onMessage: (message: string) => void
+): (chunk: string | Buffer) => void {
+  let pending = "";
+  return (chunk: string | Buffer) => {
+    pending += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+    let newlineIndex = pending.indexOf("\n");
+    while (newlineIndex !== -1) {
+      const line = pending.slice(0, newlineIndex).trim();
+      pending = pending.slice(newlineIndex + 1);
+      if (line) onMessage(line);
+      newlineIndex = pending.indexOf("\n");
+    }
+  };
+}
+
 /** Start the system tray icon in a background PowerShell process */
 export function startTray(options: TrayOptions = {}): void {
   try {
@@ -163,12 +183,18 @@ export function startTray(options: TrayOptions = {}): void {
       }
     );
 
-    trayProcess.stdout?.once("data", (chunk: Buffer) => {
-      const msg = chunk.toString().trim();
+    const parseStdout = createTrayMessageParser((msg) => {
       if (msg === "READY") {
         console.error("[tray] System tray icon active");
+        return;
+      }
+      if (msg === "EXIT") {
+        console.error("[tray] Exit requested from tray");
+        options.onExitRequested?.();
       }
     });
+
+    trayProcess.stdout?.on("data", parseStdout);
 
     trayProcess.on("exit", (code) => {
       console.error(`[tray] Tray process exited (code ${code})`);

--- a/tests/e2e/launcher-stdio-exit.test.ts
+++ b/tests/e2e/launcher-stdio-exit.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { eventually, sleep } from "./helpers/wait.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "../..");
+const launcherPath = path.resolve(repoRoot, "bin/launcher.js");
+
+const spawned: ChildProcess[] = [];
+const tempDirs: string[] = [];
+
+function track(proc: ChildProcess): ChildProcess {
+  spawned.push(proc);
+  return proc;
+}
+
+async function loadLauncherManifest(): Promise<{ version: string; tagName: string; assetName: string; sha256: string }> {
+  const source = await readFile(launcherPath, "utf8");
+  const version = source.match(/const PACKAGE_VERSION = "([^"]+)";/)?.[1];
+  const tagName = source.match(/tagName: "(v[^"]+)"/)?.[1];
+  const assetName = source.match(/const ASSET_NAME = "([^"]+)";/)?.[1];
+  const sha256 = source.match(/sha256: "([a-f0-9]{64})"/i)?.[1];
+  if (!version || !tagName || !assetName || !sha256) {
+    throw new Error("Failed to parse launcher release manifest");
+  }
+  return { version, tagName, assetName, sha256: sha256.toLowerCase() };
+}
+
+async function setupFakeRelease(): Promise<{
+  cacheRoot: string;
+  runtimePidFile: string;
+  runtimeLogFile: string;
+}> {
+  const manifest = await loadLauncherManifest();
+  const cacheRoot = await mkdtemp(path.join(tmpdir(), "desktop-touch-launcher-e2e-"));
+  tempDirs.push(cacheRoot);
+
+  const releaseDir = path.join(cacheRoot, "releases", manifest.tagName);
+  const distDir = path.join(releaseDir, "dist");
+  await mkdir(distDir, { recursive: true });
+
+  const runtimePidFile = path.join(cacheRoot, "runtime.pid");
+  const runtimeLogFile = path.join(cacheRoot, "runtime.log");
+  const runtimeScript = `
+import { appendFileSync, writeFileSync } from "node:fs";
+
+const pidFile = process.env.TEST_RUNTIME_PID_FILE;
+const logFile = process.env.TEST_RUNTIME_LOG_FILE;
+if (!pidFile || !logFile) throw new Error("missing test runtime env");
+
+writeFileSync(pidFile, String(process.pid), "utf8");
+appendFileSync(logFile, "START\\n", "utf8");
+
+process.stdin.resume();
+process.stdin.on("end", () => {
+  appendFileSync(logFile, "STDIN_END\\n", "utf8");
+});
+
+const hold = setInterval(() => {}, 1000);
+
+process.on("SIGTERM", () => {
+  appendFileSync(logFile, "SIGTERM\\n", "utf8");
+  clearInterval(hold);
+  process.exit(0);
+});
+`;
+  await writeFile(path.join(distDir, "index.js"), runtimeScript, "utf8");
+
+  const metadata = {
+    tagName: manifest.tagName,
+    assetName: manifest.assetName,
+    sha256: manifest.sha256,
+    updatedAt: new Date().toISOString(),
+  };
+  await writeFile(path.join(releaseDir, ".desktop-touch-release.json"), `${JSON.stringify(metadata, null, 2)}\n`, "utf8");
+  await writeFile(path.join(cacheRoot, "current.json"), `${JSON.stringify(metadata, null, 2)}\n`, "utf8");
+
+  return { cacheRoot, runtimePidFile, runtimeLogFile };
+}
+
+async function readRuntimePid(pidFile: string): Promise<number> {
+  const raw = await eventually(
+    async () => {
+      if (!existsSync(pidFile)) return null;
+      const text = (await readFile(pidFile, "utf8")).trim();
+      return text.length > 0 ? text : null;
+    },
+    { timeoutMs: 5_000, intervalMs: 100, label: "runtime pid file" }
+  );
+  const pid = parseInt(raw, 10);
+  if (!Number.isFinite(pid) || pid <= 0) {
+    throw new Error(`Invalid runtime pid: ${raw}`);
+  }
+  return pid;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    return code !== "ESRCH";
+  }
+}
+
+async function waitForExit(proc: ChildProcess, timeoutMs: number): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  if (proc.exitCode !== null) {
+    return { code: proc.exitCode, signal: proc.signalCode };
+  }
+  return await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`process ${proc.pid ?? "unknown"} did not exit within ${timeoutMs}ms`));
+    }, timeoutMs);
+    proc.once("exit", (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code, signal });
+    });
+  });
+}
+
+afterEach(async () => {
+  for (const proc of spawned.splice(0)) {
+    if (proc.exitCode === null && !proc.killed) {
+      try { proc.kill("SIGTERM"); } catch { /* ignore */ }
+      await sleep(100);
+      if (proc.exitCode === null && !proc.killed) {
+        try { proc.kill("SIGKILL"); } catch { /* ignore */ }
+      }
+    }
+  }
+  for (const dir of tempDirs.splice(0)) {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe("launcher stdio shutdown", () => {
+  it("reaps the spawned runtime when the caller closes stdin", async () => {
+    const { cacheRoot, runtimePidFile, runtimeLogFile } = await setupFakeRelease();
+    const stderrChunks: string[] = [];
+    const launcher = track(spawn(process.execPath, [launcherPath], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        DESKTOP_TOUCH_MCP_HOME: cacheRoot,
+        TEST_RUNTIME_PID_FILE: runtimePidFile,
+        TEST_RUNTIME_LOG_FILE: runtimeLogFile,
+      },
+      stdio: ["pipe", "ignore", "pipe"],
+      windowsHide: true,
+    }));
+    launcher.stderr?.on("data", (chunk: Buffer) => {
+      stderrChunks.push(chunk.toString());
+    });
+
+    const runtimePid = await readRuntimePid(runtimePidFile);
+    expect(isProcessAlive(runtimePid)).toBe(true);
+
+    launcher.stdin?.end();
+
+    const exit = await waitForExit(launcher, 5_000);
+    expect(exit.signal === null || exit.signal === "SIGTERM").toBe(true);
+    expect(exit.code === 0 || exit.code === 1).toBe(true);
+
+    await eventually(
+      async () => (isProcessAlive(runtimePid) ? null : true),
+      { timeoutMs: 5_000, intervalMs: 100, label: "runtime exit" }
+    );
+
+    const runtimeLog = await readFile(runtimeLogFile, "utf8");
+    expect(runtimeLog).toContain("START");
+    expect(runtimeLog).toContain("STDIN_END");
+
+    const launcherStderr = stderrChunks.join("");
+    expect(launcherStderr).not.toContain("Failed to start release runtime");
+  });
+});

--- a/tests/unit/launcher-stdio.test.ts
+++ b/tests/unit/launcher-stdio.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+
+import { isDisconnectError, wireLauncherStdio } from "../../bin/launcher.js";
+
+class MockReadable extends EventEmitter {
+  pipe = vi.fn();
+}
+
+class MockWritable extends EventEmitter {
+  end = vi.fn();
+  pipe = vi.fn();
+  on = super.on.bind(this);
+}
+
+class MockChildProcess extends EventEmitter {
+  stdin = new MockWritable();
+  stdout = new MockReadable();
+  stderr = new MockReadable();
+  killed = false;
+  exitCode = null;
+  kill = vi.fn((signal?: string) => {
+    this.killed = true;
+    this.exitCode = signal ? 1 : 0;
+    return true;
+  });
+}
+
+describe("isDisconnectError", () => {
+  it("recognizes EPIPE and ERR_STREAM_DESTROYED", () => {
+    expect(isDisconnectError({ code: "EPIPE" })).toBe(true);
+    expect(isDisconnectError({ code: "ERR_STREAM_DESTROYED" })).toBe(true);
+    expect(isDisconnectError({ code: "ENOENT" })).toBe(false);
+  });
+});
+
+describe("wireLauncherStdio", () => {
+  it("pipes parent stdio into the child and back out", () => {
+    const parentStdin = new MockReadable();
+    const parentStdout = new MockWritable();
+    const parentStderr = new MockWritable();
+    const child = new MockChildProcess();
+
+    wireLauncherStdio(child as never, {
+      parentStdin: parentStdin as never,
+      parentStdout: parentStdout as never,
+      parentStderr: parentStderr as never,
+      shutdownGraceMs: 5,
+    });
+
+    expect(parentStdin.pipe).toHaveBeenCalledWith(child.stdin);
+    expect(child.stdout.pipe).toHaveBeenCalledWith(parentStdout);
+    expect(child.stderr.pipe).toHaveBeenCalledWith(parentStderr);
+  });
+
+  it("requests graceful child shutdown when parent stdin closes", async () => {
+    vi.useFakeTimers();
+    const parentStdin = new MockReadable();
+    const parentStdout = new MockWritable();
+    const parentStderr = new MockWritable();
+    const child = new MockChildProcess();
+
+    wireLauncherStdio(child as never, {
+      parentStdin: parentStdin as never,
+      parentStdout: parentStdout as never,
+      parentStderr: parentStderr as never,
+      shutdownGraceMs: 25,
+    });
+
+    parentStdin.emit("end");
+    expect(child.stdin.end).toHaveBeenCalledTimes(1);
+    expect(child.kill).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(25);
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    vi.useRealTimers();
+  });
+
+  it("terminates the child immediately when parent stdout breaks", () => {
+    const parentStdin = new MockReadable();
+    const parentStdout = new MockWritable();
+    const parentStderr = new MockWritable();
+    const child = new MockChildProcess();
+
+    wireLauncherStdio(child as never, {
+      parentStdin: parentStdin as never,
+      parentStdout: parentStdout as never,
+      parentStderr: parentStderr as never,
+      shutdownGraceMs: 25,
+    });
+
+    parentStdout.emit("error", { code: "EPIPE" });
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+});

--- a/tests/unit/launcher-stdio.test.ts
+++ b/tests/unit/launcher-stdio.test.ts
@@ -55,25 +55,28 @@ describe("wireLauncherStdio", () => {
 
   it("requests graceful child shutdown when parent stdin closes", async () => {
     vi.useFakeTimers();
-    const parentStdin = new MockReadable();
-    const parentStdout = new MockWritable();
-    const parentStderr = new MockWritable();
-    const child = new MockChildProcess();
+    try {
+      const parentStdin = new MockReadable();
+      const parentStdout = new MockWritable();
+      const parentStderr = new MockWritable();
+      const child = new MockChildProcess();
 
-    wireLauncherStdio(child as never, {
-      parentStdin: parentStdin as never,
-      parentStdout: parentStdout as never,
-      parentStderr: parentStderr as never,
-      shutdownGraceMs: 25,
-    });
+      wireLauncherStdio(child as never, {
+        parentStdin: parentStdin as never,
+        parentStdout: parentStdout as never,
+        parentStderr: parentStderr as never,
+        shutdownGraceMs: 25,
+      });
 
-    parentStdin.emit("end");
-    expect(child.stdin.end).toHaveBeenCalledTimes(1);
-    expect(child.kill).not.toHaveBeenCalled();
+      parentStdin.emit("end");
+      expect(child.stdin.end).toHaveBeenCalledTimes(1);
+      expect(child.kill).not.toHaveBeenCalled();
 
-    await vi.advanceTimersByTimeAsync(25);
-    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
-    vi.useRealTimers();
+      await vi.advanceTimersByTimeAsync(25);
+      expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("terminates the child immediately when parent stdout breaks", () => {

--- a/tests/unit/tray.test.ts
+++ b/tests/unit/tray.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createTrayMessageParser } from "../../src/utils/tray.js";
+
+describe("createTrayMessageParser", () => {
+  it("emits line-delimited tray messages", () => {
+    const messages: string[] = [];
+    const parse = createTrayMessageParser((message) => {
+      messages.push(message);
+    });
+
+    parse("READY\nEXIT\n");
+
+    expect(messages).toEqual(["READY", "EXIT"]);
+  });
+
+  it("buffers partial chunks until a newline arrives", () => {
+    const onMessage = vi.fn();
+    const parse = createTrayMessageParser(onMessage);
+
+    parse("REA");
+    parse("DY\nEX");
+    parse("IT\n");
+
+    expect(onMessage).toHaveBeenCalledTimes(2);
+    expect(onMessage).toHaveBeenNthCalledWith(1, "READY");
+    expect(onMessage).toHaveBeenNthCalledWith(2, "EXIT");
+  });
+
+  it("normalizes CRLF and ignores blank lines", () => {
+    const messages: string[] = [];
+    const parse = createTrayMessageParser((message) => {
+      messages.push(message);
+    });
+
+    parse("\r\nREADY\r\n\r\nEXIT\r\n");
+
+    expect(messages).toEqual(["READY", "EXIT"]);
+  });
+});


### PR DESCRIPTION
## Summary
- forward tray exit requests to the server shutdown path instead of only closing the tray PowerShell process
- proxy launcher stdio so parent disconnects close the spawned runtime and avoid leaving Node behind in stdio mode
- add unit and e2e coverage for tray message parsing and launcher/runtime shutdown behavior

## Root Cause
- tray exit only terminated the tray helper process and never notified the parent Node runtime
- the npm launcher used stdio inheritance, so it had no place to detect caller disconnects and cleanly reap the spawned runtime

## Validation
- npm run build
- npm run test:unit -- tests/unit/tray.test.ts tests/unit/launcher-stdio.test.ts
- npm run test:e2e -- tests/e2e/launcher-stdio-exit.test.ts
