### PR TITLE
perf(desktop_discover): 100ms TTL cache for windowsProvider (audit P1-1)

### DIFF
--- a/src/tools/desktop-register.ts
+++ b/src/tools/desktop-register.ts
@@ -100,7 +100,15 @@ function productionGetFocusedEntityId(): string | undefined {
  * expires; OS-level focus changes between snapshots are observed by the
  * separate `getFocusedEntityId` path).
  *
- * `nowFn` and `ttlMs` are injectable for unit testing.
+ * Time source: defaults to `performance.now()` (monotonic), so wall-clock
+ * adjustments — NTP step-back, manual clock changes, VM snapshot restore —
+ * never make a stale entry look fresh. The path also defends with `t >=
+ * cached.at` so an injected non-monotonic `nowFn` (or any future regression)
+ * still falls through to a re-enumeration on backward time travel rather
+ * than serving the previous snapshot. (Codex PR #53 P2.)
+ *
+ * `nowFn`, `ttlMs`, `enumerate`, and `resolveProcessName` are injectable for
+ * unit testing.
  */
 export interface WindowsProviderCacheOptions {
   ttlMs?: number;
@@ -124,14 +132,18 @@ export function createCachedProductionWindowsProvider(
   options: WindowsProviderCacheOptions = {},
 ): () => DesktopWindowMeta[] {
   const ttlMs = options.ttlMs ?? 100;
-  const now = options.nowFn ?? Date.now;
+  const now = options.nowFn ?? (() => performance.now());
   const enumerate = options.enumerate ?? enumWindowsInZOrder;
   const resolveProcessName = options.resolveProcessName ?? defaultResolveProcessName;
   let cached: { at: number; result: DesktopWindowMeta[] } | undefined;
 
   return () => {
     const t = now();
-    if (cached && t - cached.at < ttlMs) return cached.result;
+    // Defensive: ignore the cached entry if the clock moved backward since it
+    // was stored. With the default monotonic clock this branch is unreachable;
+    // it exists so an injected non-monotonic `nowFn` (or a future regression)
+    // can't keep serving stale windows past the TTL.
+    if (cached && t >= cached.at && t - cached.at < ttlMs) return cached.result;
     const result = enumerate().map((w) => {
       const processName = resolveProcessName(w.hwnd);
       return {

--- a/src/tools/desktop-register.ts
+++ b/src/tools/desktop-register.ts
@@ -16,7 +16,7 @@
 
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { DesktopFacade, type CandidateProvider, type DesktopSeeInput } from "./desktop.js";
+import { DesktopFacade, type CandidateProvider, type DesktopSeeInput, type DesktopWindowMeta } from "./desktop.js";
 import type { EntityLease, UiEntity } from "../engine/world-graph/types.js";
 import {
   SnapshotIngress,
@@ -85,6 +85,69 @@ function productionGetFocusedEntityId(): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Production windowsProvider with a short-lived (default 100ms) result cache.
+ *
+ * Audit P1-1 (docs/v1-release-readiness-review.md §8.2): every desktop_discover
+ * call previously re-ran enumWindowsInZOrder + getWindowProcessId +
+ * getProcessIdentityByPid for every visible window — on a desktop with 40+
+ * windows this is tens of ms per call and shows up in chained workflows
+ * (desktop_state → desktop_discover → desktop_act). A coarse TTL cache
+ * collapses bursts of see() calls without hiding real focus shifts (the
+ * windowsProvider is intentionally re-evaluated whenever the cache TTL
+ * expires; OS-level focus changes between snapshots are observed by the
+ * separate `getFocusedEntityId` path).
+ *
+ * `nowFn` and `ttlMs` are injectable for unit testing.
+ */
+export interface WindowsProviderCacheOptions {
+  ttlMs?: number;
+  nowFn?: () => number;
+  /** Override the raw window enumerator. Tests inject a fake; production uses enumWindowsInZOrder. */
+  enumerate?: typeof enumWindowsInZOrder;
+  /** Override per-hwnd process info. Tests inject a fake; production uses getWindowProcessId + getProcessIdentityByPid. */
+  resolveProcessName?: (hwnd: bigint | number) => string | undefined;
+}
+
+function defaultResolveProcessName(hwnd: bigint | number): string | undefined {
+  try {
+    const pid = getWindowProcessId(hwnd);
+    return getProcessIdentityByPid(pid).processName;
+  } catch {
+    return undefined;
+  }
+}
+
+export function createCachedProductionWindowsProvider(
+  options: WindowsProviderCacheOptions = {},
+): () => DesktopWindowMeta[] {
+  const ttlMs = options.ttlMs ?? 100;
+  const now = options.nowFn ?? Date.now;
+  const enumerate = options.enumerate ?? enumWindowsInZOrder;
+  const resolveProcessName = options.resolveProcessName ?? defaultResolveProcessName;
+  let cached: { at: number; result: DesktopWindowMeta[] } | undefined;
+
+  return () => {
+    const t = now();
+    if (cached && t - cached.at < ttlMs) return cached.result;
+    const result = enumerate().map((w) => {
+      const processName = resolveProcessName(w.hwnd);
+      return {
+        zOrder: w.zOrder,
+        title: w.title,
+        hwnd: String(w.hwnd),
+        region: w.region,
+        isActive: w.isActive,
+        isMinimized: w.isMinimized,
+        isMaximized: w.isMaximized,
+        processName,
+      };
+    });
+    cached = { at: t, result };
+    return result;
+  };
 }
 
 // ── Process-level facade singleton ───────────────────────────────────────────
@@ -230,25 +293,9 @@ export function getDesktopFacade(): DesktopFacade {
       // Phase 4 (Codex PR #41 round 5 P1): production windows enumerator —
       // wraps enumWindowsInZOrder + processName resolution. The facade catches
       // any throw and returns [] in that case, so this is allowed to fail.
-      windowsProvider: () => enumWindowsInZOrder().map((w) => {
-        let processName: string | undefined;
-        try {
-          const pid = getWindowProcessId(w.hwnd);
-          processName = getProcessIdentityByPid(pid).processName;
-        } catch {
-          processName = undefined;
-        }
-        return {
-          zOrder: w.zOrder,
-          title: w.title,
-          hwnd: String(w.hwnd),
-          region: w.region,
-          isActive: w.isActive,
-          isMinimized: w.isMinimized,
-          isMaximized: w.isMaximized,
-          processName,
-        };
-      }),
+      // Audit P1-1: 100ms TTL cache prevents the per-window pid+processName
+      // round-trip storm when chained tool calls land in the same tick.
+      windowsProvider: createCachedProductionWindowsProvider(),
     });
 
     // Wire the visual runtime (non-blocking — failure does not prevent facade creation).

--- a/tests/unit/desktop-register.test.ts
+++ b/tests/unit/desktop-register.test.ts
@@ -4,6 +4,7 @@ import {
   registerDesktopTools,
   getDesktopFacade,
   _resetFacadeForTest,
+  createCachedProductionWindowsProvider,
 } from "../../src/tools/desktop-register.js";
 import { DesktopFacade } from "../../src/tools/desktop.js";
 
@@ -169,5 +170,97 @@ describe("Activation policy — v0.17 server-windows env expressions", () => {
     vi.stubEnv("DESKTOP_TOUCH_DISABLE_FUKUWARAI_V2", "1");
     vi.stubEnv("DESKTOP_TOUCH_ENABLE_FUKUWARAI_V2",  "1");
     expect(process.env["DESKTOP_TOUCH_DISABLE_FUKUWARAI_V2"] === "1").toBe(true);
+  });
+});
+
+// Audit P1-1: production windowsProvider used to re-run enumWindowsInZOrder +
+// per-hwnd process info on every desktop_discover call. A short-lived TTL
+// cache collapses bursts; these tests pin both the cache-hit and the
+// TTL-expiry behaviour with deterministic time + injectable enumerate /
+// resolveProcessName fakes (no Win32 calls inside the test).
+describe("createCachedProductionWindowsProvider — TTL cache", () => {
+  type WinSpec = {
+    hwnd: bigint; title: string; zOrder: number;
+    region: { x: number; y: number; width: number; height: number };
+    isActive: boolean; isMinimized: boolean; isMaximized: boolean;
+  };
+  function spec(overrides: Partial<WinSpec> = {}): WinSpec {
+    return {
+      hwnd: BigInt(1000),
+      title: "Notepad",
+      zOrder: 0,
+      region: { x: 0, y: 0, width: 800, height: 600 },
+      isActive: true,
+      isMinimized: false,
+      isMaximized: false,
+      ...overrides,
+    };
+  }
+
+  it("returns the cached snapshot for repeated calls within TTL (no re-enumeration)", () => {
+    const enumerate = vi.fn().mockReturnValue([spec()]);
+    const resolveProcessName = vi.fn().mockReturnValue("notepad.exe");
+    let now = 1000;
+
+    const provider = createCachedProductionWindowsProvider({
+      ttlMs: 100,
+      nowFn: () => now,
+      enumerate,
+      resolveProcessName,
+    });
+
+    const a = provider();
+    now = 1050; // still inside TTL
+    const b = provider();
+    now = 1099; // last instant inside TTL
+    const c = provider();
+
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+    expect(enumerate).toHaveBeenCalledTimes(1);
+    expect(resolveProcessName).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-runs enumerate after TTL expires", () => {
+    const enumerate = vi.fn()
+      .mockReturnValueOnce([spec({ title: "First" })])
+      .mockReturnValueOnce([spec({ title: "Second" })]);
+    let now = 1000;
+
+    const provider = createCachedProductionWindowsProvider({
+      ttlMs: 100,
+      nowFn: () => now,
+      enumerate,
+      resolveProcessName: () => "x.exe",
+    });
+
+    const first = provider();
+    now = 1100; // exactly at TTL boundary → expired
+    const second = provider();
+
+    expect(first[0]!.title).toBe("First");
+    expect(second[0]!.title).toBe("Second");
+    expect(enumerate).toHaveBeenCalledTimes(2);
+  });
+
+  it("maps DesktopWindowMeta fields correctly (hwnd to string, processName attached)", () => {
+    const provider = createCachedProductionWindowsProvider({
+      enumerate: () => [spec({ hwnd: BigInt(0xABCD), title: "App" })],
+      resolveProcessName: () => "app.exe",
+    });
+    const out = provider();
+    expect(out).toHaveLength(1);
+    expect(out[0]!.hwnd).toBe(String(BigInt(0xABCD))); // string, not bigint
+    expect(out[0]!.title).toBe("App");
+    expect(out[0]!.processName).toBe("app.exe");
+  });
+
+  it("propagates resolveProcessName === undefined as processName: undefined", () => {
+    const provider = createCachedProductionWindowsProvider({
+      enumerate: () => [spec()],
+      resolveProcessName: () => undefined, // production fallback when Win32 throws
+    });
+    const out = provider();
+    expect(out[0]!.processName).toBeUndefined();
   });
 });

--- a/tests/unit/desktop-register.test.ts
+++ b/tests/unit/desktop-register.test.ts
@@ -263,4 +263,36 @@ describe("createCachedProductionWindowsProvider — TTL cache", () => {
     const out = provider();
     expect(out[0]!.processName).toBeUndefined();
   });
+
+  // Codex PR #53 P2: with a non-monotonic clock (NTP step-back, manual time
+  // change, VM snapshot restore) the original `t - cached.at < ttlMs` check
+  // would treat the negative delta as a cache hit and serve a stale snapshot
+  // until wall-time caught back up to the prior `cached.at` + 100ms. The
+  // `t >= cached.at` defensive guard plus the monotonic default close that
+  // window. This test pins the guard with an injected `nowFn` that walks
+  // backward — re-enumeration must still fire.
+  it("re-enumerates when the injected clock walks backward past cached.at (P2 guard)", () => {
+    const enumerate = vi.fn()
+      .mockReturnValueOnce([spec({ title: "First" })])
+      .mockReturnValueOnce([spec({ title: "Second" })]);
+    let now = 1000;
+
+    const provider = createCachedProductionWindowsProvider({
+      ttlMs: 100,
+      nowFn: () => now,
+      enumerate,
+      resolveProcessName: () => "x.exe",
+    });
+
+    const first = provider();
+    expect(first[0]!.title).toBe("First");
+
+    // Wall-clock rolled back. Without the guard `t - cached.at = -500` would
+    // still satisfy `< 100ms` and the cache would lock on the old result.
+    now = 500;
+    const second = provider();
+
+    expect(second[0]!.title).toBe("Second");
+    expect(enumerate).toHaveBeenCalledTimes(2);
+  });
 });

--- a/tests/unit/tool-naming-phase4.test.ts
+++ b/tests/unit/tool-naming-phase4.test.ts
@@ -651,9 +651,14 @@ describe("Phase 4 — Codex PR #41 round 5 P1: desktop_discover.windows[] is imp
     expect(out.windows).toHaveLength(0);
   });
 
-  it("desktop-register wires the production windowsProvider via enumWindowsInZOrder", () => {
+  it("desktop-register wires the production windowsProvider via the cached factory", () => {
     const src = readFileSync(join(ROOT, "src", "tools", "desktop-register.ts"), "utf-8");
-    expect(src).toMatch(/windowsProvider:\s*\(\)\s*=>\s*enumWindowsInZOrder/);
+    // Audit P1-1: the inline closure was replaced with createCachedProductionWindowsProvider().
+    // Both the factory definition and its use at the facade construction site must be present.
+    expect(src).toMatch(/export function createCachedProductionWindowsProvider/);
+    expect(src).toMatch(/windowsProvider:\s*createCachedProductionWindowsProvider\(\)/);
+    // The factory itself must still call enumWindowsInZOrder under the hood.
+    expect(src).toMatch(/enumerate\s*=\s*options\.enumerate\s*\?\?\s*enumWindowsInZOrder/);
   });
 });
 


### PR DESCRIPTION
## Summary
audit P1-1 (\`docs/v1-release-readiness-review.md\` §8.2): production windowsProvider が \`desktop_discover\` 毎呼出で \`enumWindowsInZOrder\` + 全 hwnd 分の \`getWindowProcessId\` + \`getProcessIdentityByPid\` を回していた。40+ window で数十 ms cost、しかも chained tool dispatch (desktop_state → desktop_discover → desktop_act) で連続発生。

### 修正
- \`createCachedProductionWindowsProvider()\` factory を export、100ms TTL cache 内蔵
- \`enumerate\` / \`resolveProcessName\` を inject 可能に (test 用 seam)
- inline 閉包だった部分を factory 呼び出しに置換
- \`getFocusedEntityId\` 経路は別の Win32 path (cache の影響なし、focus shift は引き続き live で検出)

### 100ms を選んだ理由
chained tool 呼び出しは ms オーダーで連続するので 1 tick で十分。OS-level focus shift は別経路で検出するので、windows[] が 100ms 古くても誤動作しない。

## Test plan
- [x] \`npm run build\` → ok
- [x] \`tests/unit/desktop-register.test.ts\` → 20 pass (was 16, +4 cache cases)
  - cache hit (3 calls within TTL) — enumerate 1 回のみ
  - TTL 境界での再 enumerate
  - DesktopWindowMeta 型 mapping (hwnd → string)
  - resolveProcessName=undefined → processName: undefined
- [x] \`npm run test:unit\` → 1974 pass / 2 skip
- [ ] CI で確認

## Refs
- audit: \`docs/v1-release-readiness-review.md\` §8.2 P1-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)