### PR TITLE
test: stub checkFailsafe in run_macro behavioural tests (PR #42 follow-up)

### DIFF
--- a/tests/unit/tool-naming-phase4.test.ts
+++ b/tests/unit/tool-naming-phase4.test.ts
@@ -25,11 +25,20 @@
  * Design reference: docs/tool-surface-phase4-privatize-absorb-design.md
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+
+// Stub the cursor-based failsafe so behavioural run_macro tests below are
+// deterministic regardless of where the host's pointer happens to be.
+// (Codex PR #42 P2: runMacroHandler always invokes checkFailsafe before
+// dispatch — without this stub, a top-left pointer fails the step before
+// the kill-switch logic runs.)
+vi.mock("../../src/utils/failsafe.js", () => ({
+  checkFailsafe: vi.fn().mockResolvedValue(undefined),
+}));
 
 import { registerEventTools } from "../../src/tools/events.js";
 import { registerPerceptionTools } from "../../src/tools/perception.js";


### PR DESCRIPTION
## Summary
PR #42 で追加した \`run_macro × v2 kill-switch\` の behavioural test 4 件が、host の cursor 位置に依存する flake を内包していた件の follow-up 修正。

**Codex PR #42 P2 指摘**: \`runMacroHandler\` は dispatch 前に必ず \`checkFailsafe()\` を実行する (\`src/tools/macro.ts\`)。pointer が top-left failsafe zone にあると、kill-switch ロジックに到達する前にステップが fail し、機能は正しいのにテストが落ちる。

**修正**: \`tests/unit/tool-naming-phase4.test.ts\` の file scope で \`checkFailsafe\` を stub:
\`\`\`ts
vi.mock("../../src/utils/failsafe.js", () => ({
  checkFailsafe: vi.fn().mockResolvedValue(undefined),
}));
\`\`\`

## Test plan
- [x] \`npx vitest run tests/unit/tool-naming-phase4.test.ts\` → 127/127 pass
- [x] build pass
- [ ] full unit + e2e regression check (CI 上で確認)

## Refs
- 親 PR: #42 (merged)
- Codex review: PR #42 inline P2 on \`tests/unit/tool-naming-phase4.test.ts:822-824\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)