### PR TITLE
chore(build): preserve uncommitted index.d.ts/index.js across build:rs

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
     "check:stub-catalog": "node scripts/generate-stub-tool-catalog.mjs && git diff --exit-code src/stub-tool-catalog.ts",
     "check:napi-safe": "node scripts/check-napi-safe.mjs",
     "check:native-types": "node scripts/check-native-types.mjs",
-    "build:rs": "napi build --platform --release && node -e \"const d=require('child_process').execSync('git diff -- index.d.ts').toString();if(d){console.warn('\\n⚠️  napi changed index.d.ts — update native-types.ts!\\n');console.warn(d)}\" && git restore --source=HEAD -- index.d.ts index.js",
-    "build:rs:debug": "napi build --platform && node -e \"const d=require('child_process').execSync('git diff -- index.d.ts').toString();if(d){console.warn('\\n⚠️  napi changed index.d.ts — update native-types.ts!\\n');console.warn(d)}\" && git restore --source=HEAD -- index.d.ts index.js",
+    "build:rs": "node scripts/build-rs.mjs --release",
+    "build:rs:debug": "node scripts/build-rs.mjs --debug",
     "artifacts:rs": "napi artifacts"
   },
   "devDependencies": {

--- a/scripts/build-rs.mjs
+++ b/scripts/build-rs.mjs
@@ -32,8 +32,12 @@
 import { spawnSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const ROOT = new URL("..", import.meta.url).pathname.replace(/^\/([A-Z]):/, "$1:");
+// `fileURLToPath` decodes percent-encoded URL segments (so paths containing
+// spaces or non-ASCII characters round-trip correctly) and normalises
+// Windows drive prefixes — both of which `new URL(...).pathname` mangles.
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
 const D_TS = join(ROOT, "index.d.ts");
 const INDEX_JS = join(ROOT, "index.js");
 const FILES = [D_TS, INDEX_JS];

--- a/scripts/build-rs.mjs
+++ b/scripts/build-rs.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+// Run `napi build` while preserving uncommitted edits to the hand-maintained
+// `index.d.ts` / `index.js`.
+//
+// Why this script exists
+// ──────────────────────
+// `napi build` writes (or truncates) `index.d.ts` and `index.js`. The repo
+// intentionally diverges from napi's output — `index.d.ts` is the hand-
+// maintained source of truth alongside `src/engine/native-types.ts`, and
+// `index.js` is hand-extended too.
+//
+// The previous one-liner did `git restore --source=HEAD -- index.d.ts index.js`
+// after `napi build`, which discards napi's regen — but it ALSO discards any
+// uncommitted edits a developer made before running the build (e.g. adding
+// new `export declare function` entries for new Rust APIs that haven't been
+// committed yet). That bit ADR-007 P1 mid-implementation: each new export
+// added to index.d.ts vanished on the next `npm run build:rs`.
+//
+// What this script does instead
+// ─────────────────────────────
+//   1. Snapshot current contents of index.d.ts / index.js (HEAD content +
+//      any uncommitted edits — this is the dev's "intent").
+//   2. Run `napi build` (--release for prod, --debug for CI-fast).
+//   3. Restore the snapshot, so the dev's edits AND the hand-maintained
+//      override of napi's regen both survive the build.
+//
+// Drift detection (Rust #[napi] vs hand-maintained index.d.ts) lives in
+// `scripts/check-native-types.mjs` and runs in CI; that is the meaningful
+// safety net. napi 3.x's regen is empty, so a diff against it is no longer
+// a useful signal.
+
+import { spawnSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = new URL("..", import.meta.url).pathname.replace(/^\/([A-Z]):/, "$1:");
+const D_TS = join(ROOT, "index.d.ts");
+const INDEX_JS = join(ROOT, "index.js");
+const FILES = [D_TS, INDEX_JS];
+
+const args = process.argv.slice(2);
+const release = args.includes("--release");
+const passthrough = args.filter((a) => a !== "--release" && a !== "--debug");
+
+// ── 1. Snapshot ─────────────────────────────────────────────────────────────
+/** Read each file once. Defensive against fresh clones where the addon has
+ *  never been built — the files always exist in this repo today, but we tag
+ *  missing entries so `restore()` can decide what to do. */
+const snapshot = new Map();
+for (const f of FILES) {
+  try {
+    snapshot.set(f, readFileSync(f, "utf8"));
+  } catch {
+    snapshot.set(f, undefined);
+  }
+}
+
+function restore() {
+  for (const f of FILES) {
+    const original = snapshot.get(f);
+    if (original !== undefined) writeFileSync(f, original);
+  }
+}
+
+// ── 2. Run `napi build` ─────────────────────────────────────────────────────
+// Invoke the napi CLI's JS entry directly with `node`. Going through
+// `npx`/`npx.cmd` requires `shell: true` (DEP0190 on Node ≥ 22), and the
+// shell lookup is brittle across MSYS bash / pwsh / cmd / GitHub Actions
+// runners. Calling node with an absolute path is portable and explicit.
+const napiCli = join(ROOT, "node_modules", "@napi-rs", "cli", "dist", "cli.js");
+const napiArgs = ["build", "--platform", ...(release ? ["--release"] : []), ...passthrough];
+console.log(`[build-rs] running: node ${napiCli} ${napiArgs.join(" ")}`);
+const napiResult = spawnSync(process.execPath, [napiCli, ...napiArgs], {
+  stdio: "inherit",
+  cwd: ROOT,
+});
+
+// Always restore — including on failure — so a broken build never leaves the
+// working tree in napi's auto-truncated state.
+restore();
+
+if (napiResult.status !== 0) {
+  console.error(`[build-rs] napi build failed (exit ${napiResult.status}); snapshots restored.`);
+  process.exit(napiResult.status ?? 1);
+}
+
+console.log(
+  `[build-rs] napi build OK; restored hand-maintained index.d.ts / index.js ` +
+  `(uncommitted edits preserved).`,
+);

--- a/scripts/check-napi-safe.mjs
+++ b/scripts/check-napi-safe.mjs
@@ -15,8 +15,12 @@
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const ROOT = new URL("..", import.meta.url).pathname.replace(/^\/([A-Z]):/, "$1:");
+// `fileURLToPath` decodes percent-encoded URL segments (paths with spaces or
+// non-ASCII characters) and normalises Windows drive prefixes — both of
+// which `new URL(...).pathname` mangles.
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
 const SCAN_DIR = join(ROOT, "src", "win32");
 
 /** Recursively collect *.rs files under `dir`. */

--- a/scripts/check-native-types.mjs
+++ b/scripts/check-native-types.mjs
@@ -10,8 +10,12 @@
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, sep } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const ROOT = new URL("..", import.meta.url).pathname.replace(/^\/([A-Z]):/, "$1:");
+// `fileURLToPath` decodes percent-encoded URL segments (paths with spaces or
+// non-ASCII characters) and normalises Windows drive prefixes — both of
+// which `new URL(...).pathname` mangles.
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
 const SRC_DIR = join(ROOT, "src");
 const INDEX_DTS = join(ROOT, "index.d.ts");
 


### PR DESCRIPTION
## Summary

Replace the inline `napi build && git restore` one-liner in `package.json`'s `build:rs` / `build:rs:debug` with `scripts/build-rs.mjs`.

The old flow restored `index.d.ts` and `index.js` from HEAD after every `napi build`, which silently discarded any **uncommitted** edits a developer had made before invoking the build (e.g. adding new `export declare function` entries for Rust APIs that hadn't been committed yet). ADR-007 P1 (PR #74) hit this twice during implementation — each new export added to `index.d.ts` vanished on the next `npm run build:rs`.

This was tracked as a follow-up in `memory/todo_adr007_p1_followups.md` ("仕組みで対応 / build:rs git restore 罠").

## What the new script does

1. Snapshot `index.d.ts` / `index.js` to memory **before** `napi build` (HEAD content + uncommitted edits = the dev's intent).
2. Invoke the napi CLI directly via `node node_modules/@napi-rs/cli/dist/cli.js`.
3. Restore the snapshot after the build, **including on failure**, so the tree never ends up in napi's auto-truncated state.

Side benefits:
- Avoids the Node ≥ 22 `DEP0190` warning that `spawn(args, { shell: true })` triggers
- Removes the brittle `npx` / `npx.cmd` shell lookup (varies across MSYS bash, pwsh, cmd, GitHub Actions)
- Drops the diff-warning step against napi's regen — napi 3.x writes an empty `index.d.ts`, so that comparison was a false positive every build. Real drift detection is `scripts/check-native-types.mjs` (CI-enforced).

## Test plan

- [x] Smoke test: append a sentinel line to `index.d.ts`, run `npm run build:rs:debug`, confirm the sentinel survives
- [x] Smoke test: clean rebuild of `npm run build:rs:debug` produces a working `.node` (Rust compile + linking succeed, hand-maintained d.ts intact)
- [x] `npm run check:napi-safe` still passes (10 win32 exports wrap `napi_safe_call`)
- [x] `npm run check:native-types` still passes (15 Rust exports all declared in `index.d.ts`)
- [x] No `DEP0190` warning in the new output

🤖 Generated with [Claude Code](https://claude.com/claude-code)