### PR TITLE
test: v1.0.0 P0/P1 test-infra fixes (audit findings)

### DIFF
--- a/tests/e2e/http-transport.test.ts
+++ b/tests/e2e/http-transport.test.ts
@@ -153,7 +153,7 @@ describe("H2: MCP initialize (stateless)", () => {
 
 describe("H3: tools/list", () => {
   // Phase 4: stub catalog 26 + 2 dynamic v2 (desktop_discover / desktop_act) = 28.
-  it("returns 200 with ≥ 26 tools", async () => {
+  it("returns 200 with ≥ 28 tools", async () => {
     const r = await mcpPost({
       jsonrpc: "2.0",
       id: 2,
@@ -164,7 +164,7 @@ describe("H3: tools/list", () => {
 
     const json = (await r.json()) as { result?: { tools?: unknown[] } };
     expect(Array.isArray(json.result?.tools)).toBe(true);
-    expect((json.result!.tools as unknown[]).length).toBeGreaterThanOrEqual(26);
+    expect((json.result!.tools as unknown[]).length).toBeGreaterThanOrEqual(28);
   });
 });
 

--- a/tests/unit/registry-lru.test.ts
+++ b/tests/unit/registry-lru.test.ts
@@ -10,17 +10,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
-vi.mock("../../src/engine/win32.js", () => ({
-  enumWindowsInZOrder: vi.fn().mockReturnValue([]),
-  getWindowProcessId: vi.fn().mockReturnValue(1),
-  getProcessIdentityByPid: vi.fn().mockReturnValue({ name: "test.exe", startTimeMs: 0 }),
-  getWindowRectByHwnd: vi.fn().mockReturnValue({ x: 0, y: 0, width: 100, height: 100 }),
-  getForegroundHwnd: vi.fn().mockReturnValue(BigInt(0)),
-  isWindowTopmost: vi.fn().mockReturnValue(false),
-  getWindowClassName: vi.fn().mockReturnValue("test"),
-  getWindowIdentity: vi.fn(),
-  restoreAndFocusWindow: vi.fn(),
-}));
 vi.mock("../../src/engine/event-bus.js", () => ({
   subscribe: vi.fn().mockReturnValue("sub"),
   unsubscribe: vi.fn(),

--- a/tests/unit/tool-naming-phase4.test.ts
+++ b/tests/unit/tool-naming-phase4.test.ts
@@ -790,3 +790,105 @@ describe("Phase 4 — run_macro DSL TOOL_REGISTRY uses v1.0.0 dispatcher names",
     expect(src).toContain("action:'type'");
   });
 });
+
+// ─── 9. run_macro × v2 kill-switch behavioural contract (v1.0.0 P1-10) ───────
+//
+// Source-grep tests above prove the gate exists; these tests prove the gate
+// actually short-circuits the dispatch without reaching the real handler
+// (which would touch Win32). All 4 cases set/restore process.env so they are
+// deterministic regardless of how the host invokes vitest.
+
+describe("Phase 4 — run_macro honours DESKTOP_TOUCH_DISABLE_FUKUWARAI_V2 at runtime", () => {
+  const KILL_VAR = "DESKTOP_TOUCH_DISABLE_FUKUWARAI_V2";
+
+  function withKillSwitch<T>(value: "1" | undefined, fn: () => Promise<T>): Promise<T> {
+    const prev = process.env[KILL_VAR];
+    if (value === undefined) delete process.env[KILL_VAR];
+    else process.env[KILL_VAR] = value;
+    return fn().finally(() => {
+      if (prev === undefined) delete process.env[KILL_VAR];
+      else process.env[KILL_VAR] = prev;
+    });
+  }
+
+  function summaryOf(result: { content: Array<{ type: string; text?: string }> }): {
+    results: Array<{ tool: string; ok: boolean; text?: string[]; error?: string }>;
+  } {
+    const first = result.content.find((b) => b.type === "text");
+    return JSON.parse(first!.text!) as ReturnType<typeof summaryOf>;
+  }
+
+  it("kill-switch ON → run_macro({tool:'desktop_discover'}) returns kill-switch error without invoking the facade", async () => {
+    const { runMacroHandler } = await import("../../src/tools/macro.js");
+    await withKillSwitch("1", async () => {
+      const out = await runMacroHandler({
+        steps: [{ tool: "desktop_discover", params: {} }],
+        stop_on_error: true,
+      });
+      const summary = summaryOf(out);
+      expect(summary.results).toHaveLength(1);
+      const step = summary.results[0]!;
+      expect(step.tool).toBe("desktop_discover");
+      expect(step.ok).toBe(true);
+      const payload = step.text!.join("\n");
+      expect(payload).toContain("DESKTOP_TOUCH_DISABLE_FUKUWARAI_V2=1");
+      expect(payload).toContain("\"ok\": false");
+    });
+  });
+
+  it("kill-switch ON → run_macro({tool:'desktop_act'}) returns kill-switch error without invoking the facade", async () => {
+    const { runMacroHandler } = await import("../../src/tools/macro.js");
+    await withKillSwitch("1", async () => {
+      const out = await runMacroHandler({
+        steps: [{
+          tool: "desktop_act",
+          params: {
+            lease: {
+              entityId: "fake-entity",
+              viewId: "fake-view",
+              targetGeneration: "g0",
+              expiresAtMs: Date.now() + 60_000,
+              evidenceDigest: "fake-digest",
+            },
+            action: "click",
+          },
+        }],
+        stop_on_error: true,
+      });
+      const summary = summaryOf(out);
+      expect(summary.results[0]!.ok).toBe(true);
+      expect(summary.results[0]!.text!.join("\n")).toContain("DESKTOP_TOUCH_DISABLE_FUKUWARAI_V2=1");
+    });
+  });
+
+  it("kill-switch OFF (default) → run_macro({tool:'set_element_value'}) returns v1-fallback hint without invoking the legacy handler", async () => {
+    const { runMacroHandler } = await import("../../src/tools/macro.js");
+    await withKillSwitch(undefined, async () => {
+      const out = await runMacroHandler({
+        steps: [{
+          tool: "set_element_value",
+          params: { windowTitle: "@active", name: "Search", value: "foo" },
+        }],
+        stop_on_error: true,
+      });
+      const summary = summaryOf(out);
+      expect(summary.results[0]!.ok).toBe(true);
+      const payload = summary.results[0]!.text!.join("\n");
+      expect(payload).toContain("V1 fallback only available when DESKTOP_TOUCH_DISABLE_FUKUWARAI_V2=1");
+      expect(payload).toContain("desktop_act({action:'setValue'");
+    });
+  });
+
+  it("kill-switch OFF (default) → run_macro({tool:'get_windows'}) returns v1-fallback hint pointing at desktop_discover.windows[]", async () => {
+    const { runMacroHandler } = await import("../../src/tools/macro.js");
+    await withKillSwitch(undefined, async () => {
+      const out = await runMacroHandler({
+        steps: [{ tool: "get_windows", params: {} }],
+        stop_on_error: true,
+      });
+      const summary = summaryOf(out);
+      expect(summary.results[0]!.ok).toBe(true);
+      expect(summary.results[0]!.text!.join("\n")).toContain("desktop_discover.windows[]");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
v1.0.0 release readiness audit (`docs/v1-release-readiness-review.md` §8) で同定した release-blocker のうち test 系 3 件を修正。

- **P0-6**: `tests/unit/registry-lru.test.ts` の重複 `vi.mock("../win32.js")` を削除。empty-mock (lines 13-23) と TestWindow 入り mock (lines 90-102) が同一ファイルにあり、full-suite parallel で mock 解決順が undefined → 既知 flake の真因。
- **P1-10**: `tests/unit/tool-naming-phase4.test.ts` に `run_macro × v2 kill-switch` の behavioural test 4 件を追加。`process.env.DESKTOP_TOUCH_DISABLE_FUKUWARAI_V2` を切替えて、(a) ON で `desktop_discover`/`desktop_act` がエラー、(b) OFF で `set_element_value`/`get_windows` が v1FallbackOnlyError を返すことを検証。源 grep だけだった既存 test を engine-real に拡張。
- **P1-11**: `tests/e2e/http-transport.test.ts` H3 threshold を `≥ 26` → `≥ 28` (Phase 4 stub catalog 26 + dynamic v2 2 = 28、コメントとの整合)。

## Test plan
- [x] `npx vitest run tests/unit/registry-lru.test.ts tests/unit/tool-naming-phase4.test.ts` → 132 pass (123 既存 + 4 新規 + 5 lru)
- [x] full unit + e2e: 2186 pass / 22 skip (1 fail は `screenshot-electron` の VS Code 依存 pre-existing flake、本 PR と無関係)
- [ ] CI 上で再確認 (現時点で CI は test を回さない — P0-1/P0-2 で修正予定)

## Refs
- Audit doc: \`docs/v1-release-readiness-review.md\` (PR #TBD on \`chore/v1-release-readiness-review\`)
- 後続 PR: P0-1/P0-2 (CI gap fix), P0-3/4/5 (terminal text gate + Rust hardening)

🤖 Generated with [Claude Code](https://claude.com/claude-code)