### PR TITLE
chore: remove deprecated fluentKeyFor (dead code, audit P1-5)

### DIFF
--- a/src/engine/perception/lens.ts
+++ b/src/engine/perception/lens.ts
@@ -32,15 +32,6 @@ export function nextLensId(seed?: () => string): string {
 export function resetLensCounter(): void { _lensCounter = 0; }
 
 /**
- * Build the concrete fluent-store key for a given fluent kind on a bound window.
- * Format: "window:<hwnd>.<property>"
- * @deprecated Use fluentKeyForEntity for new code.
- */
-export function fluentKeyFor(hwnd: string, property: string): string {
-  return `window:${hwnd}.${property}`;
-}
-
-/**
  * Build the concrete fluent-store key for any entity kind.
  * Format: "<kind>:<id>.<property>"
  * Throws on unknown entity kind to catch missed migrations during testing.

--- a/tests/unit/lens-matcher.test.ts
+++ b/tests/unit/lens-matcher.test.ts
@@ -8,7 +8,6 @@ import {
   compileLens,
   resolveBindingFromSnapshot,
   expandFluentKeys,
-  fluentKeyFor,
   resetLensCounter,
   type WindowSnapshot,
 } from "../../src/engine/perception/lens.js";
@@ -118,13 +117,6 @@ describe("compileLens", () => {
     const binding = resolveBindingFromSnapshot(baseSpec, windows)!;
     const lens = compileLens(baseSpec, binding, baseIdentity, 42);
     expect(lens.registeredAtSeq).toBe(42);
-  });
-});
-
-describe("fluentKeyFor", () => {
-  it("formats key as window:<hwnd>.<property>", () => {
-    expect(fluentKeyFor("100", "target.title")).toBe("window:100.target.title");
-    expect(fluentKeyFor("999", "modal.above")).toBe("window:999.modal.above");
   });
 });
 


### PR DESCRIPTION
## Summary
Audit P1-5 (\`docs/v1-release-readiness-review.md\` §8.2) は \"Phase 4 で消えた tool 系の error code が dead\" を指摘していたが、実調査の結果:
- 名指しされた \`src/engine/error/error-codes.ts\` は存在しない
- production の中央 error-code 定数で privatized tool 由来のものは grep で 0 件
- V1_ONLY 系の error 文字列は macro.ts の gate handler にインラインで存在し、現役

audit の specific finding は overstatement (P0-4 と同パターン)。spirit に従い、@deprecated 付きの dead export 1 件を削除:

- \`src/engine/perception/lens.ts\` の \`fluentKeyFor()\` — \`fluentKeyForEntity\` 移行済みで production caller 0、test だけが参照していた

他の @deprecated annotation は legacy \`sourceId\` (executor fallback で現役) / \`buildUiaText\` (screenshot.ts:808 から call 中) でまだ load-bearing なので touch しない。

## Test plan
- [x] \`npm run build\` → ok
- [x] \`tests/unit/lens-matcher.test.ts\` → 13 pass (was 14、-1 from removed test)
- [x] \`npm run test:unit\` → 1967 pass / 2 skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)