### PR TITLE
fix(terminal): PR #36 follow-up — Codex review of Phase 2c run() workflow

### DIFF
--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -589,21 +589,25 @@ export const terminalRunHandler = async ({
   // Reject invalid sendOptions/readOptions BEFORE doing any I/O so unbounded
   // values (e.g. chunkSize:0 hanging the background loop, source:'uia' on a
   // non-TextPattern terminal) cannot bypass the public schema bounds.
+  // Use fail() directly (not failWith) so we get code:"InvalidArgs" and the
+  // suggest[] array stays at the top level. failWith would classify "Invalid
+  // sendOptions" as the generic "ToolError" code and bury our custom suggest
+  // strings under context.suggest, which mis-classifies argument errors as
+  // internal errors and hides actionable remediation guidance from callers.
   let validatedSendOptions: z.infer<typeof TERMINAL_RUN_SEND_OPTIONS_SCHEMA> = {};
   if (sendOptions !== undefined) {
     const parsed = TERMINAL_RUN_SEND_OPTIONS_SCHEMA.safeParse(sendOptions);
     if (!parsed.success) {
-      return failWith(
-        new Error(`Invalid sendOptions: ${describeZodIssues(parsed.error)}`),
-        "terminal:run",
-        {
-          windowTitle,
-          suggest: [
-            "Refer to terminal(action='send') schema for valid keys/types",
-            "windowTitle, input, and sinceMarker cannot be overridden via sendOptions",
-          ],
-        }
-      );
+      return fail({
+        ok: false,
+        code: "InvalidArgs",
+        error: `terminal:run: Invalid sendOptions: ${describeZodIssues(parsed.error)}`,
+        suggest: [
+          "Refer to terminal(action='send') schema for valid keys/types",
+          "windowTitle, input, and sinceMarker cannot be overridden via sendOptions",
+        ],
+        context: { windowTitle },
+      });
     }
     validatedSendOptions = parsed.data;
   }
@@ -611,17 +615,16 @@ export const terminalRunHandler = async ({
   if (readOptions !== undefined) {
     const parsed = TERMINAL_RUN_READ_OPTIONS_SCHEMA.safeParse(readOptions);
     if (!parsed.success) {
-      return failWith(
-        new Error(`Invalid readOptions: ${describeZodIssues(parsed.error)}`),
-        "terminal:run",
-        {
-          windowTitle,
-          suggest: [
-            "Refer to terminal(action='read') schema for valid keys/types",
-            "windowTitle and sinceMarker cannot be overridden via readOptions",
-          ],
-        }
-      );
+      return fail({
+        ok: false,
+        code: "InvalidArgs",
+        error: `terminal:run: Invalid readOptions: ${describeZodIssues(parsed.error)}`,
+        suggest: [
+          "Refer to terminal(action='read') schema for valid keys/types",
+          "windowTitle and sinceMarker cannot be overridden via readOptions",
+        ],
+        context: { windowTitle },
+      });
     }
     validatedReadOptions = parsed.data;
   }

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -524,7 +524,15 @@ interface TerminalRunResponse {
 // Forwarded-option whitelists derived from the public terminal_send / _read schemas.
 // `windowTitle` and `input` are excluded because run() owns those, and `sinceMarker`
 // is excluded because run() computes the baseline marker itself.
-const TERMINAL_RUN_SEND_OPTIONS_SCHEMA = z.object({
+//
+// IMPORTANT: every wrapped field still carries its `.default(...)` from the public
+// schema. Zod v4's `.partial()` makes the key optional but does NOT strip defaults;
+// the parsed object will materialise default values for any missing key. We rely
+// on `keepOnlyProvidedKeys()` below to filter the parsed result back down to the
+// keys the caller actually supplied — otherwise an empty `sendOptions:{}` would
+// silently overwrite run-specific defaults (`restoreFocus:false`, `trackFocus:false`,
+// `settleMs:100`) with terminal_send's defaults (true / true / 300).
+export const TERMINAL_RUN_SEND_OPTIONS_SCHEMA = z.object({
   method: terminalSendSchema.method,
   chunkSize: terminalSendSchema.chunkSize,
   pressEnter: terminalSendSchema.pressEnter,
@@ -537,7 +545,7 @@ const TERMINAL_RUN_SEND_OPTIONS_SCHEMA = z.object({
   settleMs: terminalSendSchema.settleMs,
 }).partial().strict();
 
-const TERMINAL_RUN_READ_OPTIONS_SCHEMA = z.object({
+export const TERMINAL_RUN_READ_OPTIONS_SCHEMA = z.object({
   lines: terminalReadSchema.lines,
   stripAnsi: terminalReadSchema.stripAnsi,
   source: terminalReadSchema.source,
@@ -548,6 +556,25 @@ function describeZodIssues(err: z.ZodError): string {
   return err.issues
     .map((i) => `${i.path.length > 0 ? i.path.join(".") + ": " : ""}${i.message}`)
     .join("; ");
+}
+
+/**
+ * Filter a Zod-parsed object to only the keys actually present in the original
+ * caller input. Required because `z.partial()` does not strip `.default(...)`
+ * markers from inner field types — without this, defaults injected by Zod for
+ * absent keys would leak into the merged sendArgs/readArgs and overwrite run's
+ * intentional non-default values.
+ */
+function keepOnlyProvidedKeys<T extends Record<string, unknown>>(
+  parsed: T,
+  input: Record<string, unknown>
+): Partial<T> {
+  const inputKeys = new Set(Object.keys(input));
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(parsed)) {
+    if (inputKeys.has(k)) out[k] = v;
+  }
+  return out as Partial<T>;
 }
 
 /**
@@ -594,7 +621,7 @@ export const terminalRunHandler = async ({
   // sendOptions" as the generic "ToolError" code and bury our custom suggest
   // strings under context.suggest, which mis-classifies argument errors as
   // internal errors and hides actionable remediation guidance from callers.
-  let validatedSendOptions: z.infer<typeof TERMINAL_RUN_SEND_OPTIONS_SCHEMA> = {};
+  let validatedSendOptions: Partial<z.infer<typeof TERMINAL_RUN_SEND_OPTIONS_SCHEMA>> = {};
   if (sendOptions !== undefined) {
     const parsed = TERMINAL_RUN_SEND_OPTIONS_SCHEMA.safeParse(sendOptions);
     if (!parsed.success) {
@@ -609,9 +636,9 @@ export const terminalRunHandler = async ({
         context: { windowTitle },
       });
     }
-    validatedSendOptions = parsed.data;
+    validatedSendOptions = keepOnlyProvidedKeys(parsed.data, sendOptions);
   }
-  let validatedReadOptions: z.infer<typeof TERMINAL_RUN_READ_OPTIONS_SCHEMA> = {};
+  let validatedReadOptions: Partial<z.infer<typeof TERMINAL_RUN_READ_OPTIONS_SCHEMA>> = {};
   if (readOptions !== undefined) {
     const parsed = TERMINAL_RUN_READ_OPTIONS_SCHEMA.safeParse(readOptions);
     if (!parsed.success) {
@@ -626,7 +653,7 @@ export const terminalRunHandler = async ({
         context: { windowTitle },
       });
     }
-    validatedReadOptions = parsed.data;
+    validatedReadOptions = keepOnlyProvidedKeys(parsed.data, readOptions);
   }
 
   // ── Phase 1: Send ──────────────────────────────────────────────────────────

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -746,13 +746,18 @@ export const terminalRunHandler = async ({
   // Pattern matching must only consider content that appeared AFTER the
   // baseline marker. Otherwise prompt-shaped patterns (e.g. "PS>", "$ ") that
   // already exist in scrollback would fire pattern_matched immediately.
-  // applySinceMarker returns matched:true with the new content; on miss it
-  // returns the full text — which is the safest default if the terminal has
-  // scrolled past the marker window.
-  const newContentSinceBaseline = (text: string): string => {
-    if (!sinceMarker) return text;
+  // Returns:
+  //   - string: the new content since the baseline marker (may be "" when no
+  //     diff has accumulated yet — empty is a valid pattern target).
+  //   - undefined: the baseline boundary has been lost (no marker, or
+  //     applySinceMarker scanned past its 32k window without finding it).
+  //     Callers MUST skip pattern matching in this case — falling back to the
+  //     full buffer would re-introduce prior-history false positives because
+  //     scrollback past the scan window can still hold pre-baseline text.
+  const newContentSinceBaseline = (text: string): string | undefined => {
+    if (!sinceMarker) return undefined;
     const sliced = applySinceMarker(text, sinceMarker);
-    return sliced.text;
+    return sliced.matched ? sliced.text : undefined;
   };
 
   // Immediate post-send pattern check — runs once before the first POLL_INTERVAL_MS
@@ -764,7 +769,9 @@ export const terminalRunHandler = async ({
     const initialPostSend = await readTerminalRaw(windowTitle);
     if (initialPostSend) {
       const newContent = newContentSinceBaseline(initialPostSend.text);
-      if (patternRe.test(newContent)) {
+      // newContent === undefined → baseline lost, skip to avoid prior-history match.
+      // newContent === "" is still a valid input for patterns like /^$/.
+      if (newContent !== undefined && patternRe.test(newContent)) {
         completionReason = "pattern_matched";
         matchedPattern = until.mode === "pattern" ? until.pattern : undefined;
       }
@@ -800,9 +807,9 @@ export const terminalRunHandler = async ({
 
     if (until.mode === "pattern" && patternRe) {
       const newContent = newContentSinceBaseline(currentText);
-      // No truthiness gate: empty newContent is valid input for patterns
-      // like "" or /^$/ that intentionally match emptiness.
-      if (patternRe.test(newContent)) {
+      // newContent === undefined → baseline lost, skip to avoid prior-history match.
+      // newContent === "" is still valid input for patterns like /^$/.
+      if (newContent !== undefined && patternRe.test(newContent)) {
         completionReason = "pattern_matched";
         matchedPattern = until.mode === "pattern" ? until.pattern : undefined;
         break;

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -755,6 +755,22 @@ export const terminalRunHandler = async ({
     return sliced.text;
   };
 
+  // Immediate post-send pattern check — runs once before the first POLL_INTERVAL_MS
+  // sleep so transient lines (e.g. CR-updated progress indicators that overwrite
+  // themselves rapidly) are not missed by waiting for the first poll tick. The
+  // truthiness gate on newContent is intentionally absent: empty content is a
+  // valid input for patterns like "" or /^$/ that match emptiness.
+  if (patternRe) {
+    const initialPostSend = await readTerminalRaw(windowTitle);
+    if (initialPostSend) {
+      const newContent = newContentSinceBaseline(initialPostSend.text);
+      if (patternRe.test(newContent)) {
+        completionReason = "pattern_matched";
+        matchedPattern = until.mode === "pattern" ? until.pattern : undefined;
+      }
+    }
+  }
+
   while (completionReason === null) {
     await new Promise<void>((r) => setTimeout(r, POLL_INTERVAL_MS));
 
@@ -784,7 +800,9 @@ export const terminalRunHandler = async ({
 
     if (until.mode === "pattern" && patternRe) {
       const newContent = newContentSinceBaseline(currentText);
-      if (newContent && patternRe.test(newContent)) {
+      // No truthiness gate: empty newContent is valid input for patterns
+      // like "" or /^$/ that intentionally match emptiness.
+      if (patternRe.test(newContent)) {
         completionReason = "pattern_matched";
         matchedPattern = until.mode === "pattern" ? until.pattern : undefined;
         break;

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -716,11 +716,17 @@ export const terminalRunHandler = async ({
     }
   }
 
-  // Check if initial output already matches pattern
-  if (patternRe && lastText && patternRe.test(lastText)) {
-    completionReason = "pattern_matched";
-    matchedPattern = until.mode === "pattern" ? until.pattern : undefined;
-  }
+  // Pattern matching must only consider content that appeared AFTER the
+  // baseline marker. Otherwise prompt-shaped patterns (e.g. "PS>", "$ ") that
+  // already exist in scrollback would fire pattern_matched immediately.
+  // applySinceMarker returns matched:true with the new content; on miss it
+  // returns the full text — which is the safest default if the terminal has
+  // scrolled past the marker window.
+  const newContentSinceBaseline = (text: string): string => {
+    if (!sinceMarker) return text;
+    const sliced = applySinceMarker(text, sinceMarker);
+    return sliced.text;
+  };
 
   while (completionReason === null) {
     await new Promise<void>((r) => setTimeout(r, POLL_INTERVAL_MS));
@@ -750,7 +756,8 @@ export const terminalRunHandler = async ({
     const currentText = current.text;
 
     if (until.mode === "pattern" && patternRe) {
-      if (patternRe.test(currentText)) {
+      const newContent = newContentSinceBaseline(currentText);
+      if (newContent && patternRe.test(newContent)) {
         completionReason = "pattern_matched";
         matchedPattern = until.mode === "pattern" ? until.pattern : undefined;
         break;

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -501,6 +501,12 @@ export const terminalSendHandler = async ({
 
 type CompletionReason = "quiet" | "pattern_matched" | "timeout" | "window_closed" | "window_not_found";
 
+interface ReadFailurePayload {
+  code?: string;
+  error?: string;
+  suggest?: string[];
+}
+
 interface TerminalRunResponse {
   ok: boolean;
   output: string;
@@ -510,8 +516,38 @@ interface TerminalRunResponse {
     matchedPattern?: string;
   };
   marker?: string;
+  readError?: ReadFailurePayload;
   warnings?: string[];
   hwnd?: string;
+}
+
+// Forwarded-option whitelists derived from the public terminal_send / _read schemas.
+// `windowTitle` and `input` are excluded because run() owns those, and `sinceMarker`
+// is excluded because run() computes the baseline marker itself.
+const TERMINAL_RUN_SEND_OPTIONS_SCHEMA = z.object({
+  method: terminalSendSchema.method,
+  chunkSize: terminalSendSchema.chunkSize,
+  pressEnter: terminalSendSchema.pressEnter,
+  focusFirst: terminalSendSchema.focusFirst,
+  restoreFocus: terminalSendSchema.restoreFocus,
+  preferClipboard: terminalSendSchema.preferClipboard,
+  pasteKey: terminalSendSchema.pasteKey,
+  forceFocus: terminalSendSchema.forceFocus,
+  trackFocus: terminalSendSchema.trackFocus,
+  settleMs: terminalSendSchema.settleMs,
+}).partial().strict();
+
+const TERMINAL_RUN_READ_OPTIONS_SCHEMA = z.object({
+  lines: terminalReadSchema.lines,
+  stripAnsi: terminalReadSchema.stripAnsi,
+  source: terminalReadSchema.source,
+  ocrLanguage: terminalReadSchema.ocrLanguage,
+}).partial().strict();
+
+function describeZodIssues(err: z.ZodError): string {
+  return err.issues
+    .map((i) => `${i.path.length > 0 ? i.path.join(".") + ": " : ""}${i.message}`)
+    .join("; ");
 }
 
 /**
@@ -549,6 +585,47 @@ export const terminalRunHandler = async ({
   const startedAt = Date.now();
   const warnings: string[] = [];
 
+  // ── Phase 0: Validate forwarded options ────────────────────────────────────
+  // Reject invalid sendOptions/readOptions BEFORE doing any I/O so unbounded
+  // values (e.g. chunkSize:0 hanging the background loop, source:'uia' on a
+  // non-TextPattern terminal) cannot bypass the public schema bounds.
+  let validatedSendOptions: z.infer<typeof TERMINAL_RUN_SEND_OPTIONS_SCHEMA> = {};
+  if (sendOptions !== undefined) {
+    const parsed = TERMINAL_RUN_SEND_OPTIONS_SCHEMA.safeParse(sendOptions);
+    if (!parsed.success) {
+      return failWith(
+        new Error(`Invalid sendOptions: ${describeZodIssues(parsed.error)}`),
+        "terminal:run",
+        {
+          windowTitle,
+          suggest: [
+            "Refer to terminal(action='send') schema for valid keys/types",
+            "windowTitle, input, and sinceMarker cannot be overridden via sendOptions",
+          ],
+        }
+      );
+    }
+    validatedSendOptions = parsed.data;
+  }
+  let validatedReadOptions: z.infer<typeof TERMINAL_RUN_READ_OPTIONS_SCHEMA> = {};
+  if (readOptions !== undefined) {
+    const parsed = TERMINAL_RUN_READ_OPTIONS_SCHEMA.safeParse(readOptions);
+    if (!parsed.success) {
+      return failWith(
+        new Error(`Invalid readOptions: ${describeZodIssues(parsed.error)}`),
+        "terminal:run",
+        {
+          windowTitle,
+          suggest: [
+            "Refer to terminal(action='read') schema for valid keys/types",
+            "windowTitle and sinceMarker cannot be overridden via readOptions",
+          ],
+        }
+      );
+    }
+    validatedReadOptions = parsed.data;
+  }
+
   // ── Phase 1: Send ──────────────────────────────────────────────────────────
   const win = findTerminalWindow(windowTitle);
   if (!win) {
@@ -563,6 +640,13 @@ export const terminalRunHandler = async ({
 
   const hwnd = win.hwnd;
 
+  // Capture the baseline marker BEFORE sending. If we wait until after the send
+  // returns, fast-completing commands (e.g. `echo`) may already have written
+  // their output, and using a post-send marker would slice that output off in
+  // the final sinceMarker diff.
+  const baselineRead = await readTerminalRaw(windowTitle);
+  const sinceMarker = baselineRead?.marker;
+
   const sendArgs = {
     windowTitle,
     input,
@@ -575,7 +659,7 @@ export const terminalRunHandler = async ({
     pasteKey: "auto" as const,
     trackFocus: false,
     settleMs: 100,
-    ...(sendOptions as object ?? {}),
+    ...validatedSendOptions,
   };
 
   const sendResult = await terminalSendHandler(sendArgs);
@@ -604,15 +688,15 @@ export const terminalRunHandler = async ({
     return ok(res);
   }
 
-  // Take a marker snapshot just after sending (for sinceMarker diff)
-  const initialRead = await readTerminalRaw(windowTitle);
-  const sinceMarker = initialRead?.marker;
-
   // ── Phase 2: Wait ──────────────────────────────────────────────────────────
+  // Quiet detection starts from the pre-send baseline. The first poll iteration
+  // will observe the new prompt + command echo + early output as a diff and
+  // reset the quiet timer — this is correct: we want to wait quietMs from the
+  // moment output actually starts appearing, not from the send completion.
   const POLL_INTERVAL_MS = 200;
   let completionReason: CompletionReason | null = null;
   let matchedPattern: string | undefined;
-  let lastText = initialRead?.text ?? "";
+  let lastText = baselineRead?.text ?? "";
   let lastTextTime = Date.now();
   const quietMs = until.mode === "quiet" ? until.quietMs : 800;
 
@@ -688,23 +772,44 @@ export const terminalRunHandler = async ({
     stripAnsi: true,
     source: "auto" as const,
     ocrLanguage: "ja",
-    ...(readOptions as object ?? {}),
+    ...validatedReadOptions,
   };
 
   const readResult = await terminalReadHandler(readArgs);
   let output = "";
   let finalMarker: string | undefined;
+  let readError: ReadFailurePayload | undefined;
   try {
     const block = readResult.content[0];
     if (block?.type === "text") {
-      const parsed = JSON.parse(block.text) as { text?: string; marker?: string; hints?: unknown };
-      output = parsed.text ?? "";
-      finalMarker = parsed.marker;
+      const parsed = JSON.parse(block.text) as {
+        ok?: boolean;
+        text?: string;
+        marker?: string;
+        code?: string;
+        error?: string;
+        suggest?: string[];
+        hints?: unknown;
+      };
+      if (parsed.ok === false) {
+        // Surface read-handler failures (e.g. source:'uia' on a terminal
+        // without TextPattern) instead of silently returning ok:true with
+        // empty output.
+        readError = {
+          ...(parsed.code ? { code: parsed.code } : {}),
+          ...(parsed.error ? { error: parsed.error } : {}),
+          ...(parsed.suggest && parsed.suggest.length > 0 ? { suggest: parsed.suggest } : {}),
+        };
+        warnings.push("Final read failed — output may be unavailable. See readError for details.");
+      } else {
+        output = parsed.text ?? "";
+        finalMarker = parsed.marker;
+      }
     }
   } catch { /* output stays empty */ }
 
   const response: TerminalRunResponse = {
-    ok: true,
+    ok: readError === undefined,
     output,
     completion: {
       // Loop only exits via the four break paths (each assigns completionReason)
@@ -715,6 +820,7 @@ export const terminalRunHandler = async ({
       ...(matchedPattern !== undefined ? { matchedPattern } : {}),
     },
     ...(finalMarker ? { marker: finalMarker } : {}),
+    ...(readError ? { readError } : {}),
     hwnd: String(hwnd),
     ...(warnings.length > 0 ? { warnings } : {}),
   };

--- a/tests/unit/terminal-run-validation.test.ts
+++ b/tests/unit/terminal-run-validation.test.ts
@@ -9,7 +9,11 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { terminalRunHandler } from "../../src/tools/terminal.js";
+import {
+  terminalRunHandler,
+  TERMINAL_RUN_SEND_OPTIONS_SCHEMA,
+  TERMINAL_RUN_READ_OPTIONS_SCHEMA,
+} from "../../src/tools/terminal.js";
 
 function parseRunResponse(result: { content: Array<{ type: string; text?: string }> }): {
   ok?: boolean;
@@ -132,6 +136,61 @@ describe("terminal(action='run') — sendOptions/readOptions validation (Phase 2
     // window_not_found is reported as ok:false on the run-response shape (not failWith)
     expect(parsed.ok).toBe(false);
     expect(parsed.completion?.reason).toBe("window_not_found");
+  });
+});
+
+describe("terminal(action='run') — Zod default leak guard (PR #37 Codex P1)", () => {
+  // Background: TERMINAL_RUN_SEND_OPTIONS_SCHEMA / READ_OPTIONS_SCHEMA wrap fields
+  // from terminalSendSchema / _readSchema that already carry .default(...). In
+  // Zod v4, .partial() makes keys optional but does NOT strip .default markers,
+  // so the parsed result materialises defaults for absent keys. Without filtering,
+  // those leak into the merged sendArgs/readArgs and overwrite run-specific
+  // defaults (restoreFocus:false, trackFocus:false, settleMs:100).
+
+  it("documents the Zod default-leak behavior so the filter cannot be silently removed", () => {
+    const input = { chunkSize: 50 };
+    const parsed = TERMINAL_RUN_SEND_OPTIONS_SCHEMA.parse(input);
+    // Zod injects defaults for keys NOT in the input — this is the bug source.
+    expect(parsed.restoreFocus).toBe(true);
+    expect(parsed.trackFocus).toBe(true);
+    expect(parsed.settleMs).toBe(300);
+    // The chunkSize the caller actually provided survives.
+    expect(parsed.chunkSize).toBe(50);
+  });
+
+  it("documents the same default-leak for readOptions", () => {
+    const input = { lines: 10 };
+    const parsed = TERMINAL_RUN_READ_OPTIONS_SCHEMA.parse(input);
+    expect(parsed.stripAnsi).toBe(true);
+    expect(parsed.source).toBe("auto");
+    expect(parsed.ocrLanguage).toBe("ja");
+    expect(parsed.lines).toBe(10);
+  });
+
+  it("verifies the keepOnlyProvidedKeys filter pattern strips the leaked defaults", () => {
+    const input = { chunkSize: 50 };
+    const parsed = TERMINAL_RUN_SEND_OPTIONS_SCHEMA.parse(input);
+    const inputKeys = new Set(Object.keys(input));
+    const filtered = Object.fromEntries(
+      Object.entries(parsed).filter(([k]) => inputKeys.has(k))
+    );
+    // Only the explicitly-provided key remains.
+    expect(filtered).toEqual({ chunkSize: 50 });
+    expect("restoreFocus" in filtered).toBe(false);
+    expect("trackFocus" in filtered).toBe(false);
+    expect("settleMs" in filtered).toBe(false);
+  });
+
+  it("filter handles empty sendOptions:{} without leaking any defaults", () => {
+    const input = {};
+    const parsed = TERMINAL_RUN_SEND_OPTIONS_SCHEMA.parse(input);
+    // Empty input → Zod parsed object is full of defaults.
+    expect(Object.keys(parsed).length).toBeGreaterThan(0);
+    // Filter to provided keys only → empty result.
+    const filtered = Object.fromEntries(
+      Object.entries(parsed).filter(([k]) => Object.prototype.hasOwnProperty.call(input, k))
+    );
+    expect(filtered).toEqual({});
   });
 });
 

--- a/tests/unit/terminal-run-validation.test.ts
+++ b/tests/unit/terminal-run-validation.test.ts
@@ -1,0 +1,136 @@
+/**
+ * terminal-run-validation.test.ts
+ *
+ * Regression tests for PR #36 Codex review (follow-up):
+ *   - Invalid sendOptions / readOptions must be rejected before any I/O so
+ *     unbounded values cannot bypass the public terminal_send / _read schemas.
+ *   - terminalReadHandler ok:false must be surfaced as run.ok:false + readError
+ *     instead of silently returning ok:true with empty output.
+ */
+
+import { describe, it, expect } from "vitest";
+import { terminalRunHandler } from "../../src/tools/terminal.js";
+
+function parseRunResponse(result: { content: Array<{ type: string; text?: string }> }): {
+  ok?: boolean;
+  output?: string;
+  completion?: { reason?: string; elapsedMs?: number };
+  warnings?: string[];
+  readError?: { code?: string; error?: string; suggest?: string[] };
+  // failWith shape:
+  error?: string;
+  code?: string;
+  suggest?: string[];
+} {
+  const block = result.content[0];
+  if (block?.type !== "text" || !block.text) return {};
+  return JSON.parse(block.text);
+}
+
+describe("terminal(action='run') — sendOptions/readOptions validation (Phase 2c follow-up)", () => {
+  it("rejects sendOptions with chunkSize:0 (below schema minimum) before touching the terminal", async () => {
+    const result = await terminalRunHandler({
+      windowTitle: "__nonexistent_window_for_validation_test__",
+      input: "echo hi",
+      until: { mode: "quiet", quietMs: 800 },
+      timeoutMs: 5_000,
+      sendOptions: { chunkSize: 0 },
+    });
+    const parsed = parseRunResponse(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error ?? "").toMatch(/Invalid sendOptions/);
+    expect(parsed.error ?? "").toMatch(/chunkSize/);
+  });
+
+  it("rejects sendOptions with unknown keys (strict mode)", async () => {
+    const result = await terminalRunHandler({
+      windowTitle: "__nonexistent_window_for_validation_test__",
+      input: "echo hi",
+      until: { mode: "quiet", quietMs: 800 },
+      timeoutMs: 5_000,
+      sendOptions: { unrecognizedKey: "x" },
+    });
+    const parsed = parseRunResponse(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error ?? "").toMatch(/Invalid sendOptions/);
+  });
+
+  it("rejects sendOptions trying to override windowTitle (not in whitelist)", async () => {
+    const result = await terminalRunHandler({
+      windowTitle: "__nonexistent_window_for_validation_test__",
+      input: "echo hi",
+      until: { mode: "quiet", quietMs: 800 },
+      timeoutMs: 5_000,
+      sendOptions: { windowTitle: "different" },
+    });
+    const parsed = parseRunResponse(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error ?? "").toMatch(/Invalid sendOptions/);
+  });
+
+  it("rejects sendOptions with method:'invalid' (not in enum)", async () => {
+    const result = await terminalRunHandler({
+      windowTitle: "__nonexistent_window_for_validation_test__",
+      input: "echo hi",
+      until: { mode: "quiet", quietMs: 800 },
+      timeoutMs: 5_000,
+      sendOptions: { method: "invalid" },
+    });
+    const parsed = parseRunResponse(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error ?? "").toMatch(/Invalid sendOptions/);
+    expect(parsed.error ?? "").toMatch(/method/);
+  });
+
+  it("rejects readOptions with lines beyond schema maximum", async () => {
+    const result = await terminalRunHandler({
+      windowTitle: "__nonexistent_window_for_validation_test__",
+      input: "echo hi",
+      until: { mode: "quiet", quietMs: 800 },
+      timeoutMs: 5_000,
+      readOptions: { lines: 999_999 },
+    });
+    const parsed = parseRunResponse(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error ?? "").toMatch(/Invalid readOptions/);
+    expect(parsed.error ?? "").toMatch(/lines/);
+  });
+
+  it("rejects readOptions with source:'invalid' (not in enum)", async () => {
+    const result = await terminalRunHandler({
+      windowTitle: "__nonexistent_window_for_validation_test__",
+      input: "echo hi",
+      until: { mode: "quiet", quietMs: 800 },
+      timeoutMs: 5_000,
+      readOptions: { source: "invalid" },
+    });
+    const parsed = parseRunResponse(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error ?? "").toMatch(/Invalid readOptions/);
+  });
+
+  it("returns window_not_found (not validation error) when sendOptions/readOptions are valid", async () => {
+    // Sanity check: a clean call with valid (default) options against a missing
+    // window should fall through validation and reach the findTerminalWindow check.
+    const result = await terminalRunHandler({
+      windowTitle: "__nonexistent_window_for_validation_test__",
+      input: "echo hi",
+      until: { mode: "quiet", quietMs: 800 },
+      timeoutMs: 5_000,
+      sendOptions: { method: "auto", chunkSize: 50 },
+      readOptions: { lines: 20, source: "auto" },
+    });
+    const parsed = parseRunResponse(result);
+    // window_not_found is reported as ok:false on the run-response shape (not failWith)
+    expect(parsed.ok).toBe(false);
+    expect(parsed.completion?.reason).toBe("window_not_found");
+  });
+});
+
+// Note on Fix 3 (read-failure propagation) coverage:
+// terminalRunHandler imports terminalReadHandler statically from the same
+// module, so vi.doMock cannot intercept the in-module call. The behavioral
+// contract (run.ok:false + readError when the final read returns ok:false) is
+// verified by code review + an E2E that exercises readOptions:{source:'uia'}
+// on a terminal without TextPattern. Refactoring to inject the read function
+// is deliberately out of scope for this fix PR.

--- a/tests/unit/terminal-run-validation.test.ts
+++ b/tests/unit/terminal-run-validation.test.ts
@@ -181,6 +181,21 @@ describe("terminal(action='run') — Zod default leak guard (PR #37 Codex P1)", 
     expect("settleMs" in filtered).toBe(false);
   });
 
+  it("regex.test() works on empty string — pattern '^$' or '' must not be guarded by truthiness", () => {
+    // Codex P3: the previous loop guard `if (newContent && patternRe.test(newContent))`
+    // would silently skip matching when newContent was the empty string — so legitimate
+    // patterns that match emptiness (`""` literal, `/^$/`) hung until timeout.
+    expect(/^$/.test("")).toBe(true);
+    expect(new RegExp("").test("")).toBe(true);
+    // The pre-PR-#37 behavior with the truthiness gate would short-circuit:
+    const newContent = "";
+    const patternRe = /^$/;
+    const buggy = newContent && patternRe.test(newContent);  // → "" (falsey)
+    const fixed = patternRe.test(newContent);                 // → true
+    expect(Boolean(buggy)).toBe(false);
+    expect(fixed).toBe(true);
+  });
+
   it("filter handles empty sendOptions:{} without leaking any defaults", () => {
     const input = {};
     const parsed = TERMINAL_RUN_SEND_OPTIONS_SCHEMA.parse(input);

--- a/tests/unit/terminal-run-validation.test.ts
+++ b/tests/unit/terminal-run-validation.test.ts
@@ -17,10 +17,11 @@ function parseRunResponse(result: { content: Array<{ type: string; text?: string
   completion?: { reason?: string; elapsedMs?: number };
   warnings?: string[];
   readError?: { code?: string; error?: string; suggest?: string[] };
-  // failWith shape:
+  // fail() shape (used for InvalidArgs validation errors):
   error?: string;
   code?: string;
   suggest?: string[];
+  context?: Record<string, unknown>;
 } {
   const block = result.content[0];
   if (block?.type !== "text" || !block.text) return {};
@@ -38,8 +39,12 @@ describe("terminal(action='run') — sendOptions/readOptions validation (Phase 2
     });
     const parsed = parseRunResponse(result);
     expect(parsed.ok).toBe(false);
+    expect(parsed.code).toBe("InvalidArgs");
     expect(parsed.error ?? "").toMatch(/Invalid sendOptions/);
     expect(parsed.error ?? "").toMatch(/chunkSize/);
+    // Custom suggest stays at top level (not nested under context)
+    expect(parsed.suggest).toBeDefined();
+    expect(parsed.suggest!.some((s) => /terminal\(action='send'\)/.test(s))).toBe(true);
   });
 
   it("rejects sendOptions with unknown keys (strict mode)", async () => {
@@ -92,8 +97,11 @@ describe("terminal(action='run') — sendOptions/readOptions validation (Phase 2
     });
     const parsed = parseRunResponse(result);
     expect(parsed.ok).toBe(false);
+    expect(parsed.code).toBe("InvalidArgs");
     expect(parsed.error ?? "").toMatch(/Invalid readOptions/);
     expect(parsed.error ?? "").toMatch(/lines/);
+    expect(parsed.suggest).toBeDefined();
+    expect(parsed.suggest!.some((s) => /terminal\(action='read'\)/.test(s))).toBe(true);
   });
 
   it("rejects readOptions with source:'invalid' (not in enum)", async () => {


### PR DESCRIPTION
## Summary

Three pre-existing bugs in `terminalRunHandler` (Phase 2c, merged via #36) that Codex flagged on the merge commit `cf41b08`. Fixing in a follow-up PR so `main` is clean before Phase 3 (browser 再配置).

| Pri | File | Issue |
|---|---|---|
| **P1** | `src/tools/terminal.ts:609` | `sinceMarker` baseline taken AFTER send → fast commands' output sliced off |
| **P1** | `src/tools/terminal.ts:579` | `sendOptions` / `readOptions` forwarded raw, bypassing public schemas (`chunkSize:0` can hang) |
| **P2** | `src/tools/terminal.ts:702` | Final read's `ok:false` ignored → false-success when `source:'uia'` on TextPattern-less terminal |

## Changes

### P1 — Pre-send baseline marker
Capture `sinceMarker` BEFORE `terminalSendHandler` returns. The same baseline text is reused as the quiet-mode change-detection start so the timer correctly waits "quietMs from when output starts appearing" (net read count unchanged).

### P1 — Strict-mode option whitelists
New `TERMINAL_RUN_SEND_OPTIONS_SCHEMA` / `TERMINAL_RUN_READ_OPTIONS_SCHEMA` derived from the public `terminalSendSchema` / `terminalReadSchema`, with owned fields (`windowTitle`, `input`, `sinceMarker`) excluded. `.partial().strict()` rejects unknown keys, schema-bounds enforce min/max, enums enforce literals. Validation runs before any I/O so invalid options cannot trigger side effects. Returns `failWith` with a clear pointer to the public schemas.

### P2 — Surface read failures
Added `ReadFailurePayload` (`code`, `error`, `suggest`) to `TerminalRunResponse.readError`. When the final read returns `ok:false`, run sets `ok:false` and attaches the error payload + warning instead of silently returning `output:""`.

## Test plan

- [x] `npm run build` (tsc clean)
- [x] `tests/unit/terminal-run-validation.test.ts` — 7 new cases (chunkSize:0, unknown keys, windowTitle override, method enum, lines overflow, source enum, sanity-fallthrough)
- [x] Full vitest unit suite — 0 regressions (2068 prior pass + 7 new = 2075 pass)
- [x] Local E2E (1811 unit + 217 e2e + 22 skipped) — only environmental flakies in `context-consistency.test.ts > hasModal/pageState`, all caused by the local Claude Code window title containing the literal word "errors" (matches `MODAL_RE`); does not reproduce on CI runners
- [ ] CI (GH Actions) — build + CodeQL must stay green; expect 0 failures since no Claude Code window exists on the runner

## Notes for reviewer

- P2 read-failure propagation is not unit-tested. `terminalReadHandler` is closed over via static import inside `terminalRunHandler`, so `vi.doMock` cannot intercept the in-module call. Refactoring to inject the read function is deliberately out of scope; behavioral contract is verified by code review and the `source:'uia'` E2E path.
- `MODAL_RE` substring matching (`/error/i` matches "errors") is a separate latent issue — out of scope here, candidate for its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)