### PR TITLE
fix(desktop_state): tighten MODAL_RE — drop substring false positives

### DIFF
--- a/src/tools/desktop-state.ts
+++ b/src/tools/desktop-state.ts
@@ -20,6 +20,26 @@ import type { AttentionState } from "../engine/perception/types.js";
 
 const _defaultPort = getCdpPort();
 
+/**
+ * Heuristic regex used by desktop_state.hasModal to flag windows whose titles
+ * look like modal dialogs.
+ *
+ * English keywords use \b word boundaries so that substring noise does not
+ * trigger false positives — e.g. "errors" must NOT match /error/, "Prompt
+ * Engineering" must NOT match /prompt/, "Confirmation" must NOT match
+ * /confirm/, "Alerting" must NOT match /alert/, "Dialogue" must NOT match
+ * /dialog/. The bare "prompt" keyword is intentionally absent because it is
+ * almost always a non-modal noun in real-world window titles.
+ *
+ * Japanese keywords are matched as bare substrings since \b does not recognise
+ * Japanese word boundaries; substring false positives for these terms are rare
+ * in practice (window titles like "通知センター" exist but are infrequent).
+ *
+ * Exported so unit tests can pin both the true-positive and false-positive
+ * contracts down — see tests/unit/modal-detection.test.ts.
+ */
+export const MODAL_RE = /\b(?:dialog|confirm|alert|error|warning|save as)\b|警告|エラー|確認|通知|ダイアログ|名前を付けて/i;
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Schemas
 // ─────────────────────────────────────────────────────────────────────────────
@@ -92,9 +112,8 @@ export const desktopStateHandler = async (): Promise<ToolResult> => {
       }
     }
 
-    // Modal heuristic
+    // Modal heuristic — title-substring detection.
     let hasModal = false;
-    const MODAL_RE = /dialog|confirm|prompt|alert|error|警告|エラー|確認|通知|ダイアログ|名前を付けて|Save As/i;
     for (const w of wins) {
       if (MODAL_RE.test(w.title)) { hasModal = true; break; }
     }

--- a/tests/unit/modal-detection.test.ts
+++ b/tests/unit/modal-detection.test.ts
@@ -1,0 +1,93 @@
+/**
+ * modal-detection.test.ts
+ *
+ * Pin the MODAL_RE contract down so the next time someone "improves" the
+ * regex they cannot silently re-introduce the substring false positives that
+ * caused PR #36's E2E flakiness (a Claude Code conversation titled
+ * "Review PR#36 feedback and CI errors" matched /error/ and falsely set
+ * hasModal=true on every desktop_state call).
+ */
+
+import { describe, it, expect } from "vitest";
+import { MODAL_RE } from "../../src/tools/desktop-state.js";
+
+describe("MODAL_RE — true positives (real modal dialog titles)", () => {
+  const positives = [
+    // English standalone keywords
+    "Save As",
+    "Confirm Delete",
+    "Error",
+    "Warning: Disk Full",
+    "Dialog Box",
+    "File Open Dialog",
+    // English mixed-case
+    "save as",
+    "ERROR",
+    // Japanese keywords
+    "警告",
+    "エラー",
+    "ファイルを保存しますか? - 確認",
+    "通知",
+    "ダイアログ",
+    "名前を付けて保存",
+    // Common composite titles
+    "Save As - Notepad",
+    "Confirm File Replace",
+  ];
+
+  for (const title of positives) {
+    it(`detects "${title}" as modal`, () => {
+      expect(MODAL_RE.test(title)).toBe(true);
+    });
+  }
+});
+
+describe("MODAL_RE — false positives prevented (regular window titles)", () => {
+  const negatives = [
+    // The exact bug that caused PR #36 E2E flakiness:
+    "⠂ Review PR#36 feedback and CI errors",
+    // English plurals / suffixes that previously matched substrings:
+    "Review CI errors",
+    "Confirmation Number 12345",
+    "Alerting Service Logs",
+    "Prompt Engineering Guide",
+    "Dialogue Editor",
+    // Compound/related words:
+    "errorList.json - VS Code",
+    "alerts-dashboard - Grafana",
+    "Conversation Prompts",
+    // Application titles that contain the keyword as part of a word:
+    "Sentry Errors Dashboard",
+    "Slack Notifications", // English "Notifications" doesn't match anything (we don't have "notification" in EN)
+    // Browser tabs that might contain similar substrings:
+    "Stack Overflow - 'errors' search results",
+    "GitHub - prompt-toolkit/python-prompt-toolkit: Library for building interactive command lines",
+    // Editor / IDE windows showing modal-related code:
+    "modal.ts - VS Code",
+    "DialogService.tsx - WebStorm",
+  ];
+
+  for (const title of negatives) {
+    it(`does NOT flag "${title}" as modal`, () => {
+      expect(MODAL_RE.test(title)).toBe(false);
+    });
+  }
+});
+
+describe("MODAL_RE — known acceptable Japanese substring matches", () => {
+  // Japanese terms are matched as substrings because \b does not recognise
+  // Japanese word boundaries. These cases are intentional false positives
+  // that we accept as a trade-off for catching legitimate Japanese modals.
+  // Documented here so the trade-off is explicit and reviewable.
+  const acceptedSubstrings = [
+    "通知センター", // notification center — substring of 通知
+    "確認事項",     // checklist — substring of 確認
+    "Twitter 通知", // tweet notifications — substring of 通知
+  ];
+
+  for (const title of acceptedSubstrings) {
+    it(`(known trade-off) flags "${title}" as modal due to JA substring match`, () => {
+      expect(MODAL_RE.test(title)).toBe(true);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

`desktop_state.hasModal` used a flat substring regex that triggered false positives whenever any window title contained "error", "confirm", "alert", "prompt", or "dialog" as part of a longer word. PR #36's local E2E surfaced this when a Claude Code conversation tab was titled `"Review PR#36 feedback and CI errors"` — `/error/` matched `errors`, and 4 `tests/e2e/context-consistency.test.ts > C1/C3` cases broke even though no actual modal was open.

## Changes

| Old | New |
|---|---|
| `/dialog\|confirm\|prompt\|alert\|error\|警告\|エラー\|確認\|通知\|ダイアログ\|名前を付けて\|Save As/i` | `/\b(?:dialog\|confirm\|alert\|error\|warning\|save as)\b\|警告\|エラー\|確認\|通知\|ダイアログ\|名前を付けて/i` |

- **English keywords use `\b` word boundaries** — `errors` no longer matches `/error/`, `Confirmation` no longer matches `/confirm/`, `Alerting` no longer matches `/alert/`, `Dialogue` no longer matches `/dialog/`.
- **Drop bare `prompt`** — most commonly a non-modal noun (`Prompt Engineering`), which `\b` cannot disambiguate.
- **Add `warning`** — parallels the existing Japanese `警告` term that was already covered.
- **Japanese keywords stay as bare substrings** — `\b` does not recognise Japanese word boundaries; substring matches like `通知センター` → `/通知/` are documented as an accepted trade-off.
- **`MODAL_RE` is now exported** so unit tests can pin both the true-positive and false-positive contracts.

## Test plan

- [x] `npm run build` — tsc clean
- [x] `tests/unit/modal-detection.test.ts` — 34 new cases (16 true positives, 15 false positives including the exact PR #36 trigger string, 3 Japanese-substring trade-offs)
- [x] `tests/unit/modal-predicate.test.ts` — 16 existing cases still pass
- [x] CI (GH Actions) — build + CodeQL stay green; previously-flaky `context-consistency.test.ts > hasModal/pageState` cases should pass on local runs that previously hit the Claude Code window title issue

## Out of scope

A fully proper UIA-based modal detector (checking window class names, owner chain, `WS_POPUP` style) is a larger redesign and not required to unblock local E2E. Documented as a future-improvement candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)