### PR TITLE
docs(adr-007/008): P5c plan + D1 plan reconcile (root owns integration)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ docs/release-process.md
 !docs/ocr-quality-improvement-plan.md
 !docs/visual-gpu-dataplane-plan.md
 !docs/adr-008-d1-plan.md
+!docs/adr-007-p5c-plan.md
 
 # Claude Code session data (auto-memory, local settings) — never distribute
 .claude/

--- a/docs/adr-007-koffi-to-rust-migration.md
+++ b/docs/adr-007-koffi-to-rust-migration.md
@@ -368,9 +368,10 @@ P1 で **本 ADR §3.4 acceptance のうち**「panic-fuzz CI でプロセス全
 
 - P1-P4 は各 Phase を 1 PR で main 入れる (互換維持で段階導入)
 - P5 は **subphase 化**:
-  - P5a: EventEnvelope schema + ring buffer (TS API は変えない)
-  - P5b: WAL + replay E2E (record モード default off で導入)
-  - P5c: DXGI dirty rect 統合 + Tier dispatch
+  - P5a: EventEnvelope schema + ring buffer (TS API は変えない) — **完了 (2026-04-29)**
+  - P5b: (consumed) `#[napi_safe]` proc_macro 評価 — 保留決定 (PR #80、`docs/adr-007-p5b-evaluation.md`)
+  - P5c: 観測系 event 生成 (UIA hooks + DXGI dirty rect + Scroll/Window) + Tier 1 graceful disable (詳細: `docs/adr-007-p5c-plan.md`)
+  - WAL + replay E2E は **ADR-008 D6 へ移管** (SSOT §10.2 / ADR-008 §4 D6 と整合、本 ADR scope 外)
   - P5d: timestamp source 多重化 (Reflex/DXGI/DWM)
 
 ---
@@ -441,8 +442,8 @@ build 時に platform-aware で win32.ts vs _linux-stub.ts を切替。
 | P3 | sizeof 地雷 0 件 (gauntlet test pass)、AttachThreadInput 既存挙動維持 |
 | P4 | `git grep koffi` 行数 0、`package.json` から koffi 削除、launcher zip size を memory に記録 |
 | P5a | EventEnvelope が ring buffer に push される、TS から poll 取得可能 |
-| P5b | WAL に fsync 10ms batch、replay E2E で 1 session 再生成功 |
-| P5c | DXGI dirty rect を `EventKind::DirtyRect` として emit、Tier 1 cascade 動作 |
+| P5b | (consumed) proc_macro 評価で保留決定 — acceptance: `docs/adr-007-p5b-evaluation.md` の「復活条件」が観測されないこと |
+| P5c | 観測系 event 7 種 (UiaFocusChanged / DirtyRect / WindowChanged / ScrollChanged を **emit**、TreeChanged / Invoked / ValueChanged は enum + payload struct を **reserved**) を実装、Tier 1 graceful disable 動作。WAL/replay は ADR-008 D6 |
 | P5d | timestamp_source が capability に応じて自動選択、`server_status` に統計 |
 
 ### 9.2 統合書 SLO 達成 (本 ADR 範囲)
@@ -451,7 +452,7 @@ build 時に platform-aware で win32.ts vs _linux-stub.ts を切替。
 - dirty rect detect cycle: DXGI 60Hz 同期 ✓
 - ring buffer overflow rate: < 0.001% ✓
 - WAL write latency p99: < 5ms ✓
-- replay 一致率: 100% (本 ADR では P5b のスコープのみ、L2-3 は ADR-008 D6 で完成)
+- replay 一致率: ADR-008 D6 で測定 (WAL/replay は本 ADR scope 外、SSOT §10.2 と整合)
 
 ### 9.3 観測されるべき副次効果
 
@@ -465,14 +466,14 @@ build 時に platform-aware で win32.ts vs _linux-stub.ts を切替。
 
 | # | OQ | 決定タイミング |
 |---|---|---|
-| 1 | bincode vs capnproto vs flatbuffers (payload encoder) | P5a 着手時 |
-| 2 | WAL rotation サイズ (1GB / 4GB / 時間ベース) | P5b 着手時 |
-| 3 | DXGI dirty rect の secondary monitor 扱い | P5c 着手時 |
-| 4 | sub_ordinal 採番を per-source か global か | P5a 着手前 (sourceごとが推奨、tie 軽減) |
-| 5 | Intel PT 統合は本 ADR か別 ADR か | P5d 完了後 |
-| 6 | ring buffer back-pressure: drop oldest vs throttle producer | P5a 着手前 (drop oldest 推奨) |
+| 1 | bincode vs capnproto vs flatbuffers (payload encoder) | P5a 着手時 (bincode 採用済) |
+| 2 | WAL rotation サイズ (1GB / 4GB / 時間ベース) | **ADR-008 D6 へ移管** |
+| 3 | DXGI dirty rect の secondary monitor 扱い | P5c-2 着手時 (本 plan §10 OQ #3 と同期) |
+| 4 | sub_ordinal 採番を per-source か global か | P5a 着手前 (global 単一 counter 採用済) |
+| 5 | Intel PT 統合は本 ADR か別 ADR か | **ADR-008 D6 完了後** (replay と組み合わせて再評価) |
+| 6 | ring buffer back-pressure: drop oldest vs throttle producer | P5a 着手前 (drop oldest 採用済) |
 | 7 | event_id を u64 で十分か、UUID にするか | P5a (u64 で十分、replay は (record_id, event_id) で識別) |
-| 8 | `koffi-replacement` を別 crate にするか同 crate か | 着手前 (同 crate 推奨、分離価値低) |
+| 8 | `koffi-replacement` を別 crate にするか同 crate か | 着手前 (同 crate 採用済) |
 
 ---
 

--- a/docs/adr-007-p5c-plan.md
+++ b/docs/adr-007-p5c-plan.md
@@ -421,7 +421,7 @@ PR-P5c-0a で D1 plan §3 D1-2 sub-batch 内に「ring を broadcast 化 (subscr
 ### 11.3 PR-P5c-1 (UIA Focus hook、D1 blocker)
 - [ ] safe target で UIA focus 移動 → `EventKind::UiaFocusChanged` event が ring に push
 - [ ] **`AddFocusChangedEventHandler` を 2 引数 `(cache_request, handler)` で正しく呼び出し** (Codex P2 API mismatch)
-- [ ] **payload `UiaFocusChangedPayload.after.hwnd` が non-zero、`window_title` が空でない** (Codex review v3 P2: bridge が `FocusEvent { hwnd, window_title, ... }` を組めることを ring 経由で verify)
+- [ ] **resolvable な focus イベントで `payload.after.hwnd` が non-zero かつ `window_title` が空でない** (Codex review v3 P2 + v4 P2-2): bridge が `FocusEvent { hwnd, window_title, ... }` を組めることを ring 経由で verify。**unresolved case** (`hwnd == 0` / `payload.after == None`) も valid な data point として扱い、handler / bridge が panic / abort せず graceful に処理することを確認
 - [ ] **`UIA_NativeWindowHandlePropertyId` が cache に乗っていることを確認** (`cached_element_to_focus_info` 内で slow path が走っていないか log で計測)
 - [ ] handler 内 panic で UIA thread / Node プロセス全滅しない
 - [ ] shutdown 時 `RemoveFocusChangedEventHandler` 呼ばれる、5 サイクル test

--- a/docs/adr-007-p5c-plan.md
+++ b/docs/adr-007-p5c-plan.md
@@ -1,0 +1,523 @@
+# ADR-007 P5c — 観測系 event 生成 (拡大スコープ) プラン
+
+- Status: **Draft v4 (Codex review v3 反映、Opus)**
+- Date: 2026-04-29
+- 親 ADR: `docs/adr-007-koffi-to-rust-migration.md`
+- SSOT: `docs/architecture-3layer-integrated.md`
+- 後続: `docs/adr-008-d1-plan.md` (本書完了後に real L1 接続で復帰、PR-P5c-0a で同時更新)
+- review history:
+  - v1 → Codex (P1×1 + P2×4 + P3×1 + 整合性メモ) → v2
+  - v2 → Codex (P1×1 + P2×3 + 漏れ 1) → v3
+  - v3 → Codex (P2×1 + P3×1) → **v4 (本書)**
+
+---
+
+## 1. Background — なぜ scope 拡大か
+
+### 1.1 P5a までの状態
+
+ADR-007 §6.1 の P5 subphase 当初定義:
+- P5a: EventEnvelope schema + ring buffer
+- P5b: WAL + replay E2E
+- P5c: **DXGI dirty rect 統合 + Tier dispatch**
+- P5d: timestamp source 多重化
+
+**P5a 完了** (2026-04-29): main 直 push 8 commits `20c95da..2b631bf` (PR 経由ではない、メモリ `project_adr007_p5a_done.md` 参照)。これで以下が揃った:
+- `EventKind` enum 全種 (観測系 7 / 副作用系 3 / システム系 3 / replay 系 2、`src/l1_capture/envelope.rs:62-83`)
+- ring buffer (`src/l1_capture/ring.rs`)
+- worker thread (heartbeat / SessionStart / SessionEnd を push)
+- 副作用系 + システム系 + replay 系の payload struct (`src/l1_capture/payload.rs:3-51`、`ToolCallStarted/Completed`、`HwInputPostMessage`、`Failure`、`Heartbeat`、`SessionStart/End`)
+- napi exports 7 個 (l1Poll など)
+
+### 1.2 P5b 名前空間の bookkeeping
+
+PR #80 (`eea3d9e`、merged 2026-04-29) で `docs/adr-007-p5b-evaluation.md` を導入し、**`#[napi_safe]` proc_macro 化を「P5b」と呼んで保留決定**した。一方 ADR-007 本体 §6.1 / §9.1 / §10 では依然 **「P5b: WAL + replay E2E」** の記述が残っている。
+
+→ **P5b の意味が二重定義**。本 plan §3 で ADR-007 を更新し、WAL/replay を **ADR-008 D6 へ移管** (SSOT §10.2 と整合)、P5b 名は proc_macro 評価で消費済として deprecate。
+
+### 1.3 ADR-008 D1 着手前に判明した gap
+
+`EventKind::UiaFocusChanged = 1` などの観測系 enum 値は P5a で定義済。しかし:
+- **観測系 payload struct (`UiaFocusChangedPayload` / `DirtyRectPayload` / `WindowChangedPayload` / `ScrollChangedPayload`) は実装ゼロ** (副作用系 + システム系 + replay 系のみ存在)
+- これらを ring に push する emitter code もゼロ
+- ADR-007 のどの phase にも「観測系 event の生成」は割り当てられていない
+
+→ **P5c のスコープを「観測系 event 全般 + Tier 1 graceful disable」に拡大**。判断の lesson: `memory/feedback_north_star_reconciliation.md`。
+
+---
+
+## 2. Scope
+
+### 2.1 本 P5c で実装するもの
+
+| # | 範囲 | 出力 EventKind | 後続 view (ADR-008) |
+|---|---|---|---|
+| **P5c-0** | payload struct 追加 + UIA thread shutdown 機構 + L3 bridge scaffold (root → engine-perception 依存) | (基盤) | (D1-2 が利用) |
+| **P5c-1** | UIA Focus Changed event hook | `UiaFocusChanged` (=1) | `current_focused_element` (D1) |
+| **P5c-2** | DXGI dirty rect → ring | `DirtyRect` (=0) | `dirty_rects_aggregate` (D2) |
+| **P5c-3** | UIA Window Changed hooks (open/close/foreground) | `WindowChanged` (=5) | `semantic_event_stream` (D2) |
+| **P5c-4** | UIA Scroll Changed hooks | `ScrollChanged` (=6) | `semantic_event_stream` (D2) |
+
+### 2.2 本 P5c で実装しないもの (担当 phase 明示)
+
+| 項目 | 担当 phase | 備考 |
+|---|---|---|
+| `UiaTreeChanged` (=2) / `UiaInvoked` (=3) / `UiaValueChanged` (=4) emit | 将来 (ADR-008 D2 で必要が出たら個別追加) | enum/payload struct は本 P5c では reserved |
+| **WAL persistence + replay E2E** | **ADR-008 D6 へ移管** (元 P5b) | 本 plan §3 で ADR-007 §6.1 修正 |
+| Tier dispatch 本格 cascade (T0/T1/T2/T3) | **ADR-008 D5** | 本 P5c では DXGI 利用不可時の graceful disable + Failure event log のみ |
+| timestamp source 多重化 | **P5d** | 本 P5c では `TimestampSource::StdTime` 統一 |
+| `#[napi_safe]` proc_macro 化 | P5b 保留決定 (PR #80) | 本 P5c では既存 manual `napi_safe_call` 流用 |
+| **engine-perception → root crate 依存** | **採用しない** (Codex review v2 P1) | engine-perception は napi 非依存・純 Rust の約束を維持。代わりに **root crate 内の bridge 経由**で engine-perception に decoded data を push する (本 plan §6 / §12) |
+
+---
+
+## 3. ADR-007 への修正提案 (PR-P5c-0a で同梱)
+
+### 3.1 §6.1 PR 単位 granularity
+
+```diff
+  - P5a: EventEnvelope schema + ring buffer (TS API は変えない)
+- - P5b: WAL + replay E2E (record モード default off で導入)
+- - P5c: DXGI dirty rect 統合 + Tier dispatch
++ - P5b: (consumed) `#[napi_safe]` proc_macro 評価 — 保留決定 (PR #80、`docs/adr-007-p5b-evaluation.md`)
++ - P5c: 観測系 event 生成 (UIA hooks + DXGI dirty rect + Scroll/Window) + Tier 1 graceful disable
++ - WAL + replay E2E は **ADR-008 D6 へ移管** (SSOT §10.2 / ADR-008 §4 D6 と整合)
+  - P5d: timestamp source 多重化 (Reflex/DXGI/DWM)
+```
+
+### 3.2 §9.1 Phase 単位 acceptance
+
+```diff
+- | P5b | WAL に fsync 10ms batch、replay E2E で 1 session 再生成功 |
++ | P5b | (consumed) proc_macro 評価で保留決定 — acceptance: `docs/adr-007-p5b-evaluation.md` の「復活条件」が観測されないこと |
+- | P5c | DXGI dirty rect を `EventKind::DirtyRect` として emit、Tier 1 cascade 動作 |
++ | P5c | 観測系 event 7 種 (UiaFocusChanged / DirtyRect / WindowChanged / ScrollChanged を **emit**、TreeChanged / Invoked / ValueChanged は enum + payload struct を **reserved**) を実装、Tier 1 graceful disable 動作。WAL/replay は本 ADR scope 外 (ADR-008 D6) |
+```
+
+### 3.3 §10 OQ + §11.3 (省略部分)
+
+- OQ #2「WAL rotation サイズ」→ ADR-008 D6 へ移管 (本 ADR から削除)
+- OQ #3「DXGI secondary monitor」→ P5c-2 着手時 (本 plan §10 OQ #3 と同期)
+- §11.3 「replay 一致率」記述を「ADR-008 D6 で測定」に書き換え
+
+---
+
+## 4. Sub-batch 分解 (checklist)
+
+### P5c-0a: plan + ADR-007 修正 + D1 plan 整合更新 (PR 1)
+- [ ] `.gitignore` に `!docs/adr-007-p5c-plan.md` 追加 (tracking 化)
+- [ ] 本 plan doc を tracked 化
+- [ ] ADR-007 §6.1 / §9.1 / §10 / §11.3 の修正適用 (本 plan §3 通り)
+- [ ] **`docs/adr-008-d1-plan.md` の整合更新** (Codex review v2 P2 D1 plan 不整合):
+  - [ ] §3 D1-0 checkbox を `[x]` に flip (PR #81 で完了済)
+  - [ ] §3 D1-1 checkbox を `[x]` に flip (PR #82 で完了済、本 plan の前任 PR で flip 漏れ)
+  - [ ] §1.2 「D1 で実装しないもの」に「**D1-2 (real L1 adapter) 着手前**に ADR-007 P5c-1 完了が前提」を追記 (Codex review v3 P3、D1-0/D1-1 は完了済のため「D1 着手前」では衝突)
+  - [ ] §2 / §5 を **root owns integration** 経路に更新: 「`Arc<L1Inner>` を engine-perception に渡す」→ 「**root crate 内の `src/l3_bridge/` adapter** が L1 ring を decode して engine-perception の `L1Sink` に push、engine-perception は napi 非依存・純 Rust crate のまま」
+  - [ ] §3 D1-2 sub-batch checklist を新経路で書き直し (`engine-perception::FocusInput` / `L1Sink trait` / `crates/engine-perception/src/input.rs`)
+  - [ ] §11 acceptance に「root crate 内 bridge が L1 ring → engine-perception sink 経路で動作」追加
+- [ ] CI green (docs only、type check 影響なし)
+
+### P5c-0b: 基盤コード (PR 2)
+- [ ] `src/l1_capture/payload.rs` に観測系 payload struct を追加 (Codex review v3 P2: D1 が hwnd / window_title を復元できる shape にする):
+  - **`UiElementRef { hwnd: u64, name: String, automation_id: Option<String>, control_type: u32 }`** ← ADR-007 §4.2 で未定義の shape を本 plan で確定。`hwnd: 0` は unresolved (focus element が child で window 解決不可) を示す
+  - `UiaFocusChangedPayload { before: Option<UiElementRef>, after: Option<UiElementRef>, window_title: String }` (ADR-007 §4.2 の shape、top-level `window_title` あり)
+  - `DirtyRectPayload { rect: [i32; 4], monitor_index: u32, frame_index: u64 }` (ADR-007 §4.2 の `DirtyRectPayload` 寄せ、`kind` は本 P5c では Update のみ)
+  - `WindowChangedPayload { kind: WindowChangeKind, hwnd: u64, title: String, process_name: String }` (`enum WindowChangeKind { Opened, Closed, Foreground }`)
+  - `ScrollChangedPayload { hwnd: u64, h_percent: f32, v_percent: f32 }`
+- [ ] `mod.rs` の `pub use payload::{..., UiElementRef, UiaFocusChangedPayload, ...}` に追加
+- [ ] **`src/uia/thread.rs` に shutdown 機構を追加** (本 plan §6.2):
+  - 現状 `OnceLock<Sender<UiaTask>>` のみ → `OnceLock<Mutex<Option<Arc<UiaThreadHandle>>>>` に変更
+  - `pub(crate) fn shutdown_uia_for_test(timeout: Duration)` を追加 (L1 と同型)
+  - `UiaContext` に handler owner slot を保持できるよう拡張 (`event_owner: Option<Arc<UiaEventHandlerOwner>>`)
+  - 5 サイクル shutdown/restart test (P5a と同等の検証)
+- [ ] **`src/uia/thread.rs::configure_cache_properties` に `UIA_NativeWindowHandlePropertyId` を追加** (Codex review v3 P2: hwnd を Cached* で取得可能にするため必須)
+- [ ] **`src/uia/focus.rs` に `pub(crate) fn cached_element_to_focus_info(elem: &IUIAutomationElement) -> Option<UiaFocusInfoExt>`** 新規追加 (Codex review v2 P2 + v3 P2):
+  - Cached* methods のみ使用: `CachedName`, `CachedControlType`, `CachedAutomationId`, `CachedNativeWindowHandle` (上記 cache 追加で取得可)
+  - 戻り値 `UiaFocusInfoExt`: 既存 `UiaFocusInfo { name, control_type, automation_id, value }` に **`hwnd: u64`** を追加した拡張 type (or `UiaFocusInfo` 自体に `hwnd: Option<u64>` を追加、既存 caller は None で互換維持)
+  - **value は省略** (D1 範囲では `current_focused_element` view が value を要求しないため)。D2 以降で必要なら cached pattern 経由を検討
+  - **`hwnd == 0` のとき** (`CachedNativeWindowHandle` が NULL = focus element が直接 window でない child): walker で root window へ辿って `CachedNativeWindowHandle` を取得 (cache に乗る)、それでも 0 ならそのまま 0 で返す (bridge 側で reject or default)
+  - 既存 `element_to_focus_info` は napi polling 経由の caller (`get_focused_element` など) のため **そのまま残置**
+- [ ] **`window_title` 取得は handler 側の責務**: hwnd 取得後に Win32 `GetWindowTextW` で window_title 取得 (既存 `src/win32/window.rs` の wrapper を流用、UIA polling より cheap、< 1ms 想定)
+- [ ] **L3 bridge scaffold 新設** (本 plan §6 / §12 の核):
+  - `Cargo.toml` の root crate dependencies に `engine-perception = { path = "crates/engine-perception" }` 追加
+  - `src/l3_bridge/mod.rs` 新設 (空でも OK、実装は ADR-008 D1-2 で fill)
+  - **root crate の `[lib] crate-type` は `["cdylib"]` のまま変更しない** (Codex review v2 P1: 逆方向の依存は採用しない、rlib 化不要)
+- [ ] **`crates/engine-perception/src/input.rs` を新設**:
+  - `pub trait L1Sink { fn push_focus(&self, event: FocusEvent); /* P5c-3/4 で window/scroll/dirty 追加 */ }`
+  - `pub struct FocusEvent { hwnd: u64, name: String, automation_id: Option<String>, control_type: u32, window_title: String, wallclock_ms: u64, sub_ordinal: u32 }` (純データ型、windows-rs 依存なし)
+  - 中身は scaffold (D1-2 で拡張)、`#[allow(dead_code)]` でも OK
+- [ ] CI green、`build:rs:debug` artifact が従来 path に copy 成立、`check:rs-workspace` pass
+
+### P5c-1: UIA Focus Changed event hook (PR 3、ADR-008 D1 の blocker)
+- [ ] `src/uia/event_handlers/mod.rs` 新設
+- [ ] `src/uia/event_handlers/focus.rs`:
+  - `IUIAutomationFocusChangedEventHandler` を windows-rs `#[implement]` で実装する `FocusEventHandler`
+  - 内部 state: `Arc<L1Inner>` (root crate 内のため `crate::l1_capture::*` を直接参照可能、`pub` 拡張不要)
+  - `HandleFocusChangedEvent(sender)` で:
+    - `catch_unwind` で panic catch
+    - `sender` (`IUIAutomationElement`) → `cached_element_to_focus_info()` (slow path 回避、Codex review v2 P2)
+    - `UiaFocusChangedPayload` encode → `ring.push()`
+- [ ] `src/uia/event_handlers/owner.rs`:
+  - `UiaEventHandlerOwner { automation: IUIAutomation, focus_handler: Option<IUIAutomationFocusChangedEventHandler> }`
+  - **`Drop` 実装で `unsafe { automation.RemoveFocusChangedEventHandler(&handler) }`** (リーク防止)
+- [ ] **register 経路** (Codex review v2 P2 API mismatch 反映):
+  - **FocusChanged**: `automation.AddFocusChangedEventHandler(&cache_request, &handler)` ← **2 引数** (scope なし)
+  - cache_request は既存 `UiaContext::cache_request` を流用 (Name/ControlType/AutomationId/BoundingRect cache 済)
+- [ ] shutdown ordering (本 plan §6.4 で確定):
+  1. `shutdown_uia_for_test(3s)` — UIA thread に signal
+  2. UIA thread loop exit、`UiaEventHandlerOwner.Drop` (`RemoveFocusChangedEventHandler`)
+  3. `CoUninitialize`
+  4. `shutdown_l1_for_test(3s)`
+- [ ] integration test: safe target で focus 移動 → ring に `UiaFocusChanged` event push、5 サイクル shutdown/restart
+
+### P5c-2: DXGI dirty rect emit (PR 4)
+- [ ] `src/duplication/thread.rs` に `enable_l1_emit: AtomicBool` 追加、emit 経路を fork
+- [ ] `device.rs` で DXGI 利用不可時 graceful disable + Failure event 1 度だけ log
+- [ ] integration test
+
+### P5c-3: WindowChanged hooks (PR 5、Codex review v2 P2 API shape 反映)
+- [ ] `src/uia/event_handlers/window.rs`:
+  - **`AddAutomationEventHandler(event_id, &root, scope, &cache_request, &handler)` ← 5 引数**
+  - WindowOpened: `event_id = UIA_Window_WindowOpenedEventId`
+  - WindowClosed: `event_id = UIA_Window_WindowClosedEventId`
+  - foreground 切替は Win32 `SetWinEventHook(EVENT_SYSTEM_FOREGROUND)` で補完
+- [ ] `UiaEventHandlerOwner` を拡張: `window_handler: Option<IUIAutomationEventHandler>`、`Drop` で `RemoveAutomationEventHandler` 呼び出し追加
+- [ ] payload: `WindowChangedPayload { kind, hwnd, title, process_name }`
+- [ ] integration test
+
+### P5c-4: ScrollChanged hooks (PR 6、Codex review v2 P2 API shape 反映)
+- [ ] `src/uia/event_handlers/scroll.rs`:
+  - **`AddPropertyChangedEventHandler(&element, scope, &cache_request, &handler, &property_array)` ← 5 引数**
+  - property_array: `[UIA_ScrollHorizontalScrollPercentPropertyId, UIA_ScrollVerticalScrollPercentPropertyId]`
+  - element: 通常 `automation.GetRootElement()` (全 desktop)
+- [ ] スロットリング: 16ms / frame ベース rate limit (`AtomicU64` last_emit_ms)
+- [ ] `UiaEventHandlerOwner` を拡張: `scroll_handler: Option<IUIAutomationPropertyChangedEventHandler>`、`Drop` で `RemovePropertyChangedEventHandler`
+- [ ] payload: `ScrollChangedPayload { hwnd, h_percent, v_percent }`
+- [ ] integration test
+
+---
+
+## 5. PR 切り方
+
+| PR | 範囲 | risk | size 想定 |
+|---|---|---|---|
+| **PR-P5c-0a** | plan doc tracking + ADR-007 §6.1/§9.1/§10/§11.3 修正 + **D1 plan §1.2/§2/§3/§5/§11 整合更新 + D1-0/D1-1 checkbox flip** | 極低 (docs only) | ~150 line + plan |
+| **PR-P5c-0b** | payload struct + UIA thread shutdown 機構 + `cached_element_to_focus_info` + L3 bridge scaffold (root → engine-perception dep + `L1Sink` trait + `FocusEvent` 型) | 中 (root crate に engine-perception dep 追加が初体験) | 300-400 line |
+| **PR-P5c-1** | UIA Focus Changed hook + handler owner + integration test (**ADR-008 D1 blocker**) | 高 (UIA COM event handling 初実装) | 300-400 line |
+| **PR-P5c-2** | DXGI dirty rect emit | 中 | 150-200 line |
+| **PR-P5c-3** | Window Changed hooks (UIA + Win32 EventHook) | 中 | 200 line |
+| **PR-P5c-4** | Scroll Changed hooks (rate-limited) | 低 | 150 line |
+
+PR-P5c-1 完了で **ADR-008 D1 着手可**。P5c-2/3/4 は ADR-008 D2 と並行進行可能。
+
+---
+
+## 6. UIA event handler 実装方針 (P5c-0b/P5c-1 中核)
+
+### 6.1 既存 `src/uia/thread.rs` の現状 (full read 結果)
+
+- COM thread: `OnceLock<Sender<UiaTask>>`、process-long、shutdown 経路なし
+- COM mode: `CoInitializeEx(None, COINIT_MULTITHREADED)` (MTA、UIA event delivery と整合)
+- task loop: `rx.recv()` で task 受信、panic は `catch_unwind` (eprintln のみ)
+- `UiaContext`: `IUIAutomation` / walker / cache_request / control_view_condition、handler 保持なし
+- cache_request: 7 property + 6 pattern が cache 済 (Name/ControlType/AutomationId/BoundingRectangle/IsEnabled/IsOffscreen/ClassName)
+
+### 6.2 P5c-0b で追加する shutdown 機構
+
+```rust
+// 擬似コード — 既存 thread.rs を破壊的に変更しない、L1 worker と同型
+pub(crate) struct UiaThreadHandle {
+    sender: Sender<UiaTask>,
+    shutdown_tx: Sender<()>,
+    join_handle: Mutex<Option<JoinHandle<()>>>,
+}
+
+static UIA_THREAD: OnceLock<Mutex<Option<Arc<UiaThreadHandle>>>> = OnceLock::new();
+
+pub(crate) fn ensure_uia_thread() -> Arc<UiaThreadHandle> { /* L1 と同型 */ }
+pub(crate) fn shutdown_uia_for_test(timeout: Duration) -> Result<(), &'static str> { /* L1 と同型 */ }
+```
+
+ADR-007 §3.4.3 の「shutdown 3s 以内」を UIA thread にも適用。
+
+### 6.3 UIA event handler の所有権 — register API は 3 系統で形が違う (Codex review v2 P2)
+
+```rust
+#[implement(IUIAutomationFocusChangedEventHandler)]
+struct FocusEventHandler {
+    l1: Arc<L1Inner>,
+}
+
+impl IUIAutomationFocusChangedEventHandler_Impl for FocusEventHandler_Impl {
+    fn HandleFocusChangedEvent(
+        &self,
+        sender: Ref<'_, IUIAutomationElement>,
+    ) -> windows::core::Result<()> {
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            if let Some(elem) = sender.as_ref() {
+                if let Some(info) = crate::uia::focus::cached_element_to_focus_info(elem) {
+                    // hwnd → window_title は Win32 GetWindowTextW (既存 windows-rs wrapper)。
+                    // info.hwnd == 0 なら window_title 空、bridge 側 decode で reject 可。
+                    let window_title = if info.hwnd != 0 {
+                        crate::win32::window::get_window_title(info.hwnd).unwrap_or_default()
+                    } else {
+                        String::new()
+                    };
+                    let payload = UiaFocusChangedPayload {
+                        before: None,                  // P5c-1 範囲では before track せず
+                        after: Some(UiElementRef {
+                            hwnd: info.hwnd,
+                            name: info.name,
+                            automation_id: info.automation_id,
+                            control_type: info.control_type,
+                        }),
+                        window_title,                  // top-level (ADR-007 §4.2 shape)
+                    };
+                    let event = build_event(
+                        EventKind::UiaFocusChanged as u16,
+                        encode_payload(&payload),
+                        None, None,
+                    );
+                    self.l1.ring.push(event);
+                }
+            }
+        }));
+        Ok(())
+    }
+}
+
+struct UiaEventHandlerOwner {
+    automation: IUIAutomation,
+    focus_handler: Option<IUIAutomationFocusChangedEventHandler>,
+    window_handler: Option<IUIAutomationEventHandler>,             // P5c-3
+    scroll_handler: Option<IUIAutomationPropertyChangedEventHandler>, // P5c-4
+}
+
+impl Drop for UiaEventHandlerOwner {
+    fn drop(&mut self) {
+        // リーク防止 — 各 Remove* API も形が違う
+        if let Some(h) = self.focus_handler.take() {
+            unsafe { let _ = self.automation.RemoveFocusChangedEventHandler(&h); }
+        }
+        if let Some(h) = self.window_handler.take() {
+            unsafe {
+                let _ = self.automation.RemoveAutomationEventHandler(
+                    UIA_Window_WindowOpenedEventId, /* root: */ &..., &h,
+                );
+                // WindowClosed も同様
+            }
+        }
+        if let Some(h) = self.scroll_handler.take() {
+            unsafe {
+                let _ = self.automation.RemovePropertyChangedEventHandler(
+                    /* element: */ &..., &h,
+                );
+            }
+        }
+    }
+}
+```
+
+#### 各 register API の引数形 (windows-rs 0.62 / Microsoft docs ベース)
+
+| Event 系 | Add API | 引数 | 対応 phase |
+|---|---|---|---|
+| FocusChanged | `AddFocusChangedEventHandler` | `(cache_request, handler)` 2 引数 (scope なし、root も指定しない — desktop 全体 default) | P5c-1 |
+| AutomationEvent (WindowOpened/Closed) | `AddAutomationEventHandler` | `(event_id, root, scope, cache_request, handler)` 5 引数 | P5c-3 |
+| PropertyChanged (Scroll) | `AddPropertyChangedEventHandler` | `(element, scope, cache_request, handler, property_array)` 5 引数 | P5c-4 |
+
+### 6.4 shutdown ordering (統合書 §17.6 と整合)
+
+```
+shutdown 開始
+  ↓
+1. shutdown_uia_for_test(3s) ← UIA thread に signal
+  ↓
+2. UIA thread loop exit、UiaEventHandlerOwner Drop:
+     - automation.RemoveFocusChangedEventHandler          (P5c-1 後)
+     - automation.RemoveAutomationEventHandler            (P5c-3 後)
+     - automation.RemovePropertyChangedEventHandler       (P5c-4 後)
+  ↓
+3. CoUninitialize
+  ↓
+4. shutdown_l1_for_test(3s)
+  ↓
+ring 全 drop 完了
+```
+
+UIA event は L1 ring を target にするため、L1 を先に止めると handler が orphan ring に push して Failure event 量産 → 逆順 (UIA → L1) が正しい。
+
+---
+
+## 7. DXGI dirty rect emit 方針 (P5c-2)
+
+`src/duplication/` 既存 polling 経路に L1 emit fork 追加、capability detect 不可時は graceful disable + Failure event 1 度のみ log。本格 cascade は ADR-008 D5。
+
+---
+
+## 8. EventRing fan-out 戦略
+
+現状 `EventRing::poll()` は **破壊的 drain** (single consumer 想定)。multi-consumer (既存 napi `l1Poll` + 将来 root-side bridge) 対応の時期:
+
+**(A) P5c では emitter のみ追加、broadcast 化は ADR-008 D1-2 sub-batch に持ち越し** ← 推奨
+
+理由:
+- P5c の scope を「emitter の正しさ」に集中
+- broadcast 化は consumer 設計 = ADR-008 側の関心事
+- 北極星「次版送り禁止」と整合: D1 plan §3 D1-2 で必ず実装
+
+PR-P5c-0a で D1 plan §3 D1-2 sub-batch 内に「ring を broadcast 化 (subscribe 別 cursor)」を明記 (現在の D1 plan からは欠けている、Codex review v2 P2 D1 plan 不整合への対応)。
+
+---
+
+## 9. Risks / Mitigation
+
+| # | Risk | 影響 | Mitigation |
+|---|---|---|---|
+| R1 | UIA event handler 内 panic で UIA thread 全滅 → 以後 event 来ない | 致命 | handler 内で `catch_unwind` 必須、Failure event 化、UIA thread loop は既存の `catch_unwind` でも保護されている (二重) |
+| R2 | UIA event delivery thread が deadlock or 死亡 | 高 | health-check thread (5s 周期 re-register attempt)、`server_status` に統計 |
+| R3 | `Remove*EventHandler` 忘れリーク | 中 | `Drop for UiaEventHandlerOwner` で必ず Remove、shutdown ordering を §6.4 で確定 |
+| R4 | 高頻度 event (Scroll) で ring 満杯、drop_count 急増 | 中 | P5c-4 で 16ms rate limit + drop メトリクス出力 |
+| R5 | UIA cache_request hit せず slow path → p99 悪化 | 中 | `cached_element_to_focus_info()` で Cached* methods のみ使用、bench で hit rate 計測 |
+| R6 | DXGI secondary monitor 扱い | 中 | P5c-2 着手時に decision、当面 primary monitor のみ |
+| R7 | windows-rs 0.62 で `#[implement]` macro が UIA event handler trait を正しく扱えるか | 低 | windows-rs sample / docs で確認、ダメなら手動 vtable で代替 |
+| R8 | root crate に engine-perception 依存追加で root build time が増加 | 低 | engine-perception は timely + DD のみ ~16s、root の vision-gpu/ORT/tokenizers と比べ加算は小、CI cache で吸収 |
+| R9 | API mismatch を実装担当が踏む (FocusChanged 2 引数 vs Automation 5 引数) | 中 | 本 plan §6.3 表で API 形を明示、windows-rs sample へのリンクを sub-batch checklist に貼る |
+
+---
+
+## 10. Open Questions
+
+| # | OQ | 決定タイミング |
+|---|---|---|
+| 1 | UIA event handler thread の COM mode 維持 (現状 MTA で OK か) | PR-P5c-0b 着手時、windows-rs sample 確認 |
+| 2 | `EventRing::poll()` の broadcast 化実装方針 (cursor 別 / channel fan-out / etc) | ADR-008 D1-2 着手時 |
+| 3 | DXGI secondary monitor 対応の是非 | P5c-2 着手時 |
+| 4 | Scroll event rate limit 閾値 | P5c-4 着手時、bench 後 |
+| 5 | `L1Sink` trait の API 名と method 数 (focus/dirty/window/scroll を 4 method or 1 method + enum) | PR-P5c-0b 着手時、ADR-008 D1-2 で実装する側の使い勝手を踏まえて |
+| 6 | `cached_element_to_focus_info` の value 取得方針 (省略 / cached pattern / live ValuePattern) | D2 で `current_focused_element` 以外の view が value を要求した時 |
+
+---
+
+## 11. Acceptance Criteria
+
+### 11.1 PR-P5c-0a (plan + ADR-007 修正 + D1 plan 整合)
+- [ ] 本 plan doc tracked
+- [ ] ADR-007 §6.1 / §9.1 / §10 / §11.3 が更新済 (P5b WAL 移管 / P5c 拡大スコープ)
+- [ ] **D1 plan §3 D1-0 / D1-1 checkbox flip 済** (Codex 漏れ指摘)
+- [ ] **D1 plan §1.2 / §2 / §5 / §3 D1-2 / §11 が「root owns integration」経路で書き直し済**
+- [ ] CI green、`docs/` のみ変更で type check 影響なし
+
+### 11.2 PR-P5c-0b (基盤コード)
+- [ ] `payload.rs` に観測系 4 struct 追加、`mod.rs` re-export 追加
+- [ ] `src/uia/focus.rs::cached_element_to_focus_info` 新規追加 (Cached* only、value 省略)
+- [ ] `src/uia/thread.rs` に shutdown 機構追加、5 サイクル shutdown/restart test pass
+- [ ] **`Cargo.toml` (root) に `engine-perception = { path = "crates/engine-perception" }`** 追加
+- [ ] **root crate の `[lib] crate-type` は `["cdylib"]` のまま変更しない** (rlib 化なし)
+- [ ] `src/l3_bridge/mod.rs` scaffold (空でも OK)
+- [ ] `crates/engine-perception/src/input.rs` に `pub trait L1Sink` + `pub struct FocusEvent` 純データ型を追加
+- [ ] CI green、`build:rs:debug` artifact が従来 path に copy 成立
+
+### 11.3 PR-P5c-1 (UIA Focus hook、D1 blocker)
+- [ ] safe target で UIA focus 移動 → `EventKind::UiaFocusChanged` event が ring に push
+- [ ] **`AddFocusChangedEventHandler` を 2 引数 `(cache_request, handler)` で正しく呼び出し** (Codex P2 API mismatch)
+- [ ] **payload `UiaFocusChangedPayload.after.hwnd` が non-zero、`window_title` が空でない** (Codex review v3 P2: bridge が `FocusEvent { hwnd, window_title, ... }` を組めることを ring 経由で verify)
+- [ ] **`UIA_NativeWindowHandlePropertyId` が cache に乗っていることを確認** (`cached_element_to_focus_info` 内で slow path が走っていないか log で計測)
+- [ ] handler 内 panic で UIA thread / Node プロセス全滅しない
+- [ ] shutdown 時 `RemoveFocusChangedEventHandler` 呼ばれる、5 サイクル test
+- [ ] integration test pass
+
+### 11.4 PR-P5c-2 (DXGI dirty rect)
+- [ ] 画面変化で `EventKind::DirtyRect` event が ring push
+- [ ] 既存 napi polling と並行動作可
+- [ ] DXGI 利用不可環境で graceful disable
+
+### 11.5 PR-P5c-3 (Window Changed)
+- [ ] WindowOpened / WindowClosed / Foreground 切替で event 発火
+- [ ] `AddAutomationEventHandler` を 5 引数で正しく呼び出し
+- [ ] integration test
+
+### 11.6 PR-P5c-4 (Scroll)
+- [ ] Scroll で event 発火、rate limit 効果確認
+- [ ] `AddPropertyChangedEventHandler` を 5 引数で正しく呼び出し
+
+### 11.7 全体共通
+- [ ] CI green、`build:rs` / `check:napi-safe` / `check:rs-workspace` 全 pass
+- [ ] ADR-007 §6.1 / §9.1 が拡大スコープに更新
+- [ ] `docs/adr-008-d1-plan.md` が root owns integration 経路で整合
+
+(担当者の auto-memory 更新は repo 外のローカル機構、本 plan acceptance には含めない)
+
+---
+
+## 12. ADR-008 D1 への接続 (root owns integration、Codex review v2 P1 反映)
+
+### 12.1 経路図
+
+```
+[L1 Capture]                          [L3 bridge — root crate 内]            [engine-perception — 純 Rust]
+src/l1_capture/ring.rs    ─poll─→  src/l3_bridge/focus_pump.rs  ─push─→  crates/engine-perception/src/input.rs
+  (EventEnvelope を保持)              (decode + filter)                     (L1Sink trait + FocusInputHandle)
+                                                                                       │
+                                                                                       ▼
+                                                                            timely InputSession
+                                                                                       │
+                                                                                       ▼
+                                                                            crates/engine-perception/src/views/
+                                                                            (current_focused_element view、D1-3)
+```
+
+### 12.2 PR-P5c-0b 完了時に確立される境界
+
+- root crate (`desktop-touch-engine`):
+  - L1 ring 所有 (`pub(crate) struct L1Inner`、変更なし — 公開しない)
+  - `engine-perception` を dep として import
+  - `src/l3_bridge/` で adapter 実装 (PR-P5c-0b は scaffold のみ、実装は ADR-008 D1-2)
+- engine-perception:
+  - **napi 非依存・純 Rust** (約束維持、Codex review v2 P1)
+  - `L1Sink` trait、`FocusEvent` 純データ型、`FocusInputHandle` (timely InputSession wrapper) を public export
+  - root crate 以外の external crate からは import されない (publish=false 維持)
+
+### 12.3 ADR-008 D1-2 sub-batch (PR-P5c-0a で D1 plan を更新)
+
+PR-P5c-0a で D1 plan §3 D1-2 を以下のように書き直す:
+
+```diff
+  ### D1-2: L1 → timely Input Adapter (PR 3 の前半)
+- - [ ] `crates/engine-perception/src/l1_input.rs` 新設
+- - [ ] L1 ring の `Arc<L1Inner>` を借りる API を `src/l1_capture/` に追加
+- - [ ] adapter が独立 thread で `ring.pop()` → timely input session に push
++ - [ ] **`crates/engine-perception/src/input.rs`** (P5c-0b で scaffold 済) に `FocusInputHandle::push(FocusEvent)` 実装
++ - [ ] **`src/l3_bridge/focus_pump.rs`** (P5c-0b で scaffold 済、root crate 側) で adapter thread 実装
++ - [ ] adapter thread が `EventRing` を broadcast subscribe (cursor 別、本 plan §8 (A))
++ - [ ] L1 EventEnvelope を decode → `engine_perception::FocusEvent` に変換 → `FocusInputHandle::push()`
++ - [ ] `EventKind::UiaFocusChanged` のみを filter (D1 スコープ限定、他 event は drop)
++ - [ ] `(wallclock_ms, sub_ordinal)` を `Pair<u64, u32>` (logical_time) に変換
++ - [ ] L1 worker / UIA thread が停止しても adapter thread が deadlock しない
+```
+
+### 12.4 acceptance 達成
+
+PR-P5c-1 完了で:
+- L1 ring に **real `UiaFocusChanged` event** が流れる
+- ADR-008 D1-2 で root crate 内 bridge が adapter thread で pump
+- engine-perception 側 view (D1-3) が incremental に更新
+- D1-5 bench で **real input** での「TS 版より latency 1/10」を真正に達成
+
+これにより ADR-008 D1 acceptance「Whole-System Dataflow」(統合書 §1.1 / P3) が成立。
+
+---
+
+## 13. 関連
+
+- 親 ADR: `docs/adr-007-koffi-to-rust-migration.md` (本 plan で §6.1 / §9.1 / §10 / §11.3 修正)
+- SSOT: `docs/architecture-3layer-integrated.md` §1.1 / §3 P3 (Whole-System Dataflow) / §10.2 (replay は ADR-008 D6)
+- 後続: `docs/adr-008-d1-plan.md` (本 plan PR-P5c-0a で §1.2/§2/§3/§5/§11 を root owns integration 経路に更新)
+- 既存 UIA wrapper: `src/uia/{thread,focus,scroll,tree,actions,types}.rs`
+- 既存 DXGI: `src/duplication/{device,thread,types,mod}.rs`
+- 既存 L1: `src/l1_capture/{envelope,ring,worker,napi,payload,mod}.rs`
+- review:
+  - Codex v1 → 5 件 (P1×1 + P2×3 + P3×1 + 整合性メモ) 全件反映 (v2)
+  - Codex v2 → 4 件 (P1×1 + P2×3) + 漏れ 1 全件反映 (v3)
+  - Codex v3 → 2 件 (P2×1 payload shape + P3×1 D1 prerequisite 表現) 全件反映 (本 v4)
+- judgment lesson: `memory/feedback_north_star_reconciliation.md`

--- a/docs/adr-008-d1-plan.md
+++ b/docs/adr-008-d1-plan.md
@@ -32,6 +32,14 @@ L3 Compute (timely + differential-dataflow) を本リポジトリに組込み、
 - HW-accelerated view (D5)
 - replay / WAL 統合 (D6)
 
+### 1.3 D1-2 着手前の前提 (ADR-007 P5c-1)
+
+D1-0 / D1-1 は既に完了 (PR #81 / #82) だが、**D1-2 (real L1 adapter) 着手前に ADR-007 P5c-1 完了が前提**:
+
+- P5c-1 で **UIA Focus Changed event hook → L1 ring に `UiaFocusChanged` event push** が実装される
+- これがないと bridge が pump する input が空、D1 acceptance「TS 版より 1/10」が synthetic 比較に格下げ → 北極星「Whole-System Dataflow」と矛盾
+- 詳細経緯: `docs/adr-007-p5c-plan.md`、判断 lesson: `memory/feedback_north_star_reconciliation.md`
+
 ---
 
 ## 2. Workspace 化方針
@@ -48,25 +56,33 @@ L3 Compute (timely + differential-dataflow) を本リポジトリに組込み、
 - 将来 `crates/` 配下に proc-macros (P5b 復活) / winml (ADR-006) を増やす土台
 - workspace `target/` 共有でビルド成果物のキャッシュは引き継がれる
 
-**Workspace 構成 (D1 完了時):**
+**Workspace 構成 (D1 完了時、root owns integration 反映):**
 
 ```
 desktop-touch-mcp/
 ├── Cargo.toml          # [workspace] + [package] desktop-touch-engine
 ├── Cargo.lock
-├── src/                # 既存 (root crate のまま)
+├── src/                # root crate (重い: napi / vision-gpu / windows-rs)
+│   ├── l1_capture/     # 既存 + P5c で観測系 payload 追加
+│   ├── uia/            # 既存 + P5c で event_handlers/ 拡張
+│   ├── duplication/    # 既存 + P5c-2 で L1 emit fork
+│   └── l3_bridge/      # 新設 (PR-P5c-0b scaffold、D1-2 で fill)
+│       ├── mod.rs
+│       └── focus_pump.rs   # L1 ring → decode → engine_perception::FocusInputHandle::push
 ├── crates/
-│   └── engine-perception/
-│       ├── Cargo.toml  # [package] engine-perception
+│   └── engine-perception/   # 純 Rust crate (timely + DD のみ、napi 非依存維持)
+│       ├── Cargo.toml
 │       └── src/
 │           ├── lib.rs
-│           ├── l1_input.rs
-│           └── views/
+│           ├── input.rs         # L1Sink trait + FocusEvent 純データ型 (PR-P5c-0b scaffold)
+│           └── views/           # D1-3 で実装
 │               └── current_focused_element.rs
 └── benches/
     ├── README.md       # 既存 (skeleton)
-    └── d1_view_latency.rs  # 新規
+    └── d1_view_latency.rs  # D1-5 で実装
 ```
+
+**依存方向**: root → engine-perception (workspace path、PR-P5c-0b で `Cargo.toml` に追加)。逆方向 (engine-perception → root) は採用しない (Codex review v2 P1 で確定、`docs/adr-007-p5c-plan.md` §2.2 / §6 / §12 と整合)。
 
 ---
 
@@ -74,28 +90,36 @@ desktop-touch-mcp/
 
 実装担当者は完了したら `[ ]` → `[x]` に flip する。
 
-### D1-0: workspace 化 + 空 crate (PR 1)
-- [ ] root `Cargo.toml` を `[workspace] + [package]` 兼用に変換、`members = ["", "crates/engine-perception"]`
-- [ ] `crates/engine-perception/Cargo.toml` 新設 (空、`[package]` のみ)
-- [ ] `crates/engine-perception/src/lib.rs` 新設 (空)
-- [ ] `npm run build:rs` がエラーなく通ること (既存 napi build に影響なし)
-- [ ] `npm test` (vitest) が回帰なく通ること
-- [ ] `scripts/check-no-koffi.mjs` / `check-napi-safe.mjs` / `check-native-types.mjs` が pass
-- [ ] `.github/workflows/release.yml` で workspace 認識を確認 (CI green)
+### D1-0: workspace 化 + 空 crate (PR 1) — **完了 PR #81 (`a1cd5e8`)**
+- [x] root `Cargo.toml` を `[workspace] + [package]` 兼用に変換、`members = [".", "crates/engine-perception"]`
+- [x] `crates/engine-perception/Cargo.toml` 新設 (空、`[package]` のみ)
+- [x] `crates/engine-perception/src/lib.rs` 新設 (空)
+- [x] `npm run build:rs` がエラーなく通ること (既存 napi build に影響なし)
+- [x] CI green、`scripts/check-no-koffi.mjs` / `check-napi-safe.mjs` / `check-native-types.mjs` が pass
+- [x] `default-members` + `check:rs-workspace` script で全 workspace member が CI で type check される (Codex P2 fix `58c1199`)
 
-### D1-1: timely + DD 依存追加 (PR 2)
+### D1-1: timely + DD 依存追加 (PR 2) — **完了 PR #82 (`f8877a8`)**
 - [x] `crates/engine-perception/Cargo.toml` に `timely = "0.29"` `differential-dataflow = "0.23"` 追加
 - [x] `cargo check --workspace` が通る (engine-perception 含む)
 - [x] root crate の build が依然 pass (Cargo.lock の影響は engine-perception の transitive のみ、root crate 経由 dep は変化なし)
 - [x] timely / DD の crates.io latest stable を確認、決定根拠を本書 §6 に追記
 
-### D1-2: L1 → timely Input Adapter (PR 3 の前半)
-- [ ] `crates/engine-perception/src/l1_input.rs` 新設
-- [ ] L1 ring の `Arc<L1Inner>` を借りる API を `src/l1_capture/` に追加 (e.g. `pub(crate) fn share_inner() -> Arc<...>` か、既存 worker 取得 API 流用)
-- [ ] adapter が独立 thread で `ring.pop()` → timely input session に push
-- [ ] `EventEnvelope` のうち `UiaFocusChanged` のみを filter (D1 スコープ限定)
+### D1-2: root → engine-perception Input Adapter (PR 3 の前半、root owns integration)
+
+**前提**: ADR-007 P5c-1 完了 (UIA Focus Changed event hook → ring に `UiaFocusChanged` event push 経路成立)。詳細: `docs/adr-007-p5c-plan.md` §11.3。
+
+- [ ] **`src/l3_bridge/focus_pump.rs`** (root crate 側、PR-P5c-0b で scaffold 済) に adapter thread 実装
+- [ ] **`EventRing` の broadcast 化** (subscribe 別 cursor):
+  - 既存 destructive `poll()` (single consumer) は維持
+  - 新規 `subscribe()` API を追加、subscriber ごとに cursor を保持、non-destructive read
+  - 詳細実装は本 sub-batch 内で確定 (P5c plan §8 (A) で「ADR-008 D1-2 で実装」と確定済)
+- [ ] adapter thread が `ring.subscribe()` で broadcast 受信、`EventKind::UiaFocusChanged` のみ filter (D1 スコープ、他 event は drop)
+- [ ] L1 EventEnvelope を decode → `UiaFocusChangedPayload` (`{ before, after: UiElementRef, window_title }`) を取り出す
+- [ ] **`engine_perception::FocusEvent`** に変換: `{ hwnd, name, automation_id, control_type, window_title, wallclock_ms, sub_ordinal }`
+- [ ] **`crates/engine-perception/src/input.rs`** (PR-P5c-0b で scaffold 済) に `FocusInputHandle::push_focus(FocusEvent)` 実装 (timely InputSession への push)
 - [ ] `(wallclock_ms, sub_ordinal)` を `Pair<u64, u32>` (logical_time) に変換
-- [ ] L1 worker が停止してもこの thread が deadlock しない (timeout pop or shutdown signal)
+- [ ] L1 worker / UIA thread / 本 adapter thread の shutdown 順序 (本書 §5.3 で確定)
+- [ ] L1 worker が停止しても adapter thread が deadlock しない (subscribe 側 timeout or shutdown signal)
 
 ### D1-3: `current_focused_element` view (PR 3 の後半)
 - [ ] `crates/engine-perception/src/views/current_focused_element.rs` 新設
@@ -143,29 +167,75 @@ PR-α が merge されないと PR-β 以降が衝突するので、stack PR で
 
 ---
 
-## 5. L1 → timely Input Source 仕様
+## 5. L1 → engine-perception Input Adapter 仕様 (root owns integration)
+
+`docs/adr-007-p5c-plan.md` §6 / §12 で確立した「root crate 内 bridge が L1 ring を所有して decode、engine-perception には純データ (`FocusEvent`) を push」経路の D1 側仕様。
 
 ### 5.1 Adapter 構造
 
 ```rust
-// crates/engine-perception/src/l1_input.rs (擬似コード)
+// src/l3_bridge/focus_pump.rs (root crate 側、擬似コード)
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
-use timely::dataflow::operators::{Input, InputHandle};
-use differential_dataflow::input::InputSession;
+use std::sync::atomic::AtomicBool;
 
-pub struct L1ToTimelyAdapter {
+use crate::l1_capture::{EventRing, EventEnvelope, EventKind, UiaFocusChangedPayload};
+use engine_perception::input::{FocusInputHandle, FocusEvent};
+
+pub(crate) struct L1ToPerceptionPump {
     handle: JoinHandle<()>,
     shutdown: Arc<AtomicBool>,
 }
 
-impl L1ToTimelyAdapter {
-    pub fn spawn(
-        l1_inner: Arc<L1Inner>,           // L1 ring の共有 handle
-        input: InputSession<Pair<u64, u32>, FocusEvent, isize>,
-    ) -> Self { /* ... */ }
+impl L1ToPerceptionPump {
+    pub(crate) fn spawn(
+        ring: Arc<EventRing>,                 // root crate 内、L1Inner の ring 借用
+        input: FocusInputHandle,              // engine-perception 側 InputSession wrapper
+    ) -> Self {
+        // adapter thread:
+        //   ring.subscribe(my_cursor) → loop:
+        //     for env in ring.poll_since(cursor, max):
+        //       if env.kind == UiaFocusChanged as u16:
+        //         let payload = bincode::decode(env.payload_bytes);
+        //         let ev = FocusEvent {
+        //             hwnd: payload.after.hwnd,
+        //             name: payload.after.name,
+        //             automation_id: payload.after.automation_id,
+        //             control_type: payload.after.control_type,
+        //             window_title: payload.window_title,
+        //             wallclock_ms: env.wallclock_ms,
+        //             sub_ordinal: env.sub_ordinal,
+        //         };
+        //         input.push_focus(ev);  // engine-perception InputSession に流す
+    }
 
-    pub fn shutdown(self, timeout: Duration) -> Result<(), ShutdownError> { /* ... */ }
+    pub(crate) fn shutdown(self, timeout: Duration) -> Result<(), ShutdownError> { /* ... */ }
+}
+```
+
+```rust
+// crates/engine-perception/src/input.rs (純 Rust crate 側、抜粋)
+pub struct FocusEvent {
+    pub hwnd: u64,
+    pub name: String,
+    pub automation_id: Option<String>,
+    pub control_type: u32,
+    pub window_title: String,
+    pub wallclock_ms: u64,
+    pub sub_ordinal: u32,
+}
+
+pub trait L1Sink: Send + Sync {
+    fn push_focus(&self, event: FocusEvent);
+    // P5c-3/4 拡張で push_dirty_rect / push_window_change / push_scroll を追加
+}
+
+pub struct FocusInputHandle {
+    inner: Arc<Mutex<InputSession<Pair<u64, u32>, FocusEvent, isize>>>,
+}
+
+impl L1Sink for FocusInputHandle {
+    fn push_focus(&self, event: FocusEvent) { /* InputSession に advance + insert */ }
 }
 ```
 
@@ -173,22 +243,30 @@ impl L1ToTimelyAdapter {
 
 | L1 EventEnvelope フィールド | timely / DD 表現 |
 |---|---|
-| `event_id: u64` | (engine 内部の trace key) |
+| `event_id: u64` | (engine 内部の trace key、L3 では使わず) |
 | `wallclock_ms: u64` + `sub_ordinal: u32` | logical_time = `Pair<u64, u32>` |
-| `kind: UiaFocusChanged { hwnd, name, ... }` | `FocusEvent { hwnd, ... }` row、diff = +1 |
-| (前回の focus row の retraction) | 同 logical_time に diff = -1 |
+| `payload_bytes` (decoded `UiaFocusChangedPayload`) → `FocusEvent` | `FocusEvent` row、diff = +1 |
+| (前回 focus row の retraction) | 同 logical_time に diff = -1 (state view の last-by-time semantics) |
 
-D1 範囲では `UiaFocusChanged` のみ拾い、他 event kind は drop。
+D1 範囲では `EventKind::UiaFocusChanged` のみ拾い、他 event kind は drop。
 
-### 5.3 Shutdown ordering (制約 §17.6 / 統合書 §3.4 / SSOT layer-constraints と整合)
-
-L5 → L1 逆順で shutdown する規約。adapter は L1 worker より先に止める：
+### 5.3 Shutdown ordering (統合書 §17.6 / `docs/adr-007-p5c-plan.md` §6.4 と整合)
 
 ```
-1. adapter.shutdown(2s)  // ring pop loop に shutdown signal、timely input session を drop
-2. timely worker join (timely 内部で graceful drain)
-3. L1 worker shutdown (既存 P5a の l1_shutdown_for_test と同パターン)
+shutdown 開始
+  ↓
+1. l3_bridge::focus_pump.shutdown(2s)  ← adapter thread に signal、ring subscribe を drop
+  ↓
+2. timely worker join (engine-perception 内、graceful drain)
+  ↓
+3. shutdown_uia_for_test(3s)  (P5c-0b で追加、UIA event handler を Drop で Remove*)
+  ↓
+4. shutdown_l1_for_test(3s)
+  ↓
+ring 全 drop 完了
 ```
+
+UIA / DXGI event は L1 ring に push される側、L1 を先に止めると orphan ring に push して Failure event 量産 → 逆順 (Bridge → timely → UIA → L1) が正しい (`docs/adr-007-p5c-plan.md` §6.4 と整合)。
 
 ---
 
@@ -285,12 +363,14 @@ collection<UiElementRef>  (1 row per current foreground hwnd)
 
 | # | Risk | 影響 | Mitigation |
 |---|---|---|---|
-| R1 | `napi build` が workspace 化で壊れる | 高 | D1-0 で `npm run build:rs` を必ず通す。失敗時は root を `[package]` のみに戻し、選択肢 C (同 crate 内モジュール) に切替 |
-| R2 | timely 0.13/0.14 に compile-time の重い transitive dep | 中 | `engine-perception` を napi 非依存に保ち、root crate の build に乗せない。CI cache で吸収 |
-| R3 | L1 ring から pop する thread が L1 worker と deadlock | 中 | timeout pop (`recv_timeout(100ms)`) + shutdown flag |
+| ~~R1~~ | ~~`napi build` が workspace 化で壊れる~~ | — | **解消済** (PR #81 / #82 で wkspc 化 + Codex P2 fix `58c1199` 完了) |
+| ~~R2~~ | ~~timely 0.13/0.14 に compile-time~~ | — | **解消済** (timely 0.29 / DD 0.23 採用済、PR #82) |
+| R3 | adapter thread が L1 worker / UIA thread と deadlock | 中 | broadcast subscribe + shutdown signal (本書 §5.3 ordering)、timeout subscribe |
 | R4 | partial-order semantics を間違えて view が deterministic にならない | 中 | unit test で out-of-order event を必ず covers (D1-4) |
-| R5 | bench で 1/10 達成しない | 中 | プロファイリング後に operator graph を最適化、最悪 D2 に carry over (acceptance を D1 メイル基準に変更し、再評価) |
-| R6 | windows-rs / vision-gpu feature gate との衝突 | 低 | `engine-perception` は windows-rs 直接依存しない、L1 経由 event 受信のみ |
+| R5 | bench で 1/10 達成しない | 中 | プロファイリング後に operator graph を最適化、最悪 D2 に carry over (acceptance 再評価) |
+| R6 | windows-rs / vision-gpu feature gate との衝突 | 低 | `engine-perception` は windows-rs 直接依存しない (`FocusEvent` は純データ型)、root crate の vision-gpu は本 D1 で触らない |
+| R7 | broadcast 化で既存 napi `l1Poll` 経路が壊れる | 中 | broadcast 追加時、既存 destructive `poll()` API は **そのまま維持** (single consumer 用)、新規 `subscribe()` API を別ルートで実装 (本書 §5.1 / D1-2 sub-batch で詳細化) |
+| R8 | UIA / DXGI / Bridge / L1 の shutdown ordering で deadlock | 中 | 本書 §5.3 と `docs/adr-007-p5c-plan.md` §6.4 で integrated form を確定、5 サイクル shutdown/restart test (P5a と同水準) |
 
 ---
 
@@ -298,7 +378,7 @@ collection<UiElementRef>  (1 row per current foreground hwnd)
 
 | # | OQ | 決定タイミング |
 |---|---|---|
-| 1 | timely 0.13 vs 0.14 どちらを採用 | D1-1 着手時、crates.io の latest stable を確認 |
+| ~~1~~ | ~~timely 0.13 vs 0.14 どちらを採用~~ | **解決済** (timely 0.29 / DD 0.23、PR #82、本書 §6) |
 | 2 | L1 `Arc<L1Inner>` 共有 API のシグネチャ (既存 worker と干渉しない形) | D1-2 着手前、既存 `src/l1_capture/worker.rs` を読む |
 | 3 | `current_focused_element` の "current" の定義 (foreground 1 つ vs 全 window 最新) | D1-3 着手前、ADR-008 / views-catalog を再確認 |
 | 4 | bench harness の TS 版測定方法 (criterion から MCP tool を呼ぶか、Node 別プロセスか) | D1-5 着手時 |
@@ -308,10 +388,12 @@ collection<UiElementRef>  (1 row per current foreground hwnd)
 
 ## 11. Acceptance Criteria (ADR-008 §8 D1 と完全一致)
 
+- [ ] **ADR-007 P5c-1 完了**を前提として、real L1 input (UIA Focus Changed event) が ring 経由で bridge → engine-perception に流れる
+- [ ] **`src/l3_bridge/focus_pump.rs`** が `EventRing` broadcast subscribe → decode → `engine_perception::FocusInputHandle::push_focus()` で動作 (root owns integration、`docs/adr-007-p5c-plan.md` §12.3 と整合)
 - [ ] 1 view が incremental に更新される (`current_focused_element`)
 - [ ] unit test pass (partial-order 含む)
-- [ ] bench で TS 版より latency 1/10
-- [ ] CI green、`npm run build:rs` / `npm test` 回帰なし
+- [ ] bench で TS 版より latency 1/10 (real L1 input ベース、synthetic ではない)
+- [ ] CI green、`npm run build:rs` / `npm test` 回帰なし、`check:rs-workspace` で engine-perception 含む
 - [ ] D1-6 完了 (ドキュメント / メモリ整合)
 
 ---
@@ -323,4 +405,9 @@ collection<UiElementRef>  (1 row per current foreground hwnd)
 - view 契約: `docs/views-catalog.md` §3.1
 - 制約 (起草中): `docs/layer-constraints.md` §3-§4 (本書執筆時、参照のみ)
 - L1 base: ADR-007 P5a 完了 (`src/l1_capture/`、`memory/project_adr007_p5a_done.md`)
-- 関連 PR (履歴): #79 (main-push guard、merged)、#80 (P5b defer、open)
+- **D1-2 前提**: ADR-007 P5c-1 完了 (`docs/adr-007-p5c-plan.md`)
+- 関連 PR (履歴):
+  - #79 (main-push guard、merged)
+  - #80 (P5b defer、merged)
+  - #81 (D1-0 workspace + plan tracking、merged `a1cd5e8`)
+  - #82 (D1-1 timely + DD deps、merged `f8877a8`)

--- a/docs/adr-008-d1-plan.md
+++ b/docs/adr-008-d1-plan.md
@@ -114,8 +114,10 @@ desktop-touch-mcp/
   - 新規 `subscribe()` API を追加、subscriber ごとに cursor を保持、non-destructive read
   - 詳細実装は本 sub-batch 内で確定 (P5c plan §8 (A) で「ADR-008 D1-2 で実装」と確定済)
 - [ ] adapter thread が `ring.subscribe()` で broadcast 受信、`EventKind::UiaFocusChanged` のみ filter (D1 スコープ、他 event は drop)
-- [ ] L1 EventEnvelope を decode → `UiaFocusChangedPayload` (`{ before, after: UiElementRef, window_title }`) を取り出す
-- [ ] **`engine_perception::FocusEvent`** に変換: `{ hwnd, name, automation_id, control_type, window_title, wallclock_ms, sub_ordinal }`
+- [ ] L1 EventEnvelope を decode → `UiaFocusChangedPayload { before: Option<UiElementRef>, after: Option<UiElementRef>, window_title: String }` を取り出す (P5c plan §4 P5c-0b の shape 準拠)
+- [ ] **`payload.after` の Option を正しく handle** (Codex review v4 P2-1):
+  - `Some(after)` → `engine_perception::FocusEvent { hwnd: after.hwnd, name: after.name, automation_id: after.automation_id, control_type: after.control_type, window_title: payload.window_title, wallclock_ms, sub_ordinal }` に変換して push
+  - `None` (focus dropped、UIA で resolvable な focus がない状態) → **D1 範囲では skip** (current_focused_element view を更新しない)。「focus dropped」を意味的に view に反映するのは D2 (semantic_event_stream) のスコープ
 - [ ] **`crates/engine-perception/src/input.rs`** (PR-P5c-0b で scaffold 済) に `FocusInputHandle::push_focus(FocusEvent)` 実装 (timely InputSession への push)
 - [ ] `(wallclock_ms, sub_ordinal)` を `Pair<u64, u32>` (logical_time) に変換
 - [ ] L1 worker / UIA thread / 本 adapter thread の shutdown 順序 (本書 §5.3 で確定)
@@ -196,12 +198,14 @@ impl L1ToPerceptionPump {
         //   ring.subscribe(my_cursor) → loop:
         //     for env in ring.poll_since(cursor, max):
         //       if env.kind == UiaFocusChanged as u16:
-        //         let payload = bincode::decode(env.payload_bytes);
+        //         let payload: UiaFocusChangedPayload = bincode::decode(env.payload_bytes);
+        //         // payload.after is Option — None means focus dropped, skip in D1
+        //         let Some(after) = payload.after else { continue };
         //         let ev = FocusEvent {
-        //             hwnd: payload.after.hwnd,
-        //             name: payload.after.name,
-        //             automation_id: payload.after.automation_id,
-        //             control_type: payload.after.control_type,
+        //             hwnd: after.hwnd,                  // 0 = unresolved (P5c plan §4 P5c-0b)
+        //             name: after.name,
+        //             automation_id: after.automation_id,
+        //             control_type: after.control_type,
         //             window_title: payload.window_title,
         //             wallclock_ms: env.wallclock_ms,
         //             sub_ordinal: env.sub_ordinal,


### PR DESCRIPTION
## Summary

PR-P5c-0a per [\`docs/adr-007-p5c-plan.md\`](../blob/docs/adr-007-p5c-plan/docs/adr-007-p5c-plan.md) §4 PR-P5c-0a checklist. Establishes the **observation-event emit phase** as ADR-007 P5c (expanded scope) and reconciles ADR-008 D1 plan to the **root owns integration** path that emerged from three Codex review rounds.

No source-code changes. This is the doc/plan groundwork for the next implementation PR (PR-P5c-0b).

## Why this PR exists

While preparing ADR-008 D1's L1 → engine-perception adapter, two facts surfaced:

1. **Observation events have no emitter** — `EventKind::UiaFocusChanged = 1` (and the rest of the observation kinds) are defined in `src/l1_capture/envelope.rs:62-83`, but no code pushes them into the ring. ADR-007 P5a finished the schema + ring + worker for side-effect / system / replay events only; the observation generators were never assigned to a phase.
2. **P5b name was consumed by proc_macro deferral** (PR #80) but ADR-007 §6.1 / §9.1 / §10 still describe P5b as WAL + replay E2E.

Without (1), ADR-008 D1's acceptance \"TS-baseline / 10\" can only be met against synthetic input — which violates the integrated architecture's North Star \"Whole-System Dataflow\" (`docs/architecture-3layer-integrated.md` §1.1 / §3 P3). See `memory/feedback_north_star_reconciliation.md` for the judgment trail.

## Changes

### \`docs/adr-007-p5c-plan.md\` (new, tracked via .gitignore negate)

v4 plan covering:
- **P5c-0a** (this PR): plan tracking + ADR-007 modifications + D1 plan reconcile
- **P5c-0b**: payload structs / `UIA_NativeWindowHandlePropertyId` cache addition / UIA thread shutdown machinery / `src/l3_bridge/` scaffold / `engine-perception::input::L1Sink` trait
- **P5c-1**: UIA Focus Changed hook (D1-2 blocker)
- **P5c-2/3/4**: DXGI dirty rect / Window / Scroll hooks (D2 prerequisites)

Codex v1 + v2 + v3 reviews fully absorbed (history: review log in §13).

### \`docs/adr-007-koffi-to-rust-migration.md\` (§6.1 / §9.1 / §9.2 / §10)

- P5b name now consumed by proc_macro evaluation (deferred, PR #80)
- WAL + replay E2E relocated to ADR-008 D6 (matches SSOT §10.2)
- P5c expanded: observation events 7 kinds (4 emit + 3 reserved) + Tier 1 graceful disable
- OQs reconciled (WAL rotation → D6, DXGI secondary → P5c-2)

### \`docs/adr-008-d1-plan.md\`

- D1-0 / D1-1 checkboxes flipped (#81 / #82 already merged, prior PRs forgot to flip)
- §1.3 added: \"D1-2 着手前に ADR-007 P5c-1 完了が前提\" (P3 reword from v3 review)
- §2 workspace tree shows root's \`src/l3_bridge/\` and explicit \"root → engine-perception\" dep direction (reverses v2 proposal)
- §3 D1-2 rewritten: \`focus_pump.rs\` in root crate decodes the ring and pushes pure \`FocusEvent\` to \`engine_perception::FocusInputHandle\`. \`engine-perception\` stays \"napi-free, timely + DD only\".
- §5 adapter spec rewritten on the same path with pseudo-code for both crate boundaries
- §11 acceptance now requires real L1 input through the bridge (not synthetic)
- §9 risks: R1 napi build / R2 timely version marked resolved; R7 broadcast compat / R8 shutdown ordering added

## Test plan

- [x] No code changes — \`cargo check\`, \`build:rs\`, \`check:rs-workspace\`, \`check:napi-safe\` unaffected
- [x] \`git diff --check\` clean (whitespace)
- [x] Reviewer: confirm the three-way docs (P5c plan / ADR-007 / D1 plan) tell one consistent story
- [x] Reviewer: confirm the dependency direction is **root → engine-perception** everywhere

## Caveats

- v1+v2+v3 of P5c plan kept the review history visible in §13. Future cleanups can collapse this once the plan is merged and stable.
- Anchor link from the body to \`docs/adr-007-p5c-plan.md\` uses the branch ref since the file is added in this PR; once merged the canonical link will be \`main\`.

## Subsequent PRs

- **PR-P5c-0b** — the foundation code: payload structs / cache property / UIA shutdown / \`src/l3_bridge/\` scaffold / \`engine-perception::input::L1Sink\` trait. ~300-400 lines.
- **PR-P5c-1** — UIA Focus Changed hook (ADR-008 D1-2 unblocker). ~300-400 lines, high risk (first UIA COM event implementation).
- **PR-P5c-2/3/4** — DXGI dirty rect / Window / Scroll hooks. Run in parallel with ADR-008 D2 once D1 is on real input.

## Related

- Plan: \`docs/adr-007-p5c-plan.md\` (introduced in this PR)
- Parent ADR: \`docs/adr-007-koffi-to-rust-migration.md\`
- Reconciled plan: \`docs/adr-008-d1-plan.md\`
- SSOT: \`docs/architecture-3layer-integrated.md\` §1.1 / §3 P3 / §10.2
- Companion PRs: #79 (main-push guard) / #80 (P5b defer) / #81 (D1-0 workspace) / #82 (D1-1 deps)
- Judgment trail: \`memory/feedback_north_star_reconciliation.md\` (Claude-side auto-memory, repo-external)

🤖 Generated with [Claude Code](https://claude.com/claude-code)