### PR TITLE
chore(tools): drop unused buildDesc imports (CodeQL #98-#101)

### DIFF
--- a/src/tools/dock.ts
+++ b/src/tools/dock.ts
@@ -10,7 +10,7 @@ import {
   findAncestorWindow,
 } from "../engine/win32.js";
 import type { WindowZInfo, MonitorInfo } from "../engine/win32.js";
-import { ok, buildDesc } from "./_types.js";
+import { ok } from "./_types.js";
 import type { ToolResult } from "./_types.js";
 import { failWith } from "./_errors.js";
 import { pollUntil } from "../engine/poll.js";

--- a/src/tools/scroll-capture.ts
+++ b/src/tools/scroll-capture.ts
@@ -3,7 +3,6 @@ import sharp from "sharp";
 import { screen, keyboard, mouse, getWindows, Region } from "../engine/nutjs.js";
 import { getWindowTitleW } from "../engine/win32.js";
 import { parseKeys } from "../utils/key-map.js";
-import { buildDesc } from "./_types.js";
 import type { ToolResult } from "./_types.js";
 
 // Horizontal mouse scroll units per step (matches nut-js scroll granularity)

--- a/src/tools/scroll-to-element.ts
+++ b/src/tools/scroll-to-element.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { evaluateInTab } from "../engine/cdp-bridge.js";
 import { scrollElementIntoView } from "../engine/uia-bridge.js";
 import { getCdpPort } from "../utils/desktop-config.js";
-import { ok, buildDesc } from "./_types.js";
+import { ok } from "./_types.js";
 import type { ToolResult } from "./_types.js";
 import { failWith, failArgs } from "./_errors.js";
 

--- a/src/tools/smart-scroll.ts
+++ b/src/tools/smart-scroll.ts
@@ -21,7 +21,7 @@ import {
 } from "../engine/image.js";
 import { captureWindowRawAndHash, getCachedRaw } from "../engine/layer-buffer.js";
 import { getCdpPort } from "../utils/desktop-config.js";
-import { ok, buildDesc } from "./_types.js";
+import { ok } from "./_types.js";
 import type { ToolResult } from "./_types.js";
 import { failWith, failArgs } from "./_errors.js";
 import { coercedBoolean } from "./_coerce.js";


### PR DESCRIPTION
## Summary

Resolves CodeQL alerts #98-#101 (`js/unused-local-variable`, severity=note) on `main`.

The Phase 2c dispatcher refactor consolidated description-building into the new dispatchers (`scroll.ts`, `window-dock.ts`). The four legacy handler files no longer invoke `buildDesc()` themselves, so the import was dead code.

## Changes

| File | Line | Action |
|---|---|---|
| `src/tools/dock.ts` | 13 | `import { ok, buildDesc } from "./_types.js"` → `import { ok } from "./_types.js"` |
| `src/tools/scroll-capture.ts` | 6 | Drop the entire `import { buildDesc } from "./_types.js"` line |
| `src/tools/scroll-to-element.ts` | 5 | `import { ok, buildDesc } from "./_types.js"` → `import { ok } from "./_types.js"` |
| `src/tools/smart-scroll.ts` | 24 | `import { ok, buildDesc } from "./_types.js"` → `import { ok } from "./_types.js"` |

No behavior change — these imports were never used at runtime.

## Test plan

- [x] `npm run build` — tsc clean
- [ ] CI (GH Actions) — build + CodeQL stay green; expect open CodeQL alert count on `main` to drop to zero after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)