### PR TITLE
docs: v1.0.0 release prep stage 1 (CHANGELOG + README workflow)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
-## [1.0.0] - DRAFT — Tool Surface Reduction Phase 1 + Phase 2 + Phase 3 + Phase 4
+## [1.0.0] - 2026-04-26 — Tool Surface Reduction (Phase 1+2+3+4) + V2 World-Graph default-on + lease hardening
+
+### Highlights
+
+- **65 → 28 public tools.** Tool Surface Reduction Phase 1 (naming redesign), Phase 2 (family-merge dispatchers), Phase 3 (browser rearrangement), Phase 4 (privatize / absorb) all shipped. The MCP catalogue is 26 stub-catalog entries plus 2 dynamic v2 World-Graph tools (`desktop_discover` / `desktop_act`).
+- **Anti-Fukuwarai v2 (World-Graph) is the default surface.** `desktop_discover` issues entity leases; `desktop_act` consumes them. Kill switch `DESKTOP_TOUCH_DISABLE_FUKUWARAI_V2=1` exposes a v1 fallback tool set (`get_windows` / `get_ui_elements` / `set_element_value`) for troubleshooting only.
+- **Lease hardening.** Payload-size aware TTL with a soft-expiry advisory (`response.softExpiresAtMs` ≈ 60 % of the TTL window) tells the LLM when to refresh proactively; cap raised to 60 s for large explore + payload combos. Session eviction is now wired into a `.unref`'d 30 s timer so long-running processes don't leak.
+- **Security audit pass.** CWE-94 in CDP `cdpFill` fixed (raw selector interpolation → JSON.stringify), HTTP CORS narrowed from `*` to a localhost-origin allowlist with proper `Vary: Origin`, native vision-backend Mutex poison handled.
+- **CI gains Rust regression coverage.** windows-latest CI now runs the napi-rs build (`build:rs:debug`) on every PR, so any drift in the FFI shape / `build.rs` / Cargo features fails fast.
+- **Two new browser DX wins.** `wait_until(url_matches)` waits on `location.href`; `browser_get_dom` now attaches a body-structure hint to ElementNotFound errors so the LLM gets an alternative-selector starting point.
+
+
 
 ### Breaking Changes — Phase 1 (Naming Redesign, 10 tools)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -218,6 +218,41 @@ DOM を触る `browser_*` ツールは `includeContext:false` で末尾の `acti
 | `scroll(action='to_element')` | 要素名またはCSS selectorで対象をviewportへスクロール |
 | `scroll(action='smart')` | CDP → UIA → 画像binary-searchの統合スクロール。ネスト・仮想リスト・sticky header対応 |
 
+---
+
+## 推奨ワークフロー (v1.0.0)
+
+v2 World-Graph (`desktop_discover` / `desktop_act`) が標準ディスパッチパス。ネイティブアプリ・ブラウザ・ターミナルを同じ 4 ステップで扱えます。
+
+```
+desktop_state          → 状況把握: focused window/element / modal / attention
+desktop_discover       → 操作可能 entity を取得 (lease + windows[] 付き)
+desktop_act(lease, …)  → entity 操作 (attention + post.perception を返す)
+desktop_state          → 期待通りに状態が変わったか確認
+```
+
+クリック優先順:
+
+```
+browser_click(selector)               → Chrome / Edge (CDP、再描画に強い)
+desktop_act(lease, action='click')    → ネイティブ / ダイアログ / ビジュアル (entity ベース)
+click_element(name | automationId)    → desktop_act が ok:false の時の UIA フォールバック
+mouse_click(x, y, origin?, scale?)    → 最終手段。dotByDot screenshot の origin+scale を使うこと
+```
+
+リカバリ — `response.attention` を毎観測でチェック、`desktop_discover` / `desktop_act` の `response.warnings[]` を読む:
+
+- `lease_expired` / `lease_generation_mismatch` / `lease_digest_mismatch` / `entity_not_found` → `desktop_discover` を再実行
+- `modal_blocking` → `click_element` で modal を閉じてからリトライ
+- `entity_outside_viewport` → `scroll(action='to_element' | 'raw')` 後に `desktop_discover` 再実行
+- `executor_failed` → V1 (`click_element` / `mouse_click` / `browser_click`) にフォールバック
+
+Lease ライフサイクル:
+
+- `desktop_discover` のレスポンスに `softExpiresAtMs` (TTL の約 60%) が含まれます。これを過ぎたら lease 自体は valid でも proactive に `desktop_discover` を再実行することを推奨。`lease.expiresAtMs` だけが本当の correctness 境界です。
+- TTL は `view` モード (`action`/`explore`/`debug`)、entity 数、レスポンスサイズに応じて伸縮 (上限 60 秒)。
+- `DESKTOP_TOUCH_DISABLE_FUKUWARAI_V2=1` で V1 ツール (`get_windows` / `get_ui_elements` / `set_element_value`) にフォールバック可能 — トラブルシューティング目的のみ。標準は V2。
+
 ### Reactive Perception Graph (4)
 | ツール | 概要 |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -222,6 +222,41 @@ All `browser_*` tools that touch the DOM accept `includeContext:false` to omit t
 
 ---
 
+## Standard workflow (v1.0.0)
+
+The v2 World-Graph surface (`desktop_discover` / `desktop_act`) is the recommended dispatch path. The four-call shape works for native apps, browsers, and terminals identically.
+
+```
+desktop_state          → orient: focused window/element, modal, attention signal
+desktop_discover       → find actionable entities (returns lease + windows[])
+desktop_act(lease, …)  → act on entity (returns attention + post.perception)
+desktop_state          → confirm the world changed as expected
+```
+
+Clicking — priority order:
+
+```
+browser_click(selector)               → Chrome / Edge (CDP, stable across repaints)
+desktop_act(lease, action='click')    → native / dialog / visual (entity-based; use after desktop_discover)
+click_element(name | automationId)    → native UIA fallback if desktop_act returns ok:false
+mouse_click(x, y, origin?, scale?)    → pixel last resort; origin+scale from dotByDot screenshots only
+```
+
+Recovery hints — read `response.attention` after every observation and `response.warnings[]` on `desktop_discover` / `desktop_act`. Common reasons:
+
+- `lease_expired` / `lease_generation_mismatch` / `lease_digest_mismatch` / `entity_not_found` → re-call `desktop_discover`
+- `modal_blocking` → dismiss via `click_element`, then retry
+- `entity_outside_viewport` → `scroll(action='to_element' | 'raw')`, then re-call `desktop_discover`
+- `executor_failed` → fall back to `click_element` / `mouse_click` / `browser_click`
+
+Lease lifecycle:
+
+- Each `desktop_discover` response carries `softExpiresAtMs` (≈ 60 % of the TTL window). Past that timestamp the LLM should consider re-calling `desktop_discover` even though the lease is still technically valid — `lease.expiresAtMs` is the only correctness wall.
+- TTL adapts to `view` mode (`action`/`explore`/`debug`), entity count, and response payload size. Cap is 60 s.
+- Set `DESKTOP_TOUCH_DISABLE_FUKUWARAI_V2=1` to fall back to the v1 tool surface (`get_windows` / `get_ui_elements` / `set_element_value`) for troubleshooting only — V2 is the recommended default.
+
+---
+
 ## Browser CDP automation
 
 For web automation, connect Chrome or Edge with the remote debugging port enabled — no Selenium or Playwright needed.


### PR DESCRIPTION
## Summary
v1.0.0 release prep の **Stage 1**: pre-release docs polish。コード変更なし。

### CHANGELOG.md
- \`[1.0.0] - DRAFT\` → \`[1.0.0] - 2026-04-26 — Tool Surface Reduction (Phase 1+2+3+4) + V2 World-Graph default-on + lease hardening\`
- 冒頭に **Highlights セクション**追加 (28-tool surface / V2 default-on / lease hardening / security / CI Rust / browser DX)

### README.md / README.ja.md
- 新規 \"Standard workflow (v1.0.0)\" セクション追加:
  - 4-call shape (\`desktop_state → desktop_discover → desktop_act → desktop_state\`)
  - Clicking 優先順 (browser_click > desktop_act > click_element > mouse_click)
  - Reason ごとの recovery hint
  - Lease lifecycle (\`softExpiresAtMs\`, payload-aware TTL cap, kill switch)
- 英日同等の文言

## 次の Stage
- Stage 2: \`npm version 1.0.0\` (Phase 1 of release-process.md)
- Stage 3: HTTP transport verification
- Stage 4: tag push → CI auto publish
- Stage 5-6: smoke + MCP Registry

## Test plan
- [x] \`npm run build\` → ok
- [x] \`npx vitest run --project=unit\` → 1997 pass / 2 skip
- [x] CI 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)