### PR TITLE
fix(screenshot): return resolved window title in SoM response

### DIFF
--- a/src/engine/ocr-bridge.ts
+++ b/src/engine/ocr-bridge.ts
@@ -338,6 +338,8 @@ export interface SomPipelineResult {
   elements: SomElement[];
   /** Upscale factor used during OCR preprocessing (for debugging). */
   preprocessScale: number;
+  /** Full title of the resolved window. When hwnd is passed, reflects the window's current title rather than the windowTitle argument. */
+  resolvedWindowTitle: string;
 }
 
 /**
@@ -399,6 +401,7 @@ export async function runSomPipeline(
   // ── Locate window & capture raw RGBA ───────────────────────────────────────
   let targetHwnd: unknown = hwnd ?? null;
   let origin = { x: 0, y: 0 };
+  let resolvedWindowTitle = windowTitle;
 
   if (!targetHwnd) {
     const wins = enumWindowsInZOrder();
@@ -406,12 +409,14 @@ export async function runSomPipeline(
     if (!win) throw new Error(`runSomPipeline: window not found: "${windowTitle}"`);
     targetHwnd = win.hwnd;
     origin = { x: win.region.x, y: win.region.y };
+    resolvedWindowTitle = win.title;
   } else {
     // Resolve origin from enumWindowsInZOrder for the known hwnd
     const wins = enumWindowsInZOrder();
     const win  = wins.find((w) => w.hwnd === targetHwnd);
     if (win) {
       origin = { x: win.region.x, y: win.region.y };
+      resolvedWindowTitle = win.title;
     } else {
       console.error(
         `[SoM] WARNING: hwnd provided but window not found in enumWindowsInZOrder ` +
@@ -564,5 +569,5 @@ export async function runSomPipeline(
 
   console.error(`[SoM] total pipeline: ${(performance.now() - _somT0).toFixed(1)}ms`);
 
-  return { somImage, elements, preprocessScale: effectiveScale };
+  return { somImage, elements, preprocessScale: effectiveScale, resolvedWindowTitle };
 }

--- a/src/engine/ocr-bridge.ts
+++ b/src/engine/ocr-bridge.ts
@@ -385,7 +385,7 @@ export function clusterOcrWords(words: OcrWord[], elementGapThreshold = 35): Som
  *  5. Convert image-local coords → absolute screen coords (+ origin).
  *  6. `mergeNearbyWords` → `clusterOcrWords` → `SomElement[]`.
  *  7. Render SoM image via Rust `drawSomLabels` (or skip if unavailable).
- *  8. Return `{ somImage, elements, preprocessScale }`.
+ *  8. Return `{ somImage, elements, preprocessScale, resolvedWindowTitle }`.
  *
  * @param windowTitle  Partial window title (same matching convention as UIA calls).
  * @param hwnd         Optional HWND (bigint) — uses enumWindowsInZOrder when null.

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -386,7 +386,7 @@ export const screenshotHandler = async ({
           type: "text" as const,
           text: JSON.stringify(
             {
-              window: resolvedTitle,
+              window: somResult.resolvedWindowTitle,
               detail: "som",
               elements: somResult.elements,
               preprocessScale: somResult.preprocessScale,
@@ -615,7 +615,7 @@ export const screenshotHandler = async ({
               type: "text" as const,
               text: JSON.stringify(
                 {
-                  window: resolvedTitle,
+                  window: somResult.resolvedWindowTitle,
                   hints,
                   // Step 5: structured element list with ID-to-coordinate mapping
                   elements: somResult.elements,

--- a/tests/unit/screenshot-som.test.ts
+++ b/tests/unit/screenshot-som.test.ts
@@ -60,6 +60,7 @@ describe("screenshotHandler - detail='som' mode", () => {
       elements: [{ id: 1, text: "Click Me", region: { x: 10, y: 10, width: 50, height: 20 }, clickAt: { x: 35, y: 20 } }],
       somImage: { base64: "fake-image", mimeType: "image/png" },
       preprocessScale: 1.0,
+      resolvedWindowTitle: "My App",
     });
 
     const result = await screenshotHandler({
@@ -78,16 +79,22 @@ describe("screenshotHandler - detail='som' mode", () => {
     expect(result.isError).toBeUndefined();
     expect(mockRunSomPipeline).toHaveBeenCalledWith("My App", 12345n, "ja");
     const textContent = JSON.parse(result.content[0].text);
+    expect(textContent.window).toBe("My App");
     expect(textContent.detail).toBe("som");
     expect(textContent.elements).toHaveLength(1);
     expect(result.content[1].type).toBe("image");
   });
 
-  it("should prioritize hwnd from resolveWindowTarget", async () => {
+  it("should prioritize hwnd from resolveWindowTarget and use resolved title in output", async () => {
     mockResolveWindowTarget.mockResolvedValue({ title: "My App", hwnd: 54321n });
-    mockRunSomPipeline.mockResolvedValue({ elements: [], somImage: null, preprocessScale: 1.0 });
+    mockRunSomPipeline.mockResolvedValue({
+      elements: [],
+      somImage: null,
+      preprocessScale: 1.0,
+      resolvedWindowTitle: "My App — Full Title",
+    });
 
-    await screenshotHandler({
+    const result = await screenshotHandler({
       detail: "som",
       confirmImage: true,
       windowTitle: "My App",
@@ -102,13 +109,20 @@ describe("screenshotHandler - detail='som' mode", () => {
 
     expect(mockRunSomPipeline).toHaveBeenCalledWith("My App", 54321n, "ja");
     expect(mockEnumWindowsInZOrder).not.toHaveBeenCalled();
+    const textContent = JSON.parse(result.content[0].text);
+    expect(textContent.window).toBe("My App — Full Title");
   });
 
   it("should delegate title search to runSomPipeline when resolveWindowTarget returns null", async () => {
     mockResolveWindowTarget.mockResolvedValue(null);
-    mockRunSomPipeline.mockResolvedValue({ elements: [], somImage: null, preprocessScale: 1.0 });
+    mockRunSomPipeline.mockResolvedValue({
+      elements: [],
+      somImage: null,
+      preprocessScale: 1.0,
+      resolvedWindowTitle: "My App (Actual)",
+    });
 
-    await screenshotHandler({
+    const result = await screenshotHandler({
       detail: "som",
       confirmImage: true,
       windowTitle: "My App",
@@ -124,6 +138,9 @@ describe("screenshotHandler - detail='som' mode", () => {
     // Handler passes null hwnd; runSomPipeline handles its own window search
     expect(mockRunSomPipeline).toHaveBeenCalledWith("My App", null, "ja");
     expect(mockEnumWindowsInZOrder).not.toHaveBeenCalled();
+    // window field must reflect the full resolved title, not the partial input
+    const textContent = JSON.parse(result.content[0].text);
+    expect(textContent.window).toBe("My App (Actual)");
   });
 
   it("should return only text content when somImage is null", async () => {
@@ -132,6 +149,7 @@ describe("screenshotHandler - detail='som' mode", () => {
       elements: [],
       somImage: null,
       preprocessScale: 1.0,
+      resolvedWindowTitle: "My App",
     });
 
     const result = await screenshotHandler({


### PR DESCRIPTION
Closes #31

## 問題

`detail='som'` で `windowTitle` に部分文字列を渡し、`resolveWindowTarget` が null を返す場合（hwnd / `@active` なしの通常フロー）、レスポンス JSON の `window` フィールドがユーザー入力の部分タイトルのままになっていた。

```json
{ "window": "Notepad", ... }  // 実際の対象は "無題 - メモ帳"
```

## 修正

`SomPipelineResult` に `resolvedWindowTitle: string` を追加。`runSomPipeline` 内部で `enumWindowsInZOrder` から取得した完全タイトルを返す（title検索・hwnd両ブランチ対応）。呼び出し元の `window` フィールドは `somResult.resolvedWindowTitle` を使用。

## 変更ファイル

| ファイル | 変更 |
|---|---|
| `src/engine/ocr-bridge.ts` | `SomPipelineResult.resolvedWindowTitle` 追加、両ブランチで設定 |
| `src/tools/screenshot.ts` | SoMブランチ・自動フォールバックパスで `resolvedWindowTitle` を使用 |
| `tests/unit/screenshot-som.test.ts` | モックに `resolvedWindowTitle` 追加、`window` フィールド検証追加 |

## テスト

- 5/5 SoM ユニットテストパス
- 1130 全ユニットテストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)