### PR TITLE
fix(server): defer shutdown while tool calls are in flight (#68)

### DIFF
--- a/src/server-windows.ts
+++ b/src/server-windows.ts
@@ -268,8 +268,11 @@ let shuttingDown = false;
 // Deferred-shutdown state (issue #68): when stdin EOF or stdout EPIPE arrives mid-flight,
 // wait for in-flight JSON-RPC responses to drain before exiting so long-running tool calls
 // (terminal/wait_until) can deliver their results instead of returning "Connection closed".
-// Ids normalized via String() so number/string mismatches between peer and SDK don't leak.
-const inflightIds = new Set<string>();
+// Ids are stored with their original type — JSON-RPC 2.0 allows both string and number ids,
+// and a spec-compliant client can legitimately send id=1 and id="1" concurrently. Collapsing
+// them into the same string key (e.g. via String()) would undercount and cause early shutdown
+// on the first response. JS Set's SameValueZero semantics (1 !== "1") keeps them distinct.
+const inflightIds = new Set<string | number>();
 let shutdownPending = false;
 let shutdownTimer: NodeJS.Timeout | null = null;
 const SHUTDOWN_GRACE_MS = 60_000;
@@ -463,13 +466,13 @@ if (useHttp) {
   transport.onmessage = ((msg: unknown, ...rest: unknown[]) => {
     const m = msg as { id?: string | number; method?: string };
     const isRequest = !!m && m.id !== undefined && typeof m.method === "string";
-    const key = isRequest ? String(m.id) : "";
-    if (isRequest) inflightIds.add(key);
+    const id = isRequest ? (m.id as string | number) : undefined;
+    if (id !== undefined) inflightIds.add(id);
     try {
       origOnmessage?.(msg, ...rest);
     } catch (err) {
-      if (isRequest) {
-        inflightIds.delete(key);
+      if (id !== undefined) {
+        inflightIds.delete(id);
         maybeFinishShutdown();
       }
       throw err;
@@ -482,7 +485,7 @@ if (useHttp) {
     } finally {
       const m = msg as { id?: string | number; method?: string };
       if (m && m.id !== undefined && m.method === undefined) {
-        inflightIds.delete(String(m.id));
+        inflightIds.delete(m.id);
         maybeFinishShutdown();
       }
     }

--- a/src/server-windows.ts
+++ b/src/server-windows.ts
@@ -265,15 +265,66 @@ failsafeTimer.unref(); // don't keep process alive for this alone
 let httpServerRef: HttpServer | null = null;
 let shuttingDown = false;
 
+// Deferred-shutdown state (issue #68): when stdin EOF or stdout EPIPE arrives mid-flight,
+// wait for in-flight JSON-RPC responses to drain before exiting so long-running tool calls
+// (terminal/wait_until) can deliver their results instead of returning "Connection closed".
+// Ids normalized via String() so number/string mismatches between peer and SDK don't leak.
+const inflightIds = new Set<string>();
+let shutdownPending = false;
+let shutdownTimer: NodeJS.Timeout | null = null;
+const SHUTDOWN_GRACE_MS = 60_000;
+
 function shutdown(): void {
   if (shuttingDown) return;
   shuttingDown = true;
+  if (shutdownTimer) {
+    clearTimeout(shutdownTimer);
+    shutdownTimer = null;
+  }
   console.error("[desktop-touch] Shutting down...");
   stopNativeRuntime();
   stopTray();
   httpServerRef?.close();
   // In-flight requests clean up their own server/transport instances via res.on("close").
   process.exit(0);
+}
+
+// Issue #68: defer shutdown until in-flight tool calls drain. Used by stdin EOF /
+// stdout EPIPE only; explicit signals (SIGINT/SIGTERM/disconnect) still shutdown immediately.
+function requestShutdown(reason: string): void {
+  if (shuttingDown || shutdownPending) return;
+  if (inflightIds.size === 0) {
+    console.error(`[desktop-touch] ${reason} — shutting down.`);
+    shutdown();
+    return;
+  }
+  shutdownPending = true;
+  console.error(
+    `[desktop-touch] ${reason} — deferring shutdown for ${inflightIds.size} in-flight request(s) (grace ${SHUTDOWN_GRACE_MS}ms).`
+  );
+  // Note: do NOT unref() the timer. We want the safety timeout to keep the
+  // event loop alive so that — even if every other handle disappears — we still
+  // hit the explicit "forcing shutdown" path (with stopNativeRuntime/stopTray)
+  // instead of a silent natural exit that leaves tray icons / native runtime behind.
+  shutdownTimer = setTimeout(() => {
+    console.error(
+      `[desktop-touch] in-flight requests still pending after ${SHUTDOWN_GRACE_MS}ms — forcing shutdown.`
+    );
+    shutdown();
+  }, SHUTDOWN_GRACE_MS);
+}
+
+function maybeFinishShutdown(): void {
+  if (shutdownPending && !shuttingDown && inflightIds.size === 0) {
+    // Defer one tick so the response just written via transport.send has a
+    // chance to flush from Node's writable-stream buffer to the OS pipe before
+    // process.exit() drops the buffer.
+    setImmediate(() => {
+      if (shuttingDown) return;
+      console.error("[desktop-touch] in-flight requests drained — shutting down.");
+      shutdown();
+    });
+  }
 }
 
 process.on("SIGINT", shutdown);
@@ -392,18 +443,61 @@ if (useHttp) {
   const transport = new StdioServerTransport();
   await server.connect(transport);
 
+  // Issue #68: track in-flight JSON-RPC requests at the transport layer so that
+  // stdin EOF / stdout EPIPE can defer shutdown until responses drain. We wrap
+  // transport.onmessage (assigned by server.connect) and transport.send to ++/--
+  // a shared id set. Notifications (no id) and responses received from peer
+  // (we never act as MCP client here) are ignored.
+  // Variadic rest-spread so SDK options/extra args (relatedRequestId, resumptionToken,
+  // MessageExtraInfo, etc.) pass through transparently — the StdioServerTransport class
+  // currently has 1-arg signatures, but the Transport interface and Protocol callers
+  // pass options. Cast through `Function` so we don't fight the narrower class types.
+  const origOnmessage = transport.onmessage as
+    | ((msg: unknown, ...rest: unknown[]) => void)
+    | undefined;
+  const origSend = transport.send.bind(transport) as (
+    msg: unknown,
+    ...rest: unknown[]
+  ) => Promise<void>;
+
+  transport.onmessage = ((msg: unknown, ...rest: unknown[]) => {
+    const m = msg as { id?: string | number; method?: string };
+    const isRequest = !!m && m.id !== undefined && typeof m.method === "string";
+    const key = isRequest ? String(m.id) : "";
+    if (isRequest) inflightIds.add(key);
+    try {
+      origOnmessage?.(msg, ...rest);
+    } catch (err) {
+      if (isRequest) {
+        inflightIds.delete(key);
+        maybeFinishShutdown();
+      }
+      throw err;
+    }
+  }) as typeof transport.onmessage;
+
+  transport.send = (async (msg: unknown, ...rest: unknown[]) => {
+    try {
+      return await origSend(msg, ...rest);
+    } finally {
+      const m = msg as { id?: string | number; method?: string };
+      if (m && m.id !== undefined && m.method === undefined) {
+        inflightIds.delete(String(m.id));
+        maybeFinishShutdown();
+      }
+    }
+  }) as typeof transport.send;
+
   // Detect parent process exit: stdin EOF when the client's write-end closes.
   // The MCP SDK only listens for 'data' and 'error', not 'end'.
   process.stdin.on("end", () => {
-    console.error("[desktop-touch] stdin closed — parent exited. Shutting down.");
-    shutdown();
+    requestShutdown("stdin closed — parent exited");
   });
 
   // Fallback: catch broken-pipe when writing responses after parent exits.
   process.stdout.on("error", (err: NodeJS.ErrnoException) => {
     if (err.code === "EPIPE" || err.code === "ERR_STREAM_DESTROYED") {
-      console.error("[desktop-touch] stdout broken pipe — parent exited. Shutting down.");
-      shutdown();
+      requestShutdown("stdout broken pipe — parent exited");
     }
   });
 

--- a/tests/e2e/server-stdin-eof.test.ts
+++ b/tests/e2e/server-stdin-eof.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "../..");
+const distEntry = path.join(repoRoot, "dist", "index.js");
+
+interface SpawnedServer {
+  proc: ChildProcess;
+  stderrLines: string[];
+  stdoutLines: string[];
+}
+
+const tracked: ChildProcess[] = [];
+
+function spawnServer(): SpawnedServer {
+  const proc = spawn(process.execPath, [distEntry], {
+    cwd: repoRoot,
+    stdio: ["pipe", "pipe", "pipe"],
+    windowsHide: true,
+    env: { ...process.env, DESKTOP_TOUCH_DISABLE_TRAY: "1" },
+  });
+  tracked.push(proc);
+  const stderrLines: string[] = [];
+  const stdoutLines: string[] = [];
+  proc.stderr!.setEncoding("utf8");
+  proc.stdout!.setEncoding("utf8");
+  let stderrBuf = "";
+  let stdoutBuf = "";
+  proc.stderr!.on("data", (chunk: string) => {
+    stderrBuf += chunk;
+    let idx;
+    while ((idx = stderrBuf.indexOf("\n")) >= 0) {
+      stderrLines.push(stderrBuf.slice(0, idx));
+      stderrBuf = stderrBuf.slice(idx + 1);
+    }
+  });
+  proc.stdout!.on("data", (chunk: string) => {
+    stdoutBuf += chunk;
+    let idx;
+    while ((idx = stdoutBuf.indexOf("\n")) >= 0) {
+      stdoutLines.push(stdoutBuf.slice(0, idx));
+      stdoutBuf = stdoutBuf.slice(idx + 1);
+    }
+  });
+  return { proc, stderrLines, stdoutLines };
+}
+
+function sendRpc(proc: ChildProcess, msg: unknown): void {
+  proc.stdin!.write(JSON.stringify(msg) + "\n");
+}
+
+async function waitFor<T>(predicate: () => T | null | undefined, timeoutMs: number, label: string): Promise<T> {
+  const t0 = Date.now();
+  while (Date.now() - t0 < timeoutMs) {
+    const v = predicate();
+    if (v !== null && v !== undefined && v !== false) return v as T;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(`waitFor timed out after ${timeoutMs}ms: ${label}`);
+}
+
+async function waitForExit(
+  proc: ChildProcess,
+  timeoutMs: number
+): Promise<{ code: number | null; signal: NodeJS.Signals | null; ms: number }> {
+  if (proc.exitCode !== null) return { code: proc.exitCode, signal: proc.signalCode, ms: 0 };
+  const t0 = Date.now();
+  return await new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`process did not exit within ${timeoutMs}ms`)),
+      timeoutMs
+    );
+    proc.once("exit", (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code, signal, ms: Date.now() - t0 });
+    });
+  });
+}
+
+afterEach(async () => {
+  for (const proc of tracked.splice(0)) {
+    if (proc.exitCode === null && !proc.killed) {
+      try {
+        proc.kill("SIGTERM");
+      } catch {
+        /* ignore */
+      }
+      await new Promise((r) => setTimeout(r, 100));
+      if (proc.exitCode === null && !proc.killed) {
+        try {
+          proc.kill("SIGKILL");
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+  }
+});
+
+describe("server-windows stdio EOF (issue #68)", () => {
+  it("Scenario A: closes cleanly when stdin closes with no in-flight tool call", async () => {
+    const { proc, stderrLines, stdoutLines } = spawnServer();
+    await waitFor(
+      () => stderrLines.some((l) => l.includes("MCP server running (stdio)")),
+      10_000,
+      "server start"
+    );
+
+    sendRpc(proc, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "test", version: "0" },
+      },
+    });
+    await waitFor(
+      () =>
+        stdoutLines.some((l) => {
+          try {
+            const m = JSON.parse(l);
+            return m.id === 1 && m.result;
+          } catch {
+            return false;
+          }
+        }),
+      10_000,
+      "initialize response"
+    );
+
+    proc.stdin!.end();
+    const exit = await waitForExit(proc, 5_000);
+
+    expect(exit.code).toBe(0);
+    // Should NOT defer (no in-flight) — message must be the prompt non-deferred shutdown.
+    const stderr = stderrLines.join("\n");
+    expect(stderr).toContain("stdin closed — parent exited");
+    expect(stderr).not.toContain("deferring shutdown");
+    expect(stderr).toContain("Shutting down...");
+  }, 20_000);
+
+  it("Scenario B: defers shutdown until in-flight tool call drains, response is delivered", async () => {
+    const { proc, stderrLines, stdoutLines } = spawnServer();
+    await waitFor(
+      () => stderrLines.some((l) => l.includes("MCP server running (stdio)")),
+      10_000,
+      "server start"
+    );
+
+    sendRpc(proc, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "test", version: "0" },
+      },
+    });
+    await waitFor(
+      () =>
+        stdoutLines.some((l) => {
+          try {
+            return JSON.parse(l).id === 1;
+          } catch {
+            return false;
+          }
+        }),
+      10_000,
+      "initialize response"
+    );
+    sendRpc(proc, { jsonrpc: "2.0", method: "notifications/initialized" });
+
+    // Fire a wait_until that is guaranteed to take ~5s (window will never appear).
+    // Generous timeoutMs so even on a slow Windows CI runner the call is still
+    // genuinely in-flight when we close stdin.
+    sendRpc(proc, {
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/call",
+      params: {
+        name: "wait_until",
+        arguments: {
+          condition: "window_appears",
+          target: { windowTitle: "ZZZZ-no-such-window-issue68-ZZZZ" },
+          timeoutMs: 5_000,
+          intervalMs: 100,
+        },
+      },
+    });
+
+    // Let the tool start polling, then close stdin mid-flight. 1500ms gives
+    // even slow CI runners ~15 polling iterations before stdin closes, so the
+    // "tool is in-flight when EOF arrives" precondition is robust.
+    await new Promise((r) => setTimeout(r, 1500));
+    proc.stdin!.end();
+
+    // The server must NOT exit before the response arrives.
+    const got2 = await waitFor(
+      () =>
+        stdoutLines.find((l) => {
+          try {
+            return JSON.parse(l).id === 2;
+          } catch {
+            return false;
+          }
+        }) ?? null,
+      10_000,
+      "in-flight tool response"
+    );
+    expect(got2).toBeTruthy();
+
+    const exit = await waitForExit(proc, 12_000);
+    expect(exit.code).toBe(0);
+
+    const stderr = stderrLines.join("\n");
+    expect(stderr).toContain("deferring shutdown");
+    expect(stderr).toContain("in-flight requests drained");
+    expect(stderr).toContain("Shutting down...");
+  }, 30_000);
+});

--- a/tests/repros/stdin-eof-shutdown.repro.mjs
+++ b/tests/repros/stdin-eof-shutdown.repro.mjs
@@ -101,7 +101,6 @@ async function scenarioA() {
   });
   await waitForStdoutLine(stdoutLines, (m) => m.id === 1 && m.result, 10_000);
   console.log("  initialize done, closing stdin...");
-  const t0 = Date.now();
   proc.stdin.end();
   const exit = await waitForExit(proc, 5_000);
   console.log(`  exit: code=${exit.code} signal=${exit.signal} after ${exit.ms}ms`);


### PR DESCRIPTION
## Summary
- stdio transport で long-running tool call (terminal/wait_until) 中に stdin EOF が来ると `process.exit(0)` で即死し、進行中の応答が失われて "MCP error -32000: Connection closed" になっていた問題を修正
- transport 層で JSON-RPC request id を in-flight 追跡し、stdin EOF / stdout EPIPE は deferred shutdown（60s safety timeout 付き）。SIGINT/SIGTERM/disconnect は従来どおり即時 shutdown
- HTTP transport (`--http`) は無変更（stdio ブランチに閉じている）

## 詳細

### Root cause
`src/server-windows.ts` の `process.stdin.on('end', shutdown)` と `process.stdout.on('error', ...)` が tool call の in-flight 状態を一切確認せず即 `process.exit(0)` を呼んでいた。クライアント (Claude Code) が transient に stdin の write end を閉じると、`terminal(action='run')` / `wait_until` 等の long-running tool が応答を返す前にサーバが消える。

### Fix
1. `transport.onmessage` / `transport.send` を rest-spread でラップして JSON-RPC request id を `Set<string>` で追跡（id 型混在に防御的）
2. 新規 `requestShutdown(reason)` で stdin EOF / stdout EPIPE を deferred 化、60s grace timeout 後に強制 shutdown
3. `maybeFinishShutdown` は `setImmediate` 経由で stdout flush を 1-tick 確保
4. SIGINT/SIGTERM/disconnect は従来どおり即時 `shutdown()`

### Opus 再レビュー
- Round 1: 7 件指摘 → L1 (`shutdownTimer.unref()` 削除) / H1 (id 正規化) / M2 (setImmediate flush) / L2 (e2e timing 緩和) / L5 (doc) を反映
- Round 2: L3 (rest-spread future-proof) を反映
- Round 3: 指摘ゼロ

## Test plan
- [x] `tests/e2e/server-stdin-eof.test.ts` Scenario A (no in-flight) → 即時 exit 0、deferring ログなし
- [x] `tests/e2e/server-stdin-eof.test.ts` Scenario B (wait_until in-flight 中に stdin close) → 応答配信後に exit 0、`deferring shutdown` + `in-flight requests drained` ログあり
- [x] `npm run build` 通過、TypeScript エラー 0
- [x] full suite 2272 PASS（benchmark-gates 1 件は負荷起因 flaky、再実行 10/10 PASS、本変更と無関係）
- [x] HTTP モードのコードパスは無変更（diff で確認）
- [ ] reviewer による code review

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)