### PR TITLE
fix(facade): wire automatic session eviction (no-compromise lease D)

### DIFF
--- a/src/engine/world-graph/session-registry.ts
+++ b/src/engine/world-graph/session-registry.ts
@@ -125,10 +125,21 @@ export class SessionRegistry {
     return s;
   }
 
-  /** Find the session that issued a lease by its viewId. Returns undefined if evicted. */
-  getByViewId(viewId: string): SessionState | undefined {
+  /**
+   * Find the session that issued a lease by its viewId. Returns undefined if evicted.
+   *
+   * Refreshes `lastAccessMs` so an in-flight workflow (see → think → touch)
+   * keeps the session alive past `sessionTtlMs` even if the LLM stretches
+   * past the eviction interval. Without this, the eviction timer (Codex
+   * PR #55 P2) could delete a session mid-workflow when the LLM's reasoning
+   * crosses the 120s default idle window between see() and touch().
+   */
+  getByViewId(viewId: string, nowFn: () => number = Date.now): SessionState | undefined {
     const key = this.viewIdIndex.get(viewId);
-    return key ? this.sessions.get(key) : undefined;
+    if (!key) return undefined;
+    const session = this.sessions.get(key);
+    if (session) session.lastAccessMs = nowFn();
+    return session;
   }
 
   /**

--- a/src/tools/desktop-register.ts
+++ b/src/tools/desktop-register.ts
@@ -295,6 +295,12 @@ export function getDesktopFacade(): DesktopFacade {
     );
 
     _facade = new DesktopFacade(provider, {
+      // Sweep stale sessions every 30s. The default sessionTtlMs is 120s
+      // (2 min idle), so ~one timer fire after a session goes idle is enough
+      // to keep the registry from growing unbounded over a long-running
+      // process. The timer is .unref'd inside the facade so it never
+      // holds the process open on its own.
+      sessionEvictionIntervalMs: 30_000,
       ingress,
       // G1-B: viewport guard — blocks visual-only entities outside the foreground window.
       isInViewport: productionIsInViewport,

--- a/src/tools/desktop.ts
+++ b/src/tools/desktop.ts
@@ -162,6 +162,14 @@ export interface DesktopFacadeOptions {
   /** Session eviction TTL in ms (default: 120 000 = 2 min). */
   sessionTtlMs?: number;
   /**
+   * Interval (ms) at which `evictStaleSessions()` is invoked automatically.
+   * Set to 0 (default) to disable the timer — tests rely on this so each
+   * facade is deterministic. Production wiring (`getDesktopFacade`) opts in
+   * by passing a positive value (typically 30 000 ms). The timer is .unref'd
+   * so it never holds the process open on its own.
+   */
+  sessionEvictionIntervalMs?: number;
+  /**
    * Event-driven candidate ingress. When set, see() calls ingress.getSnapshot(key)
    * instead of candidateProvider(input) directly — reducing idle refresh cost.
    * candidateProvider is still used as the underlying fetch function via the ingress.
@@ -208,11 +216,22 @@ export class DesktopFacade {
   private readonly registry: SessionRegistry;
   private readonly candidateProvider: CandidateProvider;
   private readonly opts: DesktopFacadeOptions;
+  private _evictionTimer: ReturnType<typeof setInterval> | undefined;
 
   constructor(candidateProvider: CandidateProvider, opts: DesktopFacadeOptions = {}) {
     this.candidateProvider = candidateProvider;
     this.opts = opts;
     this.registry = new SessionRegistry();
+    const intervalMs = opts.sessionEvictionIntervalMs ?? 0;
+    if (intervalMs > 0) {
+      this._evictionTimer = setInterval(() => {
+        // Never let a transient eviction error escape the timer — it would
+        // crash the host process. Worst case is one missed sweep.
+        try { this.evictStaleSessions(); } catch { /* swallow */ }
+      }, intervalMs);
+      // Don't keep the process alive just for this timer.
+      if (typeof this._evictionTimer.unref === "function") this._evictionTimer.unref();
+    }
   }
 
   /**
@@ -337,6 +356,10 @@ export class DesktopFacade {
 
   /** Dispose the facade and its ingress (event subscriptions). */
   dispose(): void {
+    if (this._evictionTimer !== undefined) {
+      clearInterval(this._evictionTimer);
+      this._evictionTimer = undefined;
+    }
     this.opts.ingress?.dispose();
   }
 

--- a/src/tools/desktop.ts
+++ b/src/tools/desktop.ts
@@ -330,6 +330,12 @@ export class DesktopFacade {
     const constraints = deriveViewConstraints(rawResult.warnings, entityViews.length);
     if (constraints) output.constraints = constraints;
 
+    // Codex PR #55 P2: refresh lastAccessMs at the END of see() too, in case
+    // candidateProvider / ingress took longer than the eviction interval to
+    // complete. getOrCreate stamps the start time; without this completion
+    // refresh, a multi-minute see() could be evicted mid-call.
+    session.lastAccessMs = (this.opts.nowFn ?? Date.now)();
+
     return output;
   }
 
@@ -339,7 +345,12 @@ export class DesktopFacade {
    * Returns "entity_not_found" if the issuing session has been evicted.
    */
   async touch(input: DesktopTouchInput): Promise<DesktopTouchOutput> {
-    const session = this.registry.getByViewId(input.lease.viewId);
+    // Pass nowFn so getByViewId can refresh lastAccessMs against the same
+    // injected clock the eviction sweep uses. Codex PR #55 P2: without
+    // this refresh, an in-flight workflow (see → think → touch) crossing
+    // the eviction interval (default 30s timer over a 120s sessionTtlMs)
+    // could find its session evicted at the moment of touch.
+    const session = this.registry.getByViewId(input.lease.viewId, this.opts.nowFn);
     if (!session) {
       return { ok: false, reason: "entity_not_found", diff: [] };
     }

--- a/tests/unit/desktop-facade.test.ts
+++ b/tests/unit/desktop-facade.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { DesktopFacade, type CandidateProvider, type DesktopSeeInput, type CandidateIngress } from "../../src/tools/desktop.js";
 import type { UiEntityCandidate } from "../../src/engine/vision-gpu/types.js";
 
@@ -765,5 +765,69 @@ describe("DesktopFacade — per-target session isolation (Batch A)", () => {
     // NOTE: the generation check would also catch it, but the index is cleaned up first.
     const result = await facade.touch({ lease: oldLease });
     expect(result.ok).toBe(false);
+  });
+});
+
+// Audit P1 / no-compromise lease hardening (D): the production facade must
+// periodically prune sessions that have gone idle past sessionTtlMs so the
+// SessionRegistry doesn't grow unbounded over a long-running process.
+// `evictStaleSessions()` was previously defined but never called — this is
+// the wiring + lifecycle pin.
+describe("DesktopFacade — automatic session eviction timer", () => {
+  it("with sessionEvictionIntervalMs unset (default), no timer is created", () => {
+    const facade = new DesktopFacade(gameProvider);
+    // No public accessor — the contract is "no setInterval handle is held",
+    // so dispose() finishes synchronously and idle. We assert the negative
+    // by ensuring the constructor doesn't reach into Node timers when
+    // disabled. (No .unref handle to inspect; the fake-timer test below
+    // covers the positive case.)
+    expect(() => facade.dispose()).not.toThrow();
+  });
+
+  it("with sessionEvictionIntervalMs > 0, calls evictStaleSessions on the configured cadence", () => {
+    vi.useFakeTimers();
+    try {
+      const evictSpy = vi.fn();
+      // Subclass to spy on evictStaleSessions without touching the registry.
+      class SpyFacade extends DesktopFacade {
+        override evictStaleSessions(): void {
+          evictSpy();
+          super.evictStaleSessions();
+        }
+      }
+      const facade = new SpyFacade(gameProvider, { sessionEvictionIntervalMs: 1000 });
+
+      vi.advanceTimersByTime(2_500); // 2 fires (at 1000, 2000)
+      expect(evictSpy).toHaveBeenCalledTimes(2);
+
+      facade.dispose();
+      vi.advanceTimersByTime(5_000); // no further fires after dispose
+      expect(evictSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("eviction errors do not crash the timer — subsequent fires still occur", () => {
+    vi.useFakeTimers();
+    try {
+      let calls = 0;
+      class ThrowingFacade extends DesktopFacade {
+        override evictStaleSessions(): void {
+          calls++;
+          if (calls === 1) throw new Error("transient registry error");
+          // 2nd call goes through normally.
+          super.evictStaleSessions();
+        }
+      }
+      const facade = new ThrowingFacade(gameProvider, { sessionEvictionIntervalMs: 500 });
+
+      vi.advanceTimersByTime(1_100); // 2 fires (500, 1000)
+      expect(calls).toBe(2);
+
+      facade.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/tests/unit/session-registry.test.ts
+++ b/tests/unit/session-registry.test.ts
@@ -141,4 +141,27 @@ describe("SessionRegistry — eviction", () => {
 
     expect(r.getByViewId("view-1")).toBeUndefined();
   });
+
+  // Codex PR #55 P2: in-flight workflows must keep their session alive.
+  // Without the lastAccessMs refresh on getByViewId, the eviction sweep
+  // could delete a session that the LLM is in the middle of using.
+  it("getByViewId refreshes lastAccessMs so eviction won't delete an in-flight workflow", () => {
+    let now = 1000;
+    const r = new SessionRegistry();
+    const opts = makeOpts({ nowFn: () => now });
+    const key = r.resolveKey({ hwnd: "1" });
+    r.getOrCreate(key, opts); // lastAccess = 1000
+    r.replaceViewId(undefined, "view-1", key);
+
+    // Simulate the LLM thinking past the TTL and then calling touch().
+    now = 1900;
+    expect(r.getByViewId("view-1", () => now)).toBeDefined(); // refreshes lastAccessMs to 1900
+
+    // Eviction sweep at 2100 with TTL=1000 → threshold=1100. lastAccessMs is
+    // now 1900 (not the original 1000), so the session survives.
+    now = 2100;
+    r.evictStale(1000, () => now);
+
+    expect(r.getByViewId("view-1", () => now)).toBeDefined();
+  });
 });


### PR DESCRIPTION
## Summary
no-compromise lease hardening 計画の D 番。\`DesktopFacade.evictStaleSessions()\` は定義済だが production でどこからも呼ばれていなかった (caller 0)。長時間 process で SessionRegistry が無限に成長する経路を解消。

### 変更
- \`DesktopFacadeOptions.sessionEvictionIntervalMs\` (default 0 = 無効)
- production (\`getDesktopFacade\`) は 30,000ms 周期で opt-in
- 既存 \`sessionTtlMs\` (default 120s idle) と組合わせ、idle 後 ~1 tick で evict
- timer は \`.unref()\` で process 維持しない
- \`dispose()\` で clearInterval
- timer 内で eviction error が出ても swallow (host crash 防止)

### test (vi.useFakeTimers で deterministic)
1. interval=0 default で timer 無し (\`dispose()\` 即終了)
2. interval=1000 で 2.5s 進めると 2 回 fire、dispose 後は fire しない
3. eviction が throw しても 2 回目 fire は通る

## Test plan
- [x] \`npm run build\` → ok
- [x] \`tests/unit/desktop-facade.test.ts\` → 53 pass (was 50, +3)
- [x] \`npx vitest run --project=unit\` → 1978 pass / 2 skip
- [ ] CI で確認

## Refs
- 計画: \"時間的妥協なしの最善策\" 議論、A + D + C 採用
- 関連: P1-2 / P1-3 (session lifecycle、v1.0.1 defer 中)

🤖 Generated with [Claude Code](https://claude.com/claude-code)