### PR TITLE
docs(architecture): introduce 3-layer integrated design (ADR-007/008/010)

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -1,0 +1,229 @@
+# Bench Harness — Layer SLO Verification
+
+- Status: **Skeleton (KPI 一覧のみ、実装は ADR-007 P1 完了後)**
+- Date: 2026-04-29
+- Scope: 統合書 §17.3 + `docs/layer-constraints.md` §8 の KPI を CI 計測する Rust ベンチハーネス
+- 場所: 既存 `desktop-touch-engine` crate (root Cargo.toml) の `[[bench]]` として配置
+
+---
+
+## 1. 役割
+
+各層の SLO 違反を **CI で fail にする** ためのベンチマークハーネス。
+
+- 設計時の絵に描いた餅ではなく、実装が SLO を守っているかを継続検証
+- bench の数値が `server_status` ツールの `tier_dispatch_stats` 等と相互参照可能
+- regression を主目的とし、絶対値より「今の main から劣化したか」を重視
+
+---
+
+## 2. 計測対象 (KPI 一覧)
+
+### 2.1 L1 Capture (`benches/l1_capture.rs`)
+
+| KPI | 目標 (制約 §2.4) | bench fn |
+|---|---|---|
+| event ingest throughput | 10k events/sec | `bench_event_ingest_throughput` |
+| event ingest latency p99 | < 1ms | `bench_event_ingest_latency` |
+| dirty rect detect cycle | DXGI 60Hz 同期 (16.67ms 周期) | `bench_dirty_rect_60hz` |
+| WAL write latency p99 | < 5ms | `bench_wal_fsync_batch` |
+| ring buffer overflow rate | < 0.001% | `bench_ring_buffer_overflow_rate` |
+
+### 2.2 L2 Storage (`benches/l2_storage.rs`)
+
+| KPI | 目標 (制約 §3.4) | bench fn |
+|---|---|---|
+| materialize latency p99 | < 100μs/event | `bench_materialize_latency` |
+| `state_at(t)` p99 | < 5ms | `bench_state_at_query` |
+| arrangement memory budget | < 512MB (default) | `bench_arrangement_memory_budget` |
+
+### 2.3 L3 Compute (`benches/l3_compute.rs`)
+
+| KPI | 目標 (制約 §4.4 + views-catalog §8) | bench fn |
+|---|---|---|
+| current_focused_element 更新 p99 | < 1ms | `bench_view_current_focused_element` |
+| dirty_rects_aggregate 更新 p99 | < 2ms | `bench_view_dirty_rects_aggregate` |
+| semantic_event_stream delta 配信 p99 | < 3ms | `bench_view_semantic_event_stream` |
+| predicted_post_state dry-run p99 | < 50ms | `bench_view_predicted_post_state` |
+| lens_attention settle p99 | < 5ms (max iter 100) | `bench_view_lens_attention` |
+
+### 2.4 L4 Envelope Assembly (`benches/l4_envelope.rs`)
+
+| KPI | 目標 (制約 §5.4) | bench fn |
+|---|---|---|
+| envelope assembly p99 (include 最大時) | < 5ms | `bench_envelope_assembly_full` |
+| envelope assembly p99 (必須最小) | < 2ms | `bench_envelope_assembly_minimal` |
+| typed reason coverage | > 95% | `bench_typed_reason_coverage` |
+
+### 2.5 L5 Tool Surface (`benches/l5_tool_surface.rs`)
+
+| KPI | 目標 (制約 §6.4) | bench fn |
+|---|---|---|
+| query tool round-trip p99 | < 50ms | `bench_query_round_trip` |
+| commit tool round-trip p99 | < 200ms | `bench_commit_round_trip` |
+| subscribe push 遅延 p99 | < 10ms | `bench_subscribe_push_latency` |
+
+### 2.6 HW Tier 別 (`benches/tier_dispatch.rs`)
+
+各 op を Tier 0-3 全パターンで計測、cascade 動作を確認。
+
+| op | T0 | T1 | T2 | T3 |
+|---|---|---|---|---|
+| screen capture | ✓ | ✓ | ✓ | (n/a) |
+| dirty rect detect | ✓ | ✓ | (n/a) | ✓ |
+| memcpy bulk | ✓ | ✓ | ✓ | (n/a) |
+| change_fraction | ✓ | ✓ | (none) | ✓ |
+| dhash | ✓ | ✓ | (none) | ✓ |
+| timestamp source | ✓ | ✓ | ✓ | ✓ |
+
+env `DESKTOP_TOUCH_MAX_TIER=N` で各 tier に pin して計測。
+
+### 2.7 Replay (`benches/replay.rs`)
+
+| KPI | 目標 (制約 §7.5) | bench fn |
+|---|---|---|
+| replay determinism | 100% (bit-for-bit 一致) | `bench_replay_determinism_check` |
+| WAL→arrangement 再生 throughput | record 時の 5-10x (オフライン) | `bench_replay_throughput` |
+
+---
+
+## 3. ハーネス構造 (criterion ベース)
+
+### 3.1 Cargo.toml 追加項目
+
+```toml
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "l1_capture"
+harness = false
+
+[[bench]]
+name = "l2_storage"
+harness = false
+
+[[bench]]
+name = "l3_compute"
+harness = false
+
+[[bench]]
+name = "l4_envelope"
+harness = false
+
+[[bench]]
+name = "l5_tool_surface"
+harness = false
+
+[[bench]]
+name = "tier_dispatch"
+harness = false
+
+[[bench]]
+name = "replay"
+harness = false
+```
+
+### 3.2 各 bench ファイル雛形
+
+```rust
+// benches/l1_capture.rs (skeleton)
+use criterion::{criterion_group, criterion_main, Criterion, BenchmarkId};
+
+fn bench_event_ingest_throughput(c: &mut Criterion) {
+    // TODO(ADR-007 P5a 完了後): EventEnvelope を ring buffer に push
+    todo!("Implement after ADR-007 P5a");
+}
+
+fn bench_event_ingest_latency(c: &mut Criterion) {
+    todo!("Implement after ADR-007 P5a");
+}
+
+// ... (他の KPI 関数)
+
+criterion_group!(benches,
+    bench_event_ingest_throughput,
+    bench_event_ingest_latency,
+);
+criterion_main!(benches);
+```
+
+実装は **対応する ADR Phase が完了してから** 各 bench fn を埋めていく。
+
+---
+
+## 4. 起動手順
+
+```bash
+# 全 bench
+cargo bench
+
+# 特定 layer のみ
+cargo bench --bench l1_capture
+
+# 特定 fn のみ
+cargo bench --bench l3_compute -- bench_view_lens_attention
+
+# Tier pin (HW Tier 別計測)
+DESKTOP_TOUCH_MAX_TIER=1 cargo bench --bench tier_dispatch
+DESKTOP_TOUCH_MAX_TIER=3 cargo bench --bench tier_dispatch
+```
+
+結果は `target/criterion/` に HTML レポート出力。
+
+---
+
+## 5. CI 連動 (将来)
+
+- main への merge 時に bench 実行
+- 前回 main からの regression を検出 → 5% 劣化で warning、20% で fail
+- `server_status` ツール経由で実運用環境の SLO とも相互参照
+- (将来) GitHub Actions で nightly benchmark + push to gh-pages
+
+---
+
+## 6. KPI と Acceptance Criteria の対応
+
+| ADR Phase | 検証する bench |
+|---|---|
+| ADR-007 P5a | `l1_capture::bench_event_ingest_*` |
+| ADR-007 P5b | `replay::bench_replay_determinism_check` |
+| ADR-007 P5c | `tier_dispatch::*` (Tier 1 DXGI dirty rect 動作確認) |
+| ADR-008 D1 | `l3_compute::bench_view_current_focused_element` |
+| ADR-008 D2 | `l3_compute::bench_view_*` (主要 4 view 全部) |
+| ADR-008 D3 | `l2_storage::bench_state_at_query` |
+| ADR-008 D4 | `l3_compute::bench_view_lens_attention` |
+| ADR-008 D5 | `tier_dispatch::*` (Tier 3 動作)、`l3_compute::bench_view_predicted_post_state` |
+| ADR-008 D6 | `replay::*` 全部 |
+| ADR-010 P1 | `l4_envelope::bench_envelope_assembly_minimal` |
+| ADR-010 P3 | `l4_envelope::bench_envelope_assembly_full` |
+| ADR-010 P5 | `l3_compute::bench_view_predicted_post_state` 経由 |
+| ADR-010 P6 | `l4_envelope::*` (working/episodic 含む include 経路) |
+
+---
+
+## 7. Skeleton の段階的肉付け
+
+| Phase | ADR の前提 | 何を埋める |
+|---|---|---|
+| **現状** (Skeleton) | (準備のみ) | README のみ。Cargo.toml の [[bench]] と空関数の `.rs` 雛形は ADR-007 P5a 着手時に追加 |
+| **ADR-007 P1-P4 完了後** | koffi 撤去完了 | bench 対象がまだ無いので skeleton のまま |
+| **ADR-007 P5a 完了後** | EventEnvelope + ring buffer 動作 | `l1_capture::bench_event_ingest_*` を実装、CI ベースライン作成 |
+| **ADR-007 P5b 完了後** | WAL + replay E2E | `replay::*` を実装 |
+| **ADR-008 D1 完了後** | timely + DD 1 view 動作 | `l3_compute::bench_view_current_focused_element` を実装、ベースライン更新 |
+| ... 以降、Phase 完了ごとに対応 bench を実装、CI で regression 監視 |
+
+---
+
+## 8. Related Files
+
+- 統合書: `docs/architecture-3layer-integrated.md` §17.3 (KPI 総覧)
+- 制約: `docs/layer-constraints.md` §8 (Acceptance Criteria 集約)
+- ADR-007: `docs/adr-007-koffi-to-rust-migration.md`
+- ADR-008: `docs/adr-008-reactive-perception-engine.md`
+- ADR-010: `docs/adr-010-presentation-layer-self-documenting-envelope.md`
+- views-catalog: `docs/views-catalog.md` §8
+
+---
+
+END OF Bench Harness README (Skeleton).

--- a/docs/adr-007-koffi-to-rust-migration.md
+++ b/docs/adr-007-koffi-to-rust-migration.md
@@ -1,0 +1,439 @@
+# ADR-007: koffi → Rust 全面移行 + L1 Capture 統一
+
+- Status: **Proposed (Draft for review)**
+- Date: 2026-04-29 (初版骨子: 2026-04-28)
+- Authors: Claude (Opus, max effort) — project `desktop-touch-mcp`
+- Related:
+  - 統合書 (SSOT): `docs/architecture-3layer-integrated.md`
+  - 制約: `docs/layer-constraints.md` §2 (L1 Capture)
+  - 後続: ADR-008 (本 ADR が L1 input source を提供)
+  - 後続: ADR-009 (HW Acceleration Plane の Tier 別実装ガイド)
+  - 後続: ADR-010 (本 ADR が EventEnvelope を提供、L5 envelope の起点)
+- 北極星: 最高パフォーマンス + 最高技術の公開 + L1 が「全層 1 graph」の入力源として機能
+
+---
+
+## 1. Context
+
+### 1.1 koffi の問題
+
+現状 `src/engine/win32.ts` と `src/engine/perception/sensors-win32.ts` で koffi の FFI binding 定義 (`koffi.func/struct/alias/load`) が **12 箇所** (実測)、call site は `src/engine/win32.ts` 内に多数:
+
+- 5 DLL: `user32` / `gdi32` / `shcore` / `kernel32` / `dwmapi`
+- 既知の地雷:
+  - `PROCESSENTRY32W.dwSize` ハードコード事故
+  - `SCROLLINFO` sizeof 検証 (`win32.ts:81-82`)
+  - `ULONG_PTR` alignment 問題
+- **致命的: koffi の sizeof / alignment ミスは Node プロセス全滅 (sigsegv)**
+- TypeScript 型は実 ABI と乖離する余地あり、コンパイル時に検出不能
+
+### 1.2 既存 Rust 資産
+
+`desktop-touch-engine` crate (napi-rs, edition 2024) は既に:
+
+- pixel_diff (SSE2 SIMD で 13.4x)
+- dhash (純 Rust)
+- UIA bridge 13 関数 (windows-rs 0.62、PowerShell から脱却済)
+- Visual GPU Phase 4b (ADR-005)
+
+→ **新規 crate ではなく、既存 crate に win32 binding を拡張する形**で進める。
+
+### 1.3 統合書で確定した L1 Capture の位置づけ
+
+ADR-007 が担うのは **単なる koffi 撤去** ではなく、**L1 Capture 層の確立**。
+
+- DXGI Desktop Duplication + dirty rect 統合 (統合書 §3)
+- EventEnvelope 統一 schema (統合書 §6)
+- wallclock_ms canonical + sub_ordinal 採番 (統合書 §5)
+- Tier 0-3 hw assist (統合書 §9)
+- WAL durability for replay (統合書 §10)
+- 全層 1 graph の input source として timely input に流入 (統合書 §2 P3)
+
+つまり **L1 を「event を生成する単一窓口」に集約する** のが本 ADR の本質。
+
+---
+
+## 2. Decision
+
+### 2.1 主要決定 (12 項目)
+
+| # | 項目 | 決定 |
+|---|---|---|
+| 1 | koffi 完全撤去 | `package.json` から削除、Linux stub は `_linux-stub.ts` で空実装維持 |
+| 2 | binding 配置 | 既存 `desktop-touch-engine` crate に `src/win32/` モジュール追加 |
+| 3 | TS API 互換 | TS 関数シグネチャ不変、内部で `nativeEngine.xxx()` に置換 |
+| 4 | DXGI 統合 | `IDXGIOutputDuplication::GetFrameDirtyRects` / `GetFrameMoveRects` を Rust から直接 |
+| 5 | EventEnvelope schema | `#[napi(object)]` で TS にも露出、本 ADR §4 で確定 |
+| 6 | wallclock canonical | 統合書 §5 の優先順 (Reflex > DXGI Present > DWM > std::time) |
+| 7 | sub_ordinal 採番 | L1 が monotonic 採番、以降 immutable (統合書 §17 X1) |
+| 8 | Ring buffer + WAL | 256MB MPSC ring + fsync batch WAL (10ms interval) |
+| 9 | Tier 0-3 dispatch | DataflowAccelerator trait の L1 担当 op を実装 (本 ADR §5) |
+| 10 | Linux stub | 関数シグネチャ維持、内部 unimplemented! → JS Error |
+| 11 | Phase 戦略 | 高頻度→低頻度の順、各 Phase 独立 PR で merge 可能 |
+| 12 | 既存 PR への影響 | RPG / lease / server_status の API 互換維持、内部実装のみ差替 |
+
+### 2.2 決め手 (本 ADR 固有)
+
+- **型安全**: Rust `repr(C)` で sizeof 地雷消滅
+- **catch_unwind**: panic を local に閉じ込める、Node プロセス生存
+- **batch 化**: AttachThreadInput + 操作 + Detach を 1 native call に融合 (FFI hop 削減)
+- **配布**: koffi prebuilt 同梱不要 → launcher zip サイズ縮小
+- **既存 napi-rs パイプライン**: build.rs / GH Actions / load-dynamic を流用
+
+---
+
+## 3. Architecture (L1 内部構造)
+
+### 3.1 component 構成
+
+```
+desktop-touch-engine (Rust crate)
+├── src/lib.rs                    ← napi-rs エントリ + L1 公開 API
+├── src/uia/                       ← 既存 (UIA bridge 13 関数)
+├── src/pixel_diff.rs              ← 既存
+├── src/dhash.rs                   ← 既存
+├── src/vision_backend/            ← 既存 (Visual GPU Phase 4b)
+├── src/win32/                     ← ★ 本 ADR で新設
+│   ├── mod.rs                     ← module re-export
+│   ├── window.rs                  ← Enum/GetWindowText/Rect/Foreground 等 (P1)
+│   ├── gdi.rs                     ← PrintWindow/GDI/DPI (P2)
+│   ├── monitor.rs                 ← Monitor/DPI 関連 (P2)
+│   ├── process.rs                 ← Process/Thread/Toolhelp32 (P3)
+│   ├── input.rs                   ← AttachThreadInput/SetWindowPos (P3)
+│   └── sensors.rs                 ← sensors-win32 移植 (P4)
+├── src/capture/                   ← ★ 本 ADR で新設、L1 のコア
+│   ├── mod.rs
+│   ├── event.rs                   ← EventEnvelope struct + EventKind enum
+│   ├── ring.rs                    ← 256MB MPSC ring buffer
+│   ├── wal.rs                     ← Write-Ahead Log (fsync batch)
+│   ├── timestamp.rs               ← Tier dispatch for timestamp source
+│   ├── dxgi_dup.rs                ← DXGI Desktop Duplication wrapper
+│   └── tier.rs                    ← DataflowAccelerator L1 実装群
+└── src/_errors.rs                 ← typed reason enum (ADR-010 と共有)
+```
+
+### 3.2 入出力の流れ
+
+```
+[OS API 群]                       [L1 内部]                       [TS / L2]
+  UIA event ─────► event.rs (EventKind 構築) ─► ring.rs (push)
+  DXGI dirty ────► dxgi_dup.rs ─► event.rs ──► ring.rs           ─► napi-rs
+  hw input ──────► input.rs ────► event.rs ──► ring.rs              poll API
+  tool call ─────► (L5 → L1) ───► event.rs ──► ring.rs           ─► subscribe
+                                       │                              capability
+                                       ▼
+                                    wal.rs (durability、record モード時)
+                                       │
+                                       ▼
+                                  fsync (10ms batch)
+```
+
+ring.rs と wal.rs は同じ EventEnvelope を 2 経路に push (durability と速度の両立)。
+
+### 3.3 windows-rs 依存範囲
+
+```toml
+[dependencies]
+windows = { version = "0.62", features = [
+    # 既存 (UIA / Visual GPU 用)
+    "Win32_UI_Accessibility",
+    "Win32_System_Com",
+    "Win32_Foundation",
+    "Win32_UI_Shell",
+    "Win32_Graphics_Direct3D11",
+    "Win32_Graphics_Dxgi",
+
+    # 本 ADR で追加
+    "Win32_UI_WindowsAndMessaging",     # EnumWindows, GetWindowText, GetWindowRect, etc.
+    "Win32_Graphics_Gdi",                # PrintWindow, GDI/DC
+    "Win32_System_Threading",            # OpenProcess, GetProcessTimes
+    "Win32_System_ProcessStatus",        # QueryFullProcessImageName
+    "Win32_System_Diagnostics_ToolHelp", # CreateToolhelp32Snapshot
+    "Win32_UI_Input_KeyboardAndMouse",   # SendInput, AttachThreadInput
+    "Win32_UI_HiDpi",                    # SetProcessDpiAwareness, GetDpiForMonitor
+    "Win32_Graphics_Dwm",                # DwmGetCompositionTimingInfo
+] }
+```
+
+---
+
+## 4. EventEnvelope Schema (本 ADR の中核)
+
+### 4.1 Rust struct
+
+```rust
+#[napi(object)]
+pub struct EventEnvelope {
+    pub event_id: BigInt,             // u64 monotonic、L1 で採番
+    pub wallclock_ms: BigInt,         // canonical (統合書 §5)
+    pub sub_ordinal: u32,             // 同 wallclock 内の tie-break
+    pub timestamp_source: String,     // "Reflex" | "DXGI" | "DWM" | "StdTime"
+    pub kind: EventKind,              // (下記 enum)
+    pub payload_bytes: Buffer,        // bincode-encoded、kind 固有 schema
+    pub session_id: Option<String>,   // L5 起源
+    pub tool_call_id: Option<String>, // L5 起源
+}
+
+#[napi]
+pub enum EventKind {
+    // === 観測系 ===
+    DirtyRect = 0,           // DXGI dirty/move rect 検知
+    UiaFocusChanged = 1,     // UIA focus event
+    UiaTreeChanged = 2,      // UIA tree structure event
+    UiaInvoked = 3,          // UIA Invoke pattern event
+    UiaValueChanged = 4,     // UIA value pattern event
+    WindowChanged = 5,       // Z-order / activation
+    ScrollChanged = 6,       // UIA Scroll pattern event
+
+    // === 副作用系 (commit の入力) ===
+    ToolCallStarted = 100,   // L5 → L1 (commit 軸の入口)
+    ToolCallCompleted = 101, // L5 → L1 (副作用結果)
+    HwInputSent = 102,       // SendInput 呼び出し
+
+    // === システム系 ===
+    Failure = 200,           // hw failure / tier fallback
+    TierFallback = 201,      // op が tier 落ちした
+    Heartbeat = 202,         // L1 alive (no event 期間でも frontier 進行用)
+
+    // === replay 系 ===
+    SessionStart = 300,      // session 起点
+    SessionEnd = 301,        // session 終了
+}
+```
+
+### 4.2 payload schema 一覧 (主要 EventKind)
+
+`payload_bytes` は bincode encoded。kind ごとに以下の Rust struct を decoder が deserialize。
+
+```rust
+// EventKind::DirtyRect
+#[derive(Serialize, Deserialize)]
+pub struct DirtyRectPayload {
+    pub rect: [i32; 4],          // [x, y, w, h]
+    pub kind: DirtyKind,         // Update | Move(src_x, src_y)
+    pub frame_index: u64,        // DXGI frame id
+}
+
+// EventKind::UiaFocusChanged
+#[derive(Serialize, Deserialize)]
+pub struct UiaFocusChangedPayload {
+    pub before: Option<UiElementRef>,
+    pub after: Option<UiElementRef>,
+    pub window_title: String,
+}
+
+// EventKind::ToolCallStarted
+#[derive(Serialize, Deserialize)]
+pub struct ToolCallStartedPayload {
+    pub tool: String,
+    pub args_json: String,        // 監査用、PII redaction layer 通過後
+}
+
+// EventKind::Failure
+#[derive(Serialize, Deserialize)]
+pub struct FailurePayload {
+    pub layer: String,            // "L1" 等
+    pub op: String,
+    pub tier: u8,
+    pub reason: String,           // typed (ADR-010 §5.4 enum と共有)
+}
+```
+
+### 4.3 不変条件 (`layer-constraints.md` §2.3 と同期)
+
+- `event_id` は monotonic、生成は L1 内部 atomic counter
+- `wallclock_ms` は単調増加 (sub_ordinal で同 ms tie-break)
+- `timestamp_source` は event 単位で固定 (混在禁止)
+- 同じ event は 2 回 emit しない
+- WAL に書き終わるまで ring buffer 上の "committed" mark を立てない
+
+### 4.4 Schema versioning
+
+EventEnvelope 自体に `_version` field は無く、payload_bytes の bincode に schema version を内包する。`EventKind` 値域の追加は MINOR 互換、既存 enum の意味変更は MAJOR 破壊。
+
+---
+
+## 5. HW Tier 0-3 (L1 観点)
+
+統合書 §9 の op kind × tier マトリクスを L1 部分だけ抜粋・詳細化。
+
+| op | T0 (Pure Rust) | T1 (OS API) | T2 (HW Assist) | T3 (Vendor) |
+|---|---|---|---|---|
+| screen capture | std GDI BitBlt | DXGI Desktop Duplication | DXGI + D3D11 compute shader | (n/a) |
+| dirty rect detect | 自前 diff (CPU) | **DXGI GetFrameDirtyRects** | (n/a) | (n/a) |
+| memcpy bulk | std::ptr::copy | rayon parallel | Intel DSA (Sapphire Rapids+) | (n/a) |
+| frame ring buffer | Vec<Vec<u8>> | DXGI shared texture | NVENC / Quick Sync / AMF | (n/a) |
+| timestamp source | std::time | DwmGetCompositionTimingInfo | DXGI Present statistics | NVIDIA Reflex Latency API |
+| event log persist | std::fs (WAL) | (n/a) | Intel PT trace (任意併用) | (n/a) |
+
+### 5.1 T1 が確実に効く環境
+
+- **Windows 11 全環境で T1 動作保証** (DXGI Desktop Duplication + DwmGetCompositionTimingInfo)
+- T0 fallback は test 用 + Linux stub のためのみ
+
+### 5.2 T2 capability detect
+
+起動時:
+1. NVENC: `D3D11Device::CheckFeatureSupport` + NVENC SDK probe
+2. Quick Sync: Intel iGPU 検出 + `oneVPL` initialize
+3. AMF: AMD GPU 検出 + `AMD AMF Runtime` initialize
+4. Intel DSA: `/dev/dsa*` (Linux) or Windows DSA driver / WMI で確認 (Sapphire Rapids+ サーバ Xeon に限る)
+5. Reflex API: NVIDIA driver 535+ + Reflex SDK
+6. Intel PT: Windows ETW Intel PT provider 有効性確認
+
+各 capability は `server_status.tier_dispatch_stats` に集約 (統合書 §13.2)。
+
+### 5.3 T3 (vendor compute) は L1 では使わない
+
+L1 の op (event capture / encode) は Tier 0-2 で完結。Tier 3 (CUDA Graph 等) は L3 view 計算側 (ADR-008 §5)。
+
+---
+
+## 6. Implementation Phases
+
+| Phase | 範囲 | 目安 | 完了基準 (acceptance criteria) |
+|---|---|---|---|
+| **P1: Hot path 高頻度系** | EnumWindows / GetWindowTextW / GetWindowRect / GetForegroundWindow / IsWindowVisible / IsIconic / IsZoomed / GetClassNameW / GetWindowThreadProcessId / GetWindowLongPtrW | 1-2 週 | enum+title 1000 回 latency 半減、perception loop frame -20% |
+| **P2: GDI/DC + Monitor/DPI** | PrintWindow / GetDC / CreateCompatibleDC / SelectObject / DeleteObject / GetDIBits / EnumDisplayMonitors / GetMonitorInfoW / MonitorFromWindow / GetDpiForMonitor / SetProcessDpiAwareness | 1-2 週 | screenshot/printWindow latency 計測、回帰なし |
+| **P3: Process/Thread + Input** | OpenProcess / GetProcessTimes / QueryFullProcessImageNameW / Toolhelp32 (snapshot/process32) / AttachThreadInput / GetCurrentThreadId / GetScrollInfo / SetWindowPos / BringWindowToTop / ShowWindow / SetForegroundWindow | 1 週 | sizeof 地雷 0 件達成 (gauntlet test) |
+| **P4: sensors + 撤去** | sensors-win32.ts、koffi 依存削除、launcher zip size 計測、`package.json` から koffi 削除、Linux stub 維持 | 0.5-1 週 | koffi 行数 33→0、zip size 削減量を memory に記録 |
+| **P5: L1 Capture コア新設 (本 ADR の核)** | EventEnvelope schema 確定 + ring buffer + WAL + DXGI dirty rect 統合 + Tier 0-2 dispatch + capability detect | 2-3 週 | event ingest 10k/s @ p99 < 1ms、DXGI 60Hz 同期、WAL fsync 10ms batch、replay E2E 1 件成立 |
+
+P1-P4 は **既存 PoC 骨子のまま**、P5 が本 ADR の追加部分。
+
+### 6.1 PR 単位の granularity
+
+- P1-P4 は各 Phase を 1 PR で main 入れる (互換維持で段階導入)
+- P5 は **subphase 化**:
+  - P5a: EventEnvelope schema + ring buffer (TS API は変えない)
+  - P5b: WAL + replay E2E (record モード default off で導入)
+  - P5c: DXGI dirty rect 統合 + Tier dispatch
+  - P5d: timestamp source 多重化 (Reflex/DXGI/DWM)
+
+---
+
+## 7. Migration Plan (koffi 33 箇所の置換手順)
+
+### 7.1 一覧 (現行 koffi 使用箇所)
+
+| ファイル | binding 定義数 / 概要 | 所属 Phase |
+|---|---|---|
+| `src/engine/win32.ts` | 12 koffi 定義 (func/struct/alias/load) + 多数 call site、5 DLL (user32 / gdi32 / shcore / kernel32 / dwmapi) | P1-P3 |
+| `src/engine/perception/sensors-win32.ts` | sensor probe (1 binding) | P4 |
+
+### 7.2 置換手順 (各箇所共通)
+
+1. windows-rs で binding 関数を Rust 側 (`src/win32/<group>.rs`) に書く
+2. `#[napi]` で公開、`index.d.ts` を再生成
+3. TS 側 `win32.ts` の koffi 呼び出しを `nativeEngine.xxx()` に置換
+4. unit test で前後比較 (戻り値・エラー・パフォーマンス)
+5. e2e test で回帰確認 (既存 RPG / lens 系を含む)
+6. PR 単位で main マージ
+
+### 7.3 互換維持の鉄則
+
+- **TS 関数のシグネチャは絶対に変えない** (呼び出し元 26+ tool に波及するため)
+- 戻り値の shape も同一 (Rust から JS object 化する際、既存 TS 型に合わせる)
+- エラー shape も同一 (`_errors.ts` の SUGGESTS が機能し続けること)
+
+### 7.4 Linux stub
+
+```typescript
+// src/_linux-stub.ts
+export function enumWindows(): never {
+    throw new Error("Linux is not supported for win32 features");
+}
+// ... (全 win32 関数を unimplemented として export)
+```
+
+build 時に platform-aware で win32.ts vs _linux-stub.ts を切替。
+
+---
+
+## 8. Risks
+
+| # | リスク | 影響度 | 軽減策 |
+|---|---|---|---|
+| 1 | 移植時に shape 微差発生 (struct field order 等) | High | Rust 側で `#[napi(object)]` 構造を TS 既存と shape-align、ゴールデンテストで検証 |
+| 2 | windows-rs API の breaking change | Medium | crate version pin (`0.62.x`)、major 上げは独立 PR で |
+| 3 | catch_unwind 漏れで Node 全滅 | High | 全 #[napi] 関数の最外周に `std::panic::catch_unwind`、CI に panic-fuzz 追加 |
+| 4 | DXGI dirty rect が一部 driver で不正値 | Medium | Tier 1 → Tier 0 fallback chain、warning event emit |
+| 5 | WAL ファイル肥大化 | Medium | rotate (1GB / 1h で renew)、古い WAL は自動 delete (env 設定) |
+| 6 | Tier 2 capability detect の偽陽性 (driver 古い等) | Medium | runtime 失敗で Tier 1 cascade、`server_status` で監視 |
+| 7 | Linux stub の動作保証 | Low | macOS/Linux CI で stub の throw 動作のみ確認 |
+| 8 | Reflex API NVIDIA 限定 | Low | DWM/DXGI fallback (T1) で全環境動作 |
+| 9 | event_id 採番の atomic counter 競合 | Low | `AtomicU64::fetch_add(Ordering::SeqCst)` で安全 |
+| 10 | bincode payload と TS 側 decoder の不一致 | Medium | Rust struct と TS interface を 1 つの IDL から自動生成 (将来課題、初期は手動同期) |
+
+---
+
+## 9. Acceptance Criteria
+
+### 9.1 Phase 単位
+
+| Phase | 検証項目 |
+|---|---|
+| P1 | enum+title 1000 回 latency 半減、既存 e2e 回帰 0 件 |
+| P2 | screenshot/printWindow 既存 e2e 回帰 0 件、PrintWindow latency 計測 |
+| P3 | sizeof 地雷 0 件 (gauntlet test pass)、AttachThreadInput 既存挙動維持 |
+| P4 | `git grep koffi` 行数 0、`package.json` から koffi 削除、launcher zip size を memory に記録 |
+| P5a | EventEnvelope が ring buffer に push される、TS から poll 取得可能 |
+| P5b | WAL に fsync 10ms batch、replay E2E で 1 session 再生成功 |
+| P5c | DXGI dirty rect を `EventKind::DirtyRect` として emit、Tier 1 cascade 動作 |
+| P5d | timestamp_source が capability に応じて自動選択、`server_status` に統計 |
+
+### 9.2 統合書 SLO 達成 (本 ADR 範囲)
+
+- event ingest throughput: 10k events/sec @ p99 < 1ms ✓
+- dirty rect detect cycle: DXGI 60Hz 同期 ✓
+- ring buffer overflow rate: < 0.001% ✓
+- WAL write latency p99: < 5ms ✓
+- replay 一致率: 100% (本 ADR では P5b のスコープのみ、L2-3 は ADR-008 D6 で完成)
+
+### 9.3 観測されるべき副次効果
+
+- Node プロセス sigsegv 件数 → 0 (koffi 撤去の効果)
+- launcher zip size → 削減 (koffi prebuilt 同梱不要)
+- LLM 体感 latency → 改善 (FFI hop 削減)
+
+---
+
+## 10. Open Questions
+
+| # | OQ | 決定タイミング |
+|---|---|---|
+| 1 | bincode vs capnproto vs flatbuffers (payload encoder) | P5a 着手時 |
+| 2 | WAL rotation サイズ (1GB / 4GB / 時間ベース) | P5b 着手時 |
+| 3 | DXGI dirty rect の secondary monitor 扱い | P5c 着手時 |
+| 4 | sub_ordinal 採番を per-source か global か | P5a 着手前 (sourceごとが推奨、tie 軽減) |
+| 5 | Intel PT 統合は本 ADR か別 ADR か | P5d 完了後 |
+| 6 | ring buffer back-pressure: drop oldest vs throttle producer | P5a 着手前 (drop oldest 推奨) |
+| 7 | event_id を u64 で十分か、UUID にするか | P5a (u64 で十分、replay は (record_id, event_id) で識別) |
+| 8 | `koffi-replacement` を別 crate にするか同 crate か | 着手前 (同 crate 推奨、分離価値低) |
+
+---
+
+## 11. 公開価値
+
+本 ADR 単独でも:
+
+- **"Replacing koffi with windows-rs in production: a Rust + Node.js story"** — Rust ecosystem の dev blog 系
+- **"Unified event capture for Windows desktop automation in Rust"** — DXGI dirty rect + UIA event + tool call の統合は希少
+- **"Crash-free FFI: how catch_unwind saved our Node.js MCP server"** — koffi sigsegv 撤廃の dev story
+
+ADR-008 / -010 と合わせて初めて世界初級の価値だが、本 ADR 単独でも認知獲得可能。
+
+---
+
+## 12. Related Artifacts
+
+- 本 ADR (`docs/adr-007-koffi-to-rust-migration.md`)
+- 統合書 (SSOT): `docs/architecture-3layer-integrated.md`
+- 制約: `docs/layer-constraints.md` §2 (本 ADR の不変条件・SLO の根拠)
+- 後続: ADR-008 (本 ADR の EventEnvelope を input source として消費)
+- 後続: ADR-009 (本 ADR §5 の Tier 0-2 を詳細化)
+- 後続: ADR-010 (本 ADR の event_id / wallclock_ms / typed reason を envelope 化)
+
+---
+
+END OF ADR-007 (Draft).

--- a/docs/adr-007-koffi-to-rust-migration.md
+++ b/docs/adr-007-koffi-to-rust-migration.md
@@ -164,6 +164,7 @@ windows = { version = "0.62", features = [
 ```rust
 #[napi(object)]
 pub struct EventEnvelope {
+    pub envelope_version: u32,        // ★ top-level schema version (現行: 1)
     pub event_id: BigInt,             // u64 monotonic、L1 で採番
     pub wallclock_ms: BigInt,         // canonical (統合書 §5)
     pub sub_ordinal: u32,             // 同 wallclock 内の tie-break
@@ -249,7 +250,14 @@ pub struct FailurePayload {
 
 ### 4.4 Schema versioning
 
-EventEnvelope 自体に `_version` field は無く、payload_bytes の bincode に schema version を内包する。`EventKind` 値域の追加は MINOR 互換、既存 enum の意味変更は MAJOR 破壊。
+EventEnvelope は **top-level に `envelope_version: u32`** を持つ (§4.1)。`payload_bytes` 側は `EventKind` 値域で schema を識別する (kind 追加は MINOR 互換、既存 kind の意味変更は MAJOR 破壊)。
+
+L5 Tool Envelope の `_version` (string `MAJOR.MINOR`、ADR-010 §5) とは **独立に進化** する (制約 layer-constraints §7.4 / cross-layer X4)。両者の互換 matrix は起動時 integration test で検証し、不一致は fatal で worker 再起動 (制約 §2.5)。
+
+互換 matrix の運用:
+- `envelope_version` 増分 ↔ L1 Capture / L2 Storage 側変更
+- L5 Envelope `_version` 増分 ↔ tool 応答 shape 変更
+- 起動時に両者を読んで integration matrix で許容組合せを判定 (`docs/schema-compat-matrix.md` で管理予定)
 
 ---
 

--- a/docs/adr-008-reactive-perception-engine.md
+++ b/docs/adr-008-reactive-perception-engine.md
@@ -138,7 +138,7 @@ timely + DD の `arrangement` は `(key, val, time, diff)` 4-tuple の LSM-tree 
 | view 名 | 入力 | 用途 | 旧 tool との対応 |
 |---|---|---|---|
 | `current_focused_element` | UIA focus event | 現在 focus 要素 | `desktop_state.focused` |
-| `dirty_rect_aggregate` | DXGI dirty/move rect event | 直近 dirty 矩形集約 | `screenshot` の差分判定 |
+| `dirty_rects_aggregate` | DXGI dirty/move rect event | 直近 dirty 矩形集約 | `screenshot` の差分判定 |
 | `semantic_event_stream` | raw UIA + dirty rect + Reflex tick | "modal_appeared" / "scroll_settled" 等 | `desktop_state.attention` の高度化 |
 | `predicted_post_state` | tool call (仮想) + 現 state | dry-run 投機実行 | (新規) |
 
@@ -183,7 +183,7 @@ external clock (hw)        timely internal frontier
 | Phase | 範囲 | 完了基準 |
 |---|---|---|
 | **D1: 最小成立** | timely + DD を `engine-perception` crate に組込み、event log → `current_focused_element` の最小 view | 1 view が incrementally 更新、unit test pass、TS 版より latency 1/10 |
-| **D2: 主要 view 4 つ** | `dirty_rect_aggregate` / `semantic_event_stream` / `predicted_post_state` を declarative に | 既存 `desktop_state` を全部 view 経由に置換、tool 結果が同一 (回帰なし) |
+| **D2: 主要 view 4 つ** | `dirty_rects_aggregate` / `semantic_event_stream` / `predicted_post_state` を declarative に | 既存 `desktop_state` を全部 view 経由に置換、tool 結果が同一 (回帰なし) |
 | **D3: time-travel** | arrangement の time slice で `state_at(t)` 実装 | 「2 秒前の state」が引ける、p95 latency < 5ms |
 | **D4: cyclic RPG** | lens 依存を timely `iterative` で実装 | lens 再計算が fixed-point で settle、無限ループなし |
 | **D5: HW operator hybrid** | `DataflowAccelerator` trait + Tier 0-3 実装 + dispatch | `change_fraction` が Tier 3 で動作、Tier 0 fallback も動作 |

--- a/docs/adr-008-reactive-perception-engine.md
+++ b/docs/adr-008-reactive-perception-engine.md
@@ -1,0 +1,357 @@
+# ADR-008: Reactive Perception Engine via Differential Dataflow
+
+- Status: **Proposed (Draft for review)**
+- Date: 2026-04-29
+- Authors: Claude (Opus, max effort) — project `desktop-touch-mcp`
+- Related:
+  - ADR-005: `docs/visual-gpu-backend-adr-v2.md` (Phase 4b 完了、本 ADR の前段)
+  - ADR-006: `docs/adr-006-winml-rust-binding.md` (Draft、Layer 5 の NPU 投影で参照)
+  - ADR-007: koffi → Rust 全面移行 (Draft、本 ADR の Layer 1 = センサー層を担う)
+  - 後続: ADR-009 (HW Acceleration Plane の Tier 別実装ガイド)
+  - 後続: ADR-010 (LLM-facing Presentation Layer、view → tool 結果の整形)
+- 北極星: 観測コスト log(N) + 時間軸 first-class + cyclic RPG + 公開価値 (世界初の埋め込み MVCC+IVM agent runtime)
+
+---
+
+## 1. Context
+
+### 1.1 これまでの痛点
+
+現状 `desktop-touch-mcp` の観測は以下の問題を抱える。
+
+1. **再 poll cost**: `desktop_state` を呼ぶたびに UIA を叩き直し。LLM context が同じ情報を何度も食う
+2. **時間文脈なし**: 「2 秒前と今でどう変わったか」を引く API がない。LLM が screenshot を 2 回撮って比較
+3. **副作用検証が手作業**: click が成功したか LLM が再観測で確認
+4. **失敗の局所化が弱い**: koffi sigsegv で Node プロセス全滅
+5. **raw event の山**: LLM が UIA event / pixel diff の生データを処理
+
+### 1.2 LLM が真に欲しいもの
+
+「Tool の量」ではなく以下が境界条件 (詳細はチャット議論参照、ADR-010 で再整理)。
+
+| 要求 | 現状 |
+|---|---|
+| 観測キャッシュ + 差分 | ❌ 毎回 refetch |
+| 時間文脈 (過去 / 直前) | ❌ なし |
+| 副作用予測 / dry-run | ❌ なし |
+| 失敗局所化 | ⚠️ 部分 (catch_unwind なし) |
+| 意味イベント (raw でなく) | ⚠️ 部分 (RPG attention のみ) |
+| 情報密度 (融合 atomic) | ❌ tool 1 呼び 1 段 |
+
+### 1.3 物理基盤側 (ADR-007 で構築するもの)
+
+センサー層 = Layer 1 Capture は ADR-007 で:
+
+- **DXGI Desktop Duplication** (`GetFrameDirtyRects` / `GetFrameMoveRects`) — Windows DWM が GPU 側で計算済みの dirty 矩形をそのまま使う
+- UIA event + tool call + 副作用 → 統一 event ring buffer
+- HW assist (任意): Intel DSA (memcpy offload) / NVENC (frame 圧縮) / Intel PT (命令 trace)
+- 時刻同期: NVIDIA Reflex Latency API / DXGI Present statistics / `DwmGetCompositionTimingInfo` の hw timestamp
+
+これは観測の **物理基盤**。本 ADR-008 はその上の **データ層** = 計算 + 保管モデルを定める。
+
+### 1.4 SSOT 参照
+
+本 ADR の不変条件・SLO・境界は **統合書** (`docs/architecture-3layer-integrated.md` §4-§5、§17) と **`docs/layer-constraints.md` §3-§4** (L2 Storage / L3 Compute) を SSOT とする。本 ADR で記述された規約と SSOT の間に齟齬が生じた場合、SSOT を優先し、本 ADR は後追い更新する (統合書 §16.1 のルール)。
+
+主な参照対応:
+- 識別子ヒエラルキー (event_id / lease_token 等) → 統合書 §4
+- 時刻モデル (wallclock_ms canonical、sub_ordinal、Reflex 等の優先順) → 統合書 §5
+- L2 Storage 制約 (materialize p99 < 100μs、`state_at(t)` p99 < 5ms 等) → layer-constraints §3
+- L3 Compute 制約 (view 更新 p99 < 1ms、cyclic max iter 100 等) → layer-constraints §4
+- Tier 0-3 dispatch (op 単位独立、`server_status` で集約) → 統合書 §9
+
+---
+
+## 2. Decision
+
+### 2.1 主要決定 (10 項目)
+
+| # | 項目 | 決定 |
+|---|---|---|
+| 1 | 計算モデル | `differential-dataflow` 0.13+ on `timely-dataflow` 0.13+ |
+| 2 | 保管モデル | arrangement = built-in MVCC store。別 store 不要 |
+| 3 | 時間モデル | timely logical time = `Pair<u64, u32>` = `(wallclock_ms, sub_ordinal)` の **partial-order** |
+| 4 | 外部時刻同期 | NVIDIA Reflex / DXGI Present statistics / `DwmGetCompositionTimingInfo` の hw timestamp で input frontier 進行 |
+| 5 | I/O インタフェース | L1 ring buffer → timely input、subscribe API は timely capability で実装 |
+| 6 | Cyclic | RPG lens 依存を timely `Loop` で表現 (fixed-point) |
+| 7 | HW 接続 | `trait DataflowAccelerator` の裏に CUDA Graph / HIP Graph / Level Zero command list を隠す。**Tier 0-3** の段階で fallback あり (§5 参照) |
+| 8 | 永続化 | arrangement snapshot + WAL で replay 可。Intel PT trace を組合せて hw replay |
+| 9 | DBSP | **不採用** (linear synchronous time が UIA out-of-order と非互換)。将来 SQL UI が必要なら上に乗せる選択肢として残す |
+| 10 | Hydroflow | **不採用** (distributed は overshoot)。複数 agent 共有 perception の話が出たら再評価 |
+
+### 2.2 決め手 — UI 観測ドメインは partial-order の世界
+
+- UIA event は遅れて届く (ProviderProxy 遅延、AccessDenied 復活など) → out-of-order datapoint を後から差し込みたい
+- tool 呼び出しと環境変化が並行 → 同 wallclock の 2 event が因果的に独立
+- Reflex hw timestamp は CPU/GPU/scan-out で別軸 → 1 次元 linear time に潰せない
+- RPG lens 依存 = cyclic、fixed-point computation が一級
+
+DBSP の linear synchronous time は上記すべてで詰まる。**partial-order + cyclic + production 実績で differential-dataflow が一択**。
+
+### 2.3 重要発見 — Arrangement = 無料の MVCC
+
+Materialize blog の実装解説より:
+
+> "An index becomes version-aware and becomes a multiversion index, or more specifically, a map from key -> versions -> list of values, which is roughly analogous to arrangements in the Rust implementation."
+
+timely + DD の `arrangement` は `(key, val, time, diff)` 4-tuple の LSM-tree 風 sorted batch を **multi-version** で保持する。つまり、
+
+- 設計の **L2 (MVCC time-travel store)** と **L3 (IVM compute)** が **同一構造体で実現**
+- 別の MVCC store を実装する必要が **無い**
+- `state_at(t)` は arrangement の time slice をなぞるだけ
+
+設計書では別レイヤーに見えていたものが、実装上は **1 個のデータ構造に畳まれる**。複雑度が大幅に下がる重要シグナル。
+
+---
+
+## 3. Architecture
+
+### 3.1 5 層との位置づけ
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ L5: MCP Tool Surface             ← ADR-010 (起草予定)   │
+│     既存ツールが view を read/subscribe/commit する    │
+│     薄いクライアントになる                              │
+├─────────────────────────────────────────────────────────┤
+│ L4: Cognitive Projection         ← ADR-010             │
+│     working / episodic / semantic / procedural を view  │
+├─────────────────────────────────────────────────────────┤
+│ L3: Compute (IVM)                ← 本 ADR-008 ★        │
+│     differential-dataflow operator graph                │
+│     change_fraction / semantic_event / dirty_rect /     │
+│     predicted_post_state を declarative に維持          │
+├─────────────────────────────────────────────────────────┤
+│ L2: Storage (MVCC)               ← 本 ADR-008 ★        │
+│     arrangement = (key, val, time, diff) の 4-tuple     │
+│     time-travel query は time slice 走査                │
+├─────────────────────────────────────────────────────────┤
+│ L1: Capture (event ring buffer)  ← ADR-007             │
+│     DXGI dirty rect + UIA + tool call + 副作用を       │
+│     統一 event log に押し出す                           │
+│     HW assist tier 別 (§5)                             │
+└─────────────────────────────────────────────────────────┘
+```
+
+### 3.2 主要 view の例 (D2 で実装する 4 view)
+
+| view 名 | 入力 | 用途 | 旧 tool との対応 |
+|---|---|---|---|
+| `current_focused_element` | UIA focus event | 現在 focus 要素 | `desktop_state.focused` |
+| `dirty_rect_aggregate` | DXGI dirty/move rect event | 直近 dirty 矩形集約 | `screenshot` の差分判定 |
+| `semantic_event_stream` | raw UIA + dirty rect + Reflex tick | "modal_appeared" / "scroll_settled" 等 | `desktop_state.attention` の高度化 |
+| `predicted_post_state` | tool call (仮想) + 現 state | dry-run 投機実行 | (新規) |
+
+### 3.3 cyclic / fixed-point の表現
+
+RPG の lens 再計算は: focus 変化 → lens 評価 → attention 更新 → さらに focus へ影響、というループ。timely の `iterative` で:
+
+```rust
+worker.dataflow::<u64, _, _>(|scope| {
+    let focus_events = make_focus_input(scope);
+    let attention = scope.iterative::<u32, _, _>(|inner| {
+        let focused = focus_events.enter(inner);
+        let lenses = compute_lenses(&focused);
+        let attention = derive_attention(&lenses);
+        // 不動点に達するまで内側で iterate
+        attention.leave()
+    });
+    attention.inspect(|x| /* push to subscribers */);
+});
+```
+
+`iterate` は **不動点に到達した値だけ外に出す** ので、lens 再計算が settle してから LLM へ通知される。
+
+### 3.4 時刻モデルの統合
+
+```
+external clock (hw)        timely internal frontier
+    │                              │
+    ├─ Reflex Latency API ─────────┤
+    ├─ DXGI Present statistics ────┤  → InputFrontier::advance(t)
+    ├─ DwmGetCompositionTimingInfo ┤
+    │                              │
+    └─ wallclock fallback ─────────┘
+```
+
+各 input event は `(wallclock_ms, sub_ordinal)` でタグ。同じ wallclock の事象は sub_ordinal で順序付け。Reflex 等が利用不可な環境では wallclock のみ → partial-order 性は保たれる。
+
+---
+
+## 4. Implementation Phases
+
+| Phase | 範囲 | 完了基準 |
+|---|---|---|
+| **D1: 最小成立** | timely + DD を `engine-perception` crate に組込み、event log → `current_focused_element` の最小 view | 1 view が incrementally 更新、unit test pass、TS 版より latency 1/10 |
+| **D2: 主要 view 4 つ** | `dirty_rect_aggregate` / `semantic_event_stream` / `predicted_post_state` を declarative に | 既存 `desktop_state` を全部 view 経由に置換、tool 結果が同一 (回帰なし) |
+| **D3: time-travel** | arrangement の time slice で `state_at(t)` 実装 | 「2 秒前の state」が引ける、p95 latency < 5ms |
+| **D4: cyclic RPG** | lens 依存を timely `iterative` で実装 | lens 再計算が fixed-point で settle、無限ループなし |
+| **D5: HW operator hybrid** | `DataflowAccelerator` trait + Tier 0-3 実装 + dispatch | `change_fraction` が Tier 3 で動作、Tier 0 fallback も動作 |
+| **D6: replay** | arrangement snapshot + WAL + (任意) Intel PT 統合 | 1 セッション replay で bit-for-bit 同一結果 |
+
+---
+
+## 5. HW Acceleration Tiers
+
+ドライバ成熟度に応じた段階分け。各 op は **fallback chain** で順次落ちる。
+
+### 5.1 Tier 定義
+
+| Tier | 名前 | 範囲 | 環境要件 | 期待 perf |
+|---|---|---|---|---|
+| **Tier 0** | Pure Rust fallback | `std::iter` + `rayon` のみ | どの環境でも 100% 動作 | ベースライン (×1) |
+| **Tier 1** | Vendor-neutral OS API | DXGI Desktop Duplication + Direct3D 11 compute shader | Windows 11 全環境 | ×3〜5 |
+| **Tier 2** | HW assist optional | Intel DSA (memcpy offload) / NVENC・QuickSync・AMF (frame 圧縮) / Reflex Latency API | capability detect で activate | ×10〜30 |
+| **Tier 3** | Full vendor compute | CUDA Graph / HIP Graph / Level Zero command list | 各 vendor SDK + driver 必要 | ×30〜100 |
+
+### 5.2 Vendor 別の成熟度 (2026-04 時点の現実認識)
+
+| Vendor | Tier 1 | Tier 2 | Tier 3 |
+|---|---|---|---|
+| NVIDIA | ✓ DXGI 標準 | ✓ NVENC (production 級) / Reflex (production) | ✓ CUDA Graph (production、CUDA 12+) |
+| AMD | ✓ DXGI 標準 | ✓ AMF (一定品質) / Anti-Lag (game 限定) | △ HIP Graph on Windows (ROCm Windows は若い) |
+| Intel | ✓ DXGI 標準 | ✓ Quick Sync (production) / DSA (Sapphire Rapids+ サーバ限定) | △ Level Zero (Arc/Battlemage で着実に成熟中) |
+
+→ **Tier 1 は全環境で確実に動作**、Tier 2/3 は capability detect で安全に activate、failure 時は自動 fallback。
+
+### 5.3 trait 案
+
+```rust
+pub enum Tier {
+    T0Fallback,   // pure Rust
+    T1OsApi,      // DXGI / D3D11
+    T2HwAssist,   // DSA / NVENC / Reflex
+    T3VendorCompute, // CUDA / HIP / Level Zero
+}
+
+pub struct Capability {
+    pub vendor: Vendor,
+    pub tier_max: Tier,
+    pub supported_ops: Vec<OpKind>,
+}
+
+pub trait DataflowAccelerator: Send + Sync {
+    fn tier(&self) -> Tier;
+    fn capability(&self) -> Capability;
+    fn cost_hint(&self, op: &OpSpec) -> CostHint;  // dispatch 判断用
+    fn launch(&self, op: &OpSpec, inputs: &[ArrangedView])
+        -> Result<ArrangedView, AccelError>;
+}
+```
+
+### 5.4 Dispatch ポリシー
+
+```
+起動時:
+  capability_detect() → Vec<Box<dyn DataflowAccelerator>>
+  各 accelerator を tier 順に登録
+
+各 op 実行時:
+  for tier in [T3, T2, T1, T0]:
+      if let Some(accel) = registry.find(op, tier):
+          match accel.launch(op, inputs):
+              Ok(result) => return result
+              Err(transient) => fallthrough
+              Err(fatal) => log + fallthrough
+  unreachable!  // T0 は必ず動く
+```
+
+### 5.5 環境変数による Tier pin
+
+ベンチや trouble shoot 用に env で上限を固定できる。
+
+| ENV | 効果 |
+|---|---|
+| `DESKTOP_TOUCH_MAX_TIER=0` | T0 のみ (純 Rust) — 性能下限ベンチ |
+| `DESKTOP_TOUCH_MAX_TIER=1` | T0-T1 — DXGI までの環境を再現 |
+| `DESKTOP_TOUCH_MAX_TIER=2` | T0-T2 — Tier 3 の bug を切り分け |
+| `DESKTOP_TOUCH_MAX_TIER=3` | 全 tier (default) |
+| `DESKTOP_TOUCH_DISABLE_VENDOR=amd` | 特定 vendor の Tier 2/3 を無効化 |
+
+---
+
+## 6. Alternatives Considered
+
+### 6.1 DBSP / Feldera
+
+- 強み: SQL の自動 IVM、数学的に綺麗 (chain rule)、新しい
+- 弱み: **linear synchronous time** のため UIA out-of-order を表現できない (DBSP 自身が論文で認める制約)
+- 判定: **不採用**。将来 SQL UI を出す価値が立証されたら、DBSP を上に "logical operator layer" として乗せる選択肢を残す (DD と DBSP は競合ではなく層が異なる)
+
+### 6.2 Hydroflow / Hydro
+
+- 強み: distributed correctness、CALM 系、POPL'25 Flo semantics
+- 弱み: 本番例まだ少ない (2024-2025)、単一ノードには overshoot、Rust API がまだ unstable
+- 判定: **不採用**。複数 LLM agent が共有 perception を持つ協調デバッグの話が来たら再評価
+
+### 6.3 自前 IVM
+
+- 強み: 最小依存、初期はシンプル
+- 弱み: partial-order time の正しい実装は 10 年級の研究、arrangement 相当の MVCC store を再実装する工数が膨大
+- 判定: **不採用**。「世界初」の公開価値を出すなら標準実装に乗るほうが説得力が高い
+
+---
+
+## 7. Risks
+
+| # | リスク | 影響度 | 軽減策 |
+|---|---|---|---|
+| 1 | timely-dataflow の API は低レベル、学習曲線 | Medium | Materialize blog の chunked ramp-up を Phase D1 で薄く始める |
+| 2 | Rust async と timely thread モデルの衝突 | High | timely は専用 worker thread、napi-rs `AsyncTask` で wrap (UIA bridge と同パターン) |
+| 3 | arrangement のメモリ消費が膨らむ | High | compaction policy を時間 budget で制御。古い epoch を圧縮、`state_at(t)` の対象期間外は強制 compact |
+| 4 | GPU tier 選択 bug で動かない環境 | Medium | env で tier pin、E2E で全 tier 通す、Tier 3 失敗時は static log で警告 |
+| 5 | Reflex API が NVIDIA 限定 | Low | DXGI Present statistics と `DwmGetCompositionTimingInfo` を fallback (これは全環境動作) |
+| 6 | replay determinism が壊れる (副作用順序入替) | High | timely logical time で順序固定、UI 副作用は L1 Capture で `(wallclock, sub_ordinal)` を二重 tag |
+| 7 | DBSP を将来導入したくなった時の互換性 | Low | view query は意味で書く (query rewrite 可)、operator graph は DD と DBSP で互換性高い |
+| 8 | Tier 3 driver が突然壊れる (NVIDIA driver update 等) | Medium | Tier 3 は **常に optional**、起動時の自己診断で broken 検出時は Tier 2 に固定 |
+| 9 | Intel PT 記録が全 session で容量爆発 | Medium | デフォルトは bug 報告時のみ、`DESKTOP_TOUCH_PT_RECORD=always` で常時 |
+
+---
+
+## 8. Acceptance Criteria
+
+| Phase | 完了基準 |
+|---|---|
+| D1 | 1 view が incremental に更新、bench で TS 版より latency 1/10 |
+| D2 | 既存 `desktop_state` を全部 view 経由に置換、tool 結果が同一 (回帰なし) |
+| D3 | `state_at(now-2s)` で過去 state が引ける、p95 latency < 5ms |
+| D4 | lens 再計算が fixed-point で settle、無限ループ自動検出 (max iter cap) |
+| D5 | `change_fraction` が Tier 3 で動作、Tier 0 fallback も動作、tier pin で挙動切替確認 |
+| D6 | 1 セッション replay で bit-for-bit 同一結果 (arrangement snapshot 経由) |
+
+---
+
+## 9. Open Questions
+
+| # | 質問 | 検討タイミング |
+|---|---|---|
+| 1 | `state_at(t)` を全 view にするか、選択 view のみか (compaction コスト次第) | D3 着手時 |
+| 2 | Subscribe API は WebSocket / MCP notification / 内部 callback どれで配るか | ADR-010 で決定 |
+| 3 | arrangement snapshot の disk format (bincode / capnproto / 自前) | D6 着手時 |
+| 4 | Intel PT 記録は全 session か bug 報告時のみか (ストレージ vs カバレッジ) | D6 + 運用フィードバック |
+| 5 | HIP Graph on Windows の本番投入時期 (ROCm Windows の成熟度待ち) | D5 完了後の re-check |
+| 6 | DBSP を logical layer として後から乗せるための protocol 互換要件 | 将来課題 |
+
+---
+
+## 10. 公開価値 (北極星の片翼)
+
+論文ネタとして見ると、本 ADR の成果物だけで独立に書ける論文が複数:
+
+1. **"GPU-accelerated incremental view maintenance for LLM agent perception"** — DXGI dirty rect + CUDA Graph + DBSP/DD の組み合わせ。SIGMOD/VLDB 系
+2. **"Hardware-assisted deterministic replay for LLM agent debugging"** — Intel PT + arrangement snapshot で agent bug を bit-for-bit 再現。USENIX ATC / ASPLOS 系
+3. **"Sub-millisecond UI observation timestamps via Reflex Latency API"** — race-free agent observation。CHI / UIST 系
+
+ナラティブ: 「Microsoft が WinAppSDK Rust を archive して撤退した一方、Intel/AMD/NVIDIA の hw assist を Rust で結合した Windows MCP server が本番投入される」 — 領域的に空白で差別化が立つ。
+
+---
+
+## 11. Related Artifacts (起草予定)
+
+- 本 ADR (`docs/adr-008-reactive-perception-engine.md`)
+- ADR-009: HW Acceleration Plane の Tier 別実装ガイド (DXGI / D3D11 compute / DSA / NVENC / CUDA Graph / HIP / Level Zero の各実装詳細)
+- ADR-010: LLM-facing Presentation Layer (view → tool 結果の整形、self-attestation / causal trail / recovery hints / time-travel link / confidence bands / what-if previews)
+
+---
+
+END OF ADR-008 (Draft).

--- a/docs/adr-010-presentation-layer-self-documenting-envelope.md
+++ b/docs/adr-010-presentation-layer-self-documenting-envelope.md
@@ -170,10 +170,9 @@ tool 呼び出しは isolated event ではなく、**直前の自分の行動の
   // ── 主データ ──
   "data": { /* tool 固有 */ },                 // 失敗時 null
 
-  // ── Self-Attestation ──
+  // ── Self-Attestation (logical_time は engine 内部、LLM には露出しない) ──
   "as_of": {
-    "wallclock_ms": 1738156823412,            // 統一 wallclock
-    "logical": [42, 7]                        // L3 logical time (epoch, sub_ordinal)
+    "wallclock_ms": 1738156823412             // 統一 wallclock (canonical、統合書 §5)
   },
   "freshness_ms": 47,                          // 観測されてからの経過
   "based_on": {
@@ -208,7 +207,7 @@ tool 呼び出しは isolated event ではなく、**直前の自分の行動の
     "escalation": "if_above_fail: capture screenshot and report"
   },
 
-  // ── Time-Travel Link (常に提供、リンクのみ) ──
+  // ── Time-Travel Link (P4 以降 default-on、Phase 別挙動は §5.5 参照) ──
   "query_past": {
     "state_2s_ago": "call: state_at(now-2s)",
     "diff_since_last_call": "call: diff(your_last_call_id, now)",
@@ -302,6 +301,9 @@ EntityNotFound | EntityOutsideViewport
 // 状態遷移
 ModalBlocking | Settling
 
+// Time-travel (views-catalog §4.3 と同期、compaction 範囲外専用)
+TimeCompacted
+
 // HW Tier
 HwTierUnavailable
 
@@ -309,7 +311,7 @@ HwTierUnavailable
 AccessDenied | Unknown
 ```
 
-合計 25 + 10 = **35 codes**。
+合計 25 + 11 = **36 codes**。
 
 #### 運用ルール
 
@@ -321,6 +323,25 @@ AccessDenied | Unknown
 #### LLM への露出
 
 `most_likely_cause: "WindowNotFound"` のように PascalCase そのまま。snake_case 変換は行わない (既存 client compat と TS型側との一貫性のため)。
+
+### 5.5 Phase 別の envelope 構造 (リリース順序と整合)
+
+実装は段階導入 (§7 + 統合書 §12) のため、各 Phase で envelope に含まれるフィールドが異なる。client SDK は server の Phase を識別して期待値を切替える (起動時 `server_status` で照会)。
+
+| Phase | 必須 | 任意 (`include` で要求) | 自動付与 (default-on) |
+|---|---|---|---|
+| **P1** (envelope 必須最小) | `_version, data, as_of, confidence` | (なし) | (なし) |
+| **P2** (typed reason) | 上記 + 失敗時 `if_unexpected.most_likely_cause` | (なし) | (なし) |
+| **P3** (include 拡張) | 上記 | `causal` (→ `caused_by`), `invariants` (→ `invariants_held`) | (なし) |
+| **P4** (time-travel link) | 上記 | 上記 | **`query_past`** (default-on、リンクのみで cost 極小) |
+| **P5** (dry-run) | 上記 | 上記 + 引数 `dry_run=true` で `if_you_did` | 上記 |
+| **P6** (working/episodic) | 上記 | 上記 + `working:N`, `episodic:N` | 上記 |
+
+注意点:
+- **`include=time_travel`** は P4 以降の **明示要求 alias** として残す (default-on でも明示で要求された場合は同じ shape を返す、後方互換のため)
+- **早期 Phase では `query_past` を返さない** → P1 段階の wrapper test は `query_past` を期待しない (test fixture が phase-aware であることが必要)
+- envelope の `_version` は Phase ごとに上げない (semver のみで上げる)、Phase 間移行は internal な enrichment 拡張として扱う
+- server 側の現 Phase は `server_status` の `engine.phase` フィールドで client に通知 (実装は P1 着手時)
 
 ---
 

--- a/docs/adr-010-presentation-layer-self-documenting-envelope.md
+++ b/docs/adr-010-presentation-layer-self-documenting-envelope.md
@@ -1,0 +1,451 @@
+# ADR-010: LLM-Facing Presentation Layer — Self-Documenting View Envelope
+
+- Status: **Proposed (Draft for review)**
+- Date: 2026-04-29
+- Authors: Claude (Opus, max effort) — project `desktop-touch-mcp`
+- Related:
+  - ADR-007: koffi → Rust 全面移行 (Layer 1 = センサー層)
+  - ADR-008: Reactive Perception Engine via Differential Dataflow (Layer 2-3 = データ層)
+  - ADR-009: HW Acceleration Plane (Tier 別実装ガイド、後続)
+  - 後続: ADR-011: Cognitive Memory Taxonomy 拡張 (Semantic / Procedural memory)
+- 北極星: LLM の不安を消す + 復帰経路を typed に提供 + Tool 数を増やさず 1 tool の表現力を上げる
+
+---
+
+## 1. Context
+
+### 1.1 LLM の不安行動
+
+現状の MCP server を使った LLM の観察可能な「不安行動」:
+
+- 同じ `desktop_state` を短時間に 3 回連続で呼ぶ
+- screenshot を保守的に多めに撮る
+- 大胆な操作を避け、小刻みな step に分割しすぎる
+- エラー時に root cause に至れず、似た tool を試行錯誤する
+- 過去の自分の認識が正しかったか確認できないまま進む
+
+これらは **「Tool が情報を返してくれない」** のではなく、**「Tool が信じる根拠を返してくれない」** が原因。
+
+### 1.2 不安源の分解
+
+LLM の不安は 7 つに分解できる。
+
+| 不安源 (人間語) | 不安源 (技術語) | 必要データ |
+|---|---|---|
+| 「今見えてるの本物？」 | state freshness 不明 | as_of timestamp + freshness_ms + confidence |
+| 「自分の click 効いた？」 | 副作用の不可視性 | caused_by (直前行動 → 観測差分) |
+| 「なぜ失敗した？」 | failure mode 不透明 | typed reason + most_likely_cause |
+| 「次どうしよう…」 | 復帰経路なし | try_next (typed action list with confidence) |
+| 「結果が矛盾してない？」 | 観測整合性不明 | invariants_held |
+| 「2 つ前の自分は正しかった？」 | 過去への信頼欠如 | query_past (time-travel link) |
+| 「やったら何起きる？」 | 副作用予見不能 | if_you_did (dry-run preview) |
+
+### 1.3 物理基盤側 (ADR-007/008 で構築済 / 構築予定)
+
+- ADR-007 = L1 Capture: 全 event は `event_id` + `(wallclock_ms, sub_ordinal)` で tagged ring buffer に
+- ADR-008 = L2 Storage + L3 Compute: arrangement = MVCC store、`state_at(t)` 可、`predicted_post_state` view あり
+- 本 ADR-010 = L4 Projection + L5 Tool Surface: 上記 view を **LLM が信じられる形** で整形して返す
+
+### 1.4 SSOT 参照
+
+本 ADR の不変条件・SLO・境界は **統合書** (`docs/architecture-3layer-integrated.md` §4-§5、§17) と **`docs/layer-constraints.md` §5-§6** (L4 Projection / L5 Tool Surface) を SSOT とする。`most_likely_cause` typed enum は **`src/tools/_errors.ts` の SUGGESTS が SSOT** (§5.4 参照)。本 ADR で記述された規約と SSOT の間に齟齬が生じた場合、SSOT を優先し、本 ADR は後追い更新する (統合書 §16.1)。
+
+主な参照対応:
+- 識別子ヒエラルキー (session_id / tool_call_id / event_id / lease_token) → 統合書 §4
+- 時刻モデル (envelope.as_of は wallclock_ms canonical) → 統合書 §5
+- lease_token は単一 ID ではなく 4-tuple (`entityId` / `viewId` / `targetGeneration` / `evidenceDigest`)、envelope 内で展開 → 統合書 §4 / `LeaseStore` 既存実装
+- L4 envelope assembly 制約 (p99 < 5ms 等) → layer-constraints §5
+- L5 tool surface 制約 (query/commit/subscribe SLO) → layer-constraints §6
+- typed reason 35 codes (PascalCase) → §5.4
+
+---
+
+## 2. Decision
+
+### 2.1 主要決定 (8 項目)
+
+| # | 項目 | 決定 |
+|---|---|---|
+| 1 | 共通 envelope 採用 | 全 tool 結果が **Self-Documenting View Envelope** で返却 (§5) |
+| 2 | 必須 vs 任意フィールド | **必須最小** (`data`, `as_of`, `confidence`) **+ 任意拡張** (`include` 引数で取捨) |
+| 3 | 4 設計原則 | Provenance over Promise / Causal Continuity / Recovery as First-Class / Time as Affordance (§4) |
+| 4 | Time-travel リンク | **全 tool に `query_past` リンクのみ提供** (overhead 小)、実呼び出しは LLM の判断 |
+| 5 | Dry-run | **副作用が大きい tool に opt-in** (`dry_run=true` で preview のみ返却)。対象: click / fill / keyboard / browser_* / mouse_drag / scroll(action='click') |
+| 6 | CoALA memory 採用度 | **段階的**。Phase A = Working + Episodic、Phase B = Semantic + Procedural は ADR-011 で切り出し |
+| 7 | 失敗時 envelope | **失敗も envelope 形式で返す**。`data: null` + `if_unexpected` を必ず埋める |
+| 8 | schema versioning | envelope に `_version` フィールド。後方互換は MAJOR 上げ時のみ破る |
+
+### 2.2 設計の核
+
+LLM 不安源 7 つに envelope の 7 セクションが 1:1 対応する。**LLM は 1 つの shape を覚えるだけ** で全 tool が読める。各セクションは L3 view からの projection で、実装上は薄い wrapper。
+
+---
+
+## 3. Architecture
+
+### 3.1 5 層との位置づけ
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ L5: MCP Tool Surface             ← 本 ADR-010 ★        │
+│     既存 tool の応答を Envelope で wrap                 │
+├─────────────────────────────────────────────────────────┤
+│ L4: Cognitive Projection         ← 本 ADR-010 (一部) ★ │
+│     Working + Episodic を view として提供               │
+│     Semantic / Procedural は ADR-011                   │
+├─────────────────────────────────────────────────────────┤
+│ L3: Compute (IVM)                ← ADR-008             │
+│     view 提供元: current_state / dirty_rect_aggregate / │
+│     semantic_event / predicted_post_state               │
+├─────────────────────────────────────────────────────────┤
+│ L2: Storage (MVCC)               ← ADR-008             │
+├─────────────────────────────────────────────────────────┤
+│ L1: Capture (event ring buffer)  ← ADR-007             │
+└─────────────────────────────────────────────────────────┘
+```
+
+### 3.2 Envelope の組立て (実装視点)
+
+```
+tool 呼び出し
+    │
+    ▼
+[Layer 5 wrapper] ─ envelope skeleton 作成
+    │
+    ├─ data         ← 旧 tool 実装の戻り値
+    ├─ as_of        ← L3 の最新 frontier
+    ├─ confidence   ← L3 view の freshness 判定
+    ├─ caused_by    ← L4 episodic memory の最近 1 件 + L3 diff view
+    ├─ invariants   ← L3 で監視中の invariant view
+    ├─ if_unexpected ← 失敗時のみ、typed reason map から検索
+    ├─ query_past   ← static link (実呼び出し時のみ L2 起動)
+    └─ if_you_did   ← (dry_run=true 時のみ) L3 predicted_post_state
+    │
+    ▼
+client (LLM) へ返却
+```
+
+各セクション組立てのコストは **すべて L3 の既存 view 参照** で、追加計算なし。
+
+---
+
+## 4. Four Design Principles
+
+### 4.1 Provenance over Promise
+
+結果には必ず「出自」と「freshness」を付ける。約束しない、根拠を示す。
+
+- ❌ "focused element is X"
+- ✓ "based on UIA event #87 at wallclock_ms=1738156823412 (47ms ago), focused element is X, confidence=fresh"
+
+### 4.2 Causal Continuity
+
+tool 呼び出しは isolated event ではなく、**直前の自分の行動の結果** として提示する。
+
+- ❌ "current state: { focused: B }"
+- ✓ "after your click(120,240) 87ms ago, focus changed: A → B"
+
+### 4.3 Recovery as First-Class
+
+失敗時、文字列 throw ではなく **typed recovery hint** を返す。
+
+- ❌ `Error("modal blocking")`
+- ✓ `if_unexpected: { most_likely_cause: "modal_blocking", try_next: [{action: "click_element", args: {name: "OK"}, confidence: "high"}] }`
+
+### 4.4 Time as Affordance
+
+過去への入口を必ず開けておく。LLM が不安なら戻れる。
+
+- ✓ 全 tool 結果に `query_past.state_2s_ago: "call: state_at(now-2s)"` を付ける
+- 実呼び出しコストは LLM が払う、リンクだけなら無料
+
+---
+
+## 5. Self-Documenting View Envelope (Schema)
+
+```jsonc
+{
+  "_version": "1.0",                          // schema version
+
+  // ── 主データ ──
+  "data": { /* tool 固有 */ },                 // 失敗時 null
+
+  // ── Self-Attestation ──
+  "as_of": {
+    "wallclock_ms": 1738156823412,            // 統一 wallclock
+    "logical": [42, 7]                        // L3 logical time (epoch, sub_ordinal)
+  },
+  "freshness_ms": 47,                          // 観測されてからの経過
+  "based_on": {
+    "events": [42, 87],                        // L1 event_id range
+    "sources": ["UIA", "DXGI", "Reflex"]
+  },
+  "confidence": "fresh",                       // fresh | cached | inferred | stale
+
+  // ── Causal Trail (任意、include に応じて) ──
+  "caused_by": {
+    "your_last_action": "click(x=120, y=240)",
+    "session_id": "abc-123",
+    "elapsed_ms": 87,
+    "produced_changes": ["focus: A→B", "modal: closed"]
+  },
+
+  // ── Invariants Surfaced (任意) ──
+  "invariants_held": [
+    "window_title_stable_since:event_42",
+    "no_concurrent_focus_change",
+    "lease_digest_matched"
+  ],
+
+  // ── Recovery Hints (失敗時必須) ──
+  "if_unexpected": {
+    "most_likely_cause": "modal_blocking",     // typed enum
+    "blocker": { "name": "確認ダイアログ", "kind": "Dialog" },
+    "try_next": [
+      { "action": "click_element", "args": { "name": "OK" }, "confidence": "high" },
+      { "action": "keyboard", "args": { "key": "Escape" }, "confidence": "medium" }
+    ],
+    "escalation": "if_above_fail: capture screenshot and report"
+  },
+
+  // ── Time-Travel Link (常に提供、リンクのみ) ──
+  "query_past": {
+    "state_2s_ago": "call: state_at(now-2s)",
+    "diff_since_last_call": "call: diff(your_last_call_id, now)",
+    "replay_session": "call: replay(session_id, from=event_42, to=event_87)"
+  },
+
+  // ── What-If Preview (dry_run=true 時のみ) ──
+  "if_you_did": {
+    "click(button='次へ')": {
+      "predicted_focus": "input_age",
+      "predicted_modal": null,
+      "predicted_dirty_rect": [120, 240, 80, 30],
+      "confidence": "high"
+    }
+  }
+}
+```
+
+### 5.1 必須最小 (default)
+
+```
+{ _version, data, as_of, confidence }
+```
+
+### 5.2 任意拡張 (`include` で要求)
+
+| include 値 | 追加されるフィールド | 想定用途 |
+|---|---|---|
+| `causal` | `caused_by` | 自分の行動と結果の因果が知りたい |
+| `invariants` | `invariants_held` | 整合性を検証したい |
+| `time_travel` | `query_past` | 過去への戻り口が欲しい (default で常時) |
+| `working:N` | `caused_by.recent_window` (直近 N event compact) | working memory が欲しい |
+| `episodic:N` | `caused_by.tool_call_history` (直近 N tool 呼び出し) | 自分の行動履歴が欲しい |
+
+### 5.3 失敗時 envelope
+
+```jsonc
+{
+  "_version": "1.0",
+  "data": null,
+  "as_of": { ... },
+  "confidence": "stale",                       // 失敗時は stale 固定
+  "if_unexpected": {                           // 必須
+    "most_likely_cause": "lease_expired",
+    "try_next": [{ "action": "desktop_discover", ... }]
+  },
+  "query_past": { ... }                        // 過去への戻り口は失敗時こそ重要
+}
+```
+
+### 5.4 typed enum 一覧 — 既存 `_errors.ts` SUGGESTS を SSOT として吸収
+
+既存 `src/tools/_errors.ts` の `SUGGESTS` には **25 個の PascalCase code** が運用済 (現行 main で classify ロジックも完備)。本 ADR の `most_likely_cause` は **これを SSOT として吸収** し、新規追加分のみ拡張する。
+
+#### 既存 25 codes (現行 main、PascalCase 維持)
+
+```
+// 引数・基本
+InvalidArgs
+
+// UIA / window
+WindowNotFound | ElementNotFound | InvokePatternNotSupported |
+ElementDisabled | UiaTimeout | BlockedKeyCombo
+
+// Browser
+BrowserNotConnected | BrowserSearchNoResults | BrowserSearchTimeout |
+ScopeNotFound
+
+// Terminal
+TerminalWindowNotFound | TerminalTextPatternUnavailable | TerminalMarkerStale
+
+// Wait / scroll
+WaitTimeout | ScrollbarUnavailable | OverflowHiddenAncestor |
+VirtualScrollExhausted | MaxDepthExceeded
+
+// RPG
+GuardFailed | LensNotFound | LensBudgetExceeded
+
+// 入力チャネル
+BackgroundInputUnsupported | BackgroundInputIncomplete |
+SetValueAllChannelsFailed
+```
+
+#### 本 ADR で追加する codes (PascalCase 統一)
+
+```
+// RPG lease (lease-store の validate 結果と 1:1 対応)
+LeaseExpired | LeaseGenerationMismatch | LeaseDigestMismatch |
+EntityNotFound | EntityOutsideViewport
+
+// 状態遷移
+ModalBlocking | Settling
+
+// HW Tier
+HwTierUnavailable
+
+// その他
+AccessDenied | Unknown
+```
+
+合計 25 + 10 = **35 codes**。
+
+#### 運用ルール
+
+1. **SSOT は `src/tools/_errors.ts`** の `SUGGESTS` map。`try_next` は SUGGESTS の各値を **typed action 化** したものに移行 (P2 で実装)
+2. 既存 SUGGESTS の **`suggest: string[]`** を envelope の **`try_next: TypedAction[]`** に進化させる際、最初は string をそのまま `try_next[].action_hint` に格納し、徐々に `{action, args, confidence}` に typed 化
+3. lease 関連 5 codes は `LeaseStore.validate()` の `reason` (`expired` / `generation_mismatch` / `entity_not_found` / `digest_mismatch`) を PascalCase に変換した値と 1:1
+4. `Unknown` は coverage 改善の対象 — 発生時に必ず log し、SSOT に追記する運用
+
+#### LLM への露出
+
+`most_likely_cause: "WindowNotFound"` のように PascalCase そのまま。snake_case 変換は行わない (既存 client compat と TS型側との一貫性のため)。
+
+---
+
+## 6. CoALA Memory Mapping (Phase A)
+
+| memory type | 本 ADR で対応 | 提供 view | 取得方法 |
+|---|---|---|---|
+| Working | ✓ Phase A | `current_state` (recent N event compact) | `include=working:N` |
+| Episodic | ✓ Phase A | `tool_call_history` (自分の過去の呼び出し + outcome) | `include=episodic:N` |
+| Semantic | ✗ Phase B (ADR-011) | `learned_ui_pattern` (page graph 風) | 将来 |
+| Procedural | ✗ Phase B (ADR-011) | `successful_macros` (fused action) | 将来 |
+
+LLM は include 引数で **「今欲しい memory layer」を select** できる:
+
+```
+desktop_state(include=["working:10", "episodic:5", "causal", "invariants"])
+```
+
+→ context window の経済的使用 + LLM が **自分の認知負荷を自分で管理**。
+
+---
+
+## 7. Implementation Phases
+
+| Phase | 範囲 | 完了基準 |
+|---|---|---|
+| **P1: Envelope 必須最小** | `_version`, `data`, `as_of`, `confidence` を全 tool に注入する wrapper 作成 | 既存 tool 全部の応答が envelope 経由、回帰なし |
+| **P2: typed reason 整備** | `most_likely_cause` enum + `try_next` テンプレ map | 既存 tool の error が typed reason に 100% mapping |
+| **P3: include 拡張 (causal / invariants)** | `caused_by` (last action linkage) と `invariants_held` を view から projection | include で取捨可能、ベンチで latency overhead < 5ms |
+| **P4: time-travel link 注入** | `query_past` を全 tool 応答に static link として常時付与 | リンク存在のみ、実呼び出しは ADR-008 D3 完了待ち |
+| **P5: dry-run** | 副作用大の tool に `dry_run=true` 引数追加、`if_you_did` を返す | 5 tool 以上で動作、predicted vs actual 一致率測定 |
+| **P6: working / episodic** | `include=working:N` / `episodic:N` 実装 | LLM context 削減効果を A/B で測定 |
+| **P7: schema versioning + migration tooling** | `_version` 進化のためのテストハーネス | MAJOR 上げ手順書、後方互換テスト pass |
+
+---
+
+## 8. Alternatives Considered
+
+### 8.1 別 schema (失敗時とは別 envelope)
+
+成功 / 失敗で別 schema にすると LLM が分岐コードを書く必要がある。**統一 envelope** にすると分岐不要、`data === null` または `if_unexpected !== null` で判定。
+
+→ 不採用。
+
+### 8.2 Envelope 全フィールド常時返却
+
+LLM の context 消費が膨らむ。include 任意拡張で **LLM 自身が経済性を判断** できる方が良い。
+
+→ 不採用。
+
+### 8.3 Time-travel を一部 tool 限定
+
+「過去への戻り口」は失敗時こそ最重要。**全 tool に link 提供** する方が安全網として強い。リンクだけならコスト極小。
+
+→ 採用 (全 tool)。
+
+### 8.4 typed reason ではなく自由文字列
+
+LLM は自由文字列を読める (LLM だから当然)。だが、**try_next の typed action list** が文字列だと parsing 失敗の可能性。typed の方が信頼性高い。
+
+→ typed reason + typed try_next を採用。
+
+---
+
+## 9. Risks
+
+| # | リスク | 影響 | 軽減策 |
+|---|---|---|---|
+| 1 | Envelope のオーバーヘッドで応答 size 増 | Medium | 必須最小 default + include で経済性、サイズベンチで監視 |
+| 2 | typed enum の網羅漏れで `unknown` 多発 | Medium | error 発生時に毎回 most_likely_cause を log → coverage を増やす運用 |
+| 3 | predicted_post_state の精度が低い | High | dry-run 結果に必ず confidence を添付、low confidence は LLM が無視可 |
+| 4 | session_id の管理 owner 不明 | High | MCP request id を session_id にマッピング (実装時に確定) |
+| 5 | schema 進化で後方互換が壊れる | Medium | `_version` を MAJOR.MINOR で管理、MAJOR 上げ時のみ破壊 |
+| 6 | LLM が include を全部付ける (経済性無視) | Low | デフォルトで最小、追加は明示的、サイズ警告を docs に明記 |
+| 7 | dry-run と実 action の挙動乖離 | High | dry-run 後の実行で diff 計測、乖離率を engine 内で監視 |
+
+---
+
+## 10. Acceptance Criteria
+
+| Phase | 完了基準 |
+|---|---|
+| P1 | 全 tool が envelope 形式で応答、既存 LLM session で回帰 0 |
+| P2 | typed reason の coverage > 95%、`unknown` 発生時の log で残り 5% を埋める |
+| P3 | `include=causal,invariants` で envelope size 1.5x 以内、latency overhead < 5ms |
+| P4 | `query_past` link が全 tool に常時、実呼び出しで ADR-008 D3 と接続成功 |
+| P5 | 主要 5 tool で dry_run=true 動作、predicted vs actual 一致率 > 80% |
+| P6 | `include=working:N` / `episodic:N` で LLM context 1/3 削減 (代表シナリオ) |
+| P7 | `_version: 2.0` への migration を test harness で全 tool シミュレート |
+
+---
+
+## 11. Open Questions
+
+| # | 質問 | 検討タイミング |
+|---|---|---|
+| 1 | session_id を MCP request id と紐付けるか、独自管理か | P1 着手前 |
+| 2 | `query_past` リンクの URI 形式 (string call: vs structured ref) | P4 着手時 |
+| 3 | dry-run の 100% 精度はムリ、許容ライン (50% / 80% / 95%) | P5 着手時に決定 |
+| 4 | include の値を文字列か enum か (typed の方が安全) | P3 着手前 |
+| 5 | error envelope の `_errors.ts` 既存 SUGGESTS との合流 | P2 着手時 |
+| 6 | working memory の N 上限 (推奨 default は何か) | P6 のベンチ後 |
+| 7 | Subscribe API (push) が来たら envelope はどう扱う | ADR-008 D2 と擦合せ |
+
+---
+
+## 12. 公開価値
+
+「LLM が不安にならない MCP server」 — UX 観点での新ニッチ。
+
+- 競合 MCP server は raw 結果を返すだけ。本 ADR の envelope は **LLM ergonomics に踏み込んだ初の試み**
+- 4 設計原則 (Provenance / Causality / Recovery / Time) は他の MCP server にも転用可、論文 / ブログ / talk のネタになる
+- ADR-008 の MVCC + IVM がこの envelope を実装上 **ほぼ無料** (各セクションが view からの projection) にする
+
+---
+
+## 13. Related Artifacts (起草前 / 起草予定)
+
+- 本 ADR (`docs/adr-010-presentation-layer-self-documenting-envelope.md`)
+- 前段: `docs/adr-007-koffi-to-rust-migration.md` (起草中、L1)
+- 前段: `docs/adr-008-reactive-perception-engine.md` (起草済、L2-3)
+- 後続: `docs/adr-009-hw-acceleration-plane.md` (Tier 別実装ガイド)
+- 後続: `docs/adr-011-cognitive-memory-extension.md` (Semantic / Procedural memory、Phase B)
+- 統合: `docs/architecture-3layer-integrated.md` (3 層俯瞰、ADR-007/008/010 を 1 ドキュメントに編む、本 ADR 完了後に起草予定)
+
+---
+
+END OF ADR-010 (Draft).

--- a/docs/architecture-3layer-integrated.md
+++ b/docs/architecture-3layer-integrated.md
@@ -65,7 +65,7 @@ P3 (Whole-System Dataflow) は本書で初出の決定。各 ADR には事後追
 ├──────────────────────────────────────────────────────────────────┤
 │ L3: Compute (IVM)                                                 │
 │     differential-dataflow operator graph                          │
-│     主要 view: current_focused_element / dirty_rect_aggregate /   │
+│     主要 view: current_focused_element / dirty_rects_aggregate /   │
 │       semantic_event_stream / predicted_post_state                │
 │     cyclic: RPG lens 依存を timely iterative で fixed-point       │
 ├──────────────────────────────────────────────────────────────────┤
@@ -205,7 +205,7 @@ T+18ms    L2 arrangement: #87/#88/#89 materialize
             
 T+19ms    L3 view 更新:
             current_focused_element: "input_age"
-            dirty_rect_aggregate: 1 rect
+            dirty_rects_aggregate: 1 rect
             semantic_event_stream: ["focus_changed", "no_modal"]
             
 T+20ms    L4 envelope assembly:
@@ -246,7 +246,7 @@ WAL に記録された #87/#88/#89 を replay worker に再注入。**logical_ti
 | **subscribe** | なし (push 配信) | delta envelope の連続、各 delta が `as_of` 持つ | (新規、ADR-010 P4 で実装) |
 | **commit** | あり | `caused_by` 即時更新 (自分が原因)、`if_unexpected` 失敗時必須 | desktop_act, click_element, keyboard, browser_click |
 
-### 7.2 既存 28 tool のマッピング (現行 main 基準)
+### 7.2 既存 tool のマッピング (現行 main 基準、29 件列挙)
 
 | tool | 軸 | 備考 |
 |---|---|---|
@@ -280,7 +280,7 @@ WAL に記録された #87/#88/#89 を replay worker に再注入。**logical_ti
 | `browser_open` | commit | tab 副作用 |
 | `browser_launch` | commit | プロセス起動 |
 
-(残 5 tool 程度は適宜追加)
+正確な tool 一覧は `src/stub-tool-catalog.ts` の `name` フィールドから自動生成して維持する (TODO: `scripts/` に generator 追加、ADR-007 P5 着手前)。
 
 ### 7.3 設計上の効果
 
@@ -537,7 +537,7 @@ timely-dataflow には [`probe`](https://docs.rs/timely/latest/timely/dataflow/o
     "worker_lag_ms": { "p50": 0.3, "p95": 1.2, "p99": 8.5 },
     "arrangement": {
       "current_focused_element": { "rows": 1, "memory_mb": 0.001 },
-      "dirty_rect_aggregate": { "rows": 47, "memory_mb": 0.012 },
+      "dirty_rects_aggregate": { "rows": 47, "memory_mb": 0.012 },
       ...
     },
     "tier_dispatch_stats": { ... },

--- a/docs/architecture-3layer-integrated.md
+++ b/docs/architecture-3layer-integrated.md
@@ -1,0 +1,725 @@
+# Architecture: 3-Layer Integrated Design
+
+- Status: **Draft (起草中、各 ADR の SSOT)**
+- Date: 2026-04-29
+- Authors: Claude (Opus, max effort) — project `desktop-touch-mcp`
+- Scope: ADR-007 / ADR-008 / ADR-010 を 1 つに編む俯瞰設計書
+- 役割: 個別 ADR は詳細設計、本書は **Source of Truth** として cross-layer の規約を持つ
+- 北極星: 最高パフォーマンス + 最高技術の公開 + LLM ergonomics
+
+---
+
+## 1. Executive Summary
+
+`desktop-touch-mcp` を 3 層に整理し、**全層を 1 つの timely dataflow graph として扱う** 統一設計を提案する。
+
+| 層 | 役割 | 主担当 ADR |
+|---|---|---|
+| **センサー層** (L1 Capture) | DXGI dirty rect + UIA + tool call + 副作用を統一 event log に押し出す。HW assist は Tier 0-3 で fallback | ADR-007 |
+| **データ層** (L2 Storage + L3 Compute) | timely + differential-dataflow による partial-order MVCC + IVM。`arrangement` が **L2/L3 を 1 構造体に畳む** | ADR-008 |
+| **プレゼンテーション層** (L4 Projection + L5 Tool Surface) | LLM 不安源 7 つに 1:1 対応する Self-Documenting Envelope。Tool 数を増やさず 1 tool の表現力を上げる | ADR-010 |
+
+### 1.1 主要な発見 (3 件)
+
+1. **Arrangement = MVCC が無料** (ADR-008 §2.3): timely + DD の `arrangement` は `(key, val, time, diff)` の 4-tuple を multi-version で持つ → L2 と L3 が同一構造体で実現
+2. **HW 物理基盤は既に揃っている** (ADR-007): DXGI dirty rect / Intel DSA / NVENC / Reflex API / Intel PT を組合せれば、観測コスト・time-travel・hw replay の物理基盤がほぼ全部既製
+3. **partial-order time が UI 観測ドメインに必須** (ADR-008 §2.2): UIA out-of-order、tool call と環境変化の並行、Reflex 多軸 hw clock — これらすべてが linear time に潰せない
+
+### 1.2 公開価値 (北極星の片翼)
+
+論文 3 本ぶんが独立に書ける。
+
+- **SIGMOD/VLDB**: GPU-accelerated IVM for LLM agent perception (DXGI dirty rect + CUDA Graph + DD)
+- **USENIX ATC/ASPLOS**: HW-assisted deterministic replay for LLM agent debugging (Intel PT + arrangement snapshot)
+- **CHI/UIST**: Sub-millisecond UI observation via Reflex Latency API (race-free agent observation)
+
+ナラティブ: Microsoft が WinAppSDK Rust を archive した一方、**Intel/AMD/NVIDIA の hw assist を Rust で結合した Windows MCP server** という空白領域。
+
+---
+
+## 2. 設計原則の体系 (6 原則)
+
+| # | 原則 | 何を保証するか | 出典 |
+|---|---|---|---|
+| **P1** | Partial-Order Time | UIA out-of-order と多軸 hw clock を正しく扱う | ADR-008 §2.2 |
+| **P2** | Arrangement = MVCC | L2/L3 を 1 構造体に畳む。time-travel が無料で来る | ADR-008 §2.3 |
+| **P3** | Whole-System Dataflow | L1 Capture も timely input source として graph に組込む。replay / dry-run / subscribe が graph 操作で統一 | 本書 §10 (D1 採用) |
+| **P4** | Self-Documenting Envelope | 全 tool 結果が共通 envelope。LLM の不安源 7 つに 1:1 対応 | ADR-010 §1-5 |
+| **P5** | Tier Fallback | HW 成熟度の段差を Tier 0-3 で吸収、env で pin 可 | ADR-008 §5 |
+| **P6** | 4 LLM-Facing Sub-Principles | Provenance / Causality / Recovery / Time as Affordance | ADR-010 §4 |
+
+P3 (Whole-System Dataflow) は本書で初出の決定。各 ADR には事後追記する。
+
+---
+
+## 3. 5 層アーキ全景図
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ L5: MCP Tool Surface                                              │
+│     既存 28 tool が envelope wrap。query / subscribe / commit の  │
+│     3 軸にマッピング (§7)                                         │
+├──────────────────────────────────────────────────────────────────┤
+│ L4: Cognitive Projection + Envelope Assembly                      │
+│     Working / Episodic memory を view 化。envelope 段階組立 (§8) │
+├──────────────────────────────────────────────────────────────────┤
+│ L3: Compute (IVM)                                                 │
+│     differential-dataflow operator graph                          │
+│     主要 view: current_focused_element / dirty_rect_aggregate /   │
+│       semantic_event_stream / predicted_post_state                │
+│     cyclic: RPG lens 依存を timely iterative で fixed-point       │
+├──────────────────────────────────────────────────────────────────┤
+│ L2: Storage (MVCC)                                                │
+│     arrangement = (key, val, time, diff) 4-tuple                  │
+│     time-travel: arrangement の time slice 走査                   │
+├──────────────────────────────────────────────────────────────────┤
+│ L1: Capture (whole-system input source)                           │
+│     DXGI Desktop Duplication (dirty/move rects)                   │
+│     UIA event + tool call + 副作用 → 統一 event ring buffer       │
+│     Tier 0-3 hw assist (DSA / NVENC / Intel PT / Reflex API)      │
+└──────────────────────────────────────────────────────────────────┘
+
+Data flow:
+  hw events → L1 input → timely worker → L2 arrangement → L3 view
+                                                              │
+                                                              ▼
+                                                     L4 envelope projection
+                                                              │
+                                                              ▼
+                                                          L5 tool API
+                                                              │
+                                                              ▼
+                                                    LLM (MCP client)
+
+Side-channel flows:
+  WAL ←─── L1 events (record 時、replay 用)
+  Replay worker ←── WAL (replay 時、本番 worker と分離、§10)
+  Dry-run subgraph ←── 投機 input (本番に書き戻さない、§10)
+```
+
+---
+
+## 4. 識別子ヒエラルキー (B2 解消)
+
+すべての層を貫通する 6 つの識別子と、その範囲・生成元・包含関係を確定する。
+
+### 4.1 識別子表
+
+| 識別子 | 範囲 | 生成元 | 形式 | LLM 露出 |
+|---|---|---|---|---|
+| `session_id` | 1 LLM session 全体 | MCP client (request 開始時) | string (UUID 等) | ✓ |
+| `tool_call_id` | 1 tool 呼び出し | L5 wrapper (tool 受信時) | `{session_id}:{seq}` | ✓ |
+| `event_id` | 1 observation/action event | L1 Capture (event 発生時) | u64 monotonic | ✓ (envelope.based_on.events) |
+| `lease_token` | RPG lease (entity 列挙の有効期間) | desktop_discover (既存) | 4-tuple = `(entityId, viewId, targetGeneration, evidenceDigest)` | ✓ (envelope 内で expanded) |
+| `logical_time` | timely epoch + sub_ordinal | L2 (arrangement materialize 時) | `(u64, u32)` partial-order | ✗ (engine 内部のみ) |
+| `arrangement_key` | view 内 row | L3 (view ごと固有) | view-defined | ✗ (engine 内部のみ) |
+
+### 4.2 包含関係
+
+```
+session_id
+    └── tool_call_id (1:N)
+            └── event_id (1:N)
+                    └── lease_token (1:1 per discover、validate 時に 4-tuple で検証)
+
+logical_time, arrangement_key は engine 内部表現で、外には event_id にマッピングして見せる。
+lease_token は単一 ID ではなく、envelope 内で `entity` / `viewId` / `generation` /
+`evidenceDigest` の 4 フィールドに展開される (LeaseStore 既存実装と整合)。
+```
+
+### 4.3 設計上の効果
+
+- **どの層のログでも event_id が pivot**: L1 ring buffer entry / L2 arrangement record / L3 view delta / L4 envelope.based_on.events のすべてが event_id で trace 可能
+- **LLM への露出は 4 識別子のみ**: session/tool_call/event/lease。logical_time は隠蔽、LLM は wallclock_ms のみ見る (§5)
+- **replay key は event_id**: WAL の primary key、再生時の anchor
+
+---
+
+## 5. 時刻モデルの統一規約 (B1 解消)
+
+### 5.1 Canonical wallclock_ms
+
+**LLM が見るのは `wallclock_ms` のみ**。他の時刻表現はすべて engine 内部。
+
+| 用途 | 時刻表現 | 露出範囲 |
+|---|---|---|
+| LLM 向け envelope | `wallclock_ms: u64` | L4-L5 |
+| timely 内部 | `(wallclock_ms, sub_ordinal): (u64, u32)` | L2-L3 |
+| arrangement 内部 | logical_time = 上記 | L2 |
+
+### 5.2 Wallclock の優先順 (時刻ソース)
+
+| 優先 | ソース | 利用可能性 | 精度 |
+|---|---|---|---|
+| 1 | NVIDIA Reflex Latency API | NVIDIA GPU + アプリ対応時のみ | < 1ms (hw 真値) |
+| 2 | DXGI `IDXGISwapChain::GetFrameStatistics` | Direct3D アプリの場合 | ~1ms |
+| 3 | `DwmGetCompositionTimingInfo` | Windows 全環境 | ~1-5ms (compositor 周期) |
+| 4 | `QueryPerformanceCounter` (`std::time::Instant`) | always | ~ns 解像度だが hw frame と無関係 |
+
+L1 Capture は起動時に capability detect、各 event tag 時に **取得可能な最上位ソース** を使い、ソース名を `EventEnvelope.timestamp_source` に記録。
+
+### 5.3 Replay 時の wallclock 扱い (B4 解消)
+
+**Record 時の wallclock を canonical**。Replay 時の "now" は計算されない。
+
+| シナリオ | freshness_ms 計算 | 出典 wallclock |
+|---|---|---|
+| Live (本番) | `wallclock_now - as_of.wallclock_ms` | 観測時刻 |
+| Replay | `event.wallclock_at_record - as_of.wallclock_ms` (両方 log から) | 全部 record 時刻 |
+| Dry-run | live と同じ (本番 worker の wallclock_now) | 投機実行直前 |
+
+→ **envelope は決定的**。replay で同じ envelope が再生される。
+
+### 5.4 Sub-ordinal の用途
+
+同一 wallclock_ms に複数 event があるとき、L1 Capture が `sub_ordinal` を 0 から順次割当。partial-order 内の deterministic ordering を保証。
+
+---
+
+## 6. データフロー貫通 — 1 event の旅 (Worked Example)
+
+ユーザーが LLM に「次へボタンを押して」と依頼した場面の trace。
+
+### 6.1 タイムライン
+
+```
+T+0ms     LLM: click_element(name="次へ") を MCP 送信
+            session_id="abc-123"
+            
+T+0.5ms   L5 wrapper: tool_call_id="abc-123:7" 割当
+            commit op を L1 へ submit
+            
+T+1ms     L1 Capture: 副作用実行 (UIA InvokePattern.Invoke)
+            event_id=#87、wallclock_ms=T+1, sub_ordinal=0
+            timestamp_source="DwmGetCompositionTimingInfo"
+            EventEnvelope を ring buffer + WAL に push
+            
+T+15ms    UIA event 発火: focus_changed (A → B)
+            event_id=#88、wallclock=T+15, sub_ord=0
+            
+T+16ms    DXGI dirty rect 発火: [120,240,80,30]
+            event_id=#89、wallclock=T+16, sub_ord=0
+            
+T+18ms    L2 arrangement: #87/#88/#89 materialize
+            logical_time = (T+18, 0)
+            
+T+19ms    L3 view 更新:
+            current_focused_element: "input_age"
+            dirty_rect_aggregate: 1 rect
+            semantic_event_stream: ["focus_changed", "no_modal"]
+            
+T+20ms    L4 envelope assembly:
+            caused_by = { your_last_action: "click_element(name='次へ')",
+                          tool_call_id: "abc-123:7", elapsed_ms: 19,
+                          produced_changes: ["focus: A→B"] }
+            invariants_held = ["window_title_stable", "lease_digest_matched"]
+            confidence = "fresh"
+            
+T+21ms    L5 wrap: _version="1.0", data={ ok: true, element: "次へ" }
+            return to LLM
+```
+
+### 6.2 各層が触る identifier
+
+| 層 | 触る identifier | 触る timestamp |
+|---|---|---|
+| L5 (受信) | session_id, tool_call_id 生成 | wallclock 開始 |
+| L1 | event_id 採番、tool_call_id を tag | wallclock + sub_ord |
+| L2 | logical_time 採番 | wallclock 継承 |
+| L3 | arrangement_key (view 内部) | logical_time |
+| L4 | envelope.based_on.events ← {#87, #88, #89} | as_of.wallclock_ms = T+18 |
+| L5 (送信) | _version stamp | freshness_ms = now - T+18 |
+
+### 6.3 Replay 時の同例
+
+WAL に記録された #87/#88/#89 を replay worker に再注入。**logical_time も同じ、wallclock も同じ、envelope も同じ** — bit-for-bit 再生。
+
+---
+
+## 7. API 3 軸 — 全 28 tool のマッピング
+
+### 7.1 軸定義
+
+| 軸 | 副作用 | envelope 特徴 | 例 |
+|---|---|---|---|
+| **query** | なし | 確定 envelope、`caused_by` は前回 commit との差分のみ | desktop_state, screenshot, browser_overview |
+| **subscribe** | なし (push 配信) | delta envelope の連続、各 delta が `as_of` 持つ | (新規、ADR-010 P4 で実装) |
+| **commit** | あり | `caused_by` 即時更新 (自分が原因)、`if_unexpected` 失敗時必須 | desktop_act, click_element, keyboard, browser_click |
+
+### 7.2 既存 28 tool のマッピング (現行 main 基準)
+
+| tool | 軸 | 備考 |
+|---|---|---|
+| `desktop_state` | query | 主要 view 4 つを default で集約 |
+| `desktop_discover` | query | 副作用なし、lease 発行 |
+| `desktop_act` | commit | lease 検証 + 副作用 |
+| `screenshot` | query | DXGI Tier 1 経由 |
+| `click_element` | commit | UIA InvokePattern |
+| `mouse_click` | commit | hw 入力 |
+| `mouse_drag` | commit | hw 入力 |
+| `keyboard` | commit | hw 入力 |
+| `clipboard` | commit | OS 副作用 |
+| `scroll` | commit | UIA ScrollPattern + (action='read' は query) |
+| `focus_window` | commit | window 副作用 |
+| `window_dock` | commit | window 副作用 |
+| `wait_until` | query | 観測のみ (時間経過待ち) |
+| `notification_show` | commit | OS 副作用 |
+| `terminal` | commit | プロセス副作用 |
+| `run_macro` | commit | 複合副作用 |
+| `workspace_launch` | commit | プロセス起動 |
+| `workspace_snapshot` | query | 観測のみ |
+| `server_status` | query | engine 情報 |
+| `browser_navigate` | commit | navigation 副作用 |
+| `browser_click` | commit | DOM 副作用 |
+| `browser_fill` | commit | DOM 副作用 |
+| `browser_form` | commit | DOM 副作用 |
+| `browser_eval` | commit (dual) | 副作用あり得る |
+| `browser_locate` | query | DOM 観測 |
+| `browser_overview` | query | DOM 観測 |
+| `browser_search` | query | DOM 観測 |
+| `browser_open` | commit | tab 副作用 |
+| `browser_launch` | commit | プロセス起動 |
+
+(残 5 tool 程度は適宜追加)
+
+### 7.3 設計上の効果
+
+- 各軸ごとに envelope 組立てパターンが固定 → 実装テンプレが 3 つで済む
+- subscribe API 追加時、commit/query との整合は軸単位で考えるだけ
+- dry-run は **commit 軸の opt-in** (`dry_run=true`)、query/subscribe には不要
+
+---
+
+## 8. Envelope 組立て契約 — 各層の責務 (D3)
+
+### 8.1 段階 enrichment
+
+```
+L1 → L2 → L3 → L4 → L5 と段階的に envelope を埋めていく:
+
+L1: as_of.wallclock_ms 始端確定、based_on.events に event_id 追加
+L2: arrangement materialize 完了、based_on.events 終端確定、confidence 暫定
+L3: data フィールド (view 値)、invariants_held、predicted_post_state (dry_run時)
+L4: caused_by, query_past リンク, if_unexpected.try_next (失敗時)
+L5: _version stamp、include filter 適用、data 最終形に整形
+```
+
+### 8.2 各層責務マトリクス
+
+| Envelope フィールド | L1 | L2 | L3 | L4 | L5 |
+|---|---|---|---|---|---|
+| `_version` | | | | | ✓ |
+| `data` | | | ✓ (raw) | | ✓ (整形) |
+| `as_of.wallclock_ms` | ✓ | | | | |
+| `freshness_ms` | | | | ✓ (計算) | |
+| `based_on.events` | ✓ (start) | ✓ (end) | | | |
+| `based_on.sources` | ✓ | | | | |
+| `confidence` | | ✓ (暫定) | ✓ (確定) | | |
+| `caused_by` | | | | ✓ | |
+| `invariants_held` | | | ✓ | | |
+| `if_unexpected` | | | | ✓ | |
+| `query_past` | | | | ✓ | |
+| `if_you_did` (dry_run) | | | ✓ | | |
+
+### 8.3 失敗時 partial envelope
+
+L1〜L5 のどこで失敗しても返せる **失敗テンプレ**:
+
+```jsonc
+{
+  "_version": "1.0",
+  "data": null,
+  "as_of": { "wallclock_ms": <最後に確定した値> },
+  "confidence": "stale",
+  "if_unexpected": {
+    "most_likely_cause": <typed enum>,
+    "failed_at_layer": "L1" | "L2" | "L3" | "L4" | "L5",
+    "try_next": [...]
+  },
+  "query_past": { ... }  // 過去への戻り口は失敗時こそ重要
+}
+```
+
+各層は **自層が失敗した時点までの enrichment を残し、`if_unexpected.failed_at_layer` を埋めて return** する。
+
+---
+
+## 9. Tier 0-3 dispatch 統一規約 (B6 解消)
+
+### 9.1 op kind × tier マトリクス
+
+| op kind | Tier 0 (Pure Rust) | Tier 1 (OS API) | Tier 2 (HW Assist) | Tier 3 (Vendor Compute) |
+|---|---|---|---|---|
+| screen capture | std GDI BitBlt | DXGI Desktop Duplication | DXGI + D3D11 compute shader | (n/a) |
+| dirty rect detect | 自前 diff | DXGI GetFrameDirtyRects | (n/a) | CUDA Graph reduce |
+| memcpy bulk | std::ptr::copy | rayon parallel chunk | Intel DSA | (n/a) |
+| frame ring buffer | Vec<Vec<u8>> | DXGI shared texture | NVENC / Quick Sync / AMF | (n/a) |
+| timestamp source | std::time | DwmGetCompositionTimingInfo | DXGI Present statistics | NVIDIA Reflex Latency API |
+| change_fraction | scalar | rayon SIMD | (none) | CUDA Graph reduce kernel |
+| dHash | scalar | rayon SIMD | (none) | CUDA / HIP / L0 kernel |
+| UIA tree walk | windows-rs sync | (n/a) | (n/a) | (n/a — UIA は CPU only) |
+| event log persist | std::fs | (n/a) | Intel PT trace | (n/a) |
+
+(空欄は将来検討、(n/a) は本質的に該当 tier が存在しないもの)
+
+### 9.2 Cascade ルール
+
+```
+for op in { capture, memcpy, frame_ring, ... }:
+    for tier in [T3, T2, T1, T0]:
+        if let Some(impl) = registry.find(op, tier):
+            match impl.launch(op, inputs):
+                Ok(result) => return result
+                Err(transient) => continue (try lower tier)
+                Err(fatal) => log + continue
+    unreachable!  // T0 は必ず存在
+```
+
+### 9.3 Failure 集約 (B6)
+
+各 tier failure は `server_status` ツールに集約。
+
+```jsonc
+// server_status ツール応答 (envelope wrap 済)
+{
+  "data": {
+    "tier_dispatch_stats": {
+      "screen_capture": { "T3": 0, "T2": 1023, "T1": 4521, "T0": 12 },
+      "memcpy_bulk": { "T3": 0, "T2": 8923, "T1": 1234, "T0": 0 }
+    },
+    "recent_failures": [
+      { "op": "frame_ring", "tier": "T2", "vendor": "NVIDIA",
+        "reason": "NVENC unavailable: driver < 535", "ts": ... }
+    ],
+    "tier_pin": { "max_tier": 3, "disable_vendor": [] }
+  }
+}
+```
+
+LLM がこれを見て「現在の環境で CUDA 効いてるか」を判断できる。
+
+### 9.4 Vendor 別成熟度 (2026-04 時点)
+
+| Vendor | T1 | T2 | T3 |
+|---|---|---|---|
+| NVIDIA | ✓ | ✓ NVENC, Reflex | ✓ CUDA Graph (production) |
+| AMD | ✓ | ✓ AMF | △ HIP Graph on Windows (ROCm Windows 若い) |
+| Intel | ✓ | ✓ Quick Sync, DSA (Sapphire Rapids+) | △ Level Zero (Arc/Battlemage 成熟中) |
+
+→ T1 全環境保証、T2/T3 は capability detect で activate、failure 時自動 fallback。
+
+---
+
+## 10. Replay / Dry-run の隔離設計 (B4 + B5 解消)
+
+### 10.1 3 系統の worker
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  本番 timely worker (Live)                                    │
+│    L1 hw events → arrangement → view 計算                    │
+│    WAL に append (record モード時)                           │
+│    LLM への応答はここから                                    │
+└──────────────────────────────────────────────────────────────┘
+                  ▲                           │
+                  │                           ▼
+                  │                   ┌───────────────────────┐
+                  │ (read-only fork)  │  Dry-run subgraph      │
+                  │                   │   投機 input を受けて  │
+                  └───────────────────┤   predicted_post_state │
+                                      │   を計算、書き戻さない │
+                                      └───────────────────────┘
+
+┌──────────────────────────────────────────────────────────────┐
+│  Replay timely worker (オフライン)                            │
+│    WAL → event を 順次再注入                                 │
+│    本番 worker と完全分離                                    │
+│    bug 報告時のみ起動                                        │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### 10.2 Replay 仕様
+
+- WAL primary key = `event_id`
+- 再生は **wallclock も logical_time も log から取る** → 完全決定的
+- Replay worker のメモリ空間は本番と隔離、副作用 (UIA Invoke 等) は no-op (再生時は観測再現のみ)
+- `replay(session_id, from=event_X, to=event_Y)` ツールで起動 (envelope.query_past.replay_session)
+- (任意) Intel PT trace と組合せて hw レベル replay → bug 報告 = WAL + PT log
+
+### 10.3 Dry-run 仕様
+
+- 本番 arrangement の `read-only fork` を timely capability で作る
+- 投機 input を fork 上に注入、`predicted_post_state` view を計算
+- 本番に書き戻さない (commit せず破棄)
+- 結果を `envelope.if_you_did` に格納
+- 投機計算と本番計算の干渉はゼロ (worker thread 別、または同 worker の sub-region)
+
+### 10.4 Implementation note
+
+timely-dataflow には [`probe`](https://docs.rs/timely/latest/timely/dataflow/operators/probe/) と worker fork の機能がある。dry-run は probe + drop パターン、replay は別 worker で実現可能。詳細実装は ADR-008 D5/D6 で。
+
+---
+
+## 11. Schema versioning matrix (C6 解消)
+
+### 11.1 各層の version 軸
+
+| 層 | schema 名 | 現行 | 本設計 v1 | v2 候補時期 |
+|---|---|---|---|---|
+| L1 | EventEnvelope | n/a | v1.0 (本設計) | NPU semantic event 統合時 |
+| L2 | Arrangement on-disk | n/a | v1.0 | timely 0.14 移行時 |
+| L4-5 | Tool Envelope `_version` | n/a (raw) | "1.0" | dry-run の if_you_did schema 拡張時 |
+
+### 11.2 互換 matrix
+
+| client | server | 対応 |
+|---|---|---|
+| pre-v1 (raw) | pre-v1 | 現行 (互換維持) |
+| pre-v1 (raw) | v1 envelope | server が `data` フィールドを top-level に hoist する compat mode |
+| v1 envelope | pre-v1 | client が defensive default を入れる |
+| v1 envelope | v1 envelope | full feature |
+| v1 envelope | v2 envelope | server が `_version` を見て v1 互換出力 |
+| v2 envelope | v1 envelope | client が unknown field 無視 |
+
+### 11.3 MAJOR 上げの条件
+
+- `data` フィールドの shape が破壊的に変わる時のみ MAJOR
+- セクション追加 (`if_you_did` 拡張等) は MINOR
+- typed enum の追加 (`most_likely_cause` 新値) は PATCH
+
+---
+
+## 12. リリース順序 (C3 解消)
+
+### 12.1 段階導入
+
+| version | 範囲 | 観測効果 |
+|---|---|---|
+| **v1.x.x** (ADR-007) | koffi → Rust 撤去 + DXGI dirty rect 統合 (L1) | hot path 速度向上、sigsegv 消滅 |
+| **v1.x+1.0** (ADR-008 D1-D2) | timely + DD core view 4 つ | desktop_state が view 経由、context 削減開始 |
+| **v1.x+2.0** (ADR-008 D3) | time-travel `state_at(t)` | 過去 state クエリ |
+| **v1.x+3.0** (ADR-010 P1-P2) | envelope 必須最小 + typed reason | LLM 不安行動の最初の改善 |
+| **v1.x+4.0** (ADR-010 P3-P4) | include 拡張 + query_past リンク | causal trail / invariants 提供 |
+| **v1.x+5.0** (ADR-010 P5) | dry-run on commit 系 tool | 副作用予測 |
+| **v1.x+6.0** (ADR-008 D4-D5 + ADR-010 P6) | cyclic RPG + GPU Tier 3 + working/episodic memory | hot path GPU 化、CoALA Phase A |
+| **v1.x+7.0** (ADR-008 D6) | replay (WAL + 任意 Intel PT) | bug 報告が log に |
+| **v2.0.0** | breaking change envelope `_version: 2` | (将来、必要時) |
+
+### 12.2 各 release のリスク制御
+
+- 各 minor は **既存 LLM session で回帰なし** が必須 (acceptance criteria)
+- envelope 導入は **server 側 compat mode** で旧 client (今の MCP client) も動かす
+- Tier 3 (CUDA/HIP/L0) は **default で off**、env で opt-in、安定後 default on
+
+---
+
+## 13. Benchmark / Observability 体系 (C4 + C5 解消)
+
+### 13.1 ベンチハーネス (`bench/` crate)
+
+| 軸 | 対象 | KPI |
+|---|---|---|
+| latency | view 更新 / envelope assembly / time-travel query | p50/p95/p99 (μs) |
+| throughput | event ingest / arrangement compaction | events/sec |
+| memory | arrangement size, ring buffer occupancy | MB / event |
+| tier dispatch | T3 hit rate / fallback rate | % |
+| replay | determinism (bit-for-bit 一致率) | % (must be 100) |
+
+### 13.2 Engine self-observability (`server_status` 拡張)
+
+既存の `server_status` ツール (v0.15.x で追加) を拡張、envelope 化。
+
+```jsonc
+// server_status 応答 (envelope wrap)
+{
+  "data": {
+    "uptime_ms": 12345678,
+    "worker_lag_ms": { "p50": 0.3, "p95": 1.2, "p99": 8.5 },
+    "arrangement": {
+      "current_focused_element": { "rows": 1, "memory_mb": 0.001 },
+      "dirty_rect_aggregate": { "rows": 47, "memory_mb": 0.012 },
+      ...
+    },
+    "tier_dispatch_stats": { ... },
+    "recent_failures": [ ... ],
+    "wal_size_mb": 12.4,
+    "subscribe_count": 2
+  },
+  "as_of": { "wallclock_ms": ... },
+  "confidence": "fresh"
+}
+```
+
+LLM が trouble shoot 時にこれを見て、tier の使い方や lag を判断できる。
+
+### 13.3 観測ダッシュボード (将来)
+
+- `server_status` を時系列で可視化する開発者向け UI (本ロードマップ外、ADR-012 候補)
+- Materialize や Feldera が Web UI を持つように、本 engine も観測 UI を出す価値がある
+
+---
+
+## 14. Open Questions の集約
+
+各 ADR の Open Questions を 1 表にまとめ、決定タイミング順にソート。
+
+| # | OQ | 決定タイミング | 担当 ADR |
+|---|---|---|---|
+| 1 | session_id を MCP request id と紐付けるか独自管理か | P1 着手前 | ADR-010 |
+| 2 | typed reason enum と `_errors.ts` SUGGESTS の合流方法 | P2 着手前 | ADR-010 |
+| 3 | `state_at(t)` を全 view にするか選択 view のみか | D3 着手時 | ADR-008 |
+| 4 | Subscribe API transport (MCP notification / WebSocket / 内部 callback) | ADR-008 D2 + ADR-010 P4 整合 | 両方 |
+| 5 | `query_past` リンクの URI 形式 (string call: vs structured ref) | ADR-010 P4 着手時 | ADR-010 |
+| 6 | dry-run の精度許容ライン (50/80/95%) | ADR-010 P5 着手時 | ADR-010 |
+| 7 | working memory の N 上限推奨 default | ADR-010 P6 着手後 bench で | ADR-010 |
+| 8 | arrangement snapshot の disk format (bincode/capnproto/自前) | ADR-008 D6 着手時 | ADR-008 |
+| 9 | Intel PT 記録は全 session か bug 時のみか | ADR-008 D6 + 運用後 | ADR-008 |
+| 10 | HIP Graph on Windows の本番投入時期 | ADR-008 D5 完了後 re-check | ADR-008 |
+| 11 | DBSP を logical layer として乗せる protocol 互換要件 | 将来 (SQL UI 必要時) | ADR-008 |
+
+---
+
+## 15. 公開価値ロードマップ
+
+### 15.1 論文候補 (3 本独立)
+
+| # | 領域 | タイトル候補 | 主 contribution |
+|---|---|---|---|
+| 1 | DB / streaming | "GPU-accelerated incremental view maintenance for LLM agent perception" | DXGI dirty rect + CUDA Graph + DD で UI 観測の IVM、計測 |
+| 2 | OS / debugging | "Hardware-assisted deterministic replay for LLM agent debugging" | Intel PT + arrangement snapshot で agent bug の bit-for-bit 再現 |
+| 3 | HCI | "Sub-millisecond UI observation timestamps via Reflex Latency API" | race-free agent observation、ユーザビリティ評価 |
+
+### 15.2 Talk / Blog 候補
+
+- **"Self-Documenting Tool Envelopes: How LLM Agents Stop Being Anxious"** — UX 観点、HN/Lobsters/dev.to
+- **"Why I Built an MCP Server on top of differential-dataflow"** — Materialize blog 系統での deep dive
+- **"Tier 0-3 HW Acceleration for Windows Agent Runtime"** — Intel/AMD/NVIDIA dev forum
+
+### 15.3 OSS リリースタイミング
+
+- 本リポジトリは既に OSS。各 minor リリースで blog post をペアにし、認知を build
+- 大きな節目 (envelope 導入 = v1.x+3.0、replay 導入 = v1.x+7.0) は talk 提案に乗せる
+
+### 15.4 ナラティブ (一貫した物語)
+
+> Microsoft が WinAppSDK Rust binding を archive した一方、Intel/AMD/NVIDIA の hw assist を Rust で結合した Windows MCP server が、partial-order time + arrangement-as-MVCC + Self-Documenting Envelope を備えて世に出る。LLM agent は "Tool 数の多さ" ではなく "1 tool あたりの情報密度・時間軸・副作用透明性" でこそ進化する、という設計仮説を実装で証明する。
+
+---
+
+## 16. SSOT としての本書の運用
+
+### 16.1 ルール
+
+- 本書が **3 層に跨る規約の Source of Truth**
+- 各 ADR (007/008/010) は本書の節を **詳細化** する形で書かれる
+- 不整合発生時は **本書を更新 → ADR を後追い更新**
+- 本書の Status が `Approved` に上がった時、各 ADR も Approved に揃える
+
+### 16.2 更新トリガー
+
+- 識別子・時刻モデル・envelope 構造の変更 → 本書 §4-§8 を先に更新
+- リリース順序変更 → 本書 §12 を更新
+- 新規 OQ 解決 → 本書 §14 から該当行を削除、決定を該当節に反映
+
+### 16.3 関連ファイル
+
+- `docs/adr-007-koffi-to-rust-migration.md` (起草中、L1)
+- `docs/adr-008-reactive-perception-engine.md` (起草済、L2-3)
+- `docs/adr-009-hw-acceleration-plane.md` (後続、Tier 別実装ガイド)
+- `docs/adr-010-presentation-layer-self-documenting-envelope.md` (起草済、L4-5)
+- `docs/adr-011-cognitive-memory-extension.md` (後続、Semantic / Procedural)
+- `docs/views-catalog.md` (後続、L3 view 一覧)
+- `docs/schema-compat-matrix.md` (後続、§11 詳細)
+- `bench/` (後続、§13.1)
+- **`docs/layer-constraints.md` (本書 §17 の詳細版、各層の制約条件マトリクス)**
+
+---
+
+## 17. 各層の制約条件 (Summary)
+
+詳細は `docs/layer-constraints.md` を参照。本節は俯瞰用の summary のみ。
+
+### 17.1 制約の 6 観点
+
+各層について以下を明文化:
+
+| 観点 | 意味 |
+|---|---|
+| 入力契約 | 何を、どの形式・順序・レートで受け取るか |
+| 出力契約 | 何を、どの形式・SLO で出すか |
+| 不変条件 | 必ず保たねばならない invariant |
+| 性能制約 | latency / memory / throughput SLO |
+| 失敗モード | 典型 failure と recovery |
+| 境界 | 越権してはいけないこと (層の責務) |
+
+### 17.2 各層の責務 1 行サマリ
+
+| 層 | 主責務 | やってはいけない |
+|---|---|---|
+| **L1 Capture** | hw event を統一形式で push、durability 保証 | 計算しない、state を持たない |
+| **L2 Storage** | event を arrangement に materialize、time-travel 提供 | view 計算しない、副作用しない |
+| **L3 Compute** | view を incremental に維持、dry-run subgraph | L2 に書き戻さない、副作用しない |
+| **L4 Projection** | envelope の段階 enrichment、working/episodic memory | 計算しない、event を生成しない |
+| **L5 Tool Surface** | MCP API の wrap、3 軸 dispatch | 計算しない、L1 を経由せず副作用しない |
+
+### 17.3 性能 SLO の総覧
+
+| 層 | KPI | 目標 |
+|---|---|---|
+| L1 | event ingest throughput | 10k/sec @ p99 < 1ms |
+| L1 | dirty rect detect | DXGI 60Hz 同期 |
+| L2 | materialize | p99 < 100μs/event |
+| L2 | `state_at(t)` | p99 < 5ms |
+| L3 | view 更新 | p99 < 1ms |
+| L3 | dry-run preview | p99 < 50ms |
+| L4 | envelope assembly (include 最大) | p99 < 5ms |
+| L5 | query round-trip | p99 < 50ms |
+| L5 | commit round-trip | p99 < 200ms |
+| L5 | subscribe push 遅延 | p99 < 10ms |
+| 全層 | replay 一致率 | 100% (bit-for-bit) |
+
+### 17.4 Cross-layer 制約
+
+| # | 制約 | 詳細 |
+|---|---|---|
+| X1 | Total ordering | partial-order `(wallclock_ms, sub_ordinal)` を全層で共有、L1 で採番、以降 immutable |
+| X2 | Memory budget | L1=256MB / L2=512MB / L3=256MB / 合計 1-2GB、env で個別調整 |
+| X3 | Error propagation | hw failure → typed event → view warning → envelope confidence 降格、の chain |
+| X4 | Schema 整合 | L1 EventEnvelope と L5 Envelope の `_version` 整合チェック (起動時 fatal) |
+| X5 | Replay determinism | record 時 wallclock を WAL → bit-for-bit 再生 |
+| X6 | Tier dispatch | op 単位で独立、`server_status` で集約観測 |
+
+### 17.5 制約の運用
+
+- 制約変更は **本書 §17 + `layer-constraints.md` を先に更新 → 該当 ADR を後追い**
+- bench/ harness で SLO 違反を CI fail に
+- server_status で本番 SLO を継続監視
+- 新規制約追加は「観測可能か」「違反時の影響を明示できるか」「SLO に根拠があるか」で評価
+
+---
+
+## Appendix A: 用語集
+
+| 用語 | 定義 |
+|---|---|
+| arrangement | timely+DD の `(key, val, time, diff)` 4-tuple LSM-tree 風 sorted batch、multi-version |
+| Z-set | 各 row に整数 weight (`±n`) を持つ集合。delta 表現の基本単位 |
+| logical_time | timely の partial-order timestamp。本設計では `(wallclock_ms, sub_ordinal)` |
+| view | DD の materialized collection。incremental に更新される |
+| capability | timely の subscribe 機構、特定 logical_time での data access 権 |
+| frontier | timely の "これ以降の event は届かない" 進行点 |
+| envelope | LLM 向け統一 tool 応答 shape (本書 §8、ADR-010 §5) |
+| Tier 0-3 | HW assist の段階。Tier 0 = pure Rust、Tier 3 = vendor compute (本書 §9) |
+| WAL | Write-Ahead Log。replay 用 event log |
+
+---
+
+## Appendix B: 改訂履歴
+
+| version | date | author | summary |
+|---|---|---|---|
+| Draft v0.1 | 2026-04-29 | Claude (Opus) | 初版起草、3 ADR を統合、6 設計原則確定、識別子ヒエラルキー / 時刻モデル / Tier 統一規約を確定 |
+
+---
+
+END OF Architecture: 3-Layer Integrated Design (Draft).

--- a/docs/layer-constraints.md
+++ b/docs/layer-constraints.md
@@ -178,7 +178,7 @@ pub struct EventEnvelope {
 | view 名 | output type | consumer |
 |---|---|---|
 | `current_focused_element` | `Collection<UiElementRef, Diff>` | L4 envelope.data |
-| `dirty_rect_aggregate` | `Collection<Rect, Diff>` | L4 envelope.invariants_held / data |
+| `dirty_rects_aggregate` | `Collection<Rect, Diff>` | L4 envelope.invariants_held / data |
 | `semantic_event_stream` | `Collection<SemanticEvent, Diff>` | L4 envelope.caused_by |
 | `predicted_post_state` | `Collection<StateDelta, Diff>` (dry-run subgraph) | L4 envelope.if_you_did |
 
@@ -375,11 +375,12 @@ L1 hw failure
 
 L1 から L5 へエラーが伝播する経路が **typed event として明示**。throw + 文字列で揺れない。
 
-### 7.4 Schema version 整合 (§11 と連動)
+### 7.4 Schema version 整合 (§11 / 統合書 §11 と連動)
 
-- L1 EventEnvelope `_version` と L5 Envelope `_version` は **独立に進化**
+- L1 EventEnvelope の **`envelope_version: u32`** (top-level、numeric、ADR-007 §4) と L5 Tool Envelope の **`_version: "MAJOR.MINOR"`** (top-level、string、ADR-010 §5) は **独立に進化**
 - ただし「L1 v2 を L5 v1 が消費する」ような mismatch は禁止
-- 起動時に整合チェック、不一致なら fatal
+- 起動時に integration matrix でチェック、不一致なら fatal で worker 再起動
+- 詳細は ADR-007 §4.4 と `docs/schema-compat-matrix.md` (起草予定、ADR-008 D6 着手前) で管理
 
 ### 7.5 Replay determinism chain
 

--- a/docs/layer-constraints.md
+++ b/docs/layer-constraints.md
@@ -1,0 +1,461 @@
+# Layer Constraints Matrix — 各層の制約条件詳細
+
+- Status: **Draft (起草中)**
+- Date: 2026-04-29
+- Authors: Claude (Opus, max effort)
+- Scope: `docs/architecture-3layer-integrated.md` §17 の詳細版
+- 役割: 各層 (L1-L5) が満たさねばならない契約・不変条件・性能 SLO・失敗モード・境界を明文化
+- 目的: 各 ADR の詳細実装を「制約を満たす設計選択」として機械的に進められるようにする
+
+---
+
+## 1. 制約条件の読み方
+
+各層について、6 観点で制約を整理する。
+
+| 観点 | 意味 |
+|---|---|
+| **入力契約** | 何を、どの形式・順序・レートで受け取るか |
+| **出力契約** | 何を、どの形式・SLO で出すか |
+| **不変条件** | 必ず保たねばならない invariant (これが破れたら設計が壊れる) |
+| **性能制約** | latency / memory / throughput の SLO (acceptance criteria の根拠) |
+| **失敗モード** | 典型的な failure と recovery 戦略 |
+| **境界** | 越権してはいけないこと (層の責務) |
+
+各層の依存関係 (どの crate / OS API / hw に依存するか) は別途明記。
+
+---
+
+## 2. L1: Capture (センサー層)
+
+### 2.1 入力契約
+
+| 入力 | 形式 | 順序 | レート (期待) |
+|---|---|---|---|
+| DXGI dirty/move rect | `IDXGIOutputDuplication::GetFrameDirtyRects` | 表示更新順 | 60Hz (DWM 周期) |
+| UIA event | `IUIAutomation` callback | provider 提供順 (out-of-order あり) | event 発生時 |
+| hw input event | windows-rs `SendInput` 系 | call 順 | 操作時のみ |
+| tool call (commit 軸) | L5 → L1 内部 channel | submission 順 | < 100/s |
+| 副作用結果 | OS API 戻り値 | 同期的 | call 同期 |
+
+### 2.2 出力契約
+
+`EventEnvelope` Rust struct (`#[napi(object)]` で TS にも露出):
+
+```rust
+#[napi(object)]
+pub struct EventEnvelope {
+    pub event_id: BigInt,             // u64 monotonic
+    pub wallclock_ms: BigInt,         // canonical
+    pub sub_ordinal: u32,             // 同 ms tie-break
+    pub timestamp_source: TimestampSource,  // Reflex/DXGI/DWM/StdTime
+    pub kind: EventKind,              // DirtyRect | UiaFocus | UiaInvoke | ToolCall | ...
+    pub payload: Vec<u8>,             // kind 別 schema、bincode encoded
+    pub session_id: Option<String>,
+    pub tool_call_id: Option<String>,
+}
+```
+
+- 出力先: ring buffer (in-memory MPSC) + WAL (record モード時)
+- WAL durability: `fsync` after each batch (interval 設定可、default 10ms)
+
+### 2.3 不変条件
+
+| # | invariant | 違反時の影響 |
+|---|---|---|
+| 1 | `event_id` は monotonic increasing | replay が壊れる、§5 の logical_time 一意性破綻 |
+| 2 | 同じ wallclock_ms 内では `sub_ordinal` が unique | partial-order tie-break 失敗 |
+| 3 | `timestamp_source` は event 単位で固定 (混在しない) | freshness_ms 計算不能 |
+| 4 | 同じ event を 2 回 emit しない | L2 materialize で duplicate row |
+| 5 | WAL に書き終わるまで L2 に push しない | crash 時の event ロスト |
+| 6 | hw failure (DXGI/UIA など) は EventKind として emit、panic しない | プロセス全滅 |
+
+### 2.4 性能制約 (SLO)
+
+| KPI | 目標 |
+|---|---|
+| event ingest throughput | 10k events/sec |
+| event ingest latency p99 | < 1ms |
+| dirty rect detect cycle | DXGI 60Hz と同期 (16.67ms 周期) |
+| ring buffer capacity | default 256MB、env で調整可 |
+| WAL write latency p99 | < 5ms (10ms batch interval 内に収まる) |
+| ring buffer overflow rate | < 0.001% (1k 中 1 以下) |
+
+### 2.5 失敗モード
+
+| failure | 検出 | recovery |
+|---|---|---|
+| DXGI Desktop Duplication 失敗 | `AcquireNextFrame` Err | Tier 1 から Tier 0 (std GDI) にフォールバック、warning event emit |
+| UIA timeout (provider 無応答) | timeout 8s | fallback PowerShell (現行互換)、warning event |
+| WAL write fail (disk full) | `io::Error` | 緊急 GC、それでもダメなら fatal で worker 再起動 |
+| ring buffer overflow | producer が consumer を越えそう | oldest drop + warning event (priority 低 event を優先 drop) |
+| Reflex API 利用不可 (NVIDIA driver 古い) | capability detect 時 | DXGI Present statistics に格下げ、env warning |
+| timestamp source 全部利用不可 | capability detect 時 | std::time、env error |
+
+### 2.6 境界 (やってはいけないこと)
+
+- **計算しない** — diff / aggregate / semantic 推論は L3 の責務
+- **state を保持しない** — arrangement は L2、L1 は ring buffer (一時) と WAL (durability) のみ
+- **L2 以上の構造を知らない** — timely / arrangement / view の概念に依存しない (event を出すだけ)
+- **副作用は OS API 直叩きのみ** — 第三者プロセスへの reach、network、外部 SDK 呼び出しは禁止
+
+### 2.7 依存
+
+- `windows-rs` 0.62+ (UIA, DXGI, DWM, Reflex)
+- `koffi` を **撤去** (ADR-007)、win32 binding は windows-rs 経由
+- Tier 2 任意: Intel DSA SDK, NVENC/Quick Sync/AMF、Intel PT (perf or自前)
+- Rust 2024 edition、stable 1.85+
+
+---
+
+## 3. L2: Storage (MVCC arrangement)
+
+### 3.1 入力契約
+
+- L1 EventEnvelope stream (ring buffer から timely input)
+- frontier 進行 hint (Reflex/DXGI tick で自動進行可)
+
+### 3.2 出力契約
+
+- `arrangement::Arrangement<G, K, V, T, R>` を view consumer (L3) に提供
+- frontier 通知 capability
+- `state_at(t: wallclock_ms)` query API (point query、batch slice 走査)
+
+### 3.3 不変条件
+
+| # | invariant | 違反時の影響 |
+|---|---|---|
+| 1 | logical_time は monotonic な partial-order | timely の semantic 破綻 |
+| 2 | 同じ event_id を 2 回 materialize しない | view duplicate |
+| 3 | `state_at(t)` は compaction frontier 内の t に対し正しい state を返す | time-travel 結果不正 |
+| 4 | arrangement に書き戻すのは L1 input のみ (L3 から書き戻し禁止) | dataflow の単方向性破綻 |
+| 5 | compaction frontier が advance したら過去 t は引けなくなる (明示) | LLM が古い t を試した時の error が typed であること |
+
+### 3.4 性能制約
+
+| KPI | 目標 |
+|---|---|
+| materialize latency p99 | < 100μs/event |
+| `state_at(t)` p99 | < 5ms |
+| arrangement memory budget | default 512MB、超過時 compaction 加速 |
+| compaction frequency | adaptive (memory pressure 連動) |
+| compaction frontier lag | < 5s (default、env で調整) |
+
+### 3.5 失敗モード
+
+| failure | 検出 | recovery |
+|---|---|---|
+| memory budget OOM | arrangement size monitor | 古い epoch を強制 compact、frontier を進める、warning event |
+| logical_time 衝突 | sub_ordinal でも tie 破れない | error event emit、event 1 つを drop (max iter で防げる) |
+| `state_at(t)` で t が compaction 済 | 範囲外 | typed error: `most_likely_cause: "time_compacted"`、L4 で envelope 化 |
+
+### 3.6 境界
+
+- **view 計算しない** — operator graph は L3
+- **副作用しない** — read-only sink for L1 input
+- **schema 進化を独立に決めない** — `_version` matrix (§11) に従う
+
+### 3.7 依存
+
+- `timely-dataflow` 0.13+
+- `differential-dataflow` 0.13+
+- L1 EventEnvelope schema (`_version` 共通)
+
+---
+
+## 4. L3: Compute (IVM)
+
+### 4.1 入力契約
+
+- L2 arrangement collection (read-only)
+- timely capability (subscribe 起点)
+- DataflowAccelerator trait 実装 (Tier 0-3、§9)
+
+### 4.2 出力契約
+
+主要 view (D2 で実装、ADR-008):
+
+| view 名 | output type | consumer |
+|---|---|---|
+| `current_focused_element` | `Collection<UiElementRef, Diff>` | L4 envelope.data |
+| `dirty_rect_aggregate` | `Collection<Rect, Diff>` | L4 envelope.invariants_held / data |
+| `semantic_event_stream` | `Collection<SemanticEvent, Diff>` | L4 envelope.caused_by |
+| `predicted_post_state` | `Collection<StateDelta, Diff>` (dry-run subgraph) | L4 envelope.if_you_did |
+
+加えて lens-dependent な cyclic view (D4):
+
+| view 名 | type | 備考 |
+|---|---|---|
+| `lens_attention` | `Collection<Lens, Diff>` | iterative scope、fixed-point |
+
+### 4.3 不変条件
+
+| # | invariant | 違反時の影響 |
+|---|---|---|
+| 1 | view は incremental 更新のみ (full recompute 禁止) | latency SLO 破綻 |
+| 2 | cyclic view は fixed-point で必ず settle | 無限ループ |
+| 3 | dry-run subgraph は本番 arrangement を変更しない | side-effect leak |
+| 4 | Tier 失敗時は cascade で必ず Tier 0 まで落ちる (op 単位) | 動かない環境発生 |
+| 5 | view から L1/L2 に書き戻さない | dataflow 単方向性 |
+
+### 4.4 性能制約
+
+| KPI | 目標 |
+|---|---|
+| view 更新 latency p99 | < 1ms |
+| dry-run preview latency p99 | < 50ms |
+| GPU op throughput (Tier 3 動作時) | change_fraction で 13.4x 以上 (現行 PoC ベース) |
+| cyclic max iter | 100 (default、超過時 abort + warning) |
+
+### 4.5 失敗モード
+
+| failure | 検出 | recovery |
+|---|---|---|
+| Tier 3 failure (CUDA Graph 不在) | capability detect or runtime err | Tier 2 cascade、`server_status` に集約 |
+| cyclic 無限ループ | max iter 超過 | abort、warning event、view を最後の安定値で fallback |
+| dry-run 計算失敗 | timely panic catch | `if_you_did = null`、本体 envelope は normal 返却 |
+| view operator panic | `catch_unwind` | view を offline、L4 で confidence=stale |
+
+### 4.6 境界
+
+- **L2 に書き戻さない** (read-only consumer)
+- **副作用しない** (UIA Invoke / hw input は L1 commit 経由)
+- **time advance を勝手に進めない** (L2 frontier に従う)
+
+### 4.7 依存
+
+- L2 arrangement
+- `DataflowAccelerator` trait (§9)
+- Tier 3: CUDA / HIP / Level Zero SDK (任意)
+
+---
+
+## 5. L4: Cognitive Projection + Envelope Assembly
+
+### 5.1 入力契約
+
+| 入力 | 出典 |
+|---|---|
+| L3 view 値 | `current_focused_element` 等 |
+| tool_call_id | L5 wrapper |
+| session_id | MCP request 起源 |
+| 直近 commit 履歴 | L4 内 episodic store (working memory) |
+
+### 5.2 出力契約
+
+完成した Envelope (ADR-010 §5、本書 §11)。
+
+### 5.3 不変条件
+
+| # | invariant | 違反時の影響 |
+|---|---|---|
+| 1 | `data` フィールドは L3 view の値のみ (L4 で計算しない) | data の出自が曖昧化 |
+| 2 | `caused_by` は session 内 1 つ前の commit との因果のみ | causal trail 嘘 |
+| 3 | `failed_at_layer` は失敗発生層を正しく示す | trouble shoot 不能 |
+| 4 | `as_of.wallclock_ms` は L1 入力時の値を継承 | freshness 嘘 |
+| 5 | `query_past` link は実 API 形式と一致 | LLM が呼んでも届かない |
+
+### 5.4 性能制約
+
+| KPI | 目標 |
+|---|---|
+| envelope assembly p99 | < 5ms (include 最大時) |
+| working memory N 上限 | default 50 (調整可) |
+| episodic memory N 上限 | default 100 (調整可) |
+
+### 5.5 失敗モード
+
+| failure | 検出 | recovery |
+|---|---|---|
+| L3 view 不在 (起動直後) | view subscribe Err | `confidence = stale`、`data = null` |
+| session_id 不在 | MCP request に無し | `caused_by = null`、ログ警告 |
+| episodic store 容量超過 | N 超 | LRU で oldest drop |
+| typed reason mapping 漏れ | enum match で fallthrough | `most_likely_cause = "unknown"`、log で coverage 改善 |
+
+### 5.6 境界
+
+- **副作用しない**
+- **L1-L3 に新しい event を生成しない** (L1 commit を経由しないと event は産まれない)
+- **計算しない** — view 値の整形・enrichment のみ
+- **session 跨ぎの記憶を持たない** (cross-session のことは ADR-011 で扱う)
+
+### 5.7 依存
+
+- L3 view
+- session_id / tool_call_id 管理 (L5 から受領)
+- typed reason enum (`_errors.ts` を SSOT として吸収)
+
+---
+
+## 6. L5: MCP Tool Surface
+
+### 6.1 入力契約
+
+- MCP request: `{ tool: string, args: object, include?: string[] }`
+- MCP transport: stdio / HTTP / WebSocket (subscribe 用)
+
+### 6.2 出力契約
+
+- 完成した envelope を MCP response として返却
+- subscribe 軸は capability に follow した notification stream
+
+### 6.3 不変条件
+
+| # | invariant | 違反時の影響 |
+|---|---|---|
+| 1 | 全 tool 応答が `_version` stamped envelope | client compat 崩壊 |
+| 2 | query 軸 tool は副作用ゼロ (event_id を新規発行しない) | dry-run / replay の semantic 破綻 |
+| 3 | commit 軸 tool は L1 commit を経由 (直接 OS API を叩かない) | event log 不完全 |
+| 4 | subscribe 軸 tool は capability 経由のみ | push 配信の整合性 |
+| 5 | `include` 引数は string array のみ受付 (struct 化しない) | schema 過剰複雑化 |
+
+### 6.4 性能制約
+
+| KPI | 目標 |
+|---|---|
+| query tool round-trip p99 | < 50ms |
+| commit tool round-trip p99 | < 200ms (UIA hw 込み) |
+| subscribe push 遅延 p99 | < 10ms (capability 通知から MCP notification まで) |
+
+### 6.5 失敗モード
+
+| failure | 検出 | recovery |
+|---|---|---|
+| L4 失敗 | partial envelope 受領 | failure テンプレで応答 (data=null + if_unexpected) |
+| timeout (hw 無応答) | timeout 設定値超過 | `most_likely_cause: "timeout"` |
+| MCP transport 切断 | connection 断 | subscribe を破棄、再接続待ち |
+| tool not found | tool registry 検索失敗 | typed error envelope (`tool_unknown`) |
+
+### 6.6 境界
+
+- **計算しない** (L4 envelope を受けて MCP に流すだけ)
+- **新しい event を生成しない** (commit は L1 経由必須)
+- **session 状態を保持しない** (session 状態は L4 working/episodic memory)
+
+### 6.7 依存
+
+- L4 envelope
+- MCP SDK (現行 stdio + 既存 HTTP transport)
+- typed reason enum (L4 と共用)
+
+---
+
+## 7. Cross-layer 制約 (層またぎ)
+
+各層単独では保証できないが、システム全体で守るべき制約。
+
+### 7.1 Total ordering
+
+- すべての event は **`(wallclock_ms, sub_ordinal)` の partial-order** に従う
+- 同 wallclock 内の sub_ordinal は L1 で **採番、以降の層は変更不可**
+- replay 時は WAL 順序が再生 → 全層で同じ順序になる
+
+### 7.2 Memory budget
+
+| 層 | budget | 超過時 |
+|---|---|---|
+| L1 ring buffer | 256MB (default) | oldest drop |
+| L2 arrangement | 512MB (default) | compaction 加速 |
+| L3 view materialization | 256MB (default) | view ごとに retention 制御 |
+| L4 episodic store | 数 MB (N=100) | LRU drop |
+| 合計 | 1-2GB 想定 | env で各 budget 調整可 |
+
+env: `DESKTOP_TOUCH_MEMORY_*=N` で個別調整。
+
+### 7.3 Error propagation chain
+
+```
+L1 hw failure
+  └─ EventKind::Failure として emit (panic しない)
+       └─ L2 materialize は警告 view に
+            └─ L3 view は warning collection を持つ
+                 └─ L4 envelope.invariants_held に "hw_warning_X" を追加
+                      └─ L5 envelope の confidence を fresh→cached に降格
+```
+
+L1 から L5 へエラーが伝播する経路が **typed event として明示**。throw + 文字列で揺れない。
+
+### 7.4 Schema version 整合 (§11 と連動)
+
+- L1 EventEnvelope `_version` と L5 Envelope `_version` は **独立に進化**
+- ただし「L1 v2 を L5 v1 が消費する」ような mismatch は禁止
+- 起動時に整合チェック、不一致なら fatal
+
+### 7.5 Replay determinism chain
+
+- L1 で record 時の wallclock を WAL に格納
+- L2 logical_time は WAL から再注入で同じ
+- L3 view は decoder が deterministic (timely の保証)
+- L4 envelope は §5.3 の record 時 wallclock を使う
+- → bit-for-bit 再現 (acceptance criteria D6)
+
+### 7.6 Tier dispatch consistency
+
+- 各 op の Tier は **op 単位で独立**、L1 と L3 は別の Tier を選んで OK
+- ただし `server_status` で全 op の Tier 状態を集約 (§13)
+
+---
+
+## 8. Acceptance Criteria の集約
+
+各層の制約を満たしているかの検証基準。各 ADR の AC を本書に集約。
+
+| 層 | 検証項目 | 出典 |
+|---|---|---|
+| L1 | event ingest 10k/s @ p99 < 1ms | 本書 §2.4 |
+| L1 | DXGI dirty rect 60Hz 同期 | 本書 §2.4 |
+| L1 | WAL durability (crash 後の event ロスト 0) | 本書 §2.3 |
+| L2 | materialize p99 < 100μs | 本書 §3.4 |
+| L2 | `state_at(t)` p99 < 5ms | 本書 §3.4 (ADR-008 D3) |
+| L2 | arrangement memory < 512MB (default) | 本書 §3.4 |
+| L3 | view 更新 p99 < 1ms | 本書 §4.4 (ADR-008 D1) |
+| L3 | dry-run latency p99 < 50ms | 本書 §4.4 (ADR-008 D5) |
+| L3 | cyclic 無限ループ自動検出 | 本書 §4.4 (ADR-008 D4) |
+| L4 | envelope assembly p99 < 5ms | 本書 §5.4 |
+| L4 | typed reason coverage > 95% | ADR-010 P2 |
+| L4 | LLM context 1/3 削減 (代表シナリオ) | ADR-010 P6 |
+| L5 | query round-trip p99 < 50ms | 本書 §6.4 |
+| L5 | commit round-trip p99 < 200ms | 本書 §6.4 |
+| L5 | subscribe push 遅延 p99 < 10ms | 本書 §6.4 |
+| 全層 | replay bit-for-bit 一致率 100% | 本書 §7.5 (ADR-008 D6) |
+
+ベンチハーネス (`bench/` crate) は上記すべてを単一 CI で測定する。
+
+---
+
+## 9. 制約の運用
+
+### 9.1 制約変更時のフロー
+
+1. 本書を更新 (constraint 行を編集)
+2. 統合書 §17 の summary も同期
+3. 該当 ADR の §性能 / §不変 / §境界 を後追い更新
+4. acceptance criteria を bench で実測 → 達成可否確認
+
+### 9.2 制約と実装の乖離検出
+
+- bench/ で SLO 違反検出 → CI で fail
+- server_status で実運用 SLO 監視 → metric を出力
+- LLM session log で「不安行動」増減を観測 → ADR-010 §1.1 の指標で
+
+### 9.3 制約の追加判断
+
+新しい制約を追加するときの基準:
+- **観測可能か** (bench / server_status で測れるか)
+- **違反時に何が壊れるか明示できるか**
+- **SLO 数値が根拠を持つか** (推測でなく現実装ベンチ起点)
+
+---
+
+## 10. Related Files
+
+- 統合書: `docs/architecture-3layer-integrated.md` (§17 が本書のサマリ)
+- ADR-007: L1 詳細 (起草中)
+- ADR-008: L2-L3 詳細 (起草済)
+- ADR-009: HW Acceleration Plane Tier 別実装 (後続)
+- ADR-010: L4-L5 詳細 (起草済)
+- ADR-011: Cognitive Memory Extension (Phase B、後続)
+
+---
+
+END OF Layer Constraints Matrix (Draft).

--- a/docs/views-catalog.md
+++ b/docs/views-catalog.md
@@ -1,0 +1,311 @@
+# Views Catalog — L3 Compute で実装する全 view 一覧
+
+- Status: **Draft (起草中)**
+- Date: 2026-04-29
+- Authors: Claude (Opus, max effort)
+- Scope: ADR-008 (L3 Compute) で実装する materialized view の一覧と契約
+- 役割: D2 着手前に view 数・shape・consumer を確定し、実装担当者がブレずに進められるようにする
+- 関連:
+  - 統合書 (SSOT): `docs/architecture-3layer-integrated.md`
+  - 制約: `docs/layer-constraints.md` §4 (L3 Compute)
+  - 詳細: `docs/adr-008-reactive-perception-engine.md`
+
+---
+
+## 1. 役割と運用
+
+### 1.1 本書の位置づけ
+
+ADR-008 D2 は「主要 view 4 つを declarative に実装」を完了基準にしているが、4 つだけでは envelope 組立て (ADR-010) や server_status 拡張 (統合書 §13) を支えきれない。
+
+本書は **L3 view 全体のカタログ** として、
+
+- view 名 (Rust API として一意)
+- input arrangement / collection
+- output collection の shape (Rust struct)
+- consumer (どの ADR / どの envelope セクションが消費するか)
+- SLO (latency / memory)
+- phase (どのリリースで実装)
+
+を全 view について定める。
+
+### 1.2 view 追加プロセス
+
+新しい view が必要になった場合:
+
+1. 本書に **行を追加** (名前 / input / output shape / consumer / SLO / phase)
+2. ADR-008 D2 のチェックリストに **未着手として登録**
+3. PR で view 実装と同時に本書を **`Implemented` に flip**
+4. envelope セクションへの projection を ADR-010 で追記 (consumer が L4 の場合)
+
+### 1.3 命名規則
+
+- snake_case (Rust 識別子と整合)
+- 名詞句、動詞は使わない (例: `current_focused_element` ✓、`get_focused_element` ✗)
+- 複数形は集約に使う (例: `dirty_rects_aggregate`)
+- 時間窓は suffix で示す (例: `recent_changes_5s`)
+- 投機 / 派生は prefix で示す (例: `predicted_post_state`、`replay_focused_element`)
+
+---
+
+## 2. View の分類 (5 カテゴリ)
+
+| カテゴリ | 性質 | 例 |
+|---|---|---|
+| **state** | 現在値、1 row | current_focused_element, current_modal |
+| **aggregate** | 集計、N rows | dirty_rects_aggregate, fallback_events |
+| **event-stream** | delta 連続、subscribe 配信 | semantic_event_stream |
+| **projection** | 既存 view の整形 | tier_dispatch_stats, worker_lag_metrics |
+| **cyclic** | 不動点 / iterative | lens_attention |
+
+特殊系:
+- **dry-run subgraph**: read-only fork 上の view (本番 arrangement に書き戻さない)
+- **time-travel point query**: arrangement の time slice に対する一発 query (連続 view ではない)
+
+---
+
+## 3. 主要 view 一覧 (Phase 別)
+
+### 3.1 D1: 最小成立 (1 view)
+
+| view 名 | category | input | output (Rust struct) | consumer | SLO | phase |
+|---|---|---|---|---|---|---|
+| `current_focused_element` | state | `UiaFocusChanged` events from L1 | `UiElementRef { name, automation_id, control_type, window_title }` | L4 envelope.data (desktop_state) | p99 < 1ms | D1 |
+
+### 3.2 D2: 主要 view 4 つ (本書の主スコープ)
+
+| view 名 | category | input | output | consumer | SLO | phase |
+|---|---|---|---|---|---|---|
+| `current_focused_element` | state | (D1 と同じ) | (D1 と同じ) | (D1 と同じ) | (D1 と同じ) | D1 (carry-over) |
+| `dirty_rects_aggregate` | aggregate | `DirtyRect` events (DXGI) | `Vec<Rect> + summary { count, total_area }` | L4 envelope.invariants_held + screenshot diff 判定 | p99 < 2ms | D2 |
+| `semantic_event_stream` | event-stream | `UiaFocusChanged`, `WindowChanged`, `DirtyRect`, `ScrollChanged` | `SemanticEvent { kind: ModalAppeared/FocusMoved/ScrollSettled/..., ts, context }` | L4 envelope.caused_by + subscribe 配信 | p99 < 3ms | D2 |
+| `predicted_post_state` | dry-run subgraph | tool_call (仮想) + 現 state | `StateDelta { focus, modal, dirty_rect_estimate, confidence }` | L4 envelope.if_you_did | p99 < 50ms | D2 (subgraph 構造、計算の本格化は D5) |
+
+### 3.3 D2.5: working / episodic memory (ADR-010 P6 と擦合せ)
+
+| view 名 | category | input | output | consumer | SLO | phase |
+|---|---|---|---|---|---|---|
+| `recent_changes_5s` | aggregate | 全 EventEnvelope (5s 窓) | `Vec<EventSummary>` (compact) | L4 envelope.caused_by.recent_window (`include=working:N`) | p99 < 3ms | D2.5 |
+| `tool_call_history` | aggregate | `ToolCallStarted` / `ToolCallCompleted` events | `Vec<ToolCallSummary { tool, args_redacted, outcome, ts, elapsed }>` | L4 envelope.caused_by.tool_call_history (`include=episodic:N`) | p99 < 3ms | D2.5 |
+
+### 3.4 D3: time-travel (point query)
+
+| view 名 | category | input | output | consumer | SLO | phase |
+|---|---|---|---|---|---|---|
+| `state_at(t: wallclock_ms)` | time-travel point query | arrangement の time slice | 上記 state/aggregate の t 時点値 | envelope.query_past 経由 | p99 < 5ms | D3 |
+| `diff(t1, t2)` | time-travel diff | arrangement の 2 time slice | `StateDelta` | envelope.query_past.diff_since_last_call | p99 < 10ms | D3 |
+
+注: `state_at` は view ではなく **arrangement への point query** だが、L3 API 表面では view 同様に扱う。compaction frontier 範囲内の t に対してのみ正しい結果を返す (制約 layer-constraints §3.3)。
+
+### 3.5 D4: cyclic (RPG lens)
+
+| view 名 | category | input | output | consumer | SLO | phase |
+|---|---|---|---|---|---|---|
+| `lens_attention` | cyclic (fixed-point) | `current_focused_element` + lens spec map + lens dependencies | `Vec<LensState { id, focus_score, attention, hot_targets }>` | L4 envelope (desktop_state attention 部) + 既存 RPG | max iter 100、p99 < 5ms (settle 含む) | D4 |
+| `modal_state` | state | UIA dialog event + window class match | `Option<ModalRef { name, kind, blocker_for }>` | L4 envelope.if_unexpected.blocker | p99 < 1ms | D4 |
+| `attention_signal` | projection | lens_attention + dirty_rects_aggregate | `AttentionLevel { ok | changed | dirty | settling | stale }` | L4 envelope.confidence、既存 RPG | p99 < 1ms | D4 |
+
+### 3.6 D5: HW-accelerated (Tier 3 動作する view)
+
+| view 名 | category | input | output | consumer | SLO | phase |
+|---|---|---|---|---|---|---|
+| `change_fraction_per_window` | aggregate (GPU 対応) | DXGI dirty rect + screenshot pixel | `f64 per window` | screenshot 判定、anti-fukuwarai | Tier 3: p99 < 0.5ms (1080p)、Tier 0: < 4ms | D5 |
+| `dhash_per_window` | projection (GPU 対応) | screenshot frame | `u64 per window` | scroll/screenshot 重複検出 | Tier 3: p99 < 0.3ms、Tier 0: < 2ms | D5 |
+
+### 3.7 server_status 拡張 view (統合書 §13.2)
+
+| view 名 | category | input | output | consumer | SLO | phase |
+|---|---|---|---|---|---|---|
+| `tier_dispatch_stats` | aggregate | 全 op の tier hit/miss event | `Map<OpKind, TierStats { T0, T1, T2, T3 }>` | server_status data | p99 < 1ms | D2 (統合書 §13.2 と同期) |
+| `worker_lag_metrics` | projection | timely worker frontier vs wallclock | `LagStats { p50, p95, p99 }` | server_status data | p99 < 1ms | D2 |
+| `arrangement_size_metrics` | projection | arrangement 内部 stat | `Map<ViewName, SizeStats>` | server_status data | p99 < 1ms | D2 |
+| `recent_failures_log` | event-stream | `Failure` / `TierFallback` events | `Vec<FailureRecord { op, tier, vendor, reason, ts }>` (LRU 100) | server_status data | p99 < 2ms | D2 |
+
+---
+
+## 4. 特殊 view の追加詳細
+
+### 4.1 `predicted_post_state` の subgraph 構造
+
+```
+本番 worker:
+  L1 input → arrangement A (read-write、本番)
+                    │
+                    │ (read-only fork)
+                    ▼
+  Dry-run subgraph (別 worker thread or sub-region):
+    投機 input (tool_call, 仮想) → arrangement A の copy → predicted_post_state view
+                                                                │
+                                                                ▼
+                                                        L4 envelope.if_you_did
+
+副作用なし、本番 arrangement 不変。
+```
+
+入力契約:
+- `tool_call_id` 必須 (どの呼び出しの予測か)
+- `tool` + `args` (実際の commit 形式と同じ shape)
+- 制約: 投機実行は **副作用を持つ tool 限定** (commit 軸のみ、ADR-010 §3 のリストと同じ)
+
+出力契約:
+```rust
+pub struct PredictedPostState {
+    pub predicted_focus: Option<UiElementRef>,
+    pub predicted_modal: Option<ModalRef>,
+    pub predicted_dirty_rect: Option<Rect>,
+    pub confidence: ConfidenceLevel,   // High | Medium | Low
+    pub computation_ms: u32,
+}
+```
+
+### 4.2 `lens_attention` の cyclic 構造 (D4)
+
+```rust
+worker.dataflow::<u64, _, _>(|scope| {
+    let focused = current_focused_element_input(scope);
+    let lens_specs = lens_spec_input(scope);
+
+    let attention = scope.iterative::<u32, _, _>(|inner| {
+        let focused_inner = focused.enter(inner);
+        let specs_inner = lens_specs.enter(inner);
+
+        // 1) lens spec ごとに binding を解決
+        let bindings = resolve_bindings(&focused_inner, &specs_inner);
+
+        // 2) maintain key を展開して fluent-store query
+        let lens_states = compute_lens_states(&bindings);
+
+        // 3) attention level を派生
+        let attention = derive_attention(&lens_states);
+
+        // 不動点に達するまで内側で iterate
+        attention.leave()
+    });
+
+    attention.inspect(|x| /* push to subscribers */);
+});
+```
+
+不動点判定 = `lens_states` の delta が空 (Z-set 加減算で 0)。
+
+### 4.3 `state_at(t)` の実装
+
+```rust
+pub fn state_at<V>(arrangement: &Arrangement<...>, t: u64) -> Result<V> {
+    if t < arrangement.compaction_frontier() {
+        return Err(typed_error("LeaseDigestMismatch"));  // (compaction で消えた相当)
+    }
+    arrangement
+        .as_collection()
+        .as_of(t)               // timely の time slice 操作
+        .first()                // state view は 1 row 想定
+        .ok_or(typed_error("EntityNotFound"))
+}
+```
+
+compaction frontier の管理は L2 担当 (制約 layer-constraints §3.3)。
+
+---
+
+## 5. View の同期保証
+
+### 5.1 view 間の整合性
+
+複数 view の値を envelope に同梱するとき、すべて **同じ logical_time** で取得することを保証。
+
+```rust
+let cap = scope.capability_for(t);
+let focused = current_focused_element.read_at(cap);
+let modal = modal_state.read_at(cap);
+let dirty = dirty_rects_aggregate.read_at(cap);
+// すべて t 時点の atomic snapshot
+```
+
+この atomic 取得が **観測整合性** を保証 (envelope.invariants_held の根拠)。
+
+### 5.2 frontier 進行と SLO の関係
+
+- worker frontier が advance する周期 = view 更新の最小単位
+- frontier がいつまでも止まると view が古い → `confidence: stale`
+- frontier 進行は **L1 input 到着 + Reflex/DXGI tick** で driven
+- アイドル時は `Heartbeat` event を L1 から流して frontier を進める (制約 §2.7)
+
+---
+
+## 6. View 計算と HW Tier の対応
+
+| view | Tier 0 (Pure Rust) | Tier 1 (OS API) | Tier 3 (Vendor compute) |
+|---|---|---|---|
+| current_focused_element | ✓ scalar | (n/a) | (n/a — UIA は CPU only) |
+| dirty_rects_aggregate | ✓ scalar | ✓ DXGI dirty rect 直接利用 | (n/a) |
+| semantic_event_stream | ✓ scalar | (n/a) | (n/a) |
+| predicted_post_state | ✓ scalar | (n/a) | (n/a — semantic 推論は L1 NPU 経由) |
+| change_fraction_per_window | ✓ scalar | ✓ rayon SIMD | ✓ CUDA Graph reduce |
+| dhash_per_window | ✓ scalar | ✓ rayon SIMD | ✓ CUDA / HIP / L0 kernel |
+| lens_attention | ✓ scalar | (n/a — 純粋 Rust) | (n/a) |
+| modal_state | ✓ scalar | (n/a) | (n/a) |
+| attention_signal | ✓ scalar | (n/a) | (n/a) |
+| 全 server_status view | ✓ scalar | (n/a) | (n/a) |
+
+→ Tier 3 が効くのは **change_fraction / dhash の数値計算系 2 view** に集中。それ以外は CPU で十分。
+
+---
+
+## 7. View 数のサマリ
+
+| Phase | 新規 view 数 | 累積 | 主な consumer |
+|---|---|---|---|
+| D1 | 1 | 1 | desktop_state minimum |
+| D2 | 7 (主要 4 + server_status 4 のうち 1 carry) | 8 | desktop_state full + server_status |
+| D2.5 | 2 | 10 | working / episodic memory |
+| D3 | (point query 2 件、view としては既存活用) | 10 | time-travel |
+| D4 | 3 | 13 | RPG cyclic + modal + attention |
+| D5 | 2 | 15 | HW-accelerated |
+
+**最終的に L3 view は 15 程度**。tool 数 28 と比べてはるかに少ない (1 view が複数 tool の data を提供)。
+
+---
+
+## 8. Acceptance Criteria
+
+各 view について bench で計測する KPI:
+
+| view | KPI | 目標 |
+|---|---|---|
+| current_focused_element | 更新 latency | p99 < 1ms |
+| dirty_rects_aggregate | 更新 latency + memory | p99 < 2ms / < 50MB |
+| semantic_event_stream | delta 配信遅延 | p99 < 3ms |
+| predicted_post_state | dry-run latency | p99 < 50ms |
+| state_at(t) | point query latency | p99 < 5ms |
+| lens_attention | settle latency (max iter 込) | p99 < 5ms |
+| change_fraction_per_window (Tier 3) | 1080p latency | p99 < 0.5ms |
+| 全 server_status view 合計 | 集約 query | p99 < 5ms |
+
+bench harness (`bench/`) で全 view を CI 計測 (制約 §13.1)。
+
+---
+
+## 9. Open Questions
+
+| # | OQ | 決定タイミング |
+|---|---|---|
+| 1 | recent_changes の窓サイズ default (3s / 5s / 10s) | D2.5 着手時 |
+| 2 | tool_call_history の args_redacted 方針 (PII / secret 検出) | D2.5 着手前 |
+| 3 | predicted_post_state の confidence 計算式 | D5 着手時 |
+| 4 | state_at(t) の compaction 範囲外エラー codes (LeaseExpired ではなく専用 code が要るか) | D3 着手時 |
+| 5 | lens_attention の max iter default (100 で十分か) | D4 着手時、bench 経由 |
+| 6 | change_fraction / dhash の Tier 3 dispatch 単位 (per-window or per-frame) | D5 着手時 |
+
+---
+
+## 10. Related Files
+
+- 統合書: `docs/architecture-3layer-integrated.md`
+- 制約: `docs/layer-constraints.md` §4 (L3 Compute)
+- ADR-008: `docs/adr-008-reactive-perception-engine.md` (D1-D6 の本体)
+- ADR-010: `docs/adr-010-presentation-layer-self-documenting-envelope.md` (consumer 側)
+- (起草予定) `bench/` crate skeleton (本書 §8 を測定するハーネス)
+
+---
+
+END OF Views Catalog (Draft).

--- a/docs/views-catalog.md
+++ b/docs/views-catalog.md
@@ -193,7 +193,7 @@ worker.dataflow::<u64, _, _>(|scope| {
 ```rust
 pub fn state_at<V>(arrangement: &Arrangement<...>, t: u64) -> Result<V> {
     if t < arrangement.compaction_frontier() {
-        return Err(typed_error("LeaseDigestMismatch"));  // (compaction で消えた相当)
+        return Err(typed_error("TimeCompacted"));  // 専用 enum (ADR-010 §5.4)
     }
     arrangement
         .as_collection()


### PR DESCRIPTION
## Summary

3 層 (Sensor/Data/Presentation) を 1 つの timely dataflow graph として編む統合設計を起草。SSOT を `docs/architecture-3layer-integrated.md` に置き、各 ADR が詳細実装を担う構成。**実装は伴わず docs のみ**、version bump なし。実装着手は ADR-007 P1 (koffi 撤去) から段階的に進め、完了で v1.2.0 minor 想定。

### 主要決定

- **partial-order time** — UI 観測ドメインは UIA out-of-order と多軸 hw clock のため linear time 不可。**differential-dataflow 採用**、DBSP の linear synchronous time は不採用、Hydroflow は overshoot で不採用
- **arrangement = built-in MVCC** — L2 (Storage) と L3 (Compute) が同一構造体で実現、time-travel が無料で来る (Materialize blog 由来)
- **Whole-System Dataflow** — L1 Capture も timely input source として 1 graph に組込む。replay/dry-run/subscribe を graph 操作で統一
- **Self-Documenting Envelope** — 全 tool 結果が共通 envelope (7 セクション)、LLM 不安源 7 つに 1:1 対応
- **Tier 0-3 dispatch** — DXGI / Intel DSA / NVENC / CUDA Graph 等の HW 段差を吸収、env で pin 可
- **typed reason 35 codes は `src/tools/_errors.ts` SUGGESTS が SSOT** — PascalCase 維持、新規 10 codes 追加

### 起草ファイル (合計 ~2,970 行)

| ファイル | 役割 |
|---|---|
| `docs/architecture-3layer-integrated.md` | **SSOT**、3 層俯瞰、§17 で各層制約 summary |
| `docs/layer-constraints.md` | 各層 6 観点 (入出力/不変/SLO/失敗/境界) + cross-layer 規約 X1-X6 |
| `docs/adr-007-koffi-to-rust-migration.md` | L1 Capture (koffi 撤去 + DXGI dirty rect + EventEnvelope + Tier 0-2 + WAL) |
| `docs/adr-008-reactive-perception-engine.md` | L2-3 (timely + differential-dataflow、arrangement = MVCC) |
| `docs/adr-010-presentation-layer-self-documenting-envelope.md` | L4-5 (Envelope 7 セクション、35 typed codes、CoALA Phase A) |
| `docs/views-catalog.md` | L3 で実装する 15 view の一覧 + SLO |
| `benches/README.md` | KPI 計測ハーネス skeleton (実装は ADR Phase 完了に応じて段階的) |

### リリース計画

| version | 範囲 | LLM 体感 |
|---|---|---|
| (この PR) | 設計 PR、bump なし | (なし) |
| v1.2.0 | ADR-007 P1-P4 完了 (koffi 撤去 + DXGI 統合) | sigsegv 消滅、hot path 高速化 |
| v1.3.0 | ADR-008 D1-D2 (timely + DD core view) | desktop_state が view 経由 |
| v1.4.0 | ADR-008 D3 + ADR-010 P1-P2 (time-travel + envelope 必須最小) | envelope 導入で挙動が大きく変わる |
| v1.5.0+ | 順次 Phase で minor (詳細は統合書 §12) |

### 公開価値 (北極星片翼)

論文 3 本独立に書ける構造:
1. SIGMOD/VLDB: GPU-accelerated IVM for LLM agent perception
2. USENIX ATC/ASPLOS: HW-assisted deterministic replay
3. CHI/UIST: Sub-millisecond UI observation timestamps (Reflex API)

ナラティブ: Microsoft が WinAppSDK Rust archive した一方、Rust + Intel/AMD/NVIDIA hw assist の Windows MCP server。

## Test plan

- [x] 設計内容のレビュー (3 ADR + SSOT + 制約 + views-catalog + bench README)
- [x] SSOT 規約 (識別子ヒエラルキー / 時刻モデル / Tier dispatch / Envelope 段階 enrichment) の妥当性確認
- [x] リリース計画 (v1.2.0 から minor 段階導入) の妥当性確認
- [x] 不整合 5 件の解消 (koffi 数 / lease_token / server_status / typed enum / lens 整合) のレビュー反映確認
- [x] 後続: ADR-007 P1 着手判断 (本 PR merge 後、別 PR で実装着手)

🤖 Generated with [Claude Code](https://claude.com/claude-code)