### PR TITLE
docs: I-audit drift fixes ahead of v1.0.0 (tool counts + Phase status)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -10,7 +10,7 @@
 > まずはここから、公開向けの解説、client setup、Reactive Perception Graph の紹介を読めます。
 
 Claude がデスクトップを直接見て、直接操作する。  
-マウス・キーボード・スクリーンショット・Windows UI Automation・Chrome DevTools Protocol・ターミナル・SmartScroll・Reactive Perception Graph を統合した 57 のツールを提供する MCP サーバーです。
+マウス・キーボード・スクリーンショット・Windows UI Automation・Chrome DevTools Protocol・ターミナル・SmartScroll・Reactive Perception Graph を統合した 28 個の public ツール (26 stub catalog + 2 dynamic v2 World-Graph: `desktop_discover` / `desktop_act`) を提供する MCP サーバーです。
 
 > *v0.15: Rust ネイティブエンジンにより**平均 82 倍高速化** — UIA フォーカス取得 2ms、SSE2 SIMD 画像差分 13〜15 倍速。設定不要：エンジンは自動ロード、不在時は PowerShell に透過フォールバック。*
 > *v0.15.5: **固定リリース検証** — npm ランチャーは対応する GitHub Release tag だけを取得し、Windows runtime zip を検証してから展開します。*
@@ -121,7 +121,7 @@ npm run build
 
 ---
 
-## ツール一覧 (57 ツール)
+## ツール一覧 (28 ツール — 26 stub catalog + 2 dynamic v2)
 
 > 📖 **詳細リファレンス**: [`docs/system-overview.md`](docs/system-overview.md) — 各ツールのパラメータ・応答形式・座標計算・レイヤーバッファ・技術ノートを網羅（英語）。
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 > **Project site:** [harusame64.github.io/desktop-touch-mcp](https://harusame64.github.io/desktop-touch-mcp/)  
 > Start here for the public explainer, client setup guides, and the Reactive Perception Graph overview.
 
-An MCP server that gives Claude eyes and hands on Windows — 57 tools covering screenshots, mouse, keyboard, Windows UI Automation, Chrome DevTools Protocol, clipboard, desktop notifications, SmartScroll, and a Reactive Perception Graph for safe multi-step automation, designed from the ground up for LLM efficiency.
+An MCP server that gives Claude eyes and hands on Windows — 28 public tools (26 stub catalog + 2 dynamic v2 World-Graph: `desktop_discover` / `desktop_act`) covering screenshots, mouse, keyboard, Windows UI Automation, Chrome DevTools Protocol, clipboard, desktop notifications, SmartScroll, and a Reactive Perception Graph for safe multi-step automation, designed from the ground up for LLM efficiency.
 
 > *v0.15: **82× average speedup** via Rust native engine — UIA focus queries in 2 ms, SSE2-accelerated image diffing at 13–15× native speed. Zero-config: the engine auto-loads when present, with transparent PowerShell fallback.*
 > *v0.15.5: **Pinned release verification** — the npm launcher now fetches only the matching GitHub Release tag and verifies the Windows runtime zip before extraction.*
@@ -121,7 +121,7 @@ For a local checkout, register the built server directly:
 
 ---
 
-## Tools (57 total)
+## Tools (28 total — 26 stub catalog + 2 dynamic v2)
 
 > 📖 **Full command reference**: [`docs/system-overview.md`](docs/system-overview.md) — every tool's parameters, response shape, coordinate math, layer-buffer strategy, and engineering notes in one place.
 

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -64,17 +64,19 @@ desktop-touch-mcp (Node.js / TypeScript)
     │       ├── envelope.ts         — projectEnvelope: attention derivation + token-budget trimming
     │       ├── sensors-win32.ts    — only impure module; piggybacks event-bus 500 ms tick
     │       └── registry.ts         — central coordinator; max 16 lenses (LRU evict)
-    └── Layer 2: 58 MCP tools
-        See [tool-descriptions.md](D:/git/desktop-touch-mcp/docs/tool-descriptions.md) for the up-to-date catalog.
+    └── Layer 2: 28 public MCP tools (26 stub catalog + 2 dynamic v2)
+        See [CHANGELOG.md](D:/git/desktop-touch-mcp/CHANGELOG.md) Phase 1+2+3+4 sections for the per-phase mapping.
 ```
 
 ### Surface status
 
-- **Current public surface**: 58 tools, including `desktop_discover` / `desktop_act`
-- **Planned redesign**: `desktop_state` / `desktop_discover` / `desktop_act` naming and single-surface cleanup are still design-stage, not the current shipped interface
-- Reference plans:
-  - [tool-surface-reduction-plan.md](D:/git/desktop-touch-mcp/docs/tool-surface-reduction-plan.md)
+- **Current public surface (v1.0.0)**: 28 tools — 26 stub catalog + 2 dynamic v2 (`desktop_discover` / `desktop_act`)
+- **Tool surface reduction (Phase 1–4) — shipped**: naming redesign, family merge dispatchers, browser rearrangement, privatize/absorb. Pre-Phase-1 surface was 65 tools.
+- Phase design references (all Implemented):
   - [tool-surface-phase1-naming-design.md](D:/git/desktop-touch-mcp/docs/tool-surface-phase1-naming-design.md)
+  - [tool-surface-phase2-family-merge-design.md](D:/git/desktop-touch-mcp/docs/tool-surface-phase2-family-merge-design.md)
+  - [tool-surface-phase3-browser-rearrangement-design.md](D:/git/desktop-touch-mcp/docs/tool-surface-phase3-browser-rearrangement-design.md)
+  - [tool-surface-phase4-privatize-absorb-design.md](D:/git/desktop-touch-mcp/docs/tool-surface-phase4-privatize-absorb-design.md)
 
 ### Rust Native Engine — Data Flow
 

--- a/docs/tool-surface-phase3-browser-rearrangement-design.md
+++ b/docs/tool-surface-phase3-browser-rearrangement-design.md
@@ -1,6 +1,6 @@
 # Phase 3 設計書 — Browser 再配置 (launch 吸収 / eval 拡張 / disconnect 非公開化)
 
-- Status: **Draft** (2026-04-26、ユーザー approve 待ち)
+- Status: **Implemented** (PR #40 merged into main 2026-04-26)
 - 設計者: Claude (Opus 4.7)
 - 実装担当: 判断系 batch は Opus 直 / 機械的 batch のみ Sonnet 委譲 (§9 サブ batch 表参照)
 - レビュー: Opus 自己レビュー → Codex (PR 提出後)

--- a/docs/tool-surface-phase4-privatize-absorb-design.md
+++ b/docs/tool-surface-phase4-privatize-absorb-design.md
@@ -1,6 +1,6 @@
 # Phase 4 設計書 — Privatize / Absorb (events / perception / get_* / mouse_move / screenshot / set_element_value)
 
-- Status: **Draft** (2026-04-26、ユーザー approve 待ち)
+- Status: **Implemented** (PR #41 merged into main 2026-04-26 — 65→28 public surface achieved)
 - 設計者: Claude (Opus 4.7)
 - 実装担当: 判断系 batch は Opus 直 / 機械的 batch のみ Sonnet 委譲 (§9 サブ batch 表参照)
 - レビュー: Opus 自己レビュー + memory `feedback_pre_push_self_review.md` の **pre-push checklist 必須** → Codex (PR 提出後)

--- a/docs/v1-release-readiness-review.md
+++ b/docs/v1-release-readiness-review.md
@@ -259,9 +259,8 @@ For each finding: file:line + 1-line summary + suggested fix direction.
 
 ### 8.5. 残タスク
 
-- **E (security audit)** — `/security-review` + CodeQL alert 残確認、suggest fixed-string ガード再点検、secret scan
-- **I (documentation audit)** — README × 2 / system-overview / CHANGELOG / known-issues / Phase 4 design 完了マーク
-- 上記 2 つは次セッションで実施 (現セッションは context 制約)
+- ~~**E (security audit)**~~ — 完了 (PR #47 merged)。CodeQL/secret-scanning 0 open。発見 = `desktop-executor.ts:236` の CWE-94 (CDP eval 内 selector raw interpolation) + HTTP CORS `*` を localhost origin allowlist に縮約。command-injection / path-traversal / failsafe / kill-switch / 他 CDP eval / secret 取扱 はすべて clean。
+- ~~**I (documentation audit)**~~ — 完了 (本 PR)。drift 修正: README × 2 の tool count (57→28)、`system-overview.md` の "planned" → "shipped"、CLAUDE.md の tool count (56→28)、Phase 3/4 design status を Draft → Implemented。CHANGELOG の v1.0.0 DRAFT 解除は release 時 (version bump + tag と同時)。
 
 ### 8.6. Release recommendation (現時点)
 


### PR DESCRIPTION
## Summary
v1.0.0 release prep の docs audit (audit §8.5 I) で発見した user-facing doc の drift 修正。中身のリライトはせず、数字・ステータスラベルだけを現状に揃える最小修正。

### 変更
| file | before | after |
|---|---|---|
| README.md | \"57 tools\" / \"Tools (57 total)\" | \"28 public tools\" / \"(28 total — 26 stub catalog + 2 dynamic v2)\" |
| README.ja.md | \"57 のツール\" / \"ツール一覧 (57 ツール)\" | \"28 個の public ツール\" / \"ツール一覧 (28 ツール)\" |
| docs/system-overview.md | \"Layer 2: 58 MCP tools\", \"design-stage, not the current shipped interface\" | \"28 public MCP tools\", \"Phase 1–4 shipped\", catalog 参照を CHANGELOG に修正 |
| tool-surface-phase3-browser-rearrangement-design.md | Status: Draft | Status: Implemented (PR #40) |
| tool-surface-phase4-privatize-absorb-design.md | Status: Draft | Status: Implemented (PR #41) |
| v1-release-readiness-review.md §8.5 | E / I 残タスク | 両方 strike-out (完了マーク) |

CLAUDE.md は gitignored (local dev) なのでコミットしません。

### Out of scope (release tag 時に対応)
- CHANGELOG \`[1.0.0] - DRAFT\` の DRAFT 解除 — version bump + tag と同時
- README の workflow / V2-primary 並び替え — 大きめのリライトなので release tag PR に集約

## Test plan
- [x] \`npm run build\` → ok (doc only changes; no code path)
- [ ] CI 上で確認

## Refs
- audit doc: \`docs/v1-release-readiness-review.md\` §8.5 I
- 関連 PR: #45 (CI), #46 (P0), #47 (security)

🤖 Generated with [Claude Code](https://claude.com/claude-code)