### PR TITLE
feat(browser): add killExisting option to browser_launch (#22)

### DIFF
--- a/docs/plan-22-browser-launch-killExisting.md
+++ b/docs/plan-22-browser-launch-killExisting.md
@@ -1,0 +1,230 @@
+# Plan: #22 `browser_launch` に `killExisting` オプション追加
+
+- **Issue**: https://github.com/Harusame64/desktop-touch-mcp/issues/22
+- **Label**: enhancement, v1.1
+- **想定スコープ**: 1 PR、1 セッションで完結
+- **作成日**: 2026-04-28
+
+---
+
+## 背景
+
+ユーザーが普段使いの Chrome / Edge / Brave を `--remote-debugging-port` なしで起動済の場合、`browser_launch` は以下の挙動になる:
+
+1. `listTabs(port)` が ECONNREFUSED → spawn パスへフォールバック
+2. spawn しても同じ `--user-data-dir` を共有するプロファイルがロックされ、新プロセスは既存ブラウザに引き継がれる (Chromium の SingleInstance 動作)
+3. CDP ポートは開かないまま `pollUntil` がタイムアウト
+
+→ ユーザーが手動で `Stop-Process -Name chrome -Force` してから再実行する必要がある = MCP だけで完結しない。
+
+---
+
+## 解決策
+
+`browserLaunchSchema` に `killExisting: boolean` (default false) を追加。true のとき、spawn の前に対象 exe を taskkill する。
+
+### スコープ外（明示）
+
+- 既存ブラウザのタブ復元 / セッション保持: NO（kill 時の未保存タブ消失はユーザー責任、ツール説明で警告）
+- 確認プロンプト: NO（MCP に対話 UI なし、`killExisting:true` を明示要求した時点で同意とみなす）
+- 他プラットフォーム対応: NO（Windows 専用 MCP）
+
+---
+
+## 設計
+
+### 1. Schema 拡張 (`src/tools/browser.ts:188-215`)
+
+```ts
+export const browserLaunchSchema = {
+  browser: z.enum(["auto", "chrome", "edge", "brave"]).default("auto").describe(...),
+  port: portParam,
+  userDataDir: z.string().default("C:\\tmp\\cdp").describe(...),
+  url: z.string().optional().describe(...),
+  waitMs: z.coerce.number().int().min(1000).max(30_000).default(10_000).describe(...),
+  // 追加 ↓
+  killExisting: coercedBoolean().default(false).describe(
+    "When true, terminate existing chrome.exe / msedge.exe / brave.exe processes before launch. " +
+    "Use this when a browser is already running WITHOUT --remote-debugging-port. " +
+    "WARNING: unsaved input in the existing browser session will be lost. " +
+    "Default false (preserves the user's current browser session)."
+  ),
+};
+```
+
+### 2. Kill ヘルパ (`src/utils/launch.ts` に追加)
+
+`browser.ts` 内に置くと再利用できないので、`src/utils/launch.ts` に export する。spawnDetached と同じレイヤー。
+
+```ts
+import { spawnSync } from "node:child_process";
+
+/**
+ * Terminate all instances of the given executable name(s) via taskkill /F /IM.
+ * Returns the list of exe names that actually had a process killed (taskkill exit 0).
+ * Errors / "no process found" (exit 128) are silently ignored.
+ *
+ * Windows-only — uses taskkill.exe from System32.
+ */
+export function killProcessesByName(exeNames: string[]): string[] {
+  const killed: string[] = [];
+  for (const exe of exeNames) {
+    try {
+      const result = spawnSync("taskkill.exe", ["/F", "/IM", exe], {
+        windowsHide: true,
+        timeout: 5000,
+      });
+      if (result.status === 0) killed.push(exe);
+      // exit 128 = "process not found" — ignore
+      // other non-zero = log via stderr but don't throw
+    } catch { /* ignore — best-effort */ }
+  }
+  return killed;
+}
+```
+
+**判断: なぜ taskkill か**:
+- PowerShell 子プロセス起動は ~300ms オーバーヘッド (memory: tray.ts は別目的)
+- TerminateProcess (Win32 API) は koffi 経由で書けるが、PID 列挙が増える
+- taskkill.exe は System32 標準、引数も `/F /IM exe` の単純形 → Win32 直叩きより堅牢
+- 戻り値は exit code で判別可能（0=成功 / 128=該当なし / 1=他エラー）
+
+### 3. Handler 拡張 (`src/tools/browser.ts:1371-1505`)
+
+spawn の直前 (現 L1449「Spawn with CDP flags」セクション) に kill 処理を入れる。**alreadyRunning 判定の前ではない**ことが重要 — CDP が既に live なら kill する必要はない。
+
+```ts
+// ── 1. Already running? ── (既存、変更なし)
+try {
+  const existingTabs = await listTabs(port);
+  // ...既存のロジック
+} catch { /* not running — proceed to spawn */ }
+
+// ── 2. Validate url early ── (既存、変更なし)
+
+// ── 3. Resolve browser executable ── (既存、変更なし)
+
+// ── 3.5. Kill existing if requested ── ★新規
+let killed: string[] = [];
+if (killExisting) {
+  // 'auto' でも全候補ではなく chosenKey の exe のみ kill (副作用最小化)
+  const exeToKill = chosenKey === "edge" ? "msedge.exe" : `${chosenKey}.exe`;
+  killed = killProcessesByName([exeToKill]);
+  if (killed.length > 0) {
+    // grace period: kill 直後の spawn だと同じ user-data-dir のロックが残ることがある
+    await new Promise<void>((r) => setTimeout(r, 500));
+  }
+}
+
+// ── 4. Spawn with CDP flags ── (既存)
+// ── 5. Poll listTabs ── (既存)
+
+return {
+  content: [{
+    type: "text" as const,
+    text: JSON.stringify({
+      port,
+      alreadyRunning: false,
+      launched: { browser: chosenKey, path: chosenPath, userDataDir },
+      killed, // ★ 追加
+      tabs: pageTabs.map((t) => ({ id: t.id, title: t.title, url: t.url })),
+    }, null, 2),
+  }],
+};
+```
+
+**alreadyRunning パスの戻り値にも `killed: []` を追加** (フィールド形を統一):
+
+```ts
+return {
+  content: [{
+    type: "text" as const,
+    text: JSON.stringify({
+      port,
+      alreadyRunning: true,
+      launched: null,
+      killed: [],  // ★ 統一のため空配列を返す
+      tabs: pageTabs.map(...),
+    }, null, 2),
+  }],
+};
+```
+
+### 4. handler 引数の型拡張
+
+```ts
+export const browserLaunchHandler = async ({
+  browser, port, userDataDir, url, waitMs, killExisting,
+}: {
+  browser: "auto" | "chrome" | "edge" | "brave";
+  port: number;
+  userDataDir: string;
+  url?: string;
+  waitMs: number;
+  killExisting: boolean; // ★ 追加
+}): Promise<ToolResult> => { ... }
+```
+
+---
+
+## テスト
+
+### ユニットテスト (`tests/unit/browser-launch-killexisting.test.ts` 新規)
+
+`killProcessesByName` 関数を mock せずにテストするのは難しい (実 taskkill を呼ぶ)。3 段階で書く:
+
+1. **`killProcessesByName` 単体**:
+   - `spawnSync` を vitest の `vi.mock("node:child_process")` で mock
+   - exit 0 → killed に含まれる、exit 128 → 含まれない、throw → 含まれない
+   - 複数 exe 配列で全て呼ばれる
+
+2. **schema 検証**:
+   - `browserLaunchSchema` parse で `killExisting` がデフォルト false
+   - `killExisting: "true"` (文字列) を coercedBoolean が boolean に変換
+
+3. **handler フローのドライラン** (重い E2E は不要):
+   - mock の `killProcessesByName` を呼ぶ前に alreadyRunning が true なら kill しない
+   - chosenKey が edge のとき msedge.exe で呼ばれる、chrome のとき chrome.exe
+   - `killExisting:false` (default) で kill が呼ばれない
+
+E2E (実 Chrome を kill するシナリオ) は手動 smoke test で確認、自動化しない (CI で他テストの Chrome を巻き込む危険がある)。
+
+---
+
+## 影響範囲
+
+### 触るファイル
+
+| File | 変更内容 |
+|---|---|
+| `src/tools/browser.ts` | schema に 1 フィールド、handler に kill ステップ、戻り値に `killed[]` |
+| `src/utils/launch.ts` | `killProcessesByName()` export 追加 |
+| `tests/unit/browser-launch-killexisting.test.ts` | 新規 (上記 1+2+3) |
+
+### 触らないファイル
+
+- `src/stub-tool-catalog.ts`: `npm run generate-stub-catalog` 実行で**自動再生成**される。手動編集なし。
+- `src/server-windows.ts`: 既存ツールの schema 拡張のみなので登録変更なし。
+- README: 別 PR でツール表更新（本 PR では JSDoc / describe 文言で完結）。
+
+---
+
+## チェックリスト
+
+- [ ] `src/utils/launch.ts` に `killProcessesByName()` 追加
+- [ ] `src/tools/browser.ts` schema に `killExisting` 追加
+- [ ] `src/tools/browser.ts` handler 引数型に `killExisting: boolean` 追加
+- [ ] `src/tools/browser.ts` handler に kill ステップ挿入 (chosen exe のみ kill、500ms grace)
+- [ ] `src/tools/browser.ts` 両 return に `killed[]` フィールド追加
+- [ ] `tests/unit/browser-launch-killexisting.test.ts` 新規
+- [ ] `npm run generate-stub-catalog` 実行 (auto-gen 反映)
+- [ ] `npm run build` 通過
+- [ ] `npm run test:capture > .vitest-out.txt` で全 unit pass
+- [ ] Opus レビュー (CLAUDE.md 強制命令 3) → 指摘ゼロまで反復
+- [ ] PR 出す (label: v1.1, closes #22)
+
+---
+
+## オープンクエスチョン
+
+なし。ユーザー issue の仕様 (default false / 戻り値 `killed[]` / Windows のみ) に従う。

--- a/docs/plan-25-scroll-read.md
+++ b/docs/plan-25-scroll-read.md
@@ -1,0 +1,389 @@
+# Plan: #25 `scroll_read` — スクロール + OCR を 1 呼び出しで完結
+
+- **Issue**: https://github.com/Harusame64/desktop-touch-mcp/issues/25
+- **Label**: enhancement, v1.1
+- **想定スコープ**: 2 PR 推奨 (Phase 1 + Phase 2)。Phase 3 は将来
+- **作成日**: 2026-04-28
+
+---
+
+## 重要な設計判断: 新ツール vs 既存 dispatcher の action 追加
+
+### 前提知識
+
+`src/tools/scroll.ts` は **dispatcher パターン**で、MCP には **1 つのツール `scroll`** しか公開していない。LLM はそのツール内の `action` パラメータで挙動を切り替える:
+
+```
+scroll({action: 'raw',         direction: 'down', amount: 5})           # 純粋なホイール
+scroll({action: 'to_element',  name: 'OK', windowTitle: 'Dialog'})      # 要素を viewport に
+scroll({action: 'smart',       target: '#btn'})                          # 多戦略フォールバック
+scroll({action: 'capture',     windowTitle: 'Chrome'})                   # 全ページ画像化
+```
+
+これは **Phase 2 (Family Merge)** という明示的な project goal の結果で、PR #36 / #37 / #38 / #39 で他の家族（window-dock 等）も同じ統合をしてきた。v1.0.0 release prep の柱。
+
+### 案 A: 新ツール `scroll_read` として独立公開
+
+LLM のツール一覧に **2 つ目のスクロール系ツール** が現れる:
+
+```
+- scroll(action: raw|to_element|smart|capture, ...)
+- scroll_read(windowTitle, maxPages, ...)        ← 新規
+```
+
+**コード構造:**
+- `src/tools/scroll-read.ts` 新規（schema + handler + register 関数）
+- `src/server-windows.ts` に `registerScrollReadTool(server)` 追加
+- `scripts/generate-stub-tool-catalog.mjs` の `TOOL_FILES` に `'scroll-read.ts'` 追加
+- `src/stub-tool-catalog.ts` 自動再生成
+
+**メリット:**
+- ツール名 `scroll_read` 自体が機能を表す → LLM の prompt に「scroll_read で読んで」と書ける
+- grep で意図ごとに引ける（`scroll_read` 単独で）
+- Issue タイトルと完全一致
+- scroll() の discriminatedUnion が肥大化しない
+
+**デメリット:**
+- ツール総数が 1 つ増える（v1.0.0 の Tool Surface Reduction 方針に逆行）
+- LLM 視点では「スクロールしたい」とき選択肢が 2 つに増えて迷いやすい
+- README ツール表が +1 行
+- `scroll(action='capture')` と `scroll_read()` の使い分けを caveats で説明する必要
+
+### 案 B: `scroll(action='read')` として既存 dispatcher に追加
+
+```
+scroll({action: 'raw',         ...})
+scroll({action: 'to_element',  ...})
+scroll({action: 'smart',       ...})
+scroll({action: 'capture',     ...})
+scroll({action: 'read',        windowTitle: '...'})    ← 追加
+```
+
+**コード構造:**
+- `src/tools/scroll-read.ts` 新規（handler のみ、schema は scroll.ts に書く）
+- `src/tools/scroll.ts` の discriminatedUnion に 1 ブランチ追加、dispatchHandler に case 追加、buildDesc 拡張
+- TOOL_FILES 修正不要（`scroll.ts` は既に登録済）
+- `server-windows.ts` 修正不要（既存の `registerScrollTools` がそのまま動く）
+
+**メリット:**
+- ツール総数 ±0（Phase 2/3 方針と整合）
+- LLM の選択肢が「スクロール系は scroll() 1 個」で一貫
+- stub-tool-catalog 修正 0 箇所
+- `scroll(action='capture')` (画像) と `scroll(action='read')` (テキスト) が同じ家族で並ぶ → 使い分けが自然
+
+**デメリット:**
+- ツール名で `scroll_read` を grep できない（`action: "read"` で検索する必要）
+- Issue タイトル `scroll_read` とは命名が異なる
+- discriminatedUnion が 4 → 5 ブランチに膨らむ（許容範囲）
+- LLM が「OCR で長文を読む」機能を発見するには scroll の examples / prefer 文を読む必要
+
+### 推奨
+
+**案 B (`scroll(action='read')`) を推奨**します。理由:
+
+1. **方針整合**: Phase 2/3 で「family merge → ツール総数削減」を意図的に進めてきた直後に、新規 top-level ツールを足すのは設計判断として一貫性を欠く
+2. **使い分けの自然さ**: `scroll(action='capture')` (= 画像で読む) と `scroll(action='read')` (= テキストで読む) は対の関係で、同じ家族に並べた方が直感的
+3. **保守コスト**: stub-tool-catalog 修正 / register 追加 / 公開 API 増加が無く、PR が薄い
+4. **LLM 発見性は description で補える**: scroll() の `prefer` 文に「長文ドキュメント読み取りには action='read'」と書けば誘導できる（capture との使い分け含めて）
+
+**反対意見の余地**:
+- 「LLM はツール名で機能を選ぶ傾向があり、`scroll_read` の方が見つかりやすい」という主張は一理ある。ただし現状 `scroll(action='capture')` も「画像化」という別機能を内包していて、これが見つからずに困った報告は memory に無い。
+- 将来 scroll の action が 7-8 個に膨らんだら family を割る必要が出るが、現時点では 5 個は健全範囲。
+
+**もし案 A にしたい場合の差分**: 約 30-40 行（schema/handler を別ファイルに切り出し、register 関数追加、TOOL_FILES に追加）。後から A → B、B → A への移行は 1 回ずつなら低コスト。
+
+→ **判断はユーザーに委ねます**。OK なら B で進めます。
+
+---
+
+## 解決策
+
+`scroll(action='read')` を新設。サーバ側で「スクロール → OCR → 重複行除去 → 末尾判定」を完結し、結合済みテキストを返す。
+
+### 入力
+
+```ts
+z.object({
+  action: z.literal("read"),
+  windowTitle: z.string().describe("Partial window title (case-insensitive)."),
+  maxPages: z.coerce.number().int().min(1).max(50).default(20).describe(...),
+  scrollKey: z.enum(["PageDown", "Space", "ArrowDown"]).default("PageDown").describe(...),
+  scrollDelayMs: z.coerce.number().int().min(100).max(3000).default(400).describe(...),
+  stopWhenNoChange: coercedBoolean().default(true).describe(...),
+  language: z.string().optional().describe(
+    "OCR language code (e.g. 'ja', 'en', 'zh'). Omit to auto-detect from Windows system locale " +
+    "(via Intl.DateTimeFormat().resolvedOptions().locale). Default: auto."
+  ),
+})
+```
+
+### 出力 JSON
+
+```json
+{
+  "ok": true,
+  "text": "…結合済テキスト…",
+  "pages": 7,
+  "stoppedReason": "no_change" | "max_pages" | "ocr_empty",
+  "dedupedLines": 42,
+  "perPage": [
+    { "page": 1, "addedLines": 35, "duplicateLines": 0 },
+    { "page": 2, "addedLines": 28, "duplicateLines": 7 }
+  ]
+}
+```
+
+### スコープ外（明示）
+
+- **Phase 1 では対象外**: PDF 横スクロール / Markdown 整形 / grep モード（issue 本文の「将来拡張」）
+- **Phase 1 では対象外**: browser (CDP) 版 — Phase 3 で別途
+- **画像出力は無し**: OCR テキストのみ。視覚情報必要なら `scroll(action='capture')` を使う
+
+---
+
+## Phase 分割
+
+### Phase 1: Native スクロール + OCR + 単純な重複除去 (本 PR)
+
+最小実装。重複除去は「直前ページの末尾 N 行が新ページ先頭に含まれる場合に削除」の素朴アルゴリズム。
+
+#### 設計
+
+**ファイル: `src/tools/scroll-read.ts` 新規**
+
+```ts
+import { recognizeWindow, ocrWordsToLines } from "../engine/ocr-bridge.js";
+import { keyboard } from "@nut-tree-fork/nut-js";  // Page Down 送信
+import { focusWindowByTitle } from "../engine/win32.js";
+
+/**
+ * Detect OCR language from Windows system locale.
+ * Returns a primary language tag (e.g. "ja", "en", "zh") that win-ocr.exe accepts.
+ * Falls back to "en" for unrecognized locales.
+ */
+function detectOcrLanguage(): string {
+  // Intl.DateTimeFormat().resolvedOptions().locale returns BCP-47 e.g. "ja-JP", "en-US"
+  // It reads OS preferred language on Windows (CRT inherits from GetUserDefaultLocaleName)
+  const locale = Intl.DateTimeFormat().resolvedOptions().locale;
+  const primary = locale.split("-")[0]?.toLowerCase() ?? "en";
+  // win-ocr.exe / Windows.Media.Ocr supports languages installed in OS.
+  // We pass primary tag; if the OS lacks the pack, win-ocr returns error which we fall back to "en".
+  const KNOWN = new Set(["ja", "en", "zh", "ko", "fr", "de", "es", "it", "pt", "ru", "nl", "pl", "tr", "ar"]);
+  return KNOWN.has(primary) ? primary : "en";
+}
+
+export interface ScrollReadResult {
+  ok: boolean;
+  text: string;
+  pages: number;
+  language: string;  // 実際に使った言語（自動検出結果のレポート）
+  stoppedReason: "no_change" | "max_pages" | "ocr_empty";
+  dedupedLines: number;
+  perPage: Array<{ page: number; addedLines: number; duplicateLines: number }>;
+}
+
+export async function scrollReadHandler(args: ScrollReadArgs): Promise<ToolResult> {
+  const language = args.language ?? detectOcrLanguage();
+  await focusWindowByTitle(args.windowTitle);
+  await new Promise(r => setTimeout(r, 200));  // focus settle
+
+  const allLines: string[] = [];
+  const perPage: Array<{ page: number; addedLines: number; duplicateLines: number }> = [];
+  let stoppedReason: "no_change" | "max_pages" | "ocr_empty" = "max_pages";
+  let noChangeStreak = 0;
+
+  for (let page = 1; page <= args.maxPages; page++) {
+    // OCR current viewport
+    const { words } = await recognizeWindow(args.windowTitle, language);
+    const lineText = ocrWordsToLines(words);
+    const lines = lineText.split("\n").map(s => s.trim()).filter(Boolean);
+
+    if (lines.length === 0) {
+      stoppedReason = "ocr_empty";
+      break;
+    }
+
+    // Dedupe: longest suffix-of-allLines that is a prefix-of-lines
+    const dupCount = findOverlap(allLines.slice(-20), lines);
+    const newLines = lines.slice(dupCount);
+
+    perPage.push({ page, addedLines: newLines.length, duplicateLines: dupCount });
+    allLines.push(...newLines);
+
+    if (args.stopWhenNoChange && newLines.length === 0) {
+      noChangeStreak++;
+      if (noChangeStreak >= 2) {
+        stoppedReason = "no_change";
+        break;
+      }
+    } else {
+      noChangeStreak = 0;
+    }
+
+    if (page === args.maxPages) break;
+
+    // Send scroll key
+    await keyboard.pressKey(keyMap[args.scrollKey]);
+    await keyboard.releaseKey(keyMap[args.scrollKey]);
+    await new Promise(r => setTimeout(r, args.scrollDelayMs));
+  }
+
+  return {
+    content: [{
+      type: "text" as const,
+      text: JSON.stringify({
+        ok: true,
+        text: allLines.join("\n"),
+        pages: perPage.length,
+        language,                 // 自動検出 or 引数指定の値をエコー
+        stoppedReason,
+        dedupedLines: perPage.reduce((s, p) => s + p.duplicateLines, 0),
+        perPage,
+      }, null, 2),
+    }],
+  };
+}
+
+/** Longest suffix-of-prev that equals prefix-of-curr. Naive O(n*m), n,m <= 20. */
+function findOverlap(prev: string[], curr: string[]): number {
+  const maxOverlap = Math.min(prev.length, curr.length);
+  for (let k = maxOverlap; k > 0; k--) {
+    let match = true;
+    for (let i = 0; i < k; i++) {
+      if (prev[prev.length - k + i] !== curr[i]) { match = false; break; }
+    }
+    if (match) return k;
+  }
+  return 0;
+}
+```
+
+#### 既存資産の流用
+
+- `recognizeWindow(windowTitle, language)` (`src/engine/ocr-bridge.ts:247-284`) — ウィンドウキャプチャ + OCR、ローカル座標で `OcrWord[]` 返す
+- `ocrWordsToLines(words)` (`src/engine/ocr-bridge.ts:291-311`) — y-midpoint クラスタリングで行配列 → 改行区切り文字列
+- `focusWindowByTitle()` — 既存の win32 ヘルパ
+- nut-js `keyboard.pressKey/releaseKey` — 既存パターン (`src/tools/keyboard.ts:78-82`)
+
+#### dispatcher 統合 (`src/tools/scroll.ts`)
+
+```ts
+// 追加
+import { scrollReadHandler } from "./scroll-read.js";
+
+export const scrollSchema = z.discriminatedUnion("action", [
+  // 既存4つ
+  z.object({ action: z.literal("raw"), ... }),
+  z.object({ action: z.literal("to_element"), ... }),
+  z.object({ action: z.literal("smart"), ... }),
+  z.object({ action: z.literal("capture"), ... }),
+  // 追加
+  z.object({
+    action: z.literal("read"),
+    windowTitle: z.string()...,
+    maxPages: z.coerce.number()...,
+    scrollKey: z.enum([...])...,
+    scrollDelayMs: z.coerce.number()...,
+    stopWhenNoChange: coercedBoolean()...,
+    language: z.enum(["ja", "en"]).default("ja")...,
+  }),
+]);
+
+export const scrollDispatchHandler = async (args: ScrollArgs): Promise<ToolResult> => {
+  switch (args.action) {
+    case "raw":         return rawScrollHandler(args);
+    case "to_element":  return scrollToElementHandler(args);
+    case "smart":       return smartScrollHandler(args);
+    case "capture":     return scrollCaptureHandler(args);
+    case "read":        return scrollReadHandler(args);  // ★ 追加
+  }
+};
+```
+
+`registerScrollTools()` の `buildDesc` 内 `details` / `prefer` / `examples` に `read` の説明を追加。
+
+#### テスト (`tests/unit/scroll-read.test.ts` 新規)
+
+1. **`findOverlap` 単体**:
+   - `findOverlap(["a","b","c"], ["b","c","d"])` → 2
+   - `findOverlap(["a","b"], ["c","d"])` → 0
+   - 空配列対応
+
+2. **handler ドライラン** (重い OCR / nut-js は mock):
+   - `recognizeWindow` mock で 3 ページ分の `OcrWord[]` を返す → 期待 text と pages 確認
+   - 連続2回 newLines=0 → stoppedReason="no_change"
+   - maxPages 到達 → stoppedReason="max_pages"
+   - OCR 空配列 → stoppedReason="ocr_empty"
+
+3. **schema 検証**:
+   - default 値、enum 制約、min/max 制約
+
+E2E は手動 smoke test で notepad / browser / VS Code 等を実機確認 (ただし notepad-launcher MSStore hang 問題に注意 — memory: feedback_notepad_launcher_msstore_hang.md)。
+
+---
+
+### Phase 2: 重複除去精緻化 (別 PR、後日)
+
+Phase 1 の素朴アルゴリズムでは以下のケースで誤検出する:
+
+- 改行位置が微妙にずれた場合（OCR ノイズで "abc def" / "abc  def" が別行扱い）
+- ヘッダ / フッタが固定で残るページ（ページ番号 "1/10" → "2/10" など）
+
+#### 検討する改善
+
+- 文字列正規化 (連続空白圧縮 / トリム / 全角/半角統一)
+- ページ末尾 / 先頭の固定領域検出 (Y 座標クラスタ)
+- 単語ベースではなく行ベースの Levenshtein 編集距離 (閾値 < length × 0.1)
+
+実装前に Phase 1 の dogfood で「実際にどこで誤検出するか」を観察してから、必要な精緻化のみ入れる (over-engineering 防止)。
+
+---
+
+### Phase 3: Browser (CDP) 版 (将来、別 PR)
+
+ブラウザ内では JS で `document.body.innerText` を直接取れるので OCR 不要、精度が圧倒的に高い。`browser_get` 等の既存ブラウザ系ツールで賄えるなら不要かもしれない (issue を再評価)。
+
+---
+
+## 影響範囲
+
+### 触るファイル (Phase 1)
+
+| File | 変更 |
+|---|---|
+| `src/tools/scroll-read.ts` | 新規 (ハンドラ + findOverlap) |
+| `src/tools/scroll.ts` | discriminatedUnion に `read` 追加、dispatcher case 追加、buildDesc 拡張 |
+| `tests/unit/scroll-read.test.ts` | 新規 |
+
+### 触らないファイル (action 追加のため)
+
+- `src/stub-tool-catalog.ts`: 自動再生成
+- `scripts/generate-stub-tool-catalog.mjs`: TOOL_FILES に既に `scroll.ts` 含む (line 16)
+- `src/server-windows.ts`: 既存 `registerScrollTools` をそのまま呼ぶ
+- `src/engine/ocr-bridge.ts`: 既存関数 (`recognizeWindow`, `ocrWordsToLines`) を import するのみ、変更なし
+
+→ **stub-tool-catalog の 3 箇所登録は今回 0 箇所** (= dispatcher 統合の利点)
+
+---
+
+## チェックリスト (Phase 1)
+
+- [ ] `src/tools/scroll-read.ts` 新規作成
+- [ ] `src/tools/scroll.ts` discriminatedUnion に `read` action 追加
+- [ ] `src/tools/scroll.ts` dispatchHandler に case 追加
+- [ ] `src/tools/scroll.ts` `buildDesc` の details/prefer/examples に read 説明追加
+- [ ] `tests/unit/scroll-read.test.ts` 新規 (findOverlap + handler mock + schema)
+- [ ] `npm run generate-stub-catalog` 実行 (auto-gen 反映確認)
+- [ ] `npm run build` 通過
+- [ ] `npm run test:capture > .vitest-out.txt` で全 unit pass
+- [ ] 手動 smoke test: notepad / chrome / vscode で `scroll(action='read', windowTitle:'...')` 動作確認
+- [ ] Opus レビュー → 指摘ゼロまで反復
+- [ ] PR 出す (label: v1.1, closes #25)
+
+---
+
+## ユーザー判断ログ (2026-04-28)
+
+1. **新ツール vs action 追加**: 詳細比較を本ドキュメント上部「重要な設計判断」に追記済み。判断はユーザーへ。
+2. **OCR 言語**: ✅ Windows OS locale から自動切替 (Intl.DateTimeFormat().resolvedOptions().locale)。`detectOcrLanguage()` 実装済（ハンドラ内）
+3. **`scrollKey` 送信**: ✅ nut-js (前景必須) で進める

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -18,7 +18,7 @@ import {
   getTabContext,
   type TabContext,
 } from "../engine/cdp-bridge.js";
-import { resolveWellKnownPath, spawnDetached } from "../utils/launch.js";
+import { resolveWellKnownPath, spawnDetached, killProcessesByName } from "../utils/launch.js";
 import { getCdpPort } from "../utils/desktop-config.js";
 import { fail } from "./_types.js";
 import { setBrowserSearchHook } from "./wait-until.js";
@@ -84,6 +84,11 @@ export const browserOpenSchema = {
         .max(30_000)
         .default(10_000)
         .describe("Max ms to wait for the CDP endpoint to become ready (default 10000)."),
+      killExisting: coercedBoolean().default(false).describe(
+        "When true, terminate existing browser processes before launch. " +
+        "Use when a browser is already running WITHOUT --remote-debugging-port. " +
+        "WARNING: unsaved input in the existing session will be lost."
+      ),
     })
     .optional()
     .describe(
@@ -212,6 +217,12 @@ export const browserLaunchSchema = {
     .max(30_000)
     .default(10_000)
     .describe("Max milliseconds to wait for the CDP endpoint to become ready (default 10000)."),
+  killExisting: coercedBoolean().default(false).describe(
+    "When true, terminate existing chrome.exe / msedge.exe / brave.exe processes before launch. " +
+    "Use this when a browser is already running WITHOUT --remote-debugging-port. " +
+    "WARNING: unsaved input in the existing browser session will be lost. " +
+    "Default false (preserves the user's current browser session)."
+  ),
 };
 
 export const browserSearchSchema = {
@@ -1374,12 +1385,14 @@ export const browserLaunchHandler = async ({
   userDataDir,
   url,
   waitMs,
+  killExisting,
 }: {
   browser: "auto" | "chrome" | "edge" | "brave";
   port: number;
   userDataDir: string;
   url?: string;
   waitMs: number;
+  killExisting: boolean;
 }): Promise<ToolResult> => {
   try {
     // ── 1. Already running? ──────────────────────────────────────────────────
@@ -1401,6 +1414,7 @@ export const browserLaunchHandler = async ({
             port,
             alreadyRunning: true,
             launched: null,
+            killed: [],
             tabs: pageTabs.map((t) => ({ id: t.id, title: t.title, url: t.url })),
           }, null, 2),
         }],
@@ -1444,6 +1458,18 @@ export const browserLaunchHandler = async ({
             : `${browser} not found in standard install locations. Install it or launch manually: ${browser === "edge" ? "msedge" : browser}.exe --remote-debugging-port=${port} --user-data-dir=${userDataDir}`,
         }],
       };
+    }
+
+    // ── 3.5. Kill existing if requested ──────────────────────────────────────
+    let killed: string[] = [];
+    if (killExisting) {
+      // Kill only the chosen browser exe — minimise side effects
+      const exeToKill = chosenKey === "edge" ? "msedge.exe" : `${chosenKey}.exe`;
+      killed = killProcessesByName([exeToKill]);
+      if (killed.length > 0) {
+        // Grace period: right after kill, same user-data-dir lock may still linger
+        await new Promise<void>((r) => setTimeout(r, 500));
+      }
     }
 
     // ── 4. Spawn with CDP flags ───────────────────────────────────────────────
@@ -1494,6 +1520,7 @@ export const browserLaunchHandler = async ({
           port,
           alreadyRunning: false,
           launched: { browser: chosenKey, path: chosenPath, userDataDir },
+          killed,
           tabs: pageTabs.map((t) => ({ id: t.id, title: t.title, url: t.url })),
         }, null, 2),
       }],
@@ -1549,6 +1576,7 @@ export const browserOpenHandler = async ({
     userDataDir: string;
     url?: string;
     waitMs: number;
+    killExisting: boolean;
   };
 }): Promise<ToolResult> => {
   if (launch) {
@@ -1558,6 +1586,7 @@ export const browserOpenHandler = async ({
       userDataDir: launch.userDataDir,
       url: launch.url,
       waitMs: launch.waitMs,
+      killExisting: launch.killExisting,
     });
     const text = launchResult.content[0]?.type === "text" ? launchResult.content[0].text : "";
     if (classifyLaunchOutcome(text) === "fail") {

--- a/src/utils/launch.ts
+++ b/src/utils/launch.ts
@@ -6,7 +6,7 @@
  * between tool files.
  */
 
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import path from "node:path";
 import fs from "node:fs";
 import { isExecutableAllowlisted } from "./launch-config.js";
@@ -122,6 +122,29 @@ export function resolveWellKnownPath(command: string): { resolved: string; wasRe
  * - The `error` event fires on the next tick for ENOENT — caught deterministically.
  * - No arbitrary delay that could be too short or too long.
  */
+/**
+ * Terminate all instances of the given executable name(s) via taskkill /F /IM.
+ * Returns the list of exe names that actually had a process killed (taskkill exit 0).
+ * Errors / "no process found" (exit 128) are silently ignored.
+ *
+ * Windows-only — uses taskkill.exe from System32.
+ */
+export function killProcessesByName(exeNames: string[]): string[] {
+  const killed: string[] = [];
+  for (const exe of exeNames) {
+    try {
+      const result = spawnSync("taskkill.exe", ["/F", "/IM", exe], {
+        windowsHide: true,
+        timeout: 5000,
+      });
+      if (result.status === 0) killed.push(exe);
+      // exit 128 = "process not found" — ignore
+      // other non-zero = silently ignore — best-effort
+    } catch { /* ignore — best-effort */ }
+  }
+  return killed;
+}
+
 export function spawnDetached(
   command: string,
   args: string[],

--- a/src/utils/launch.ts
+++ b/src/utils/launch.ts
@@ -161,17 +161,31 @@ export function spawnDetached(
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
+ * Absolute path to the trusted System32 taskkill.exe.
+ * Computed once at module load from %SystemRoot% / %WINDIR% (with C:\Windows
+ * as last-resort fallback) to avoid PATH-hijack attacks where a malicious
+ * `taskkill.exe` planted in the working directory or another earlier search
+ * location could be invoked instead of the genuine system utility.
+ */
+const TASKKILL_EXE = path.join(
+  process.env["SystemRoot"] ?? process.env["WINDIR"] ?? "C:\\Windows",
+  "System32",
+  "taskkill.exe",
+);
+
+/**
  * Terminate all instances of the given executable name(s) via taskkill /F /IM.
  * Returns the list of exe names that actually had a process killed (taskkill exit 0).
  * Errors / "no process found" (exit 128) are silently ignored.
  *
- * Windows-only — uses taskkill.exe from System32.
+ * Windows-only — invokes %SystemRoot%\System32\taskkill.exe by absolute path
+ * to prevent PATH-hijack attacks.
  */
 export function killProcessesByName(exeNames: string[]): string[] {
   const killed: string[] = [];
   for (const exe of exeNames) {
     try {
-      const result = spawnSync("taskkill.exe", ["/F", "/IM", exe], {
+      const result = spawnSync(TASKKILL_EXE, ["/F", "/IM", exe], {
         windowsHide: true,
         timeout: 5000,
       });

--- a/src/utils/launch.ts
+++ b/src/utils/launch.ts
@@ -122,29 +122,6 @@ export function resolveWellKnownPath(command: string): { resolved: string; wasRe
  * - The `error` event fires on the next tick for ENOENT — caught deterministically.
  * - No arbitrary delay that could be too short or too long.
  */
-/**
- * Terminate all instances of the given executable name(s) via taskkill /F /IM.
- * Returns the list of exe names that actually had a process killed (taskkill exit 0).
- * Errors / "no process found" (exit 128) are silently ignored.
- *
- * Windows-only — uses taskkill.exe from System32.
- */
-export function killProcessesByName(exeNames: string[]): string[] {
-  const killed: string[] = [];
-  for (const exe of exeNames) {
-    try {
-      const result = spawnSync("taskkill.exe", ["/F", "/IM", exe], {
-        windowsHide: true,
-        timeout: 5000,
-      });
-      if (result.status === 0) killed.push(exe);
-      // exit 128 = "process not found" — ignore
-      // other non-zero = silently ignore — best-effort
-    } catch { /* ignore — best-effort */ }
-  }
-  return killed;
-}
-
 export function spawnDetached(
   command: string,
   args: string[],
@@ -177,4 +154,31 @@ export function spawnDetached(
       reject(new Error(hint));
     });
   });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Process termination
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Terminate all instances of the given executable name(s) via taskkill /F /IM.
+ * Returns the list of exe names that actually had a process killed (taskkill exit 0).
+ * Errors / "no process found" (exit 128) are silently ignored.
+ *
+ * Windows-only — uses taskkill.exe from System32.
+ */
+export function killProcessesByName(exeNames: string[]): string[] {
+  const killed: string[] = [];
+  for (const exe of exeNames) {
+    try {
+      const result = spawnSync("taskkill.exe", ["/F", "/IM", exe], {
+        windowsHide: true,
+        timeout: 5000,
+      });
+      if (result.status === 0) killed.push(exe);
+      // exit 128 = "process not found" — ignore
+      // other non-zero = silently ignore — best-effort
+    } catch { /* ignore — best-effort */ }
+  }
+  return killed;
 }

--- a/tests/unit/browser-launch-killexisting.test.ts
+++ b/tests/unit/browser-launch-killexisting.test.ts
@@ -73,8 +73,11 @@ describe("killProcessesByName", () => {
 
     const result = launchModule.killProcessesByName(["chrome.exe"]);
     expect(result).toEqual(["chrome.exe"]);
+    // Security: taskkill must be invoked by absolute System32 path, not bare
+    // "taskkill.exe" (PATH hijack defense — Codex P1 review on PR #70).
     expect(childProcess.spawnSync).toHaveBeenCalledWith(
-      "taskkill.exe", ["/F", "/IM", "chrome.exe"],
+      expect.stringMatching(/[\\/]System32[\\/]taskkill\.exe$/i),
+      ["/F", "/IM", "chrome.exe"],
       { windowsHide: true, timeout: 5000 },
     );
   });

--- a/tests/unit/browser-launch-killexisting.test.ts
+++ b/tests/unit/browser-launch-killexisting.test.ts
@@ -1,0 +1,237 @@
+/**
+ * tests/unit/browser-launch-killexisting.test.ts
+ *
+ * Unit tests for the killExisting option added to browser_launch (#22).
+ *
+ * Section 1: killProcessesByName — spawnSync mock via node:child_process
+ * Section 2: browserLaunchSchema — killExisting default and coercion
+ * Section 3: browserLaunchHandler — flow assertions via vi.mock partial stubs
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { z } from "zod";
+
+// ── Top-level mocks (hoisted by Vitest) ──────────────────────────────────────
+
+// Mock node:child_process so spawnSync is controllable in section 1.
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, spawnSync: vi.fn() };
+});
+
+// Mock the external dependencies that browser.ts calls, so that
+// browserLaunchHandler can be exercised without real network / OS calls.
+vi.mock("../../src/engine/cdp-bridge.js", () => ({
+  listTabs: vi.fn(),
+  navigateTo: vi.fn(),
+  // stub out all other exports that browser.ts might use
+  evaluateInTab: vi.fn(),
+  getElementScreenCoords: vi.fn(),
+  getDomHtml: vi.fn(),
+  disconnectAll: vi.fn(),
+  getTabContext: vi.fn(),
+}));
+
+vi.mock("../../src/engine/poll.js", () => ({
+  pollUntil: vi.fn(),
+}));
+
+// Partial mock of launch.js: keep the real killProcessesByName (used in
+// section 1), but stub out resolveWellKnownPath and spawnDetached so
+// handler tests do not hit the filesystem.
+vi.mock("../../src/utils/launch.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/utils/launch.js")>();
+  return {
+    ...actual,
+    resolveWellKnownPath: vi.fn(),
+    spawnDetached: vi.fn(),
+    // killProcessesByName is kept as the real implementation so section 1 works.
+    // For section 3 we spy on it via vi.spyOn after import.
+  };
+});
+
+// ── Import modules after mocks are declared ───────────────────────────────────
+
+import * as childProcess from "node:child_process";
+import * as launchModule from "../../src/utils/launch.js";
+import * as cdpModule from "../../src/engine/cdp-bridge.js";
+import * as pollModule from "../../src/engine/poll.js";
+import { browserLaunchHandler, browserLaunchSchema } from "../../src/tools/browser.js";
+
+// ── 1. killProcessesByName ────────────────────────────────────────────────────
+
+describe("killProcessesByName", () => {
+  beforeEach(() => {
+    vi.mocked(childProcess.spawnSync).mockReset();
+  });
+
+  it("returns exe in killed list when taskkill exits 0", () => {
+    vi.mocked(childProcess.spawnSync).mockReturnValue({
+      status: 0, pid: 1, output: [], stdout: Buffer.alloc(0),
+      stderr: Buffer.alloc(0), signal: null, error: undefined,
+    });
+
+    const result = launchModule.killProcessesByName(["chrome.exe"]);
+    expect(result).toEqual(["chrome.exe"]);
+    expect(childProcess.spawnSync).toHaveBeenCalledWith(
+      "taskkill.exe", ["/F", "/IM", "chrome.exe"],
+      { windowsHide: true, timeout: 5000 },
+    );
+  });
+
+  it("does NOT include exe in killed when exit code is 128 (process not found)", () => {
+    vi.mocked(childProcess.spawnSync).mockReturnValue({
+      status: 128, pid: 0, output: [], stdout: Buffer.alloc(0),
+      stderr: Buffer.alloc(0), signal: null, error: undefined,
+    });
+
+    const result = launchModule.killProcessesByName(["chrome.exe"]);
+    expect(result).toEqual([]);
+  });
+
+  it("does NOT include exe in killed when spawnSync throws", () => {
+    vi.mocked(childProcess.spawnSync).mockImplementation(() => { throw new Error("ENOENT"); });
+
+    const result = launchModule.killProcessesByName(["chrome.exe"]);
+    expect(result).toEqual([]);
+  });
+
+  it("calls taskkill for each exe and collects only exit-0 ones", () => {
+    vi.mocked(childProcess.spawnSync)
+      .mockReturnValueOnce({
+        status: 0, pid: 1, output: [], stdout: Buffer.alloc(0),
+        stderr: Buffer.alloc(0), signal: null, error: undefined,
+      })
+      .mockReturnValueOnce({
+        status: 128, pid: 0, output: [], stdout: Buffer.alloc(0),
+        stderr: Buffer.alloc(0), signal: null, error: undefined,
+      });
+
+    const result = launchModule.killProcessesByName(["chrome.exe", "msedge.exe"]);
+    expect(result).toEqual(["chrome.exe"]);
+    expect(childProcess.spawnSync).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ── 2. browserLaunchSchema — killExisting field ───────────────────────────────
+
+describe("browserLaunchSchema killExisting field", () => {
+  it("defaults to false when not provided", () => {
+    const schema = z.object(browserLaunchSchema);
+    expect(schema.parse({}).killExisting).toBe(false);
+  });
+
+  it("parses boolean true correctly", () => {
+    const schema = z.object(browserLaunchSchema);
+    expect(schema.parse({ killExisting: true }).killExisting).toBe(true);
+  });
+
+  it('coerces string "true" to boolean true', () => {
+    const schema = z.object(browserLaunchSchema);
+    expect(schema.parse({ killExisting: "true" }).killExisting).toBe(true);
+  });
+
+  it('coerces string "false" to boolean false', () => {
+    const schema = z.object(browserLaunchSchema);
+    expect(schema.parse({ killExisting: "false" }).killExisting).toBe(false);
+  });
+});
+
+// ── 3. browserLaunchHandler flow with killExisting ───────────────────────────
+
+describe("browserLaunchHandler flow with killExisting", () => {
+  let killSpy: ReturnType<typeof vi.spyOn>;
+
+  const CHROME_PATH = "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe";
+  const EDGE_PATH = "C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe";
+
+  const GOOD_TABS = [
+    { id: "1", type: "page", title: "Tab", url: "about:blank", webSocketDebuggerUrl: "" },
+  ];
+
+  beforeEach(() => {
+    vi.mocked(launchModule.resolveWellKnownPath).mockReturnValue({
+      resolved: CHROME_PATH,
+      wasResolved: true,
+    });
+    vi.mocked(launchModule.spawnDetached).mockResolvedValue(undefined);
+    vi.mocked(cdpModule.listTabs).mockRejectedValue(new Error("ECONNREFUSED"));
+    vi.mocked(pollModule.pollUntil).mockResolvedValue({ ok: true, value: GOOD_TABS });
+    killSpy = vi.spyOn(launchModule, "killProcessesByName").mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    killSpy.mockRestore();
+  });
+
+  it("does NOT call killProcessesByName when CDP is already live (alreadyRunning)", async () => {
+    vi.mocked(cdpModule.listTabs).mockResolvedValue(GOOD_TABS);
+
+    await browserLaunchHandler({
+      browser: "chrome", port: 9222, userDataDir: "C:\\tmp\\cdp",
+      url: undefined, waitMs: 10000, killExisting: true,
+    });
+
+    expect(killSpy).not.toHaveBeenCalled();
+  });
+
+  it("calls killProcessesByName with msedge.exe when chosenKey is edge", async () => {
+    vi.mocked(launchModule.resolveWellKnownPath).mockReturnValue({
+      resolved: EDGE_PATH,
+      wasResolved: true,
+    });
+
+    await browserLaunchHandler({
+      browser: "edge", port: 9222, userDataDir: "C:\\tmp\\cdp",
+      url: undefined, waitMs: 10000, killExisting: true,
+    });
+
+    expect(killSpy).toHaveBeenCalledWith(["msedge.exe"]);
+  });
+
+  it("calls killProcessesByName with chrome.exe when chosenKey is chrome", async () => {
+    await browserLaunchHandler({
+      browser: "chrome", port: 9222, userDataDir: "C:\\tmp\\cdp",
+      url: undefined, waitMs: 10000, killExisting: true,
+    });
+
+    expect(killSpy).toHaveBeenCalledWith(["chrome.exe"]);
+  });
+
+  it("does NOT call killProcessesByName when killExisting is false", async () => {
+    await browserLaunchHandler({
+      browser: "chrome", port: 9222, userDataDir: "C:\\tmp\\cdp",
+      url: undefined, waitMs: 10000, killExisting: false,
+    });
+
+    expect(killSpy).not.toHaveBeenCalled();
+  });
+
+  it("response includes killed:[] in alreadyRunning path", async () => {
+    vi.mocked(cdpModule.listTabs).mockResolvedValue(GOOD_TABS);
+
+    const result = await browserLaunchHandler({
+      browser: "chrome", port: 9222, userDataDir: "C:\\tmp\\cdp",
+      url: undefined, waitMs: 10000, killExisting: false,
+    });
+
+    const parsed = JSON.parse(
+      result.content[0]?.type === "text" ? result.content[0].text : "{}",
+    );
+    expect(parsed.alreadyRunning).toBe(true);
+    expect(parsed.killed).toEqual([]);
+  });
+
+  it("response includes killed field in new launch path", async () => {
+    const result = await browserLaunchHandler({
+      browser: "chrome", port: 9222, userDataDir: "C:\\tmp\\cdp",
+      url: undefined, waitMs: 10000, killExisting: false,
+    });
+
+    const parsed = JSON.parse(
+      result.content[0]?.type === "text" ? result.content[0].text : "{}",
+    );
+    expect(parsed.alreadyRunning).toBe(false);
+    expect(Array.isArray(parsed.killed)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- `browser_launch` / `browser_open(launch:{...})` に `killExisting: boolean` (default `false`) を追加
- `true` のとき、選ばれた browser exe (`chrome.exe` / `msedge.exe` / `brave.exe`) のみを `taskkill /F /IM` で終了 → 500ms grace → spawn
- 戻り値 JSON に `killed: string[]` を追加（両 return path で統一、`alreadyRunning` 時は空配列）
- `killProcessesByName` ヘルパを `src/utils/launch.ts` に export 追加（windowsHide / timeout 5000ms）

## Why
普段使い Chrome を `--remote-debugging-port` なしで起動済の場合、`browser_launch` は CDP に届かず `pollUntil` でタイムアウトしていた。手動 `Stop-Process` 回避を MCP 内で完結させる。

## Implementation notes
- kill は `chosenKey` の exe に限定（auto モードでも全候補を kill しない、副作用最小化）
- `alreadyRunning` パスでは kill しない（CDP が既に live なら不要）
- `taskkill` exit 0 のみ killed[] に積む（128 = "no process found" は無視、その他のエラーも best-effort で握り潰し）
- 関数配置: `killProcessesByName` は `spawnDetached` の後の独立セクションに置き、JSDoc が混在しないよう整理

## Test plan
- [x] `tests/unit/browser-launch-killexisting.test.ts` 14 cases: spawnSync mock で killProcessesByName 4 / schema 6 / handler ドライラン 4
- [x] `npm run build` 通過
- [x] `npm run test:capture` で全 unit pass（既存 `context-consistency.test.ts` の environment-dependent failure 1 件は本 PR 範囲外）
- [ ] 手動 smoke: 既存 Chrome (no CDP) → `killExisting:true` → CDP 起動確認
- [ ] 手動 smoke: `killExisting:false` (default) で従来動作維持

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)