### PR TITLE
feat(engine): replace koffi with windows-rs for GDI/monitor/DPI (ADR-007 P2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ remote_commits.txt
 target/
 *.node
 *.node.bak
+*.node.old
 libnode.a
 libnode.dll.a
 node.def

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,17 @@ windows = { version = "0.62", features = [
     # IsWindowVisible / IsIconic / IsZoomed / GetClassNameW /
     # GetWindowThreadProcessId / GetWindowLongPtrW
     "Win32_UI_WindowsAndMessaging",
+    # ADR-007 P2: GDI / monitor enum / DPI.
+    # GetDC / ReleaseDC / CreateCompatibleDC / CreateCompatibleBitmap /
+    # SelectObject / DeleteObject / DeleteDC / GetDIBits / BITMAPINFO /
+    # EnumDisplayMonitors / GetMonitorInfoW / MonitorFromWindow / MONITORINFO
+    "Win32_Graphics_Gdi",
+    # SetProcessDpiAwareness / GetDpiForMonitor / MDT_EFFECTIVE_DPI /
+    # PROCESS_DPI_AWARENESS
+    "Win32_UI_HiDpi",
+    # PrintWindow lives under Storage_Xps in windows-rs 0.62 (matches the
+    # underlying Win32 header grouping with the printing APIs).
+    "Win32_Storage_Xps",
 ] }
 
 [build-dependencies]

--- a/docs/adr-007-p2-design-proposal.md
+++ b/docs/adr-007-p2-design-proposal.md
@@ -1,0 +1,420 @@
+# ADR-007 P2 — Implementation Design Proposal (for Opus review)
+
+- Status: **Approved by Opus 2026-04-29 (GO with changes、4 件の必須対応を本書 §11 に反映)**
+- Date: 2026-04-29
+- Author: Claude Sonnet (this session)
+- Reviewer: Opus (CLAUDE.md 強制命令 3)
+- Scope: GDI/DC + Monitor enumeration + DPI APIs (`PrintWindow` / `GetDC` / `ReleaseDC` / `CreateCompatibleDC` / `CreateCompatibleBitmap` / `SelectObject` / `DeleteObject` / `DeleteDC` / `GetDIBits` / `EnumDisplayMonitors` / `GetMonitorInfoW` / `MonitorFromWindow` / `GetDpiForMonitor` / `SetProcessDpiAwareness` = 14 koffi defs)
+
+---
+
+## 1. 設計方針サマリ
+
+P1 と異なり「primitive 1:1 binding」一辺倒は**良くない**。GDI には `CreateCompatibleDC`/`DeleteDC`、`GetDC`/`ReleaseDC`、`CreateCompatibleBitmap`/`DeleteObject` の lifetime ペアがあり、JS 側で個別 binding を握ると **ハンドルリーク** + **失敗時のリソース不解放**が起きやすい。Monitor 列挙も `EnumDisplayMonitors` callback + per-monitor `GetMonitorInfoW` + `GetDpiForMonitor` の 3 ステップ複合操作。
+
+そこで **hybrid** を採用:
+
+| 層 | 戦略 | 理由 |
+|---|---|---|
+| **High-level**: `win32_print_window_to_buffer(hwnd, flags) -> NativePrintWindowResult` | 9 GDI 関数 + RAII + BGRA→RGBA 変換を 1 native call に集約 | 失敗時 RAII で確実にリソース解放、FFI hop も削減 |
+| **High-level**: `win32_enum_monitors() -> Vec<NativeMonitorInfo>` | `EnumDisplayMonitors` callback + `GetMonitorInfoW` + `GetDpiForMonitor` を集約 | callback panic 安全 + 1 native call で全結果取得 |
+| **Mid-level**: `win32_get_window_dpi(hwnd) -> u32` | `MonitorFromWindow` + `GetDpiForMonitor` を 1 関数に折り畳む | 常に paired で呼ばれる、別 export にする利益なし |
+| **Primitive**: `win32_set_process_dpi_awareness(level) -> ()` | 単一 syscall、起動時 1 回のみ | 折り畳み余地なし |
+
+**4 native export** で 14 koffi binding を置換。
+
+P1 とは違い、TS 側の `printWindowToBuffer` / `enumMonitors` / `getWindowDpi` の **内部はほぼ消える** (1 行のネイティブ呼び出しになる)。**外側シグネチャは完全不変** (Tool Surface 不変原則 P7)。
+
+---
+
+## 2. 公開する 4 native 関数
+
+### 2.1 `win32_print_window_to_buffer`
+
+```rust
+#[napi(object)]
+pub struct NativePrintWindowResult {
+    pub data: Buffer,        // RGBA8, top-down, length = w*h*4
+    pub width: u32,
+    pub height: u32,
+}
+
+#[napi]
+pub fn win32_print_window_to_buffer(
+    hwnd: BigInt,
+    flags: u32,              // PrintWindow flags (0 / 2 / 3)
+) -> napi::Result<NativePrintWindowResult>
+```
+
+内部:
+1. `GetWindowRect(hwnd)` で width/height 取得 (失敗 = `Err`)
+2. `GetDC(NULL)` でスクリーン DC 取得
+3. `CreateCompatibleDC` + `CreateCompatibleBitmap` + `SelectObject`
+4. `PrintWindow(hwnd, memDC, flags)`
+5. `GetDIBits` でビット列を BGRA バッファにコピー
+6. SIMD or scalar で BGRA → RGBA + alpha=255 設定
+7. **RAII guard** が SelectObject 巻き戻し / DeleteObject / DeleteDC / ReleaseDC を保証 (panic / Err どちらでも漏れない)
+
+エラー時は `napi::Error::from_reason("PrintWindow: <step> failed")` で typed reason を返す。
+
+**TS 側の `printWindowToBuffer`** は次のようになる (75 行 → 5 行):
+
+```typescript
+export function printWindowToBuffer(hwnd: unknown, flags = 2): { data: Buffer; width: number; height: number } {
+  if (typeof hwnd !== "bigint") throw new Error("printWindowToBuffer requires a bigint hwnd");
+  const r = requireNativeWin32().win32PrintWindowToBuffer!(hwnd, flags);
+  return { data: r.data, width: r.width, height: r.height };
+}
+```
+
+### 2.2 `win32_enum_monitors`
+
+```rust
+#[napi(object)]
+pub struct NativeMonitorInfo {
+    pub handle: BigInt,        // HMONITOR (TS 側で `unknown` 扱いだったが BigInt で OK)
+    pub primary: bool,
+    pub bounds_left: i32,
+    pub bounds_top: i32,
+    pub bounds_right: i32,
+    pub bounds_bottom: i32,
+    pub work_left: i32,
+    pub work_top: i32,
+    pub work_right: i32,
+    pub work_bottom: i32,
+    pub dpi: u32,              // effective DPI X (Y は同値前提、TS 側既存挙動)
+}
+
+#[napi]
+pub fn win32_enum_monitors() -> napi::Result<Vec<NativeMonitorInfo>>
+```
+
+内部: `EnumDisplayMonitors` callback で `Vec<NativeMonitorInfo>` を構築。callback ボディは `catch_unwind` で wrap (P1 の EnumWindows と同パターン、Windows ABI 越え panic を防ぐ)。各 monitor について `GetMonitorInfoW` + `GetDpiForMonitor(MDT_EFFECTIVE_DPI=0)` を呼んで埋める。
+
+**TS 側の `enumMonitors`** は変換層のみ残す (~30 行 → 15 行):
+
+```typescript
+export function enumMonitors(): MonitorInfo[] {
+  const raw = requireNativeWin32().win32EnumMonitors!();
+  return raw.map((m, id) => ({
+    id,
+    handle: m.handle,                       // bigint (旧: unknown だったが互換)
+    primary: m.primary,
+    bounds: { x: m.boundsLeft, y: m.boundsTop, width: m.boundsRight - m.boundsLeft, height: m.boundsBottom - m.boundsTop },
+    workArea: { x: m.workLeft, y: m.workTop, width: m.workRight - m.workLeft, height: m.workBottom - m.workTop },
+    dpi: m.dpi || 96,
+    scale: Math.round(((m.dpi || 96) / 96) * 100),
+  }));
+}
+```
+
+注意: 既存 `MonitorInfo.handle` は `unknown` 型なので `bigint` への変更は **拡大** であり破壊変更ではない (callers は handle を opaque に扱うのみ)。
+
+### 2.3 `win32_get_window_dpi`
+
+```rust
+#[napi]
+pub fn win32_get_window_dpi(hwnd: BigInt) -> napi::Result<u32>
+```
+
+内部: `MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST=2)` → `GetDpiForMonitor(MDT_EFFECTIVE_DPI=0)`。失敗時は 96 (= 100% baseline) を返す既存挙動を維持。
+
+### 2.4 `win32_set_process_dpi_awareness`
+
+```rust
+#[napi]
+pub fn win32_set_process_dpi_awareness(level: i32) -> napi::Result<bool>
+```
+
+内部: `SetProcessDpiAwareness(level)` を呼ぶだけ。戻り値は HRESULT が `S_OK` なら true / それ以外 false (既存 try/catch swallow と同等)。
+
+TS 側 module init (line 276):
+
+```typescript
+try {
+  requireNativeWin32().win32SetProcessDpiAwareness!(2); // PROCESS_PER_MONITOR_DPI_AWARE
+} catch { /* already set or unsupported */ }
+```
+
+---
+
+## 3. Rust 実装スケッチ
+
+### 3.1 ファイル構成
+
+```
+src/win32/
+├── mod.rs            # 既存 + gdi / monitor / dpi を追加
+├── safety.rs         # napi_safe_call (既存、再利用)
+├── types.rs          # 新規: NativePrintWindowResult, NativeMonitorInfo
+├── window.rs         # P1 で実装済 (10 関数)
+├── gdi.rs            # ★ 新規: print_window_to_buffer (RAII)
+├── monitor.rs        # ★ 新規: enum_monitors (callback)
+└── dpi.rs            # ★ 新規: get_window_dpi, set_process_dpi_awareness
+```
+
+### 3.2 `src/win32/gdi.rs` の核 (RAII 抜粋)
+
+```rust
+//! GDI helpers — `print_window_to_buffer` consolidates the 9-call sequence
+//! (GetWindowRect → GetDC → CreateCompatibleDC → CreateCompatibleBitmap →
+//! SelectObject → PrintWindow → GetDIBits → cleanup) into one safe entry
+//! point. Every Win32 handle is owned by a small RAII guard so a `?` early
+//! return cannot leak DCs / bitmaps even mid-failure.
+
+use windows::Win32::Graphics::Gdi::{
+    BITMAPINFOHEADER, BI_RGB, CreateCompatibleBitmap, CreateCompatibleDC,
+    DIB_RGB_COLORS, DeleteDC, DeleteObject, GetDIBits, HBITMAP, HDC,
+    HGDIOBJ, ReleaseDC, SelectObject,
+};
+use windows::Win32::UI::WindowsAndMessaging::{GetDC, PrintWindow, PRINT_WINDOW_FLAGS};
+use windows::Win32::Foundation::{HWND, RECT};
+
+struct DcGuard {
+    target: HWND,        // None when this is a memory DC
+    dc: HDC,
+    is_mem: bool,
+}
+impl Drop for DcGuard {
+    fn drop(&mut self) {
+        unsafe {
+            if self.is_mem { let _ = DeleteDC(self.dc); }
+            else { ReleaseDC(Some(self.target), self.dc); }
+        }
+    }
+}
+
+struct BitmapGuard(HBITMAP);
+impl Drop for BitmapGuard {
+    fn drop(&mut self) { unsafe { let _ = DeleteObject(HGDIOBJ(self.0.0 as *mut _)); } }
+}
+
+struct SelectGuard {
+    dc: HDC,
+    old: HGDIOBJ,
+}
+impl Drop for SelectGuard {
+    fn drop(&mut self) { unsafe { let _ = SelectObject(self.dc, self.old); } }
+}
+```
+
+`print_window_to_buffer` の本体は `?` で early-return してもこれら guard が drop されて handle は確実に解放される。
+
+BGRA → RGBA 変換は `chunks_exact_mut(4)` で write-back、SIMD は P5a 以降で検討 (P2 acceptance には scalar で十分高速)。
+
+### 3.3 `src/win32/monitor.rs` の callback
+
+P1 の `EnumWindows` callback と同パターン:
+
+```rust
+unsafe extern "system" fn enum_monitor_collect(
+    hmonitor: HMONITOR,
+    _hdc: HDC,
+    _lprc: *mut RECT,
+    lparam: LPARAM,
+) -> BOOL {
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        let vec = unsafe { &mut *(lparam.0 as *mut Vec<NativeMonitorInfo>) };
+        if let Some(info) = build_monitor_info(hmonitor) {
+            vec.push(info);
+        }
+    }));
+    if result.is_err() {
+        super::safety::PANIC_COUNTER.fetch_add(1, Ordering::Relaxed);
+        BOOL(0)  // stop enumeration
+    } else {
+        BOOL(1)
+    }
+}
+```
+
+`build_monitor_info` は `GetMonitorInfoW` + `GetDpiForMonitor` を呼んで `NativeMonitorInfo` を作る。失敗時 `None` を返して push せずスキップ (既存 TS 挙動と互換)。
+
+---
+
+## 4. Cargo features
+
+`Cargo.toml` の `windows` features に追加:
+
+```toml
+"Win32_Graphics_Gdi",   # CreateCompatibleDC, GetDIBits, etc.
+"Win32_UI_HiDpi",       # SetProcessDpiAwareness, GetDpiForMonitor, MONITOR_DEFAULTTONEAREST
+```
+
+`MonitorFromWindow` / `EnumDisplayMonitors` は `Win32_Graphics_Gdi` 配下、`GetDC` / `ReleaseDC` / `PrintWindow` は P1 で既に追加した `Win32_UI_WindowsAndMessaging` 配下。
+
+---
+
+## 5. TS 配線
+
+### 5.1 index.d.ts に追加
+
+```ts
+export interface NativePrintWindowResult { data: Buffer; width: number; height: number }
+export interface NativeMonitorInfo {
+  handle: bigint
+  primary: boolean
+  boundsLeft: number; boundsTop: number; boundsRight: number; boundsBottom: number
+  workLeft: number; workTop: number; workRight: number; workBottom: number
+  dpi: number
+}
+
+export declare function win32PrintWindowToBuffer(hwnd: bigint, flags: number): NativePrintWindowResult
+export declare function win32EnumMonitors(): NativeMonitorInfo[]
+export declare function win32GetWindowDpi(hwnd: bigint): number
+export declare function win32SetProcessDpiAwareness(level: number): boolean
+```
+
+### 5.2 NativeWin32 interface 拡張
+
+`src/engine/native-engine.ts` の `NativeWin32` に 4 メソッド追加 (全部 optional)。
+
+### 5.3 `src/engine/win32.ts` の差分
+
+- 14 koffi 定義削除 (PrintWindow / GetDC / ReleaseDC / CreateCompatibleDC / CreateCompatibleBitmap / SelectObject / DeleteObject / DeleteDC / GetDIBits / MonitorEnumProcProto / EnumDisplayMonitors / GetMonitorInfoW / MonitorFromWindow / GetDpiForMonitor / SetProcessDpiAwareness)
+- module-init `SetProcessDpiAwareness(2)` を `nativeWin32.win32SetProcessDpiAwareness!(2)` に
+- `enumMonitors()` 内部: koffi.register callback + EnumDisplayMonitors → `nativeWin32.win32EnumMonitors!()` + `.map(...)` 変換層のみ
+- `printWindowToBuffer()` 内部: 75 行の GDI dance → `nativeWin32.win32PrintWindowToBuffer!(hwnd, flags)` 1 行
+- `getWindowDpi()` 内部: `nativeWin32.win32GetWindowDpi!(hwnd)`
+
+`getVirtualScreen()` は内部で `enumMonitors()` を呼ぶだけなので無修正で動く。
+
+### 5.4 互換テスト要点
+
+- `printWindowToBuffer` 戻り値の `data` が RGBA で alpha=255、`width`/`height` が窓サイズ
+- `enumMonitors` の `MonitorInfo.handle` 型を `bigint` に拡張するが、callers (`desktop-state.ts` / `dock.ts`) は handle を opaque に扱うのみで読み出さないので型互換 OK
+- `getWindowDpi(null)` は P1 と同じく `if (typeof hwnd !== "bigint") return 96` の defensive guard を TS wrapper 側に追加
+
+---
+
+## 6. テスト
+
+### 6.1 panic-fuzz 拡張 (`tests/unit/native-win32-panic-fuzz.test.ts`)
+
+既存 27 cases に追加:
+
+- `win32PrintWindowToBuffer(0n, 2)` / `(stale, 2)` / `(all-ones, 2)` — それぞれ throw or returns valid buffer (panic しない)
+- `win32GetWindowDpi(0n)` / `(stale)` — 96 / 0 / 既存値が返る (panic しない)
+- `win32SetProcessDpiAwareness(99)` (invalid level) — false が返る or throw、panic しない
+- `win32EnumMonitors()` 連続 50 回呼び出し、RSS 50MB 以下
+
+### 6.2 bench (`scripts/bench-print-window.mjs` 新規)
+
+`printWindowToBuffer` 100 回実行、p50/p99 計測。P1 の `bench-enum-title.mjs` と同形式。 acceptance criterion:「screenshot/printWindow latency 計測」(ADR-007 §6 P2)。
+
+---
+
+## 7. リスク
+
+| # | リスク | 軽減 |
+|---|---|---|
+| 1 | RAII guard の drop 順序ミス → 二重解放 | 各 guard は単一 handle 所有、drop 順序は LIFO で確定 |
+| 2 | BGRA→RGBA 変換が SIMD なしで遅い | 1080p 想定で scalar でも < 5ms、後続 P5a で SIMD 検討 |
+| 3 | EnumDisplayMonitors callback 内 panic | P1 EnumWindows と同パターンで catch_unwind |
+| 4 | HMONITOR が P2 で `bigint` になることで MonitorInfo.handle 型変化 | callers は opaque、互換性なし問題なし |
+| 5 | `GetDIBits` の bitfield calc 失敗 | top-down 32bpp BI_RGB は既存 TS で動作実績あり、shape 同じ |
+| 6 | Cargo features 競合 | P1 で `Win32_UI_WindowsAndMessaging` 既存、`Win32_Graphics_Gdi` + `Win32_UI_HiDpi` 追加のみ |
+
+---
+
+## 8. Implementation Phases (commit 単位)
+
+1. **commit 1**: Rust 基盤 (`src/win32/{gdi,monitor,dpi}.rs` + types.rs 追記 + mod.rs / lib.rs / Cargo.toml)
+2. **commit 2**: TS 配線 (index.d.ts / index.js / native-types.ts / native-engine.ts / win32.ts)
+3. **commit 3**: テスト + bench (panic-fuzz 拡張 + `bench-print-window.mjs`)
+
+各 commit で `cargo check` + `npm run build` + `npm run check:napi-safe` + `npm run check:native-types` がグリーンであること。
+
+---
+
+## 9. Opus に判断委譲したい点
+
+1. **§1 hybrid 採用**: 4 high-level/mid-level export で 14 koffi 置換、合理的か?
+2. **§2.1 BGRA→RGBA 変換の Rust 実装位置**: native 内部 (本提案) vs TS 残置 — native 推奨だが、SIMD 入れない scalar 実装で latency SLO 守れるか?
+3. **§2.2 NativeMonitorInfo の field flat化** (`boundsLeft/Top/Right/Bottom` vs nested struct): Rust → JS の cost / TS 側変換層の量で判断
+4. **§4 Cargo features 追加内容**: `Win32_Graphics_Gdi` / `Win32_UI_HiDpi` で必要な API 全部カバーされるか
+5. **§5.3 `MonitorInfo.handle` 型変更** (`unknown` → `bigint`): 互換 OK 判定で良いか
+6. **§6.2 bench スコープ**: `printWindowToBuffer` のみで十分か、`enumMonitors` も計測対象に入れるべきか
+
+---
+
+## 11. Opus レビュー指摘 (2026-04-29、必須対応)
+
+実装中に絶対に外さない 4 件 + 補助的な 5 件。
+
+### 11.1 (核心) `MonitorInfo.handle` 型を `unknown` 据え置き
+本書 §5 で「`bigint` に拡張」と書いていたが、Opus 指摘で **TS interface 宣言は `unknown` のまま据え置き**。実値は bigint で来るが、opaque 契約を保持することで将来 HMONITOR を struct 化したくなった時に互換破壊にならない。callers (`tools/desktop-state.ts` / `tools/dock.ts`) は `m.handle` を読み出さないので OK。
+
+### 11.2 `SelectGuard.old` を `Option<HGDIOBJ>` に
+`SelectObject` 失敗 (NULL 戻り) 時に Drop で NULL を SelectObject に巻き戻すのを防ぐ:
+
+```rust
+struct SelectGuard {
+    dc: HDC,
+    old: Option<HGDIOBJ>,
+}
+impl Drop for SelectGuard {
+    fn drop(&mut self) {
+        if let Some(old) = self.old.take() {
+            unsafe { let _ = SelectObject(self.dc, old); }
+        }
+    }
+}
+```
+
+`SelectObject` の戻り値が `HGDIOBJ(NULL)` の時は `old = None` で構築する。
+
+### 11.3 `SetProcessDpiAwareness` の `E_ACCESSDENIED` を成功扱い
+旧 TS 実装は `try { SetProcessDpiAwareness(2) } catch {}` で全エラーを swallow していた。新実装でも「既に他 API で設定済み」(`E_ACCESSDENIED`) は成功扱い:
+
+```rust
+let result = unsafe { SetProcessDpiAwareness(PROCESS_DPI_AWARENESS(level)) };
+// S_OK = 0, E_ACCESSDENIED は既に設定済みなので success 扱い (TS 旧挙動互換)
+Ok(result.is_ok() || result == E_ACCESSDENIED)
+```
+
+### 11.4 cargo features 確認 (Opus Q4)
+本書 §4 の features 名は正しいが、commit 1 で `cargo build` を通す前に **`cargo doc --features '...' --open`** で各 API のドキュメント道筋を一度確認する (P1 で `MonitorFromWindow` を `Win32_UI_HiDpi` 配下と誤記した過去事故あり)。
+
+### 11.5 GDI guard drop 順序のコメント明示
+`gdi.rs` 冒頭に Win32 作法と LIFO drop 順序の対応を明記:
+
+```rust
+//! drop order is LIFO; select must unwind before bitmap is destroyed,
+//! bitmap before its memory DC, memory DC before its source screen DC.
+//! Therefore the let order in `print_window_to_buffer` is:
+//!   screenDC → memDC → bitmap → select_guard
+```
+
+### 11.6 panic-fuzz は P1 と粒度を揃える
+本書 §6.1 で「`win32EnumMonitors()` 連続 50 回 / RSS 50MB」と書いていたが、P1 の `bench-enum-title.mjs` は 1000 iter / RSS 50MB だった。**panic-fuzz suite の RSS 検査は 100 回呼び出し / 増分 5MB 以下** に揃える (回帰検出力を上げる)。
+
+### 11.7 bench 2 サイズ実測
+`scripts/bench-print-window.mjs` は **1080p デスクトップサイズと 4K の 2 ケース** で p50/p99/RSS を計測。ADR-007 §6 P2 acceptance「latency 計測」のエビデンスとして PR description に数字を貼る。
+
+### 11.8 `MonitorEnumProcProto` の koffi.proto 削除漏れ
+`enumMonitors` 削除時、`MonitorEnumProcProto` の `koffi.proto` 行 (line 137) も削除すること。残すと next reload で「proto already exists」が出る可能性。
+
+### 11.9 4K 計測の取り扱い
+4K capture latency は `printWindowToBuffer` の単独計測のみで OK。実機 (テストマシン) が 4K display を持っていない場合は `printWindowToBuffer` を裏で 3840x2160 dummy hwnd で叩く形ではなく、**現環境の最大 monitor を使って計測**、`bench-print-window.mjs` 出力にその実 size を表示する。
+
+---
+
+## 12. やらないリスト (scope creep 防止)
+
+| やらない | 理由 |
+|---|---|
+| Toolhelp32 / Process / SetWindowPos / AttachThreadInput | P3 |
+| sensors-win32.ts の koffi 撤去 | P4 |
+| koffi npm package 削除 | P4 |
+| L1 Capture コア新設 | P5a-d |
+| napi_safe_call 既存 sync export 拡大 | P5a |
+| GDI 操作の SIMD 化 | 必要なら P5a 以降 |
+| MonitorInfo schema の互換破壊 (id/scale 等のリネーム) | 不要 |
+| `SetProcessDpiAwareness` を `SetProcessDpiAwarenessContext` (Win10 1703+) に upgrade | P3 / 別 ADR |
+| `printWindowToBuffer` 戻り値に metadata (timestamp / monitor id) 追加 | L1 Capture (P5a) |
+| `NativeMonitorInfo` に `device_name` (MONITORINFOEX) 追加 | 必要時に追加 PR |
+
+---
+
+END OF P2 DESIGN PROPOSAL

--- a/index.d.ts
+++ b/index.d.ts
@@ -99,6 +99,28 @@ export interface NativeThreadProcessId {
   processId: number
 }
 
+// ─── Win32 GDI / monitor / DPI (ADR-007 P2) ──────────────────────────────────
+
+export interface NativePrintWindowResult {
+  data: Buffer
+  width: number
+  height: number
+}
+
+export interface NativeMonitorInfo {
+  handle: bigint
+  primary: boolean
+  boundsLeft: number
+  boundsTop: number
+  boundsRight: number
+  boundsBottom: number
+  workLeft: number
+  workTop: number
+  workRight: number
+  workBottom: number
+  dpi: number
+}
+
 // ─── Image processing (Hybrid Non-CDP pipeline) ──────────────────────────────
 
 export interface NativePreprocessOptions {
@@ -175,3 +197,9 @@ export declare function win32IsZoomed(hwnd: bigint): boolean
 export declare function win32GetClassName(hwnd: bigint): string
 export declare function win32GetWindowThreadProcessId(hwnd: bigint): NativeThreadProcessId
 export declare function win32GetWindowLongPtrW(hwnd: bigint, nIndex: number): number
+
+// ─── Win32 GDI / monitor / DPI (ADR-007 P2) ──────────────────────────────────
+export declare function win32PrintWindowToBuffer(hwnd: bigint, flags: number): NativePrintWindowResult
+export declare function win32EnumMonitors(): NativeMonitorInfo[]
+export declare function win32GetWindowDpi(hwnd: bigint): number
+export declare function win32SetProcessDpiAwareness(level: number): boolean

--- a/index.js
+++ b/index.js
@@ -78,4 +78,10 @@ export const win32GetClassName              = nativeBinding.win32GetClassName;
 export const win32GetWindowThreadProcessId  = nativeBinding.win32GetWindowThreadProcessId;
 export const win32GetWindowLongPtrW         = nativeBinding.win32GetWindowLongPtrW;
 
+// ─── Win32 GDI / monitor / DPI (ADR-007 P2) ──────────────────────────────────
+export const win32PrintWindowToBuffer       = nativeBinding.win32PrintWindowToBuffer;
+export const win32EnumMonitors              = nativeBinding.win32EnumMonitors;
+export const win32GetWindowDpi              = nativeBinding.win32GetWindowDpi;
+export const win32SetProcessDpiAwareness    = nativeBinding.win32SetProcessDpiAwareness;
+
 export default nativeBinding;

--- a/scripts/bench-print-window.mjs
+++ b/scripts/bench-print-window.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+// ADR-007 P2 baseline bench. Measures `win32PrintWindowToBuffer` on the
+// largest available monitor (= dev machine's actual screen size — Opus
+// review §11.9 settled the 4K question this way; we don't fake a 4K window
+// because PrintWindow only renders real on-screen windows).
+//
+// The bench surfaces enough numbers to detect regressions in:
+//   - the GDI capture pipeline (GetWindowRect → CreateCompatibleDC →
+//     PrintWindow → GetDIBits)
+//   - the BGRA→RGBA scalar swap (the largest CPU cost after PrintWindow)
+//
+// Usage: node scripts/bench-print-window.mjs
+
+import {
+  win32EnumMonitors,
+  win32EnumTopLevelWindows,
+  win32GetForegroundWindow,
+  win32GetWindowRect,
+  win32GetWindowText,
+  win32IsWindowVisible,
+  win32PrintWindowToBuffer,
+} from "../index.js";
+
+const ITERATIONS = 100;
+
+// Pick the foreground window if it's reasonably sized; otherwise scan for
+// the largest visible window with a title — that gives us a stable target
+// with non-trivial pixel count, mirroring the OCR / screenshot use case.
+function pickTargetHwnd() {
+  const fg = win32GetForegroundWindow();
+  if (fg !== null) {
+    const r = win32GetWindowRect(fg);
+    if (r && r.right - r.left >= 800 && r.bottom - r.top >= 600) return fg;
+  }
+  const hwnds = win32EnumTopLevelWindows();
+  let best = null;
+  let bestArea = 0;
+  for (const h of hwnds) {
+    if (!win32IsWindowVisible(h)) continue;
+    if (!win32GetWindowText(h)) continue;
+    const r = win32GetWindowRect(h);
+    if (!r) continue;
+    const area = (r.right - r.left) * (r.bottom - r.top);
+    if (area > bestArea) {
+      best = h;
+      bestArea = area;
+    }
+  }
+  return best;
+}
+
+const target = pickTargetHwnd();
+if (target === null) {
+  console.error("[bench-print-window] no suitable target window found");
+  process.exit(1);
+}
+
+const rect = win32GetWindowRect(target);
+const title = win32GetWindowText(target).slice(0, 40);
+const w = rect.right - rect.left;
+const h = rect.bottom - rect.top;
+
+// Warm-up: 5 captures to amortize first-DC creation, JIT, V8 buffer alloc.
+for (let i = 0; i < 5; i++) win32PrintWindowToBuffer(target, 2);
+
+const samples = new Float64Array(ITERATIONS);
+const rssBefore = process.memoryUsage().rss;
+for (let i = 0; i < ITERATIONS; i++) {
+  const start = process.hrtime.bigint();
+  const r = win32PrintWindowToBuffer(target, 2);
+  const elapsed = Number(process.hrtime.bigint() - start) / 1e6;
+  samples[i] = elapsed;
+  // touch the buffer length so V8 can't dead-code-eliminate the call
+  if (r.data.length === 0) throw new Error("empty buffer");
+}
+const rssAfter = process.memoryUsage().rss;
+
+samples.sort();
+const p50 = samples[Math.floor(ITERATIONS * 0.5)];
+const p95 = samples[Math.floor(ITERATIONS * 0.95)];
+const p99 = samples[Math.floor(ITERATIONS * 0.99)];
+const min = samples[0];
+const max = samples[ITERATIONS - 1];
+const mean = samples.reduce((a, b) => a + b, 0) / ITERATIONS;
+
+const monitors = win32EnumMonitors();
+const largestMon = monitors.reduce((a, b) => {
+  const aArea = (a.boundsRight - a.boundsLeft) * (a.boundsBottom - a.boundsTop);
+  const bArea = (b.boundsRight - b.boundsLeft) * (b.boundsBottom - b.boundsTop);
+  return aArea >= bArea ? a : b;
+});
+const monW = largestMon.boundsRight - largestMon.boundsLeft;
+const monH = largestMon.boundsBottom - largestMon.boundsTop;
+
+console.log("\nADR-007 P2 baseline: win32PrintWindowToBuffer (100 iterations)\n");
+const rows = [
+  ["Largest monitor", `${monW}x${monH} @ ${largestMon.dpi} DPI`],
+  ["Window target", `${title}…`],
+  ["Window size (px)", `${w} x ${h}`],
+  ["Pixels per call", String(w * h)],
+  ["min (ms)", min.toFixed(3)],
+  ["p50 (ms)", p50.toFixed(3)],
+  ["p95 (ms)", p95.toFixed(3)],
+  ["p99 (ms)", p99.toFixed(3)],
+  ["max (ms)", max.toFixed(3)],
+  ["mean (ms)", mean.toFixed(3)],
+  ["RSS delta (MB)", ((rssAfter - rssBefore) / (1024 * 1024)).toFixed(2)],
+];
+const width = Math.max(...rows.map(([k]) => k.length));
+for (const [k, v] of rows) console.log("  " + k.padEnd(width + 2) + v);
+console.log("");

--- a/src/engine/native-engine.ts
+++ b/src/engine/native-engine.ts
@@ -32,6 +32,8 @@ import type {
   NativeSessionResult,
   NativeWin32Rect,
   NativeThreadProcessId,
+  NativePrintWindowResult,
+  NativeMonitorInfo,
 } from "./native-types.js";
 
 export type * from "./native-types.js";
@@ -76,6 +78,7 @@ export interface NativeEngine {
 // a missing native build (e.g. Linux dev environment) cleanly falls back to
 // the `if (!nativeWin32) throw` path inside the TS wrappers.
 export interface NativeWin32 {
+  // ADR-007 P1 hot-path
   win32EnumTopLevelWindows?(): bigint[];
   win32GetWindowText?(hwnd: bigint): string;
   win32GetWindowRect?(hwnd: bigint): NativeWin32Rect | null;
@@ -86,6 +89,12 @@ export interface NativeWin32 {
   win32GetClassName?(hwnd: bigint): string;
   win32GetWindowThreadProcessId?(hwnd: bigint): NativeThreadProcessId;
   win32GetWindowLongPtrW?(hwnd: bigint, nIndex: number): number;
+
+  // ADR-007 P2 GDI / monitor / DPI
+  win32PrintWindowToBuffer?(hwnd: bigint, flags: number): NativePrintWindowResult;
+  win32EnumMonitors?(): NativeMonitorInfo[];
+  win32GetWindowDpi?(hwnd: bigint): number;
+  win32SetProcessDpiAwareness?(level: number): boolean;
 }
 
 // ─── UIA surface (used by uia-bridge.ts) ─────────────────────────────────────

--- a/src/engine/native-types.ts
+++ b/src/engine/native-types.ts
@@ -132,6 +132,32 @@ export interface NativeThreadProcessId {
   processId: number
 }
 
+// ── Win32 GDI / monitor / DPI (ADR-007 P2) ───────────────────────────────────
+
+/** Result of `win32PrintWindowToBuffer`: RGBA top-down pixels (length = w*h*4). */
+export interface NativePrintWindowResult {
+  data: Buffer
+  width: number
+  height: number
+}
+
+/** One monitor as returned by `win32EnumMonitors`. The TS wrapper rebuilds
+ *  the nested `{ bounds, workArea }` shape that callers (`MonitorInfo`)
+ *  expect — this flat record matches the napi marshal layout. */
+export interface NativeMonitorInfo {
+  handle: bigint
+  primary: boolean
+  boundsLeft: number
+  boundsTop: number
+  boundsRight: number
+  boundsBottom: number
+  workLeft: number
+  workTop: number
+  workRight: number
+  workBottom: number
+  dpi: number
+}
+
 // ── Desktop Duplication (Phase 3) ────────────────────────────────────────────
 
 export interface NativeDirtyRect {

--- a/src/engine/win32.ts
+++ b/src/engine/win32.ts
@@ -32,15 +32,9 @@ try { _dwmapi = koffi.load("dwmapi.dll"); } catch { /* not available */ }
 // Structs
 // ─────────────────────────────────────────────────────────────────────────────
 
-const RECT = koffi.struct("RECT", {
-  left: "int32",
-  top: "int32",
-  right: "int32",
-  bottom: "int32",
-});
-
-// MONITORINFO koffi struct removed in P2 — see src/win32/monitor.rs for the
-// windows-rs replacement.
+// RECT / MONITORINFO koffi structs removed in P2 — their last consumers
+// (GetWindowRect / EnumDisplayMonitors / GetMonitorInfoW) live in
+// src/win32/{window,monitor}.rs.
 
 /** PROCESSENTRY32W — Toolhelp32 snapshot entry for process enumeration. */
 const PROCESSENTRY32W = koffi.struct("PROCESSENTRY32W", {

--- a/src/engine/win32.ts
+++ b/src/engine/win32.ts
@@ -18,12 +18,11 @@ function requireNativeWin32(): NonNullable<typeof nativeWin32> {
 // DLL loading
 // ─────────────────────────────────────────────────────────────────────────────
 
-// `user32` still hosts a handful of legacy bindings (PrintWindow, ShowWindow,
-// SetForegroundWindow, etc.) that move to windows-rs in P2/P3. The 10 hot-path
-// APIs handled in this PR are no longer loaded here.
+// `user32` still hosts a handful of legacy bindings (ShowWindow,
+// SetForegroundWindow, SetWindowPos, AttachThreadInput, etc.) that move to
+// windows-rs in P3. `gdi32` / `shcore` were retired in P2 (their last
+// callers — PrintWindow / GDI / DPI — now live in src/win32/{gdi,dpi}.rs).
 const user32 = koffi.load("user32.dll");
-const gdi32 = koffi.load("gdi32.dll");
-const shcore = koffi.load("shcore.dll");
 const kernel32 = koffi.load("kernel32.dll");
 // dwmapi — window composition queries; available on Vista+ (always present on Win 10/11)
 let _dwmapi: ReturnType<typeof koffi.load> | null = null;
@@ -40,13 +39,8 @@ const RECT = koffi.struct("RECT", {
   bottom: "int32",
 });
 
-// Registered with koffi by name; referenced as a string in func signatures below, no JS handle needed.
-koffi.struct("MONITORINFO", {
-  cbSize: "uint32",
-  rcMonitor: RECT,
-  rcWork: RECT,
-  dwFlags: "uint32",
-});
+// MONITORINFO koffi struct removed in P2 — see src/win32/monitor.rs for the
+// windows-rs replacement.
 
 /** PROCESSENTRY32W — Toolhelp32 snapshot entry for process enumeration. */
 const PROCESSENTRY32W = koffi.struct("PROCESSENTRY32W", {
@@ -62,20 +56,8 @@ const PROCESSENTRY32W = koffi.struct("PROCESSENTRY32W", {
   szExeFile: koffi.array("uint16", 260), // WCHAR[MAX_PATH]
 });
 
-// Registered with koffi by name; referenced as a string in func signatures below, no JS handle needed.
-koffi.struct("BITMAPINFOHEADER", {
-  biSize: "uint32",
-  biWidth: "int32",
-  biHeight: "int32",
-  biPlanes: "uint16",
-  biBitCount: "uint16",
-  biCompression: "uint32",
-  biSizeImage: "uint32",
-  biXPelsPerMeter: "int32",
-  biYPelsPerMeter: "int32",
-  biClrUsed: "uint32",
-  biClrImportant: "uint32",
-});
+// BITMAPINFOHEADER koffi struct removed in P2 — GetDIBits now lives in
+// src/win32/gdi.rs and constructs the struct natively.
 
 /** SCROLLINFO — passed to GetScrollInfo to query scrollbar position. */
 const SCROLLINFO = koffi.struct("SCROLLINFO", {
@@ -103,57 +85,23 @@ if (koffi.sizeof(SCROLLINFO) !== 28) {
 // Function bindings
 // ─────────────────────────────────────────────────────────────────────────────
 
-// Window functions — the 10 hot-path bindings below are now in
-// src/win32/window.rs (ADR-007 P1) and reached via `requireNativeWin32()`:
-//   EnumWindows, GetWindowTextW, GetWindowRect, GetForegroundWindow,
-//   IsWindowVisible, IsIconic, IsZoomed, GetClassNameW,
-//   GetWindowThreadProcessId, GetWindowLongPtrW.
+// Window functions — the hot-path bindings below have moved to the native
+// addon (ADR-007 P1 = src/win32/window.rs, P2 = src/win32/{gdi,monitor,dpi}.rs):
+//   P1: EnumWindows, GetWindowTextW, GetWindowRect, GetForegroundWindow,
+//       IsWindowVisible, IsIconic, IsZoomed, GetClassNameW,
+//       GetWindowThreadProcessId, GetWindowLongPtrW
+//   P2: PrintWindow, GetDC, ReleaseDC, CreateCompatibleDC, CreateCompatibleBitmap,
+//       SelectObject, DeleteObject, DeleteDC, GetDIBits, EnumDisplayMonitors,
+//       GetMonitorInfoW, MonitorFromWindow, GetDpiForMonitor, SetProcessDpiAwareness
 //
-// Remaining koffi-backed bindings stay until P2/P3 (PrintWindow, ShowWindow,
-// SetForegroundWindow, etc.).
-const PrintWindow = user32.func(
-  "bool __stdcall PrintWindow(void *hwnd, void *hdcBlt, uint32 nFlags)"
-);
+// Remaining koffi bindings move in P3 (ShowWindow, SetForegroundWindow,
+// SetWindowPos, AttachThreadInput, OpenProcess/Toolhelp32, etc.).
 const ShowWindow = user32.func("bool __stdcall ShowWindow(void *hWnd, int nCmdShow)");
 const SetForegroundWindow = user32.func("bool __stdcall SetForegroundWindow(void *hWnd)");
 
-// DC / GDI
-const GetDC = user32.func("void* __stdcall GetDC(void *hWnd)");
-const ReleaseDC = user32.func("int __stdcall ReleaseDC(void *hWnd, void *hDC)");
-const CreateCompatibleDC = gdi32.func("void* __stdcall CreateCompatibleDC(void *hdc)");
-const CreateCompatibleBitmap = gdi32.func(
-  "void* __stdcall CreateCompatibleBitmap(void *hdc, int cx, int cy)"
-);
-const SelectObject = gdi32.func(
-  "void* __stdcall SelectObject(void *hdc, void *h)"
-);
-const DeleteObject = gdi32.func("bool __stdcall DeleteObject(void *ho)");
-const DeleteDC = gdi32.func("bool __stdcall DeleteDC(void *hdc)");
-const GetDIBits = gdi32.func(
-  "int __stdcall GetDIBits(void *hdc, void *hbm, uint32 start, uint32 cLines, uint8 *lpvBits, _Inout_ BITMAPINFOHEADER *lpbmi, uint32 usage)"
-);
-
-// Monitor enumeration
-const MonitorEnumProcProto = koffi.proto(
-  "bool __stdcall MonitorEnumProc(void *hMonitor, void *hdcMonitor, RECT *lprcMonitor, intptr dwData)"
-);
-const EnumDisplayMonitors = user32.func(
-  "bool __stdcall EnumDisplayMonitors(void *hdc, RECT *lprcClip, MonitorEnumProc *lpfnEnum, intptr dwData)"
-);
-const GetMonitorInfoW = user32.func(
-  "bool __stdcall GetMonitorInfoW(void *hMonitor, _Inout_ MONITORINFO *lpmi)"
-);
-const MonitorFromWindow = user32.func(
-  "void* __stdcall MonitorFromWindow(void *hWnd, uint32 dwFlags)"
-);
-
-// DPI
-const GetDpiForMonitor = shcore.func(
-  "int __stdcall GetDpiForMonitor(void *hmonitor, int dpiType, _Out_ uint32 *dpiX, _Out_ uint32 *dpiY)"
-);
-const SetProcessDpiAwareness = shcore.func(
-  "int __stdcall SetProcessDpiAwareness(int value)"
-);
+// DC / GDI / Monitor enum / DPI bindings have all moved to the native addon
+// (ADR-007 P2). The TS wrappers below (`enumMonitors`, `printWindowToBuffer`,
+// `getWindowDpi`) call into `nativeWin32.win32*` directly.
 
 // Window → PID mapping moved to ADR-007 P1 native addon
 // (see src/win32/window.rs::win32_get_window_thread_process_id).
@@ -273,9 +221,11 @@ export function getLastActivePopup(hwnd: unknown): bigint | null {
 // ─────────────────────────────────────────────────────────────────────────────
 
 try {
-  SetProcessDpiAwareness(2);
+  // E_ACCESSDENIED ("already set by another API") is treated as success
+  // inside the native binding, matching the legacy try/catch swallow.
+  requireNativeWin32().win32SetProcessDpiAwareness!(2);
 } catch {
-  // Ignore: already set or not supported on this Windows version
+  // Ignore: not supported on this Windows version
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -294,59 +244,26 @@ export interface MonitorInfo {
 
 /** Enumerate all connected monitors */
 export function enumMonitors(): MonitorInfo[] {
-  const monitors: MonitorInfo[] = [];
-  let id = 0;
-
-  const cb = koffi.register(
-    (hMonitor: unknown) => {
-      const info = {
-        cbSize: 40, // sizeof MONITORINFO
-        rcMonitor: { left: 0, top: 0, right: 0, bottom: 0 },
-        rcWork: { left: 0, top: 0, right: 0, bottom: 0 },
-        dwFlags: 0,
-      };
-      GetMonitorInfoW(hMonitor, info);
-
-      const dpiXArr = [0];
-      const dpiYArr = [0];
-      try {
-        GetDpiForMonitor(hMonitor, 0 /* MDT_EFFECTIVE_DPI */, dpiXArr, dpiYArr);
-      } catch {
-        dpiXArr[0] = 96;
-      }
-      const dpi = dpiXArr[0] || 96;
-
-      monitors.push({
-        id: id++,
-        handle: hMonitor,
-        primary: (info.dwFlags & 1) !== 0,
-        bounds: {
-          x: info.rcMonitor.left,
-          y: info.rcMonitor.top,
-          width: info.rcMonitor.right - info.rcMonitor.left,
-          height: info.rcMonitor.bottom - info.rcMonitor.top,
-        },
-        workArea: {
-          x: info.rcWork.left,
-          y: info.rcWork.top,
-          width: info.rcWork.right - info.rcWork.left,
-          height: info.rcWork.bottom - info.rcWork.top,
-        },
-        dpi,
-        scale: Math.round((dpi / 96) * 100),
-      });
-      return true;
+  const raw = requireNativeWin32().win32EnumMonitors!();
+  return raw.map((m, id) => ({
+    id,
+    handle: m.handle, // bigint at runtime; declared `unknown` to keep callers opaque
+    primary: m.primary,
+    bounds: {
+      x: m.boundsLeft,
+      y: m.boundsTop,
+      width: m.boundsRight - m.boundsLeft,
+      height: m.boundsBottom - m.boundsTop,
     },
-    koffi.pointer(MonitorEnumProcProto)
-  );
-
-  try {
-    EnumDisplayMonitors(null, null, cb, 0);
-  } finally {
-    koffi.unregister(cb);
-  }
-
-  return monitors;
+    workArea: {
+      x: m.workLeft,
+      y: m.workTop,
+      width: m.workRight - m.workLeft,
+      height: m.workBottom - m.workTop,
+    },
+    dpi: m.dpi || 96,
+    scale: Math.round(((m.dpi || 96) / 96) * 100),
+  }));
 }
 
 /** Get the combined virtual screen bounds across all monitors */
@@ -761,74 +678,9 @@ export function printWindowToBuffer(hwnd: unknown, flags = 2): {
   width: number;
   height: number;
 } {
-  const rect = requireNativeWin32().win32GetWindowRect!(hwnd as bigint);
-  if (!rect) {
-    throw new Error("GetWindowRect failed");
-  }
-
-  const width = rect.right - rect.left;
-  const height = rect.bottom - rect.top;
-  if (width <= 0 || height <= 0) {
-    throw new Error(`Invalid window dimensions: ${width}x${height}`);
-  }
-
-  const screenDC = GetDC(null);
-  if (!screenDC) throw new Error("GetDC failed");
-
-  const memDC = CreateCompatibleDC(screenDC);
-  if (!memDC) {
-    ReleaseDC(null, screenDC);
-    throw new Error("CreateCompatibleDC failed");
-  }
-
-  const hBitmap = CreateCompatibleBitmap(screenDC, width, height);
-  if (!hBitmap) {
-    DeleteDC(memDC);
-    ReleaseDC(null, screenDC);
-    throw new Error("CreateCompatibleBitmap failed");
-  }
-
-  const oldBitmap = SelectObject(memDC, hBitmap);
-
-  try {
-    const ok = PrintWindow(hwnd, memDC, flags);
-    if (!ok) {
-      // Fall through — some windows partially render even when returning false
-    }
-
-    // Set up BITMAPINFOHEADER for 32bpp top-down DIB
-    const bmi = {
-      biSize: 40,
-      biWidth: width,
-      biHeight: -height, // negative = top-down
-      biPlanes: 1,
-      biBitCount: 32,
-      biCompression: 0, // BI_RGB
-      biSizeImage: 0,
-      biXPelsPerMeter: 0,
-      biYPelsPerMeter: 0,
-      biClrUsed: 0,
-      biClrImportant: 0,
-    };
-
-    const pixels = Buffer.alloc(width * height * 4);
-    GetDIBits(memDC, hBitmap, 0, height, pixels, bmi, 0 /* DIB_RGB_COLORS */);
-
-    // Convert BGRA → RGBA and set alpha=255
-    for (let i = 0; i < pixels.length; i += 4) {
-      const b = pixels[i]!;
-      pixels[i] = pixels[i + 2]!;   // R ← B
-      pixels[i + 2] = b;             // B ← R
-      pixels[i + 3] = 255;           // Alpha = opaque
-    }
-
-    return { data: pixels, width, height };
-  } finally {
-    SelectObject(memDC, oldBitmap);
-    DeleteObject(hBitmap);
-    DeleteDC(memDC);
-    ReleaseDC(null, screenDC);
-  }
+  if (typeof hwnd !== "bigint") throw new Error("printWindowToBuffer requires a bigint hwnd");
+  const r = requireNativeWin32().win32PrintWindowToBuffer!(hwnd, flags);
+  return { data: r.data, width: r.width, height: r.height };
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1017,21 +869,16 @@ export function vkToScanCode(vk: number): number {
 // DPI helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
-const MONITOR_DEFAULTTONEAREST = 2;
-
 /**
  * Return the effective DPI of the monitor that contains the given window.
- * Uses MonitorFromWindow → GetDpiForMonitor(MDT_EFFECTIVE_DPI).
  * Returns 96 (100% baseline) on any failure — safe fallback (keeps scale=2).
+ * `MonitorFromWindow(MONITOR_DEFAULTTONEAREST)` + `GetDpiForMonitor(MDT_EFFECTIVE_DPI)`
+ * are folded into the native binding so callers don't pay two FFI hops.
  */
 export function getWindowDpi(hwnd: unknown): number {
+  if (typeof hwnd !== "bigint") return 96;
   try {
-    const hMonitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
-    if (!hMonitor) return 96;
-    const dpiXArr = [0];
-    const dpiYArr = [0];
-    GetDpiForMonitor(hMonitor, 0 /* MDT_EFFECTIVE_DPI */, dpiXArr, dpiYArr);
-    return dpiXArr[0] || 96;
+    return requireNativeWin32().win32GetWindowDpi!(hwnd) || 96;
   } catch {
     return 96;
   }

--- a/src/win32/dpi.rs
+++ b/src/win32/dpi.rs
@@ -1,0 +1,66 @@
+//! DPI helpers (ADR-007 P2).
+//!
+//! `win32_set_process_dpi_awareness` is called once at process startup; the
+//! TS module init used to wrap `SetProcessDpiAwareness(2)` in try/catch and
+//! swallow every error. Win32 returns `E_ACCESSDENIED` when the awareness
+//! has already been set by another API (very common when the app is
+//! launched under tooling that pre-sets it), and the legacy code treated
+//! that as success — we preserve that semantics by returning `Ok(true)`
+//! for both `S_OK` and `E_ACCESSDENIED`.
+//!
+//! `win32_get_window_dpi` folds `MonitorFromWindow` + `GetDpiForMonitor`
+//! into a single sync call because they're always paired in the existing
+//! TS code (`getWindowDpi`).
+
+use napi::bindgen_prelude::BigInt;
+use napi_derive::napi;
+use windows::Win32::Foundation::{E_ACCESSDENIED, HWND};
+use windows::Win32::Graphics::Gdi::{MonitorFromWindow, MONITOR_DEFAULTTONEAREST};
+use windows::Win32::UI::HiDpi::{
+    GetDpiForMonitor, SetProcessDpiAwareness, MDT_EFFECTIVE_DPI, PROCESS_DPI_AWARENESS,
+};
+
+use super::safety::napi_safe_call;
+
+fn hwnd_from_bigint(b: BigInt) -> HWND {
+    let (_sign, val, _lossless) = b.get_u64();
+    HWND(val as isize as *mut std::ffi::c_void)
+}
+
+/// Effective DPI of the monitor containing `hwnd`. Returns 96 (= 100%
+/// baseline) on any failure to match the legacy `getWindowDpi` behavior.
+#[napi]
+pub fn win32_get_window_dpi(hwnd: BigInt) -> napi::Result<u32> {
+    napi_safe_call("win32_get_window_dpi", || {
+        let h = hwnd_from_bigint(hwnd);
+        // MonitorFromWindow always returns a valid HMONITOR for any non-null
+        // window (including DEFAULTTONEAREST fallback). For null/dead hwnd
+        // it returns NULL; treat as 96.
+        let hmon = unsafe { MonitorFromWindow(h, MONITOR_DEFAULTTONEAREST) };
+        if hmon.0.is_null() {
+            return Ok(96);
+        }
+        let mut dpi_x: u32 = 0;
+        let mut dpi_y: u32 = 0;
+        let result = unsafe { GetDpiForMonitor(hmon, MDT_EFFECTIVE_DPI, &mut dpi_x, &mut dpi_y) };
+        if result.is_err() || dpi_x == 0 {
+            return Ok(96);
+        }
+        Ok(dpi_x)
+    })
+}
+
+/// `SetProcessDpiAwareness(level)`. `level=2` is `PROCESS_PER_MONITOR_DPI_AWARE`.
+/// `E_ACCESSDENIED` ("already set by another API") is treated as success
+/// — matches the legacy try/catch-swallow behavior.
+#[napi]
+pub fn win32_set_process_dpi_awareness(level: i32) -> napi::Result<bool> {
+    napi_safe_call("win32_set_process_dpi_awareness", || {
+        let result = unsafe { SetProcessDpiAwareness(PROCESS_DPI_AWARENESS(level)) };
+        match result {
+            Ok(()) => Ok(true),
+            Err(e) if e.code() == E_ACCESSDENIED => Ok(true),
+            Err(_) => Ok(false),
+        }
+    })
+}

--- a/src/win32/gdi.rs
+++ b/src/win32/gdi.rs
@@ -1,0 +1,200 @@
+//! GDI capture (ADR-007 P2) — `print_window_to_buffer`.
+//!
+//! Replaces the koffi-driven sequence in `printWindowToBuffer`:
+//!   GetWindowRect → GetDC(NULL) → CreateCompatibleDC → CreateCompatibleBitmap
+//!   → SelectObject → PrintWindow → GetDIBits → reshape BGRA→RGBA → cleanup.
+//!
+//! Every Win32 handle is owned by a small RAII guard. The let-binding order
+//! in `print_window_to_buffer` therefore matters: `screen_dc` lives longest,
+//! then `mem_dc`, then `bitmap`, then `select_guard`. drop order is LIFO, so
+//! the SelectObject undo runs first, then DeleteObject(bitmap), then
+//! DeleteDC(mem_dc), then ReleaseDC(NULL, screen_dc) — matching the Win32
+//! lifecycle invariant ("unselect before destroy").
+//!
+//! drop order is LIFO; select must unwind before bitmap is destroyed,
+//! bitmap before its memory DC, memory DC before its source screen DC.
+
+use napi::bindgen_prelude::{BigInt, Buffer};
+use napi_derive::napi;
+use windows::Win32::Foundation::{HWND, RECT};
+use windows::Win32::Graphics::Gdi::{
+    CreateCompatibleBitmap, CreateCompatibleDC, DeleteDC, DeleteObject, GetDC, GetDIBits,
+    ReleaseDC, SelectObject, BITMAPINFO, BITMAPINFOHEADER, BI_RGB, DIB_RGB_COLORS, HBITMAP, HDC,
+    HGDIOBJ,
+};
+use windows::Win32::Storage::Xps::{PrintWindow, PRINT_WINDOW_FLAGS};
+use windows::Win32::UI::WindowsAndMessaging::GetWindowRect;
+
+use super::safety::napi_safe_call;
+use super::types::NativePrintWindowResult;
+
+fn hwnd_from_bigint(b: BigInt) -> HWND {
+    let (_sign, val, _lossless) = b.get_u64();
+    HWND(val as isize as *mut std::ffi::c_void)
+}
+
+// ── RAII guards ──────────────────────────────────────────────────────────────
+
+/// Releases either a window-DC (`ReleaseDC(target, dc)`) or a memory-DC
+/// (`DeleteDC(dc)`) on Drop, depending on `is_mem`.
+struct DcGuard {
+    target: Option<HWND>,
+    dc: HDC,
+    is_mem: bool,
+}
+impl Drop for DcGuard {
+    fn drop(&mut self) {
+        unsafe {
+            if self.is_mem {
+                let _ = DeleteDC(self.dc);
+            } else {
+                ReleaseDC(self.target, self.dc);
+            }
+        }
+    }
+}
+
+struct BitmapGuard(HBITMAP);
+impl Drop for BitmapGuard {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = DeleteObject(HGDIOBJ(self.0 .0));
+        }
+    }
+}
+
+/// Restores the previously-selected GDI object on Drop. `old = None` when
+/// the original `SelectObject` returned NULL (= failure) — in that case we
+/// have nothing to restore, so Drop is a no-op (Opus review §11.2).
+struct SelectGuard {
+    dc: HDC,
+    old: Option<HGDIOBJ>,
+}
+impl Drop for SelectGuard {
+    fn drop(&mut self) {
+        if let Some(old) = self.old.take() {
+            unsafe {
+                let _ = SelectObject(self.dc, old);
+            }
+        }
+    }
+}
+
+// ── Public entry point ──────────────────────────────────────────────────────
+
+/// Capture `hwnd` via PrintWindow into an RGBA top-down buffer.
+///
+/// `flags` matches the Win32 `PRINT_WINDOW_FLAGS` values (0 = default,
+/// 2 = `PW_RENDERFULLCONTENT`, 3 = client-only + RENDERFULLCONTENT).
+/// Returns `Err` for unrecoverable failures (window gone, all DCs failed);
+/// returns the buffer even when `PrintWindow` itself returns FALSE because
+/// some windows partially render in that case (legacy TS behavior).
+#[napi]
+pub fn win32_print_window_to_buffer(
+    hwnd: BigInt,
+    flags: u32,
+) -> napi::Result<NativePrintWindowResult> {
+    napi_safe_call("win32_print_window_to_buffer", || {
+        let target = hwnd_from_bigint(hwnd);
+
+        // 1. Resolve client size.
+        let mut rect = RECT::default();
+        unsafe { GetWindowRect(target, &mut rect) }
+            .map_err(|e| napi::Error::from_reason(format!("GetWindowRect failed: {e}")))?;
+        let width = rect.right - rect.left;
+        let height = rect.bottom - rect.top;
+        if width <= 0 || height <= 0 {
+            return Err(napi::Error::from_reason(format!(
+                "Invalid window dimensions: {width}x{height}"
+            )));
+        }
+
+        // 2. Acquire the screen DC. `screen_dc` is dropped LAST among the
+        //    guards declared below (LIFO drop order), satisfying the Win32
+        //    invariant that mem_dc / bitmap / select must all be cleaned up
+        //    before ReleaseDC on the source DC.
+        let screen_dc_raw = unsafe { GetDC(None) };
+        if screen_dc_raw.0.is_null() {
+            return Err(napi::Error::from_reason("GetDC failed"));
+        }
+        let screen_dc = DcGuard {
+            target: None,
+            dc: screen_dc_raw,
+            is_mem: false,
+        };
+
+        // 3. Memory DC compatible with the screen.
+        let mem_dc_raw = unsafe { CreateCompatibleDC(Some(screen_dc.dc)) };
+        if mem_dc_raw.0.is_null() {
+            return Err(napi::Error::from_reason("CreateCompatibleDC failed"));
+        }
+        let mem_dc = DcGuard {
+            target: None,
+            dc: mem_dc_raw,
+            is_mem: true,
+        };
+
+        // 4. Bitmap big enough for the window contents.
+        let bitmap_raw = unsafe { CreateCompatibleBitmap(screen_dc.dc, width, height) };
+        if bitmap_raw.0.is_null() {
+            return Err(napi::Error::from_reason("CreateCompatibleBitmap failed"));
+        }
+        let _bitmap = BitmapGuard(bitmap_raw);
+
+        // 5. Bind bitmap to the memory DC; the previous selection is
+        //    restored on drop (skipped when SelectObject returned NULL).
+        let prev = unsafe { SelectObject(mem_dc.dc, HGDIOBJ(bitmap_raw.0 as *mut _)) };
+        let _select_guard = SelectGuard {
+            dc: mem_dc.dc,
+            old: if prev.0.is_null() { None } else { Some(prev) },
+        };
+
+        // 6. PrintWindow. We tolerate FALSE because some windows still
+        //    render partially — the legacy TS behavior was to fall through
+        //    to GetDIBits and let the caller use whatever was produced.
+        let _ = unsafe { PrintWindow(target, mem_dc.dc, PRINT_WINDOW_FLAGS(flags)) };
+
+        // 7. Pull the DIB into a CPU buffer (32bpp top-down BI_RGB).
+        let mut bmi: BITMAPINFO = unsafe { std::mem::zeroed() };
+        bmi.bmiHeader = BITMAPINFOHEADER {
+            biSize: std::mem::size_of::<BITMAPINFOHEADER>() as u32,
+            biWidth: width,
+            biHeight: -height, // negative = top-down
+            biPlanes: 1,
+            biBitCount: 32,
+            biCompression: BI_RGB.0,
+            ..unsafe { std::mem::zeroed() }
+        };
+        let pixel_count = (width as usize) * (height as usize);
+        let mut pixels: Vec<u8> = vec![0u8; pixel_count * 4];
+        let scanlines = unsafe {
+            GetDIBits(
+                mem_dc.dc,
+                bitmap_raw,
+                0,
+                height as u32,
+                Some(pixels.as_mut_ptr() as *mut std::ffi::c_void),
+                &mut bmi,
+                DIB_RGB_COLORS,
+            )
+        };
+        if scanlines == 0 {
+            return Err(napi::Error::from_reason("GetDIBits returned 0 scanlines"));
+        }
+
+        // 8. BGRA → RGBA + opaque alpha. `chunks_exact_mut(4)` lets the
+        //    autovectorizer collapse the swap into a couple of pshufb-style
+        //    instructions on x86_64; explicit SIMD is deferred to P5a per
+        //    Opus review §11.7 / scope creep list.
+        for px in pixels.chunks_exact_mut(4) {
+            px.swap(0, 2);
+            px[3] = 255;
+        }
+
+        Ok(NativePrintWindowResult {
+            data: Buffer::from(pixels),
+            width: width as u32,
+            height: height as u32,
+        })
+    })
+}

--- a/src/win32/mod.rs
+++ b/src/win32/mod.rs
@@ -12,3 +12,9 @@ pub(crate) mod safety;
 pub(crate) mod types;
 #[cfg(windows)]
 pub(crate) mod window;
+#[cfg(windows)]
+pub(crate) mod gdi;
+#[cfg(windows)]
+pub(crate) mod monitor;
+#[cfg(windows)]
+pub(crate) mod dpi;

--- a/src/win32/monitor.rs
+++ b/src/win32/monitor.rs
@@ -1,0 +1,105 @@
+//! Monitor enumeration (ADR-007 P2).
+//!
+//! Replaces the koffi-based `enumMonitors` flow that registered a JS
+//! callback into `EnumDisplayMonitors` and called `GetMonitorInfoW` +
+//! `GetDpiForMonitor` from JS per monitor. The Rust callback runs entirely
+//! in-process and is panic-isolated against the Windows ABI boundary.
+
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::sync::atomic::Ordering;
+
+use napi::bindgen_prelude::BigInt;
+use napi_derive::napi;
+use windows::core::BOOL;
+use windows::Win32::Foundation::{LPARAM, RECT};
+use windows::Win32::Graphics::Gdi::{
+    EnumDisplayMonitors, GetMonitorInfoW, HDC, HMONITOR, MONITORINFO,
+};
+
+// Win32 stable value (winuser.h). windows-rs 0.62 does not re-export it as a
+// named constant; we hard-code rather than introduce a feature dependency.
+const MONITORINFOF_PRIMARY: u32 = 0x0000_0001;
+use windows::Win32::UI::HiDpi::{GetDpiForMonitor, MDT_EFFECTIVE_DPI};
+
+use super::safety::{napi_safe_call, PANIC_COUNTER};
+use super::types::NativeMonitorInfo;
+
+fn build_monitor_info(hmon: HMONITOR) -> Option<NativeMonitorInfo> {
+    let mut mi = MONITORINFO {
+        cbSize: std::mem::size_of::<MONITORINFO>() as u32,
+        rcMonitor: RECT::default(),
+        rcWork: RECT::default(),
+        dwFlags: 0,
+    };
+    let ok = unsafe { GetMonitorInfoW(hmon, &mut mi) };
+    if !ok.as_bool() {
+        return None;
+    }
+    let mut dpi_x: u32 = 96;
+    let mut dpi_y: u32 = 96;
+    let _ = unsafe { GetDpiForMonitor(hmon, MDT_EFFECTIVE_DPI, &mut dpi_x, &mut dpi_y) };
+    if dpi_x == 0 {
+        dpi_x = 96;
+    }
+    Some(NativeMonitorInfo {
+        handle: BigInt::from(hmon.0 as usize as u64),
+        primary: (mi.dwFlags & MONITORINFOF_PRIMARY) != 0,
+        bounds_left: mi.rcMonitor.left,
+        bounds_top: mi.rcMonitor.top,
+        bounds_right: mi.rcMonitor.right,
+        bounds_bottom: mi.rcMonitor.bottom,
+        work_left: mi.rcWork.left,
+        work_top: mi.rcWork.top,
+        work_right: mi.rcWork.right,
+        work_bottom: mi.rcWork.bottom,
+        dpi: dpi_x,
+    })
+}
+
+/// Append one monitor to the `Vec<NativeMonitorInfo>` whose pointer is
+/// passed via `lparam`. Wrapped in `catch_unwind` so a Rust panic never
+/// unwinds across the Windows ABI boundary (UB) — matches the
+/// `enum_windows_collect` pattern in `window.rs`.
+unsafe extern "system" fn enum_monitor_collect(
+    hmon: HMONITOR,
+    _hdc: HDC,
+    _lprc: *mut RECT,
+    lparam: LPARAM,
+) -> BOOL {
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        // Safety: lparam is a valid `*mut Vec<NativeMonitorInfo>` for the
+        // lifetime of the `EnumDisplayMonitors` call below.
+        let vec = unsafe { &mut *(lparam.0 as *mut Vec<NativeMonitorInfo>) };
+        if let Some(info) = build_monitor_info(hmon) {
+            vec.push(info);
+        }
+    }));
+    if result.is_err() {
+        PANIC_COUNTER.fetch_add(1, Ordering::Relaxed);
+        BOOL(0) // stop enumeration
+    } else {
+        BOOL(1) // continue
+    }
+}
+
+/// Enumerate every connected monitor. Returns one `NativeMonitorInfo` per
+/// monitor (geometry + DPI). The TS wrapper rebuilds the `MonitorInfo`
+/// shape (`bounds`/`workArea` nested objects + `id` index + `scale`
+/// percentage) that callers expect.
+#[napi]
+pub fn win32_enum_monitors() -> napi::Result<Vec<NativeMonitorInfo>> {
+    napi_safe_call("win32_enum_monitors", || {
+        let mut monitors: Vec<NativeMonitorInfo> = Vec::with_capacity(4);
+        let lparam = LPARAM(&mut monitors as *mut Vec<NativeMonitorInfo> as isize);
+        let ok = unsafe {
+            EnumDisplayMonitors(None, None, Some(enum_monitor_collect), lparam)
+        };
+        if !ok.as_bool() {
+            return Err(napi::Error::from_reason(
+                "EnumDisplayMonitors returned FALSE",
+            ));
+        }
+        Ok(monitors)
+    })
+}
+

--- a/src/win32/types.rs
+++ b/src/win32/types.rs
@@ -7,6 +7,7 @@
 //! `NativeThreadProcessId` collapses the Win32 `GetWindowThreadProcessId`
 //! out-pointer + return value into a single struct.
 
+use napi::bindgen_prelude::{BigInt, Buffer};
 use napi_derive::napi;
 
 #[napi(object)]
@@ -21,4 +22,33 @@ pub struct NativeWin32Rect {
 pub struct NativeThreadProcessId {
     pub thread_id: u32,
     pub process_id: u32,
+}
+
+/// Result of `win32_print_window_to_buffer`. `data` is RGBA8 top-down, length
+/// equals `width * height * 4`. The TS wrapper hands this through unchanged
+/// (the legacy koffi-based `printWindowToBuffer` returned the same shape).
+#[napi(object)]
+pub struct NativePrintWindowResult {
+    pub data: Buffer,
+    pub width: u32,
+    pub height: u32,
+}
+
+/// One monitor's geometry + DPI as captured by `EnumDisplayMonitors`. Kept
+/// flat (not nested) to match the existing `NativeWin32Rect` shape and keep
+/// the napi marshal layer simple. The TS wrapper rebuilds the
+/// `{ bounds, workArea }` nested object expected by `MonitorInfo`.
+#[napi(object)]
+pub struct NativeMonitorInfo {
+    pub handle: BigInt,
+    pub primary: bool,
+    pub bounds_left: i32,
+    pub bounds_top: i32,
+    pub bounds_right: i32,
+    pub bounds_bottom: i32,
+    pub work_left: i32,
+    pub work_top: i32,
+    pub work_right: i32,
+    pub work_bottom: i32,
+    pub dpi: u32,
 }

--- a/tests/unit/native-win32-panic-fuzz.test.ts
+++ b/tests/unit/native-win32-panic-fuzz.test.ts
@@ -92,5 +92,68 @@ describe.skipIf(!nativeWin32)("ADR-007 P1: native win32 panic-safety", () => {
       const deltaMB = (after - before) / (1024 * 1024);
       expect(deltaMB).toBeLessThan(50);
     });
+
+    // Opus review §11.6 wants P2 to match P1's iteration count and tighten
+    // the RSS guard. enumMonitors should not allocate per-call beyond the
+    // small Vec it returns; 5MB is generous headroom for V8 churn.
+    it("100 win32EnumMonitors() iterations stay under 5MB delta (ADR-007 P2)", () => {
+      native.win32EnumMonitors!();
+      const before = process.memoryUsage().rss;
+      for (let i = 0; i < 100; i++) {
+        const mons = native.win32EnumMonitors!();
+        expect(mons.length).toBeGreaterThanOrEqual(1);
+      }
+      const after = process.memoryUsage().rss;
+      const deltaMB = (after - before) / (1024 * 1024);
+      expect(deltaMB).toBeLessThan(5);
+    });
+  });
+
+  describe("ADR-007 P2: GDI / monitor / DPI panic safety", () => {
+    // Adversarial HWNDs for the new P2 surface. printWindowToBuffer must
+    // throw a typed Error (the underlying GetWindowRect fails) but NEVER
+    // crash the process; getWindowDpi must hand back the safe 96 fallback.
+    const adversarial: Array<[label: string, hwnd: bigint]> = [
+      ["null hwnd", 0n],
+      ["stale hwnd", 9_999_999_999n],
+      ["all-ones u64", 0xffff_ffff_ffff_ffffn],
+    ];
+
+    for (const [label, hwnd] of adversarial) {
+      it(`win32PrintWindowToBuffer(${label}) throws typed Error, process survives`, () => {
+        expect(() => native.win32PrintWindowToBuffer!(hwnd, 2)).toThrow();
+      });
+      it(`win32GetWindowDpi(${label}) returns 96`, () => {
+        expect(native.win32GetWindowDpi!(hwnd)).toBe(96);
+      });
+    }
+
+    it("win32SetProcessDpiAwareness with already-set state returns true", () => {
+      // The native binding maps E_ACCESSDENIED (already set) to success
+      // (Opus review §11.3). The process startup path already calls this
+      // once with level=2; calling again here exercises that mapping.
+      expect(native.win32SetProcessDpiAwareness!(2)).toBe(true);
+    });
+
+    it("win32SetProcessDpiAwareness with invalid level does not panic", () => {
+      // Some invalid levels return E_INVALIDARG; we accept either true/false
+      // (the contract is "no panic"), not the specific HRESULT outcome.
+      expect(typeof native.win32SetProcessDpiAwareness!(99)).toBe("boolean");
+    });
+
+    it("printWindowToBuffer round-trip on the foreground window produces RGBA8", () => {
+      const fg = native.win32GetForegroundWindow!();
+      if (fg === null) return; // headless / lock screen
+      const r = native.win32PrintWindowToBuffer!(fg, 2);
+      expect(r.width).toBeGreaterThan(0);
+      expect(r.height).toBeGreaterThan(0);
+      // length = w * h * 4 (RGBA8)
+      expect(r.data.length).toBe(r.width * r.height * 4);
+      // alpha channel is forced to 255 by the BGRA→RGBA pass
+      // (sample the first pixel's alpha and a middle pixel's alpha).
+      expect(r.data[3]).toBe(255);
+      const mid = Math.floor(r.data.length / 8) * 4;
+      expect(r.data[mid + 3]).toBe(255);
+    });
   });
 });


### PR DESCRIPTION
## Summary

ADR-007 Phase 2: replace 14 koffi bindings (GDI / monitor enum / DPI) with 4 high-level windows-rs exports under `src/win32/`. Continues the migration started in PR #74 (P1 hot-path window APIs).

- 14 koffi defs retired: `PrintWindow / GetDC / ReleaseDC / CreateCompatibleDC / CreateCompatibleBitmap / SelectObject / DeleteObject / DeleteDC / GetDIBits / EnumDisplayMonitors / GetMonitorInfoW / MonitorFromWindow / GetDpiForMonitor / SetProcessDpiAwareness`
- 4 native exports added: `win32PrintWindowToBuffer / win32EnumMonitors / win32GetWindowDpi / win32SetProcessDpiAwareness`
- TS wrapper signatures unchanged → zero changes for the callers (`tools/desktop-state.ts`, `tools/dock.ts`, `engine/image.ts`, `engine/ocr-bridge.ts`). Tool Surface 不変原則 (P7) preserved.
- Hybrid choice (high-level over primitive 1:1): `printWindowToBuffer` collapses a 9-call GDI dance + BGRA→RGBA loop into a single Rust call with RAII, eliminating the JS-side resource-leak risk on error paths.

## Bench baseline (release build)

`node scripts/bench-print-window.mjs` — 1920x1080 / 2,073,600 pixels, 100 iterations:

| metric | ms |
|---|---|
| min | 13.4 |
| **p50** | **20.3** |
| p95 | 25.6 |
| **p99** | **28.3** |
| max | 28.3 |
| mean | 20.5 |

`PrintWindow` itself dominates the wall time on full-screen overlays; the BGRA→RGBA scalar swap and the GDI handle setup are ~1ms combined. `enumMonitors` returns in <1ms (it's not bench-tracked separately — the panic-fuzz 100-iter loop is the regression guard).

P1 baseline still healthy: enum+title 1000 iter / 494 windows → p99 0.77ms.

## ADR-007 §6 P2 acceptance

- ✅ `screenshot/printWindow latency 計測` (above)
- ✅ `回帰なし` (`npm run test:capture`: 146 files / 2352 tests pass / 0 fail / 0 regression — see Test plan)

## Opus pre-implementation review

`docs/adr-007-p2-design-proposal.md` records the 9 items the Opus reviewer flagged before any code landed; every one is reflected in the implementation:

1. `MonitorInfo.handle` declared `unknown` (opaque) even though runtime value is `bigint`
2. `SelectGuard.old: Option<HGDIOBJ>` — no NULL undo on Drop
3. `SetProcessDpiAwareness` maps `E_ACCESSDENIED` → success (matches legacy try/catch)
4. Cargo features verified (`Win32_Graphics_Gdi` + `Win32_UI_HiDpi` + `Win32_Storage_Xps` for `PrintWindow`)
5. RAII drop-order documented in `gdi.rs` header (LIFO: select → bitmap → mem_dc → screen_dc)
6. panic-fuzz uses 100-iter / 5MB RSS guard for `enumMonitors` (matches P1 strictness)
7. bench picks the largest real window on the dev machine (no synthetic 4K)
8. `MonitorEnumProcProto` koffi.proto removed
9. `gdi32` / `shcore` koffi.load + `MONITORINFO` / `BITMAPINFOHEADER` koffi.struct dead-code removed in this PR (Opus final-review §3 補助 4)

## Test plan

- [x] `cargo check` clean
- [x] `npm run build:rs` (release) produces a working `.node`
- [x] `npm run build` (tsc) clean
- [x] `npm run check:napi-safe` passes (all 14 sync `#[napi]` exports under `src/win32/` wrap with `napi_safe_call`)
- [x] `npm run check:native-types` passes (19 Rust exports = 15 from P1 + 4 from P2 all declared in `index.d.ts`)
- [x] `npx vitest run --project=unit tests/unit/native-win32-panic-fuzz.test.ts` — **37/37 pass**
- [x] `npm run test:capture` — **146 files / 2352 tests pass / 0 regression / 0 fail** (versus 1 known-fixed P1 fail and 8 environmental browser-cdp fails on previous runs)
- [x] Live MCP smoke test: `desktop_state` returns Japanese-titled window correctly via `win32GetWindowText`; `enumMonitors` lights up the dock layout

## Scope (kept tight per Opus review §12)

Intentionally **not** in this PR:
- `ShowWindow` / `SetForegroundWindow` / `SetWindowPos` / `BringWindowToTop` / `AttachThreadInput` (P3)
- `OpenProcess` / `Toolhelp32` / `GetProcessTimes` / `QueryFullProcessImageNameW` (P3)
- `sensors-win32.ts` koffi removal + `koffi` npm package removal (P4)
- `SetProcessDpiAwarenessContext` upgrade (Win10 1703+) — defer to P3 / dedicated ADR
- `printWindowToBuffer` metadata (timestamp / monitor id) — L1 Capture (P5a)
- BGRA→RGBA SIMD upgrade — P5a (current scalar autovectorizes adequately)
- `napi_safe_call` extension to existing sync exports (`compute_change_fraction` etc.) — P5a alongside `#[napi_safe]` proc_macro

🤖 Generated with [Claude Code](https://claude.com/claude-code)