### PR TITLE
test: v1 surface coverage — kill-switch / lease shape / focus (P1-12)

### DIFF
--- a/tests/e2e/http-transport-kill-switch.test.ts
+++ b/tests/e2e/http-transport-kill-switch.test.ts
@@ -1,0 +1,130 @@
+/**
+ * http-transport-kill-switch.test.ts — E2E test for V2 World-Graph kill switch.
+ *
+ * Spawns the server with DESKTOP_TOUCH_DISABLE_FUKUWARAI_V2=1 and verifies
+ * tools/list returns exactly the 26 stub-catalog entries (no dynamic v2
+ * desktop_discover / desktop_act). Pairs with audit P1-12 (gap #1).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { ChildProcess, spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+// Use a different port from http-transport.test.ts (29847) so the two test
+// files can co-exist even if vitest runs them in parallel.
+const PORT = parseInt(process.env.E2E_HTTP_KILL_SWITCH_PORT ?? "29848", 10);
+const BASE = `http://127.0.0.1:${PORT}`;
+const MCP_URL = `${BASE}/mcp`;
+const HEALTH_URL = `${BASE}/health`;
+
+const SERVER_SCRIPT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../dist/index.js",
+);
+
+let serverProcess: ChildProcess;
+
+async function sleep(ms: number) {
+  return new Promise<void>((r) => setTimeout(r, ms));
+}
+
+async function mcpPost(body: unknown): Promise<Response> {
+  return fetch(MCP_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeAll(async () => {
+  serverProcess = spawn("node", [SERVER_SCRIPT, "--http", "--port", String(PORT)], {
+    stdio: ["ignore", "ignore", "pipe"],
+    env: {
+      ...process.env,
+      DESKTOP_TOUCH_NO_TRAY: "1",
+      DESKTOP_TOUCH_DISABLE_FUKUWARAI_V2: "1",
+    },
+  });
+
+  const stderrChunks: string[] = [];
+  serverProcess.stderr?.on("data", (chunk: Buffer) => {
+    stderrChunks.push(chunk.toString());
+  });
+
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    await sleep(500);
+    try {
+      const r = await fetch(HEALTH_URL);
+      if (r.ok) break;
+    } catch {
+      // still starting
+    }
+  }
+
+  let healthy = false;
+  try {
+    const r = await fetch(HEALTH_URL);
+    healthy = r.ok;
+  } catch {
+    // not up
+  }
+  if (!healthy) {
+    serverProcess.kill();
+    throw new Error(
+      `Kill-switch HTTP server did not start on port ${PORT} within 20s.\nstderr:\n${stderrChunks.join("")}`,
+    );
+  }
+}, 25_000);
+
+afterAll(() => {
+  serverProcess?.kill();
+});
+
+describe("V2 kill-switch — HTTP tools/list", () => {
+  it("with DESKTOP_TOUCH_DISABLE_FUKUWARAI_V2=1, tools/list returns 26 stub-catalog tools (no v2 dynamic)", async () => {
+    const r = await mcpPost({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/list",
+      params: {},
+    });
+    expect(r.status).toBe(200);
+
+    const json = (await r.json()) as { result?: { tools?: Array<{ name: string }> } };
+    const tools = json.result?.tools ?? [];
+
+    // Stub catalog is 26 + the v2 dispatchers add 2 dynamic. With v2 killed
+    // the count should be exactly 26 (or the published v1 fallback set, see
+    // server-windows.ts — get_windows / get_ui_elements / set_element_value
+    // are reinstated when v2 is killed). The contract is: zero v2 dynamic
+    // names exposed.
+    const names = tools.map((t) => t.name);
+    expect(names).not.toContain("desktop_discover");
+    expect(names).not.toContain("desktop_act");
+
+    // The 26 stub-catalog tools must all be present.
+    expect(names.length).toBeGreaterThanOrEqual(26);
+  });
+
+  it("v1 fallback tools (get_windows / get_ui_elements / set_element_value) ARE present when v2 is killed", async () => {
+    const r = await mcpPost({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+      params: {},
+    });
+    expect(r.status).toBe(200);
+
+    const json = (await r.json()) as { result?: { tools?: Array<{ name: string }> } };
+    const names = (json.result?.tools ?? []).map((t) => t.name);
+
+    for (const fallback of ["get_windows", "get_ui_elements", "set_element_value"]) {
+      expect(names, `${fallback} should be registered when v2 kill-switch is on`).toContain(fallback);
+    }
+  });
+});

--- a/tests/unit/desktop-facade.test.ts
+++ b/tests/unit/desktop-facade.test.ts
@@ -112,6 +112,88 @@ describe("DesktopFacade — desktop_see (game / chrome / terminal)", () => {
   });
 });
 
+// Audit P1-12 (gap #2): explicit shape validation for the lease handed back
+// from desktop_discover. The existing tests above assert `lease` is defined;
+// these add a contract on every required field so refactors can't quietly
+// drop one and still pass the previous expectations.
+describe("DesktopFacade — desktop_discover lease shape contract", () => {
+  it("each entity carries a complete EntityLease (5 required fields, all populated)", async () => {
+    const facade = new DesktopFacade(gameProvider);
+    const before = Date.now();
+    const out = await facade.see({ target: TARGET_GAME });
+    expect(out.entities.length).toBeGreaterThan(0);
+
+    for (const entity of out.entities) {
+      const lease = entity.lease;
+      expect(lease).toBeDefined();
+      expect(typeof lease!.entityId).toBe("string");
+      expect(lease!.entityId.length).toBeGreaterThan(0);
+      expect(typeof lease!.viewId).toBe("string");
+      expect(lease!.viewId).toBe(out.viewId);
+      expect(typeof lease!.targetGeneration).toBe("string");
+      expect(lease!.targetGeneration.length).toBeGreaterThan(0);
+      expect(typeof lease!.expiresAtMs).toBe("number");
+      expect(lease!.expiresAtMs).toBeGreaterThan(before); // future timestamp
+      expect(typeof lease!.evidenceDigest).toBe("string");
+      expect(lease!.evidenceDigest.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("lease.entityId matches entity.entityId so callers can route without ambiguity", async () => {
+    const facade = new DesktopFacade(gameProvider);
+    const out = await facade.see({ target: TARGET_GAME });
+    for (const entity of out.entities) {
+      expect(entity.lease!.entityId).toBe(entity.entityId);
+    }
+  });
+});
+
+// Audit P1-12 (gap #3): the windows[] array on DesktopSeeOutput is meant to
+// reflect whatever the live windowsProvider currently reports, including a
+// focus shift between calls. These tests pin the contract so a future
+// refactor that caches the snapshot can't silently freeze focus.
+describe("DesktopFacade — windows[] reflects live windowsProvider state", () => {
+  function makeWindow(overrides: Partial<{
+    title: string; hwnd: string; isActive: boolean; zOrder: number;
+  }> = {}) {
+    return {
+      zOrder: overrides.zOrder ?? 0,
+      title: overrides.title ?? "Notepad",
+      hwnd: overrides.hwnd ?? "1000",
+      region: { x: 0, y: 0, width: 800, height: 600 },
+      isActive: overrides.isActive ?? true,
+      isMinimized: false,
+      isMaximized: false,
+      processName: "notepad.exe",
+    };
+  }
+
+  it("a focus change between two see() calls is reflected by windows[].isActive", async () => {
+    let activeHwnd = "1000";
+    const facade = new DesktopFacade(() => [], {
+      windowsProvider: () => [
+        makeWindow({ hwnd: "1000", title: "Notepad", isActive: activeHwnd === "1000", zOrder: 0 }),
+        makeWindow({ hwnd: "2000", title: "Calc",    isActive: activeHwnd === "2000", zOrder: 1 }),
+      ],
+    });
+
+    const first = await facade.see({});
+    const firstActive = first.windows.find((w) => w.isActive);
+    expect(firstActive?.hwnd).toBe("1000");
+
+    activeHwnd = "2000";
+
+    const second = await facade.see({});
+    const secondActive = second.windows.find((w) => w.isActive);
+    expect(secondActive?.hwnd).toBe("2000");
+
+    // The previously-active window must now report isActive:false (focus
+    // moved away, not lost).
+    const previousNotepad = second.windows.find((w) => w.hwnd === "1000");
+    expect(previousNotepad?.isActive).toBe(false);
+  });
+});
+
 describe("DesktopFacade — desktop_touch", () => {
   it("touch with valid lease returns ok:true + diff", async () => {
     const facade = new DesktopFacade(gameProvider, { executorFn: async () => "mouse" });


### PR DESCRIPTION
## Summary
Audit P1-12 (\`docs/v1-release-readiness-review.md\` §8.2) で同定した v1 surface の test coverage gap 3 件を埋める。

### 1. HTTP \`tools/list\` × v2 kill-switch (new e2e file)
\`tests/e2e/http-transport-kill-switch.test.ts\` で別 port (29848) に \`DESKTOP_TOUCH_DISABLE_FUKUWARAI_V2=1\` 付き server を立てて確認:
- desktop_discover / desktop_act が catalog に **無い**
- v1 fallback (get_windows / get_ui_elements / set_element_value) が **ある**
- 総数 ≥ 26 (stub-catalog floor)

### 2. lease shape contract
\`tests/unit/desktop-facade.test.ts\` に EntityLease 5 fields の完全 validation 追加。既存 test は \`lease).toBeDefined()\` だけだったので future refactor で field が落ちても通っていた経路を pin。

### 3. windows[] focus change
windowsProvider が \`isActive\` を変えた状態で 2 回 \`see()\` 呼び出し → 新 active 反映 + 旧 active が \`isActive:false\` に反転。\"windows[] is live, not cached\" 契約を pin。

## Test plan
- [x] \`npm run build\` → ok
- [x] \`tests/unit/desktop-facade.test.ts\` → 50 pass (was 47, +3)
- [x] \`tests/e2e/http-transport-kill-switch.test.ts\` → 2 pass
- [x] \`npm run test:unit\` → 1970 pass / 2 skip
- [ ] CI で確認

## Refs
- audit: \`docs/v1-release-readiness-review.md\` §8.2 P1-12

🤖 Generated with [Claude Code](https://claude.com/claude-code)