### PR TITLE
fix(security): CDP CWE-94 + HTTP CORS tightening (E audit)

### DIFF
--- a/src/server-windows.ts
+++ b/src/server-windows.ts
@@ -330,8 +330,17 @@ if (useHttp) {
       return;
     }
 
-    // CORS for browser-based clients
-    res.setHeader("Access-Control-Allow-Origin", "*");
+    // CORS — only echo Origin for localhost requests. The DNS rebinding check
+    // above bounds Host to localhost; the Origin check here bounds the
+    // BROWSER side: a malicious cross-origin tab can still reach the server
+    // via the user's loopback, but without a matching Allow-Origin the
+    // browser will not expose the response to JS — preventing a tab on
+    // evil.com from exfiltrating the MCP surface.
+    const origin = req.headers.origin;
+    if (typeof origin === "string" && /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin)) {
+      res.setHeader("Access-Control-Allow-Origin", origin);
+      res.setHeader("Vary", "Origin");
+    }
     res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
     res.setHeader("Access-Control-Allow-Headers", "Content-Type, mcp-session-id, MCP-Protocol-Version");
     res.setHeader("Access-Control-Expose-Headers", "mcp-session-id");

--- a/src/tools/desktop-executor.ts
+++ b/src/tools/desktop-executor.ts
@@ -233,7 +233,7 @@ function getSharedRealDeps(): ExecutorDeps {
       const { evaluateInTab, DEFAULT_CDP_PORT } = await import("../engine/cdp-bridge.js");
       const expr = `(function(){
   const el = document.querySelector(${JSON.stringify(selector)});
-  if(!el) return { ok:false, error:"Element not found: ${selector}" };
+  if(!el) return { ok:false, error:"Element not found: " + ${JSON.stringify(selector)} };
   el.focus();
   const nativeSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype,"value")?.set
     ?? Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype,"value")?.set;

--- a/tests/e2e/http-transport.test.ts
+++ b/tests/e2e/http-transport.test.ts
@@ -182,7 +182,7 @@ describe("H4: Parallel stateless isolation", () => {
 });
 
 describe("H5: CORS preflight", () => {
-  it("OPTIONS /mcp returns 204 with Access-Control-Allow-Origin: *", async () => {
+  it("OPTIONS /mcp from a localhost origin echoes that origin back", async () => {
     const r = await fetch(MCP_URL, {
       method: "OPTIONS",
       headers: {
@@ -191,8 +191,21 @@ describe("H5: CORS preflight", () => {
       },
     });
     expect(r.status).toBe(204);
-    expect(r.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(r.headers.get("Access-Control-Allow-Origin")).toBe("http://localhost:3000");
+    expect(r.headers.get("Vary")).toMatch(/Origin/);
     expect(r.headers.get("Access-Control-Allow-Methods")).toMatch(/POST/);
+  });
+
+  it("OPTIONS /mcp from a non-localhost origin omits Allow-Origin (CORS denies the response)", async () => {
+    const r = await fetch(MCP_URL, {
+      method: "OPTIONS",
+      headers: {
+        Origin: "https://evil.example.com",
+        "Access-Control-Request-Method": "POST",
+      },
+    });
+    expect(r.status).toBe(204);
+    expect(r.headers.get("Access-Control-Allow-Origin")).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
v1.0.0 release prep の Security audit (audit §8.5 E) で発見した問題を修正。

### 1. CWE-94 (code injection) in cdpFill
\`src/tools/desktop-executor.ts:236\` で selector が JS string literal 内に raw interpolation されていた:
\`\`\`ts
error:\"Element not found: \${selector}\"   // ← unsafe
\`\`\`
selector が \`\"; alert(1); //\` のような値なら閉じ \" で抜け出して任意 JS 実行可能。リポジトリ内の他の CDP eval 箇所はすべて \`JSON.stringify\` 経由で安全 (browser.ts / scroll-to-element.ts / cdp-bridge.ts)。本箇所もその convention に揃えて \`' + \${JSON.stringify(selector)}\` 形式に。

### 2. CORS too permissive
\`src/server-windows.ts:334\` で \`Access-Control-Allow-Origin: *\` を全リクエストに返していた。DNS rebinding (Host check) で localhost 以外を 403 にしているので network 攻撃面は narrow だが、**malicious browser tab on \`https://evil.example.com\` がユーザーの loopback 経由で MCP surface を fetch + JS から read 可能**な経路が残っていた。

修正: localhost origin allowlist 方式 — \`Origin\` ヘッダが \`^https?://(localhost|127.0.0.1)(:port)?$\` に match する場合のみ echo、それ以外は \`Allow-Origin\` を出さない (ブラウザが response を JS に晒さない)。\`Vary: Origin\` も追加。

H5 e2e test を 2 case に分割:
- positive: localhost origin → echoed
- negative: evil.example.com origin → no Allow-Origin

### Audit clean
他カテゴリは clean 確認済み:
- command injection (terminal/exec/spawn)
- path traversal (screenshot/perception)
- failsafe / v2 kill-switch integrity
- secret handling
- 他の CDP eval sites
- CodeQL alerts: 0 open
- secret-scanning alerts: 0 open

## Test plan
- [x] \`npm run build\` → ok
- [x] \`npm run test:unit\` → 1968 pass / 2 skip
- [x] \`tests/e2e/http-transport.test.ts\` → 8 pass (incl. 2 new H5)
- [ ] CI 上で確認

## Refs
- audit doc: \`docs/v1-release-readiness-review.md\` §8.5 E
- 関連 PR: #45 (CI gap), #46 (P0 fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)