### PR TITLE
feat(lease): payload-size aware TTL + softExpiresAtMs hint (no-compromise A)

### DIFF
--- a/src/engine/world-graph/lease-ttl-policy.ts
+++ b/src/engine/world-graph/lease-ttl-policy.ts
@@ -1,5 +1,5 @@
 /**
- * Lease TTL policy for Anti-Fukuwarai v2 (H1 hardening).
+ * Lease TTL policy for Anti-Fukuwarai v2 (H1 hardening + no-compromise A batch).
  *
  * Why this exists:
  *   Fixed 5s TTL is too short for `view=explore` or large responses because
@@ -7,28 +7,33 @@
  *   scenarios S1 (browser-form) and S3 (terminal) hit `lease_expired` there.
  *
  * Policy:
- *   ttlMs = clamp(base + viewBonus + entityBonus, floor, cap)
- *     base        = 5_000
- *     viewBonus   = action:0 / explore:+5_000 / debug:+10_000
- *     entityBonus = max(0, entityCount - 20) * 100   [applies to all views]
- *     floor       = 2_000  (defensive; never reached by current policy)
- *     cap         = 30_000 (stale-lease safety: LLMs that think >30s must see() again)
+ *   ttlMs = clamp(base + viewBonus + entityBonus + payloadBonus, floor, cap)
+ *     base         = 5_000
+ *     viewBonus    = action:0 / explore:+5_000 / debug:+10_000
+ *     entityBonus  = max(0, entityCount - 20) * 100        [all views]
+ *     payloadBonus = max(0, payloadBytes - 2_000) * 0.5    [capped at +10_000]
+ *     floor        = 2_000  (defensive; never reached by current policy)
+ *     cap          = 60_000 (stale-lease safety; LLMs that think >60s must see() again)
  *
- * Safety contract (unchanged by this policy):
+ * The `softExpiresAtMs` recommendation (see desktop.ts) sits at 60% of the
+ * computed TTL window — the LLM is told "this is when you should consider
+ * refreshing even though the lease is still valid". The hard `expiresAtMs`
+ * remains the only correctness wall.
+ *
+ * Safety contract (unchanged):
  *   - generation_mismatch, digest_mismatch, entity_not_found are independent of TTL
  *   - TTL only controls the `expired` reason path
  *   - Cap ensures no lease lives unreasonably long
  *
  * Not in scope (future batches):
- *   - payload-size-aware TTL (when size metrics are available)
  *   - operator-mode (debug-session) extension
- *   - touch-side grace / auto-refresh (explicitly forbidden by instructions)
+ *   - touch-side grace / auto-refresh (covered by separate batch C)
  */
 
 export const LEASE_TTL_POLICY = {
   baseMs:             5_000,
   floor:              2_000,
-  cap:                30_000,
+  cap:                60_000,
   viewBonus: {
     action:  0,
     explore: 5_000,
@@ -36,6 +41,11 @@ export const LEASE_TTL_POLICY = {
   } as const,
   entityBonusThreshold: 20,
   entityBonusPerUnit:   100,
+  payloadBonusBaselineBytes: 2_000,
+  payloadBonusPerByteMs:     0.5,
+  payloadBonusCapMs:         10_000,
+  /** Soft-expiry as a fraction of the full TTL — advisory, not enforced. */
+  softExpiryFraction: 0.6,
 } as const;
 
 export interface LeaseTtlInput {
@@ -43,9 +53,8 @@ export interface LeaseTtlInput {
   view: "action" | "explore" | "debug" | undefined;
   /** Number of entities issued in this view (after maxEntities slicing). */
   entityCount: number;
-  // Reserved for future batches; not used today.
-  // payloadBytes?: number;
-  // operatorMode?: boolean;
+  /** Optional payload size in bytes — used to extend TTL when the LLM has more text to read. */
+  payloadBytes?: number;
 }
 
 function viewBonus(view: LeaseTtlInput["view"]): number {
@@ -63,6 +72,12 @@ function entityBonus(count: number): number {
   return over * LEASE_TTL_POLICY.entityBonusPerUnit;
 }
 
+function payloadBonus(bytes: number | undefined): number {
+  if (bytes === undefined || !Number.isFinite(bytes) || bytes <= 0) return 0;
+  const over = Math.max(0, bytes - LEASE_TTL_POLICY.payloadBonusBaselineBytes);
+  return Math.min(over * LEASE_TTL_POLICY.payloadBonusPerByteMs, LEASE_TTL_POLICY.payloadBonusCapMs);
+}
+
 function clamp(v: number, lo: number, hi: number): number {
   return Math.max(lo, Math.min(hi, v));
 }
@@ -73,6 +88,18 @@ function clamp(v: number, lo: number, hi: number): number {
  * Deterministic and side-effect free — safe to call from any layer.
  */
 export function computeLeaseTtlMs(input: LeaseTtlInput): number {
-  const raw = LEASE_TTL_POLICY.baseMs + viewBonus(input.view) + entityBonus(input.entityCount);
+  const raw = LEASE_TTL_POLICY.baseMs
+    + viewBonus(input.view)
+    + entityBonus(input.entityCount)
+    + payloadBonus(input.payloadBytes);
   return clamp(raw, LEASE_TTL_POLICY.floor, LEASE_TTL_POLICY.cap);
+}
+
+/**
+ * Compute the soft-expiry timestamp from an absolute issue time + the TTL.
+ * The LLM treats this as "consider refreshing"; the hard `expiresAtMs` is
+ * the only correctness wall.
+ */
+export function computeSoftExpiresAtMs(issuedAtMs: number, ttlMs: number): number {
+  return issuedAtMs + Math.floor(ttlMs * LEASE_TTL_POLICY.softExpiryFraction);
 }

--- a/src/tools/desktop-register.ts
+++ b/src/tools/desktop-register.ts
@@ -480,6 +480,7 @@ export function registerDesktopTools(server: McpServer): void {
       "visual_attempted_empty_cdp_fallback → CDP failed and visual also empty (browser); check --remote-debugging-port=9222 and retry;",
       "dialog_resolved_via_owner_chain → common dialog (Save As/Open) found via owner chain; targeting is now hwnd-based;",
       "parent_disabled_prefer_popup → parent window blocked by a modal; switched to targeting the active popup dialog.",
+      "response.softExpiresAtMs is an advisory timestamp at ~60% of the lease TTL window — past it the LLM should consider re-calling desktop_discover even though leases are still technically valid; lease.expiresAtMs remains the only correctness wall.",
     ].join(" "),
     desktopSeeSchema,
     async (input) => {

--- a/src/tools/desktop.ts
+++ b/src/tools/desktop.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { UiEntityCandidate } from "../engine/vision-gpu/types.js";
 import type { UiEntity, EntityLease } from "../engine/world-graph/types.js";
-import { computeLeaseTtlMs } from "../engine/world-graph/lease-ttl-policy.js";
+import { computeLeaseTtlMs, computeSoftExpiresAtMs } from "../engine/world-graph/lease-ttl-policy.js";
 import { resolveCandidates } from "../engine/world-graph/resolver.js";
 import {
   SessionRegistry,
@@ -91,6 +91,14 @@ export interface DesktopSeeOutput {
    * entityZeroReason explains why entities.length === 0 when set.
    */
   constraints?: ViewConstraints;
+  /**
+   * Soft-expiry advisory (no-compromise lease A): if the LLM is still
+   * deciding past this absolute timestamp, it should refresh via
+   * desktop_discover even though the leases are still technically valid.
+   * Positioned at 60% of the lease TTL window. The hard `expiresAtMs` on
+   * each entity's lease remains the only correctness wall.
+   */
+  softExpiresAtMs: number;
 }
 
 export interface DesktopTouchInput {
@@ -265,11 +273,42 @@ export class DesktopFacade {
     session.entities = resolved;
     this.registry.replaceViewId(prevViewId, newViewId, key);
 
-    // H1: response-size aware TTL. Ignored when facade.defaultTtlMs explicitly set
-    // (preserves backward compat for tests that inject a fixed TTL).
+    // Phase 4 (Codex PR #41 round 5 P1): top-level windows enumeration.
+    // Pulled forward (was after lease issue) so the TTL policy can size the
+    // payloadBytes estimate against the full response shape.
+    // Failure to enumerate is non-fatal — surface an empty list rather than
+    // failing the whole call, since see()'s primary contract is entity
+    // discovery for the targeted window.
+    let windows: DesktopWindowMeta[] = [];
+    if (this.opts.windowsProvider) {
+      try {
+        windows = this.opts.windowsProvider();
+      } catch {
+        windows = [];
+      }
+    }
+
+    // H1 + no-compromise A: TTL is response-size aware. Estimate payload
+    // bytes from entity / window / warning counts (the shape is stable enough
+    // that a coefficient-based estimate is within ~30% of the real serialized
+    // size — close enough for a soft TTL knob; we'd otherwise have to
+    // serialize twice).
+    const estimatedPayloadBytes =
+      500 +
+      resolved.length * 250 +
+      windows.length * 180 +
+      rawResult.warnings.length * 80;
+
     const policyTtl = this.opts.defaultTtlMs !== undefined
       ? this.opts.defaultTtlMs
-      : computeLeaseTtlMs({ view: input.view, entityCount: resolved.length });
+      : computeLeaseTtlMs({
+          view: input.view,
+          entityCount: resolved.length,
+          payloadBytes: estimatedPayloadBytes,
+        });
+
+    const nowFn = this.opts.nowFn ?? Date.now;
+    const issuedAtMs = nowFn();
 
     const entityViews: EntityView[] = resolved.map((e) => {
       const lease = session.leaseStore.issue(e, newViewId, policyTtl);
@@ -286,24 +325,12 @@ export class DesktopFacade {
       return view;
     });
 
-    // Phase 4 (Codex PR #41 round 5 P1): top-level windows enumeration.
-    // Failure to enumerate is non-fatal — surface an empty list rather than
-    // failing the whole call, since see()'s primary contract is entity
-    // discovery for the targeted window.
-    let windows: DesktopWindowMeta[] = [];
-    if (this.opts.windowsProvider) {
-      try {
-        windows = this.opts.windowsProvider();
-      } catch {
-        windows = [];
-      }
-    }
-
     const output: DesktopSeeOutput = {
       viewId: newViewId,
       target: { title: targetTitle(input.target), generation: session.generation },
       entities: entityViews,
       windows,
+      softExpiresAtMs: computeSoftExpiresAtMs(issuedAtMs, policyTtl),
     };
     if (rawResult.warnings.length > 0) output.warnings = rawResult.warnings;
 

--- a/tests/unit/desktop-facade.test.ts
+++ b/tests/unit/desktop-facade.test.ts
@@ -88,6 +88,20 @@ describe("DesktopFacade — desktop_see (game / chrome / terminal)", () => {
     expect(out.target.generation).toBeTruthy();
   });
 
+  // No-compromise lease A: every see() carries a softExpiresAtMs hint that
+  // sits before the lease's hard expiresAtMs. The LLM uses softExpiresAtMs
+  // to decide "should I refresh proactively?" without any TTL-related
+  // correctness coupling.
+  it("response includes softExpiresAtMs strictly less than each lease.expiresAtMs", async () => {
+    const facade = new DesktopFacade(gameProvider);
+    const out = await facade.see();
+    expect(typeof out.softExpiresAtMs).toBe("number");
+    expect(Number.isInteger(out.softExpiresAtMs)).toBe(true);
+    for (const e of out.entities) {
+      expect(out.softExpiresAtMs).toBeLessThan(e.lease.expiresAtMs);
+    }
+  });
+
   it("query filters entities by label substring", async () => {
     const facade = new DesktopFacade(gameProvider);
     const out = await facade.see({ query: "start" });
@@ -534,8 +548,12 @@ describe("DesktopFacade — response-size aware lease TTL (H1)", () => {
       Array.from({ length: 60 }, (_, i) => cand(`Item ${i}`, "uia", { digest: `d${i}` }));
     const facade = new DesktopFacade(manyProvider, { nowFn: () => 0 });
     const view = await facade.see({ view: "explore" }); // 50 entities after maxEntities slice
-    // 5000 base + 5000 explore + (50-20)*100 = 13000
-    expect(view.entities[0].lease.expiresAtMs).toBe(13_000);
+    // 5000 base + 5000 explore + (50-20)*100 entityBonus + payloadBonus
+    // (no-compromise A: payload-size aware). Estimate:
+    //   estimatedPayloadBytes = 500 + 50*250 + 0*180 + 0 warnings = 13_000
+    //   payloadBonus = (13_000 - 2_000) * 0.5 = 5_500
+    // total = 5000 + 5000 + 3000 + 5500 = 18_500
+    expect(view.entities[0].lease.expiresAtMs).toBe(18_500);
   });
 
   it("stale lease safety: TTL extension does NOT bypass generation eviction", async () => {

--- a/tests/unit/lease-ttl-policy.test.ts
+++ b/tests/unit/lease-ttl-policy.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { computeLeaseTtlMs, LEASE_TTL_POLICY } from "../../src/engine/world-graph/lease-ttl-policy.js";
+import {
+  computeLeaseTtlMs,
+  computeSoftExpiresAtMs,
+  LEASE_TTL_POLICY,
+} from "../../src/engine/world-graph/lease-ttl-policy.js";
 
 describe("computeLeaseTtlMs — view dimension", () => {
   it("action view has no bonus (base 5000ms)", () => {
@@ -49,9 +53,9 @@ describe("computeLeaseTtlMs — entity count dimension", () => {
 });
 
 describe("computeLeaseTtlMs — clamping", () => {
-  it("clamps to cap (30000ms) even for extreme inputs", () => {
-    expect(computeLeaseTtlMs({ view: "explore", entityCount: 10_000 })).toBe(30_000);
-    expect(computeLeaseTtlMs({ view: "debug",   entityCount: 10_000 })).toBe(30_000);
+  it("clamps to cap (60000ms) even for extreme inputs", () => {
+    expect(computeLeaseTtlMs({ view: "explore", entityCount: 10_000 })).toBe(60_000);
+    expect(computeLeaseTtlMs({ view: "debug",   entityCount: 10_000 })).toBe(60_000);
   });
 
   it("floor (2000ms) is respected (defensive lower bound)", () => {
@@ -69,5 +73,64 @@ describe("computeLeaseTtlMs — invariants", () => {
         expect(t).toBeGreaterThan(0);
       }
     }
+  });
+});
+
+// No-compromise lease A: payload-size aware TTL + soft expiry. Larger
+// responses give the LLM more text to read before deciding the next call,
+// so the TTL window expands with payloadBytes (capped so a multi-megabyte
+// outlier can't push the cap to absurd values).
+describe("computeLeaseTtlMs — payload-size dimension", () => {
+  it("payloadBytes <= baseline yields no payload bonus", () => {
+    // Baseline = 2000 bytes. Inputs at or below baseline behave like the
+    // no-payload path.
+    expect(computeLeaseTtlMs({ view: "action", entityCount: 5, payloadBytes: 0    })).toBe(5_000);
+    expect(computeLeaseTtlMs({ view: "action", entityCount: 5, payloadBytes: 2000 })).toBe(5_000);
+  });
+
+  it("each byte over baseline adds 0.5ms", () => {
+    // 5_000 base + (10_000 - 2_000) * 0.5 = 5_000 + 4_000 = 9_000
+    expect(computeLeaseTtlMs({ view: "action", entityCount: 5, payloadBytes: 10_000 })).toBe(9_000);
+  });
+
+  it("payload bonus is itself capped at 10000ms", () => {
+    // Even an absurd 1 MB payload can only contribute 10s on top of the
+    // other dimensions.
+    const ttl = computeLeaseTtlMs({ view: "action", entityCount: 5, payloadBytes: 1_000_000 });
+    // base(5000) + payloadCap(10000) = 15000
+    expect(ttl).toBe(15_000);
+  });
+
+  it("payloadBytes undefined / NaN / negative is silently treated as zero (defensive)", () => {
+    expect(computeLeaseTtlMs({ view: "action", entityCount: 5 })).toBe(5_000);
+    expect(computeLeaseTtlMs({ view: "action", entityCount: 5, payloadBytes: NaN  })).toBe(5_000);
+    expect(computeLeaseTtlMs({ view: "action", entityCount: 5, payloadBytes: -100 })).toBe(5_000);
+  });
+
+  it("all bonuses stack and respect the cap", () => {
+    // explore(+5000) + entityBonus((50-20)*100=3000) + payloadCap(10000)
+    // base(5000) + 5000 + 3000 + 10000 = 23000  (well under cap 60000)
+    const ttl = computeLeaseTtlMs({ view: "explore", entityCount: 50, payloadBytes: 100_000 });
+    expect(ttl).toBe(23_000);
+  });
+});
+
+describe("computeSoftExpiresAtMs", () => {
+  it("returns issuedAt + 60% of TTL by default", () => {
+    expect(computeSoftExpiresAtMs(1000, 10_000)).toBe(7_000); // 1000 + floor(6000)
+    expect(computeSoftExpiresAtMs(0,    5_000)).toBe(3_000);  // 0    + floor(3000)
+  });
+
+  it("strictly less than (issuedAt + ttl) — soft < hard", () => {
+    for (const ttl of [2_000, 5_000, 10_000, 30_000, 60_000]) {
+      const issuedAt = 100_000;
+      const soft = computeSoftExpiresAtMs(issuedAt, ttl);
+      expect(soft).toBeLessThan(issuedAt + ttl);
+    }
+  });
+
+  it("integer output (no fractional ms) so JSON round-trip is stable", () => {
+    const soft = computeSoftExpiresAtMs(100, 7_777);
+    expect(Number.isInteger(soft)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
no-compromise lease hardening 計画の **A 番**。H1 TTL policy を response size 反映に拡張し、LLM が hard TTL 到達前に re-discover を判断できる soft expiry advisory を導入。

### Policy 変更 (\`lease-ttl-policy.ts\`)
- \`payloadBytes\` input 追加: \`payloadBonus = clamp((bytes - 2000) * 0.5, 0, 10_000)\`
- \`cap\` 30s → 60s (large explore + payload で頭打ち回避)
- \`computeSoftExpiresAtMs(issuedAt, ttlMs)\` 新設: TTL の 60% を soft expiry として返す

### Response 反映 (\`desktop.ts\`)
- \`windows[]\` enumeration を see() 前半に移動 (payload size 見積に必要)
- \`estimatedPayloadBytes = 500 + entities*250 + windows*180 + warnings*80\` (実 size の ~30% 以内、JSON.stringify 二重実行を回避)
- \`DesktopSeeOutput.softExpiresAtMs\` を契約に追加、tool description にも明記

### LLM への signal
\`response.softExpiresAtMs\` を超えても lease は valid。advisory のみで correctness wall は \`lease.expiresAtMs\` のまま。

## 例
| view | entities | est. payload | TTL | softExpiresAt |
|---|---|---|---|---|
| action | 5 | ~2 KB | 5 s | +3 s |
| action | 50 | ~13 KB | 13.5 s | +8.1 s |
| explore | 50 | ~13 KB | 18.5 s | +11.1 s |
| debug | 100 | ~26 KB | 33 s | +19.8 s |
| 任意 (cap 到達) | — | — | 60 s | +36 s |

## Test plan
- [x] \`npm run build\` → ok
- [x] \`tests/unit/lease-ttl-policy.test.ts\` → 19 pass (was 11, +8)
- [x] \`tests/unit/desktop-facade.test.ts\` → 54 pass (+1 softExpiresAtMs contract)
- [x] \`npx vitest run --project=unit\` → 1984 pass / 2 skip
- [ ] CI 確認

## Refs
- 計画: \"時間的妥協なしの最善策\" 議論、A + D + C 採用
- 関連: D=PR #55 / C=次 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)