### PR TITLE
feat(adr-008): D1-3 current_focused_element view (per-hwnd last-by-time)

### DIFF
--- a/crates/engine-perception/src/input.rs
+++ b/crates/engine-perception/src/input.rs
@@ -44,6 +44,25 @@
 //! would panic on `update_at` with a time below the session time —
 //! we guard before calling).
 //!
+//! ## Idle frontier advance (PR #91 P2)
+//!
+//! Real L1 capture has no heartbeat: when a user focuses a window
+//! and stops, no further `UiaFocusChanged` events arrive. Without
+//! intervention the dataflow's input frontier would sit at
+//! `(latest_wallclock_ms - shift, 0)` forever, leaving the most
+//! recent event at the frontier and never released — the view would
+//! be stale for the *current* focus, the very state it's meant to
+//! materialise.
+//!
+//! We solve this by anchoring the most recent event's wallclock_ms
+//! to a real `Instant` and, in the idle branch of the worker loop,
+//! projecting `latest_wallclock_ms` forward by the real elapsed time
+//! since that anchor. The watermark advances accordingly. In
+//! production, where L1 events carry monotone real-time wallclocks,
+//! this projection is always ≤ a legitimate future event's
+//! wallclock_ms, so it never causes valid later events to appear
+//! back-dated relative to the frontier.
+//!
 //! ## Lifecycle
 //!
 //! [`spawn_perception_worker`] returns
@@ -310,6 +329,11 @@ fn worker_loop(
 ) {
     let shift_ms = watermark_shift_ms();
 
+    // `less_equal` for the LogicalTime guard / watermark advance is
+    // provided by `timely::order::PartialOrder`. Bring it into scope
+    // for both the cmd path and the idle-advance branch.
+    use timely::order::PartialOrder;
+
     timely::execute_directly(move |worker| {
         // D1-3: build the dataflow with the input collection +
         // `current_focused_element` view wired in. The InputSession
@@ -325,6 +349,19 @@ fn worker_loop(
         let mut latest_wallclock_ms: u64 = 0;
         let mut current_watermark: LogicalTime = LogicalTime::new(0, 0);
 
+        // Anchor for idle frontier advance (Codex PR #91 P2): when no
+        // further events arrive after a focus change, real L1 input
+        // has no built-in heartbeat, so without a synthetic
+        // wall-clock-driven advance the latest event would sit at the
+        // input frontier forever and never be released by the
+        // dataflow's reduce. We project `latest_wallclock_ms` forward
+        // in the idle branch using real elapsed time since the last
+        // received event, mirroring real-time clock progression.
+        //
+        // Holds (anchor_wallclock_ms, anchor_instant) of the most
+        // recent event whose wallclock advanced `latest_wallclock_ms`.
+        let mut last_event_anchor: Option<(u64, Instant)> = None;
+
         loop {
             match rx.try_recv() {
                 Ok(Cmd::PushFocus(ev)) => {
@@ -334,7 +371,6 @@ fn worker_loop(
                     // Our session_time tracks `current_watermark`,
                     // so out-of-order events older than the frontier
                     // would panic. Drop them with a log instead.
-                    use timely::order::PartialOrder;
                     if !current_watermark.less_equal(&event_time) {
                         eprintln!(
                             "[perception-worker] out-of-order event dropped: \
@@ -348,6 +384,7 @@ fn worker_loop(
                     // Frontier advances on monotone `wallclock_ms`.
                     if ev.wallclock_ms > latest_wallclock_ms {
                         latest_wallclock_ms = ev.wallclock_ms;
+                        last_event_anchor = Some((ev.wallclock_ms, Instant::now()));
                         let new_wm = watermark_for(latest_wallclock_ms, shift_ms);
                         if current_watermark.less_equal(&new_wm)
                             && current_watermark != new_wm
@@ -364,6 +401,35 @@ fn worker_loop(
                 }
                 Ok(Cmd::Shutdown) => break,
                 Err(TryRecvError::Empty) => {
+                    // Idle frontier advance (PR #91 P2). Without this,
+                    // a single focus event followed by quiescent input
+                    // (the common case after a user focuses an app and
+                    // stops) leaves the event at the frontier forever
+                    // — the view never materialises the current focus.
+                    //
+                    // Project the latest seen event's wallclock_ms
+                    // forward by real elapsed time since it was
+                    // received. In production, real L1 events arrive
+                    // with monotonic real-time wallclocks, so a future
+                    // event's wallclock will always be ≥ this
+                    // projection — the synthesis can never make a
+                    // legitimate later event look back-dated.
+                    if let Some((anchor_wc, anchor_inst)) = last_event_anchor {
+                        let elapsed = anchor_inst.elapsed().as_millis() as u64;
+                        let projected = anchor_wc.saturating_add(elapsed);
+                        if projected > latest_wallclock_ms {
+                            latest_wallclock_ms = projected;
+                            let new_wm =
+                                watermark_for(latest_wallclock_ms, shift_ms);
+                            if current_watermark.less_equal(&new_wm)
+                                && current_watermark != new_wm
+                            {
+                                current_watermark = new_wm.clone();
+                                input.advance_to(new_wm);
+                                input.flush();
+                            }
+                        }
+                    }
                     worker.step();
                     thread::sleep(Duration::from_millis(1));
                 }
@@ -506,6 +572,43 @@ mod tests {
         // Third push extends the frontier
         handle.push_focus(make_event(3, 1_000_500, 0));
         worker.shutdown(Duration::from_secs(2)).expect("shutdown");
+    }
+
+    #[test]
+    fn idle_advance_progresses_latest_wallclock() {
+        // PR #91 P2 regression: a single push followed by quiescent
+        // input must still cause the worker to project
+        // `latest_wallclock_ms` forward and advance the watermark via
+        // the idle branch. We can't observe the watermark directly,
+        // but the view (D1-3) reflects whether the event was released
+        // — see the integration counterpart
+        // `quiescent_focus_eventually_materialises`. This in-file
+        // test pins the *cmd path* (not the view): one push, no
+        // shutdown signal, and we wait for the worker to drain the
+        // single Cmd::PushFocus from the channel. Without idle
+        // progression the worker would still drain (cmd channel work
+        // is independent of frontier), so this test only guards
+        // against a regression that breaks the idle branch entirely
+        // (e.g. an early `break` or a panic in the projection code).
+        let (worker, handle, _view) = spawn_perception_worker();
+        handle.push_focus(make_event(1, 1_700_000_000_000, 0));
+        let deadline = Instant::now() + Duration::from_millis(500);
+        while worker.processed_count() < 1 {
+            if Instant::now() >= deadline {
+                panic!(
+                    "worker did not process the single push: processed_count={}",
+                    worker.processed_count()
+                );
+            }
+            thread::sleep(Duration::from_millis(5));
+        }
+        // Allow at least 150ms of idle so the projection runs many
+        // times. The worker must remain healthy throughout.
+        thread::sleep(Duration::from_millis(150));
+        assert_eq!(worker.processed_count(), 1, "no spurious processing");
+        worker
+            .shutdown(Duration::from_secs(2))
+            .expect("shutdown after idle");
     }
 
     #[test]

--- a/crates/engine-perception/src/input.rs
+++ b/crates/engine-perception/src/input.rs
@@ -46,9 +46,12 @@
 //!
 //! ## Lifecycle
 //!
-//! [`spawn_perception_worker`] returns `(PerceptionWorker, FocusInputHandle)`.
+//! [`spawn_perception_worker`] returns
+//! `(PerceptionWorker, FocusInputHandle, CurrentFocusedElementView)`.
 //! Drop the handle (or all clones thereof) and call
-//! `PerceptionWorker::shutdown(timeout)` to stop the thread.
+//! `PerceptionWorker::shutdown(timeout)` to stop the thread. The view
+//! handle (D1-3) is independent of the worker's lifetime — it remains
+//! readable after shutdown but stops receiving updates.
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -61,6 +64,7 @@ use serde::{Deserialize, Serialize};
 use differential_dataflow::input::{Input, InputSession};
 
 use crate::time::LogicalTime;
+use crate::views::current_focused_element::{self, CurrentFocusedElementView};
 
 /// Default per-worker command-channel capacity. Sized for UIA focus
 /// rate (< 10 events/sec under human use); the bridge sleeps for at
@@ -260,18 +264,27 @@ fn watermark_for(latest_wallclock_ms: u64, shift_ms: u64) -> LogicalTime {
     LogicalTime::new(latest_wallclock_ms.saturating_sub(shift_ms), 0)
 }
 
-/// Spawn the timely worker thread + return a paired
-/// `(PerceptionWorker, FocusInputHandle)`. The worker owns the
-/// `differential_dataflow::input::InputSession`; the handle is the
-/// bridge's seam (`Arc::new(handle): Arc<dyn L1Sink>`).
-pub fn spawn_perception_worker() -> (PerceptionWorker, FocusInputHandle) {
+/// Spawn the timely worker thread + return a triple
+/// `(PerceptionWorker, FocusInputHandle, CurrentFocusedElementView)`.
+///
+/// The worker owns the `differential_dataflow::input::InputSession`
+/// and the dataflow graph; the handle is the bridge's seam
+/// (`Arc::new(handle): Arc<dyn L1Sink>`); the view is the read-only
+/// reader-side of the `current_focused_element` materialised state
+/// (D1-3). The view handle is created on the parent thread and cloned
+/// into the worker so the dataflow's inspect callback can write to it.
+pub fn spawn_perception_worker(
+) -> (PerceptionWorker, FocusInputHandle, CurrentFocusedElementView) {
     let (tx, rx) = bounded::<Cmd>(CMD_CHANNEL_CAPACITY);
     let processed_count = Arc::new(AtomicU64::new(0));
     let processed_clone = Arc::clone(&processed_count);
 
+    let view = CurrentFocusedElementView::new();
+    let view_for_worker = view.clone();
+
     let join = thread::Builder::new()
         .name("l3-perception".into())
-        .spawn(move || worker_loop(rx, processed_clone))
+        .spawn(move || worker_loop(rx, processed_clone, view_for_worker))
         .expect("spawn l3-perception thread");
 
     let worker = PerceptionWorker {
@@ -280,7 +293,7 @@ pub fn spawn_perception_worker() -> (PerceptionWorker, FocusInputHandle) {
         processed_count,
     };
     let handle = FocusInputHandle { tx };
-    (worker, handle)
+    (worker, handle, view)
 }
 
 /// Body of the timely worker thread.
@@ -290,16 +303,22 @@ pub fn spawn_perception_worker() -> (PerceptionWorker, FocusInputHandle) {
 /// closure returns, `execute_directly` drains remaining work
 /// (`while worker.has_dataflows() { worker.step_or_park(None); }`)
 /// before the function returns.
-fn worker_loop(rx: Receiver<Cmd>, processed: Arc<AtomicU64>) {
+fn worker_loop(
+    rx: Receiver<Cmd>,
+    processed: Arc<AtomicU64>,
+    view: CurrentFocusedElementView,
+) {
     let shift_ms = watermark_shift_ms();
 
     timely::execute_directly(move |worker| {
-        // D1-2: build a minimal dataflow with just an input
-        // collection. D1-3 adds the `current_focused_element`
-        // operator graph by extending this closure.
+        // D1-3: build the dataflow with the input collection +
+        // `current_focused_element` view wired in. The InputSession
+        // returned out of the closure is the seam through which the
+        // cmd loop below feeds events.
         let mut input: InputSession<LogicalTime, FocusEvent, isize> =
             worker.dataflow::<LogicalTime, _, _>(|scope| {
-                let (input, _stream) = scope.new_collection::<FocusEvent, isize>();
+                let (input, stream) = scope.new_collection::<FocusEvent, isize>();
+                current_focused_element::build(stream, view.clone());
                 input
             });
 
@@ -378,7 +397,7 @@ mod tests {
 
     #[test]
     fn spawn_and_shutdown_clean() {
-        let (worker, _handle) = spawn_perception_worker();
+        let (worker, _handle, _view) = spawn_perception_worker();
         worker
             .shutdown(Duration::from_secs(2))
             .expect("shutdown clean");
@@ -386,7 +405,7 @@ mod tests {
 
     #[test]
     fn push_focus_roundtrip_smoke() {
-        let (worker, handle) = spawn_perception_worker();
+        let (worker, handle, _view) = spawn_perception_worker();
         for i in 0..3 {
             handle.push_focus(make_event(i, 1_000_000 + i, 0));
         }
@@ -401,7 +420,7 @@ mod tests {
         // Cmd::PushFocus from the channel, not just acknowledges
         // shutdown. Without this assertion the lifecycle test
         // could regress silently if the worker_loop body is gutted.
-        let (worker, handle) = spawn_perception_worker();
+        let (worker, handle, _view) = spawn_perception_worker();
         for i in 0..5 {
             handle.push_focus(make_event(i, 5_000_000 + i, 0));
         }
@@ -423,7 +442,7 @@ mod tests {
     #[test]
     fn five_cycle_spawn_shutdown() {
         for cycle in 0..5 {
-            let (worker, handle) = spawn_perception_worker();
+            let (worker, handle, _view) = spawn_perception_worker();
             handle.push_focus(make_event(cycle, 2_000_000 + cycle, 0));
             worker
                 .shutdown(Duration::from_secs(2))
@@ -433,7 +452,7 @@ mod tests {
 
     #[test]
     fn push_after_shutdown_silently_drops() {
-        let (worker, handle) = spawn_perception_worker();
+        let (worker, handle, _view) = spawn_perception_worker();
         worker.shutdown(Duration::from_secs(2)).expect("shutdown");
         // After worker is gone, the receiver is dropped and the
         // channel disconnects. push_focus must NOT panic.
@@ -444,7 +463,7 @@ mod tests {
     fn l1sink_object_safety() {
         // Trait must be object-safe so the bridge can hold
         // `Arc<dyn L1Sink>` without naming the concrete type.
-        let (worker, handle) = spawn_perception_worker();
+        let (worker, handle, _view) = spawn_perception_worker();
         let _h: Arc<dyn L1Sink> = Arc::new(handle);
         worker.shutdown(Duration::from_secs(2)).expect("shutdown");
     }
@@ -477,7 +496,7 @@ mod tests {
         //
         // We can't observe the dataflow output yet (D1-3), but we
         // can confirm the worker doesn't crash on a back-dated push.
-        let (worker, handle) = spawn_perception_worker();
+        let (worker, handle, _view) = spawn_perception_worker();
         // First push sets latest_wallclock_ms = 1_000_000
         handle.push_focus(make_event(1, 1_000_000, 0));
         // Sleep so the worker definitely processed the first push
@@ -494,7 +513,7 @@ mod tests {
         // event_time = (T - 500ms, 0) when latest = T, shift = 100ms
         // → watermark = (T - 100ms, 0), and event_time < watermark
         // → dropped with log. Test verifies the worker survives.
-        let (worker, handle) = spawn_perception_worker();
+        let (worker, handle, _view) = spawn_perception_worker();
         handle.push_focus(make_event(1, 2_000_000, 0));
         thread::sleep(Duration::from_millis(50));
         // 500ms back-dated — way outside the 100ms watermark default

--- a/crates/engine-perception/src/lib.rs
+++ b/crates/engine-perception/src/lib.rs
@@ -5,9 +5,9 @@
 //! `current_focused_element` view; D2 onwards adds more views, time-travel,
 //! cyclic / lens computation, HW-accelerated views, and replay.
 //!
-//! D1-2 (this PR): the input pipeline (`L1Sink` + `FocusInputHandle` +
-//! timely worker thread + watermark advance). D1-3 will add the
-//! `current_focused_element` operator graph in a `views/` submodule.
+//! D1-2 landed the input pipeline (`L1Sink` + `FocusInputHandle` +
+//! timely worker thread + watermark advance). D1-3 (this PR) adds the
+//! `current_focused_element` operator graph in `views::`.
 
 /// L1Sink trait + pure data types received from the root crate's
 /// `src/l3_bridge/` adapter. See `docs/adr-007-p5c-plan.md` §12.
@@ -16,3 +16,8 @@ pub mod input;
 /// Logical time / timestamp type (`Pair<u64, u32>`). Custom because
 /// timely 0.29 only impls `Refines<()>` for primitive ints, not tuples.
 pub mod time;
+
+/// Materialised views over the L1 input stream. D1-3 lands
+/// `current_focused_element`; D2 onwards adds more views.
+/// See `docs/views-catalog.md`.
+pub mod views;

--- a/crates/engine-perception/src/views/current_focused_element.rs
+++ b/crates/engine-perception/src/views/current_focused_element.rs
@@ -1,0 +1,330 @@
+//! `current_focused_element` view (ADR-008 D1-3).
+//!
+//! Per-hwnd last-by-time reduction over the [`FocusEvent`] collection,
+//! producing a 1-row-per-hwnd state view. Contract: see
+//! `docs/views-catalog.md` §3.1.
+//!
+//! ## Operator graph
+//!
+//! ```text
+//! FocusEvent collection
+//!     │
+//!     │ map: FocusEvent → (hwnd, ((wallclock_ms, sub_ordinal), UiElementRef))
+//!     ▼
+//! reduce(): per-hwnd, pick the (ts, ui_ref) whose ts is largest among
+//!           values with positive accumulated diff. Output one
+//!           (hwnd, UiElementRef) row with diff = +1.
+//!     │
+//!     ▼
+//! inspect: apply observed (data, time, diff) to the view's per-hwnd
+//!          per-value diff-sum HashMap. A live row is one whose count
+//!          > 0; rows whose count drops to 0 are evicted.
+//! ```
+//!
+//! ## Why diff bookkeeping inside the inspect closure
+//!
+//! When focus moves on a given hwnd, DD's reduce retracts the previous
+//! output row (-1) and asserts the new one (+1). The view's read state
+//! must tolerate seeing the retraction in any order relative to the
+//! assertion (DD does not guarantee within-time ordering of inspect
+//! callbacks). Tracking per-(hwnd, value) diff sums keeps the view
+//! convergent regardless of arrival order: any value with positive
+//! sum is "live", and only values whose sum returns to zero are
+//! evicted from the map.
+//!
+//! ## Watermark caveat
+//!
+//! Reads can lag the most recent push by up to the watermark shift
+//! (`DESKTOP_TOUCH_WATERMARK_SHIFT_MS`, default 100ms), because DD only
+//! emits output updates after the dataflow's input frontier advances
+//! past a logical time. See `crates/engine-perception/src/input.rs`
+//! module docs for the watermark semantics (北極星 N2).
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::{Arc, RwLock};
+
+use serde::{Deserialize, Serialize};
+
+use differential_dataflow::collection::vec::Collection as VecCollection;
+
+use crate::input::FocusEvent;
+use crate::time::LogicalTime;
+
+/// Output row of `current_focused_element`. Mirrors
+/// `docs/views-catalog.md` §3.1. The string mapping for
+/// `control_type` happens at the L4 envelope layer, not here — we
+/// pass the raw `UIA_CONTROLTYPE_ID` through.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct UiElementRef {
+    pub name: String,
+    pub automation_id: Option<String>,
+    pub control_type: u32,
+    pub window_title: String,
+}
+
+impl UiElementRef {
+    /// Project a [`FocusEvent`] into a [`UiElementRef`]. The pivot
+    /// fields (`source_event_id`, `wallclock_ms`, `sub_ordinal`,
+    /// `timestamp_source`) live on the event-time data axis and are
+    /// not part of the view's output shape.
+    pub fn from_event(ev: &FocusEvent) -> Self {
+        Self {
+            name: ev.name.clone(),
+            automation_id: ev.automation_id.clone(),
+            control_type: ev.control_type,
+            window_title: ev.window_title.clone(),
+        }
+    }
+}
+
+/// Reader-side handle on the materialised state of the
+/// `current_focused_element` view.
+///
+/// Cheap to clone — the inner state is `Arc<RwLock<...>>`. Reads take
+/// a shared lock; the timely worker thread takes the write lock once
+/// per inspect callback (typically in microseconds at D1's event rate).
+#[derive(Clone, Default)]
+pub struct CurrentFocusedElementView {
+    inner: Arc<RwLock<ViewState>>,
+}
+
+#[derive(Default)]
+struct ViewState {
+    /// Per-hwnd diff-sum bookkeeping. After all retractions for a key
+    /// settle, exactly one (or zero) value has a positive count; any
+    /// value whose count returns to 0 is evicted from the inner map.
+    by_hwnd: HashMap<u64, BTreeMap<UiElementRef, i64>>,
+}
+
+impl CurrentFocusedElementView {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Latest focused element for `hwnd`, if a live row exists.
+    pub fn get(&self, hwnd: u64) -> Option<UiElementRef> {
+        let g = self.inner.read().expect("view RwLock poisoned");
+        g.by_hwnd
+            .get(&hwnd)
+            .and_then(|counts| counts.iter().find(|&(_, &c)| c > 0).map(|(v, _)| v.clone()))
+    }
+
+    /// Snapshot of all `(hwnd, latest)` pairs (no particular order).
+    pub fn snapshot(&self) -> Vec<(u64, UiElementRef)> {
+        let g = self.inner.read().expect("view RwLock poisoned");
+        g.by_hwnd
+            .iter()
+            .filter_map(|(hwnd, counts)| {
+                counts
+                    .iter()
+                    .find(|&(_, &c)| c > 0)
+                    .map(|(v, _)| (*hwnd, v.clone()))
+            })
+            .collect()
+    }
+
+    /// Number of distinct hwnds with at least one live row.
+    pub fn len(&self) -> usize {
+        let g = self.inner.read().expect("view RwLock poisoned");
+        g.by_hwnd
+            .values()
+            .filter(|counts| counts.iter().any(|(_, c)| *c > 0))
+            .count()
+    }
+
+    /// `true` when no hwnd has a live row.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Apply a diff observation. Internal — called from the timely
+    /// worker's inspect closure inside [`build`]. Public visibility is
+    /// `pub(crate)` so tests inside the crate can drive the view
+    /// directly without spinning a dataflow.
+    pub(crate) fn apply_diff(&self, hwnd: u64, value: UiElementRef, diff: i64) {
+        let mut g = self.inner.write().expect("view RwLock poisoned");
+        let counts = g.by_hwnd.entry(hwnd).or_default();
+        let new = counts.get(&value).copied().unwrap_or(0) + diff;
+        // Defensive: a negative count shouldn't occur under DD's
+        // diff invariants (every retraction matches a prior assertion),
+        // but if it ever did we'd leak a `(value, -1)` entry that
+        // pinned the hwnd in `by_hwnd` forever. Drop both and surface
+        // the bug under debug builds.
+        debug_assert!(
+            new >= 0,
+            "negative diff sum at hwnd={:#x}, value name={:?}, sum={}",
+            hwnd,
+            value.name,
+            new,
+        );
+        if new <= 0 {
+            counts.remove(&value);
+        } else {
+            counts.insert(value, new);
+        }
+        if counts.is_empty() {
+            g.by_hwnd.remove(&hwnd);
+        }
+    }
+}
+
+/// Wire the `current_focused_element` operator graph onto `events`,
+/// updating the supplied [`CurrentFocusedElementView`] handle as the
+/// dataflow processes events.
+///
+/// Caller creates the view ahead of `worker.dataflow(...)` so the same
+/// handle can be returned out of the worker thread alongside the
+/// `InputSession`. `events` is consumed by the chained operator graph
+/// — DD's `Collection` is `Clone`, so callers who need it elsewhere
+/// should clone before passing it here.
+pub fn build<'scope>(
+    events: VecCollection<'scope, LogicalTime, FocusEvent, isize>,
+    view: CurrentFocusedElementView,
+) {
+    let view_for_inspect = view;
+
+    events
+        .map(|ev: FocusEvent| {
+            let key = ev.hwnd;
+            let ts: (u64, u32) = (ev.wallclock_ms, ev.sub_ordinal);
+            let value = UiElementRef::from_event(&ev);
+            (key, (ts, value))
+        })
+        .reduce(|_key, input, output| {
+            // input: &[(&((u64, u32), UiElementRef), isize)] — sorted by
+            // value (which puts the larger ts first since ts is the
+            // tuple's leading component).
+            //
+            // last-by-time semantics: pick the value with the largest
+            // ts among entries with positive accumulated diff.
+            let mut best: Option<&((u64, u32), UiElementRef)> = None;
+            for (val_ref, diff) in input.iter() {
+                if *diff <= 0 {
+                    continue;
+                }
+                let cand: &((u64, u32), UiElementRef) = *val_ref;
+                match best {
+                    None => best = Some(cand),
+                    Some(b) if cand.0 > b.0 => best = Some(cand),
+                    _ => {}
+                }
+            }
+            if let Some((_, ui_ref)) = best {
+                output.push((ui_ref.clone(), 1));
+            }
+        })
+        .inspect(move |((hwnd, ui_ref), _time, diff)| {
+            view_for_inspect.apply_diff(*hwnd, ui_ref.clone(), *diff as i64);
+        });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ui(name: &str, win: &str) -> UiElementRef {
+        UiElementRef {
+            name: name.into(),
+            automation_id: Some("auto".into()),
+            control_type: 50000,
+            window_title: win.into(),
+        }
+    }
+
+    #[test]
+    fn empty_view_get_returns_none() {
+        let v = CurrentFocusedElementView::new();
+        assert!(v.is_empty());
+        assert_eq!(v.len(), 0);
+        assert!(v.get(0xAAAA).is_none());
+        assert_eq!(v.snapshot().len(), 0);
+    }
+
+    #[test]
+    fn apply_diff_insert_then_retract_evicts_hwnd() {
+        let v = CurrentFocusedElementView::new();
+        let elem = ui("Edit", "Notepad");
+        v.apply_diff(0xAAAA, elem.clone(), 1);
+        assert_eq!(v.get(0xAAAA), Some(elem.clone()));
+        assert_eq!(v.len(), 1);
+
+        // Retract the same value: per-hwnd map empties, hwnd entry
+        // is fully removed.
+        v.apply_diff(0xAAAA, elem, -1);
+        assert!(v.is_empty());
+        assert!(v.get(0xAAAA).is_none());
+    }
+
+    #[test]
+    fn apply_diff_swap_value_at_same_hwnd() {
+        let v = CurrentFocusedElementView::new();
+        let a = ui("A", "Win");
+        let b = ui("B", "Win");
+
+        v.apply_diff(0xBBBB, a.clone(), 1);
+        // Swap: assert new value (+1), retract old (-1) — order shouldn't matter.
+        v.apply_diff(0xBBBB, b.clone(), 1);
+        v.apply_diff(0xBBBB, a, -1);
+
+        assert_eq!(v.get(0xBBBB), Some(b.clone()));
+        assert_eq!(v.len(), 1);
+        let snap = v.snapshot();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0], (0xBBBB, b));
+    }
+
+    #[test]
+    fn apply_diff_retract_first_then_assert_settles() {
+        // Out-of-order: retraction observed before the matching
+        // assertion. Net diff after both events is unchanged, view
+        // must converge to the asserted value.
+        let v = CurrentFocusedElementView::new();
+        let prev = ui("Prev", "Win");
+        let next = ui("Next", "Win");
+        v.apply_diff(0xCCCC, prev.clone(), 1);
+
+        v.apply_diff(0xCCCC, prev, -1); // retraction first
+        v.apply_diff(0xCCCC, next.clone(), 1); // then assertion
+
+        assert_eq!(v.get(0xCCCC), Some(next));
+    }
+
+    #[test]
+    fn snapshot_includes_all_live_hwnds() {
+        let v = CurrentFocusedElementView::new();
+        v.apply_diff(1, ui("A", "WA"), 1);
+        v.apply_diff(2, ui("B", "WB"), 1);
+        v.apply_diff(3, ui("C", "WC"), 1);
+        let mut snap = v.snapshot();
+        snap.sort_by_key(|(h, _)| *h);
+        assert_eq!(snap.len(), 3);
+        assert_eq!(snap[0].1.name, "A");
+        assert_eq!(snap[1].1.name, "B");
+        assert_eq!(snap[2].1.name, "C");
+    }
+
+    #[test]
+    fn from_event_projects_only_view_fields() {
+        // FocusEvent carries pivot fields (source_event_id,
+        // timestamp_source, wallclock_ms, sub_ordinal) that must NOT
+        // leak into the view's output shape — the view is consumed by
+        // L4 envelope.data which has its own slot for traceability.
+        let ev = FocusEvent {
+            source_event_id: 12345,
+            hwnd: 0xDEAD,
+            name: "Btn".into(),
+            automation_id: Some("a-id".into()),
+            control_type: 50000,
+            window_title: "App".into(),
+            wallclock_ms: 1_700_000_000_000,
+            sub_ordinal: 7,
+            timestamp_source: 2,
+        };
+        let r = UiElementRef::from_event(&ev);
+        assert_eq!(r.name, "Btn");
+        assert_eq!(r.automation_id, Some("a-id".into()));
+        assert_eq!(r.control_type, 50000);
+        assert_eq!(r.window_title, "App");
+        // No pivot fields on UiElementRef — compile-time guarantee.
+    }
+}

--- a/crates/engine-perception/src/views/mod.rs
+++ b/crates/engine-perception/src/views/mod.rs
@@ -1,0 +1,18 @@
+//! Materialised views over the L1 input stream.
+//!
+//! Each view is a separate Rust module. The convention:
+//!
+//! - A typed `*View` handle (cheap to clone, `Arc<RwLock<...>>` inside)
+//!   exposes the read-only API consumers use to query the latest state.
+//! - A `build(scope, &events, view)` function wires the view's
+//!   operator graph into a timely dataflow scope. Caller creates the
+//!   view first (so it can be returned out of the worker thread) and
+//!   passes it in.
+//!
+//! D1-3 lands `current_focused_element` only. D2 onwards adds
+//! `dirty_rects_aggregate`, `semantic_event_stream`, etc. — see
+//! `docs/views-catalog.md`.
+
+pub mod current_focused_element;
+
+pub use current_focused_element::{CurrentFocusedElementView, UiElementRef};

--- a/crates/engine-perception/tests/d1_minimum.rs
+++ b/crates/engine-perception/tests/d1_minimum.rs
@@ -14,17 +14,25 @@
 //!     → inspect → view.apply_diff → view.get / snapshot
 //! ```
 //!
-//! ## Watermark caveat
+//! ## Watermark + idle-advance semantics
 //!
 //! `worker_loop` advances the input frontier to `latest_wallclock_ms -
-//! 100ms` (default `DESKTOP_TOUCH_WATERMARK_SHIFT_MS`). For an event
-//! at logical time `(t, 0)` to be released by DD's reduce, the
-//! frontier must advance strictly past it — i.e. some later event
-//! must land with `wallclock_ms > t + 100`. Tests below space their
-//! events ≥ 200ms apart so each push advances the frontier past the
-//! preceding push, while leaving the *most recent* push at the
-//! frontier (deliberately not asserted on until a follow-up "pump"
-//! event arrives).
+//! 100ms` (default `DESKTOP_TOUCH_WATERMARK_SHIFT_MS`). Without any
+//! help, that means the most recent event sits at the frontier and is
+//! never released until a later event arrives. PR #91 P2 added an
+//! **idle frontier advance**: the worker projects
+//! `latest_wallclock_ms` forward by real elapsed time since the most
+//! recent event was received, so the latest focus event is eventually
+//! released even when L1 input goes quiescent.
+//!
+//! Tests below either:
+//!
+//! - rely on idle-advance alone (`quiescent_focus_eventually_materialises`),
+//!   waiting up to `SETTLE_TIMEOUT` (500ms) for the projection to
+//!   carry the watermark past the event, or
+//! - inject a "pump" event with wallclock_ms ≥ target + shift_ms so
+//!   the frontier advances explicitly. Pump-driven tests release
+//!   faster (no idle wait needed) and pin event ordering deterministic.
 //!
 //! ## Determinism
 //!
@@ -95,7 +103,8 @@ fn single_focus_event_appears_in_view() {
     // Event we want to verify (target).
     handle.push_focus(focus_event(1, 0xAAAA, base, "Edit", "Notepad"));
     // Watermark pump: 200ms later, advances the input frontier past
-    // the target event so the dataflow releases the target's row.
+    // the target event so the dataflow releases the target's row
+    // promptly (without waiting on idle-advance to project forward).
     handle.push_focus(focus_event(2, 0xBBBB, base + 200, "Pump", "PumpWin"));
 
     assert!(
@@ -111,9 +120,41 @@ fn single_focus_event_appears_in_view() {
     assert_eq!(elem.window_title, "Notepad");
     assert_eq!(elem.control_type, 50000);
     assert_eq!(elem.automation_id, Some("auto-1".into()));
+    // We deliberately do NOT assert on the pump hwnd's visibility:
+    // with idle-advance enabled, the pump itself eventually appears
+    // too, on a non-deterministic schedule.
 
-    // Pump's hwnd is at the frontier — not yet released.
-    assert!(view.get(0xBBBB).is_none(), "pump event should still be at frontier");
+    worker.shutdown(Duration::from_secs(2)).expect("shutdown");
+}
+
+#[test]
+fn quiescent_focus_eventually_materialises() {
+    // **PR #91 P2 regression test**. Without idle-advance, a single
+    // focus event followed by quiescent input never materialises in
+    // the view because the input frontier only advances on later
+    // events, and there are none. With idle-advance, the worker
+    // projects `latest_wallclock_ms` forward by real elapsed time and
+    // the watermark catches up, releasing the event. SETTLE_TIMEOUT
+    // (500ms) is well past the 100ms watermark shift plus
+    // worker-step jitter (~1ms per loop), so idle-advance has many
+    // opportunities to fire before the timeout.
+    let (worker, handle, view) = spawn_perception_worker();
+    let base = 1_700_000_000_000u64;
+
+    handle.push_focus(focus_event(1, 0xCAFE, base, "QuiescentEdit", "QuiescentApp"));
+    // No further events — relies entirely on idle-advance.
+
+    assert!(
+        wait_for_view(&view, SETTLE_TIMEOUT, |v| v.get(0xCAFE).is_some()),
+        "quiescent focus event must materialise via idle-advance \
+         within {:?}; snapshot={:?}",
+        SETTLE_TIMEOUT,
+        view.snapshot()
+    );
+
+    let elem = view.get(0xCAFE).expect("hwnd=0xCAFE must be live");
+    assert_eq!(elem.name, "QuiescentEdit");
+    assert_eq!(elem.window_title, "QuiescentApp");
 
     worker.shutdown(Duration::from_secs(2)).expect("shutdown");
 }

--- a/crates/engine-perception/tests/d1_minimum.rs
+++ b/crates/engine-perception/tests/d1_minimum.rs
@@ -1,0 +1,371 @@
+//! ADR-008 D1-4 — integration tests for the `current_focused_element`
+//! view (D1-3) end-to-end through the timely worker thread.
+//!
+//! Tests in this file exercise the **public API only** —
+//! `spawn_perception_worker()` + `FocusInputHandle::push_focus()` +
+//! `CurrentFocusedElementView::{get, snapshot, len, is_empty}`. They
+//! do NOT poke `apply_diff` directly (that's covered by the in-file
+//! unit tests in `views/current_focused_element.rs`). The path
+//! exercised here:
+//!
+//! ```text
+//! handle.push_focus(ev) → cmd channel → worker → InputSession::update_at
+//!     → frontier advance via watermark → reduce per-hwnd last-by-time
+//!     → inspect → view.apply_diff → view.get / snapshot
+//! ```
+//!
+//! ## Watermark caveat
+//!
+//! `worker_loop` advances the input frontier to `latest_wallclock_ms -
+//! 100ms` (default `DESKTOP_TOUCH_WATERMARK_SHIFT_MS`). For an event
+//! at logical time `(t, 0)` to be released by DD's reduce, the
+//! frontier must advance strictly past it — i.e. some later event
+//! must land with `wallclock_ms > t + 100`. Tests below space their
+//! events ≥ 200ms apart so each push advances the frontier past the
+//! preceding push, while leaving the *most recent* push at the
+//! frontier (deliberately not asserted on until a follow-up "pump"
+//! event arrives).
+//!
+//! ## Determinism
+//!
+//! Each test polls the view for up to 500ms with a `wait_for_view`
+//! helper. 500ms is chosen as ~8× the worker's idle `step` cycle
+//! (1ms sleep + worker.step) and far below the test runner's per-test
+//! timeout. If the view doesn't settle in 500ms, the worker is
+//! deadlocked or the operator graph is wrong — both are bugs the
+//! test should fail on.
+
+use std::time::{Duration, Instant};
+
+use engine_perception::input::{spawn_perception_worker, FocusEvent, FocusInputHandle, L1Sink};
+use engine_perception::views::current_focused_element::{
+    CurrentFocusedElementView, UiElementRef,
+};
+
+const SETTLE_TIMEOUT: Duration = Duration::from_millis(500);
+
+fn focus_event(
+    source_event_id: u64,
+    hwnd: u64,
+    wallclock_ms: u64,
+    name: &str,
+    window_title: &str,
+) -> FocusEvent {
+    FocusEvent {
+        source_event_id,
+        hwnd,
+        name: name.into(),
+        automation_id: Some(format!("auto-{}", source_event_id)),
+        control_type: 50000, // UIA_ButtonControlTypeId
+        window_title: window_title.into(),
+        wallclock_ms,
+        sub_ordinal: 0,
+        timestamp_source: 0,
+    }
+}
+
+fn push_all(handle: &FocusInputHandle, events: &[FocusEvent]) {
+    for ev in events {
+        handle.push_focus(ev.clone());
+    }
+}
+
+fn wait_for_view<F: Fn(&CurrentFocusedElementView) -> bool>(
+    view: &CurrentFocusedElementView,
+    timeout: Duration,
+    predicate: F,
+) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if predicate(view) {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(5));
+    }
+}
+
+#[test]
+fn single_focus_event_appears_in_view() {
+    let (worker, handle, view) = spawn_perception_worker();
+    let base = 1_700_000_000_000u64;
+
+    // Event we want to verify (target).
+    handle.push_focus(focus_event(1, 0xAAAA, base, "Edit", "Notepad"));
+    // Watermark pump: 200ms later, advances the input frontier past
+    // the target event so the dataflow releases the target's row.
+    handle.push_focus(focus_event(2, 0xBBBB, base + 200, "Pump", "PumpWin"));
+
+    assert!(
+        wait_for_view(&view, SETTLE_TIMEOUT, |v| v.get(0xAAAA).is_some()),
+        "view did not materialise hwnd=0xAAAA within {:?}; \
+         snapshot={:?}",
+        SETTLE_TIMEOUT,
+        view.snapshot()
+    );
+
+    let elem = view.get(0xAAAA).expect("hwnd=0xAAAA must be live");
+    assert_eq!(elem.name, "Edit");
+    assert_eq!(elem.window_title, "Notepad");
+    assert_eq!(elem.control_type, 50000);
+    assert_eq!(elem.automation_id, Some("auto-1".into()));
+
+    // Pump's hwnd is at the frontier — not yet released.
+    assert!(view.get(0xBBBB).is_none(), "pump event should still be at frontier");
+
+    worker.shutdown(Duration::from_secs(2)).expect("shutdown");
+}
+
+#[test]
+fn last_by_time_per_hwnd() {
+    // Three events on the same hwnd, in wallclock-increasing order.
+    // The view must converge to the LATEST (highest wallclock_ms).
+    let (worker, handle, view) = spawn_perception_worker();
+    let base = 1_700_000_000_000u64;
+    let hwnd = 0xCAFE_u64;
+
+    push_all(
+        &handle,
+        &[
+            focus_event(1, hwnd, base, "v1", "App"),
+            focus_event(2, hwnd, base + 200, "v2", "App"),
+            focus_event(3, hwnd, base + 400, "v3", "App"),
+            // Pump to advance frontier past base+400.
+            focus_event(4, 0xFEED, base + 600, "Pump", "PumpWin"),
+        ],
+    );
+
+    assert!(
+        wait_for_view(&view, SETTLE_TIMEOUT, |v| v
+            .get(hwnd)
+            .map(|e| e.name == "v3")
+            .unwrap_or(false)),
+        "view did not converge to v3; got {:?}",
+        view.get(hwnd)
+    );
+
+    let elem = view.get(hwnd).expect("hwnd live");
+    assert_eq!(elem.name, "v3", "last-by-time semantics");
+
+    worker.shutdown(Duration::from_secs(2)).expect("shutdown");
+}
+
+#[test]
+fn out_of_order_events_settle_to_latest_by_time() {
+    // **partial-order test** (D1-4 spec): submit two events for the
+    // same hwnd in REVERSE wallclock order. Watermark default 100ms
+    // means both events land within the watermark window of each
+    // other — neither is dropped. The view must still pick the one
+    // with the higher wallclock_ms (last-by-time semantics).
+    let (worker, handle, view) = spawn_perception_worker();
+    let base = 1_700_000_000_000u64;
+    let hwnd = 0xCAFE_u64;
+
+    push_all(
+        &handle,
+        &[
+            // First push sets latest_wallclock = base + 50.
+            // (Subsequent push at `base` is back-dated by 50ms;
+            // 50ms < 100ms shift, so it's accepted.)
+            focus_event(1, hwnd, base + 50, "Latest", "App"),
+            focus_event(2, hwnd, base, "Earliest", "App"),
+            // Pump to advance frontier past base+50.
+            focus_event(3, 0xDEAD, base + 200, "Pump", "PumpWin"),
+        ],
+    );
+
+    assert!(
+        wait_for_view(&view, SETTLE_TIMEOUT, |v| v
+            .get(hwnd)
+            .map(|e| e.name == "Latest")
+            .unwrap_or(false)),
+        "view did not converge under out-of-order input; got {:?}",
+        view.get(hwnd)
+    );
+
+    let elem = view.get(hwnd).expect("hwnd live");
+    assert_eq!(
+        elem.name, "Latest",
+        "out-of-order partial order must still pick highest wallclock"
+    );
+
+    worker.shutdown(Duration::from_secs(2)).expect("shutdown");
+}
+
+#[test]
+fn far_back_dated_event_dropped() {
+    // An event back-dated > watermark shift (100ms default) lies
+    // BELOW the frontier and is dropped by the worker_loop guard.
+    // Test verifies the worker does NOT crash on such an event and
+    // the view continues to reflect the in-window event.
+    let (worker, handle, view) = spawn_perception_worker();
+    let base = 1_700_000_000_000u64;
+    let hwnd = 0xCAFE_u64;
+
+    handle.push_focus(focus_event(1, hwnd, base + 1000, "Live", "App"));
+    // 500ms back-dated — far outside the 100ms watermark window.
+    handle.push_focus(focus_event(2, hwnd, base + 500, "Stale", "App"));
+    // Pump.
+    handle.push_focus(focus_event(3, 0xDEAD, base + 1200, "Pump", "PumpWin"));
+
+    assert!(
+        wait_for_view(&view, SETTLE_TIMEOUT, |v| v
+            .get(hwnd)
+            .map(|e| e.name == "Live")
+            .unwrap_or(false)),
+        "view did not converge; got {:?}",
+        view.get(hwnd)
+    );
+
+    let elem = view.get(hwnd).expect("hwnd live");
+    assert_eq!(
+        elem.name, "Live",
+        "stale back-dated event must be dropped, in-window event survives"
+    );
+
+    worker.shutdown(Duration::from_secs(2)).expect("shutdown");
+}
+
+#[test]
+fn multiple_hwnds_tracked_independently() {
+    let (worker, handle, view) = spawn_perception_worker();
+    let base = 1_700_000_000_000u64;
+
+    push_all(
+        &handle,
+        &[
+            focus_event(1, 0xA, base, "A1", "WinA"),
+            focus_event(2, 0xB, base + 200, "B1", "WinB"),
+            focus_event(3, 0xC, base + 400, "C1", "WinC"),
+            // Pump to release all of them.
+            focus_event(4, 0xFEED, base + 600, "Pump", "PumpWin"),
+        ],
+    );
+
+    let want = |v: &CurrentFocusedElementView| {
+        v.get(0xA).is_some() && v.get(0xB).is_some() && v.get(0xC).is_some()
+    };
+    assert!(
+        wait_for_view(&view, SETTLE_TIMEOUT, want),
+        "expected 3 hwnds live, snapshot={:?}",
+        view.snapshot()
+    );
+
+    assert_eq!(view.get(0xA).unwrap().name, "A1");
+    assert_eq!(view.get(0xB).unwrap().name, "B1");
+    assert_eq!(view.get(0xC).unwrap().name, "C1");
+
+    let mut snap = view.snapshot();
+    snap.sort_by_key(|(h, _)| *h);
+    assert_eq!(snap.len(), 3);
+
+    worker.shutdown(Duration::from_secs(2)).expect("shutdown");
+}
+
+#[test]
+fn shutdown_without_events_is_clean() {
+    // Acceptance criterion (D1-4 spec): "shutdown sequence で
+    // deadlock しない". Even with no events ever pushed, the worker
+    // must shut down within the timeout — the cmd channel handles
+    // Cmd::Shutdown synchronously.
+    let (worker, _handle, view) = spawn_perception_worker();
+    assert!(view.is_empty());
+    let start = Instant::now();
+    worker
+        .shutdown(Duration::from_secs(2))
+        .expect("shutdown clean");
+    assert!(
+        start.elapsed() < Duration::from_secs(2),
+        "shutdown should be near-instant when idle"
+    );
+}
+
+#[test]
+fn shutdown_with_pending_events_drains() {
+    // After pushing several events but BEFORE waiting for the view to
+    // settle, calling shutdown must still drain cleanly (the worker
+    // pumps remaining cmds before honouring Cmd::Shutdown — see
+    // worker_loop's try_recv loop). No deadlock.
+    let (worker, handle, _view) = spawn_perception_worker();
+    let base = 1_700_000_000_000u64;
+    for i in 0..50 {
+        handle.push_focus(focus_event(
+            i,
+            0xA000 + i as u64,
+            base + (i as u64 * 50),
+            "x",
+            "App",
+        ));
+    }
+    let start = Instant::now();
+    worker
+        .shutdown(Duration::from_secs(2))
+        .expect("shutdown drained");
+    assert!(start.elapsed() < Duration::from_secs(2));
+}
+
+#[test]
+fn five_cycle_spawn_run_shutdown() {
+    // Stress: 5 cycles of (spawn → push → assert view → shutdown).
+    // Mirrors the L1 worker / focus_pump 5-cycle tests; flushes any
+    // hidden state leak across cycles.
+    for cycle in 0..5u64 {
+        let (worker, handle, view) = spawn_perception_worker();
+        let base = 1_700_000_000_000u64 + cycle * 1_000_000;
+        handle.push_focus(focus_event(
+            1,
+            0xC000 + cycle,
+            base,
+            "X",
+            &format!("WX{}", cycle),
+        ));
+        handle.push_focus(focus_event(
+            2,
+            0xD000 + cycle,
+            base + 200,
+            "Pump",
+            "PumpWin",
+        ));
+
+        assert!(
+            wait_for_view(&view, SETTLE_TIMEOUT, |v| v.get(0xC000 + cycle).is_some()),
+            "cycle {} did not materialise; snapshot={:?}",
+            cycle,
+            view.snapshot()
+        );
+        let elem = view.get(0xC000 + cycle).expect("live");
+        assert_eq!(elem.window_title, format!("WX{}", cycle));
+
+        worker
+            .shutdown(Duration::from_secs(2))
+            .unwrap_or_else(|e| panic!("cycle {} shutdown: {}", cycle, e));
+    }
+}
+
+#[test]
+fn ui_element_ref_projection_is_lossy() {
+    // **Compile-time** check that UiElementRef has only the four
+    // view-output fields. `source_event_id` / `wallclock_ms` /
+    // `sub_ordinal` / `timestamp_source` are pivot data on
+    // FocusEvent and must NOT leak into the view's output shape —
+    // the L4 envelope layer carries the pivot in its own slot.
+    //
+    // If a future PR adds one of those fields to UiElementRef, the
+    // struct-literal init below will fail to compile because it
+    // doesn't list the new field, AND the destructured `_pat` arm
+    // below will start emitting an unused-field warning.
+    let r = UiElementRef {
+        name: "n".into(),
+        automation_id: None,
+        control_type: 0,
+        window_title: "w".into(),
+    };
+    let UiElementRef {
+        name: _,
+        automation_id: _,
+        control_type: _,
+        window_title: _,
+    } = r;
+}

--- a/docs/adr-008-d1-plan.md
+++ b/docs/adr-008-d1-plan.md
@@ -121,18 +121,28 @@ desktop-touch-mcp/
 - [x] L1 worker が停止しても adapter thread が deadlock しない — `recv_timeout(100ms)` + `Arc<AtomicBool> shutdown` flag、5-cycle integration test (`l3_bridge::lifecycle_tests::five_cycle_pipeline_spawn_push_shutdown`) で deadlock-free 確認
 - [x] **Codex v3 P1 反映**: `FocusPump::spawn` は parent thread で `ring.subscribe(8192)` を完了させてから worker thread を起動 (Subscription を move)、spawn 直後の同期 push race を構造的解消、regression test `spawn_then_immediate_push_arrives` で固定
 
-### D1-3: `current_focused_element` view (PR 3 の後半)
-- [ ] `crates/engine-perception/src/views/current_focused_element.rs` 新設
-- [ ] input: `UiaFocusChanged` event collection
-- [ ] operator: per-window `last-by-time` で current focus 1 row を維持 (state view)
-- [ ] output struct: `UiElementRef { name, automation_id, control_type, window_title }` (views-catalog §3.1)
-- [ ] arrangement で multi-version 保持、internal read API で最新値を取得
+### D1-3: `current_focused_element` view (PR 3 の後半) — **実装完了 (本 PR)**
+- [x] `crates/engine-perception/src/views/current_focused_element.rs` 新設
+- [x] input: `FocusEvent` collection (root crate の bridge が L1 `UiaFocusChanged` を decode し push)
+- [x] operator: per-hwnd `last-by-time` で current focus 1 row を維持 (state view) — `map → reduce(last-by-(wallclock_ms, sub_ordinal)) → inspect`
+- [x] output struct: `UiElementRef { name, automation_id, control_type, window_title }` (views-catalog §3.1) — pivot 4 フィールド (`source_event_id` / `wallclock_ms` / `sub_ordinal` / `timestamp_source`) は output から除外
+- [x] internal read API: `CurrentFocusedElementView::{get(hwnd), snapshot(), len(), is_empty()}` — `Arc<RwLock<HashMap<u64, BTreeMap<UiElementRef, i64>>>>` 経由で diff bookkeeping (retraction/assertion 順序非依存で convergent)
+- [x] `spawn_perception_worker()` 戻り値を `(PerceptionWorker, FocusInputHandle, CurrentFocusedElementView)` に拡張、view を parent thread で `clone()` して worker に move
+- [x] `src/l3_bridge/mod.rs::spawn_perception_pipeline_for_test` も view 戻り、lifecycle test (5-cycle) で `view.get(h0/h1)` assertion 追加 — L1 ring → focus_pump → handle → worker → InputSession → reduce → inspect → view まで end-to-end 観測
 
-### D1-4: unit test (PR 3 内)
-- [ ] `crates/engine-perception/tests/d1_minimum.rs`
-- [ ] event を inject → view 更新を verify
-- [ ] **partial-order test**: out-of-order event を入れても deterministic な結果になる
-- [ ] shutdown sequence で deadlock しない
+### D1-4: unit test + integration test (PR 3 内) — **実装完了 (本 PR)**
+- [x] `crates/engine-perception/src/views/current_focused_element.rs` の `mod tests` (in-file unit): `apply_diff` の insert / retract / swap / out-of-order retraction / snapshot / from_event projection
+- [x] `crates/engine-perception/tests/d1_minimum.rs` (integration, 9 件):
+  - `single_focus_event_appears_in_view` — 基本 push → view 反映
+  - `last_by_time_per_hwnd` — 同一 hwnd の連続更新で latest が勝つ
+  - `out_of_order_events_settle_to_latest_by_time` — **partial-order test** (reverse wallclock 入力で deterministic)
+  - `far_back_dated_event_dropped` — watermark shift > 100ms 超の back-dated event は drop、worker 生存
+  - `multiple_hwnds_tracked_independently` — 3 hwnd 同時 live
+  - `shutdown_without_events_is_clean` — idle shutdown deadlock-free
+  - `shutdown_with_pending_events_drains` — 50 events pending でも 2s 以内に shutdown
+  - `five_cycle_spawn_run_shutdown` — stress (state leak 検出)
+  - `ui_element_ref_projection_is_lossy` — pivot field 漏洩防止 compile-time check
+- [x] **watermark caveat**: 全 push test は target event の後に「pump event」(wallclock_ms +200ms) を 1 件入れて frontier を target を超えて進める (default `DESKTOP_TOUCH_WATERMARK_SHIFT_MS=100ms` semantics に合わせた deterministic test 設計)
 
 ### D1-5: bench harness (PR 4)
 - [ ] `benches/d1_view_latency.rs` 新規 (criterion crate ベース、または simple `#[bench]`)
@@ -392,10 +402,10 @@ collection<UiElementRef>  (1 row per current foreground hwnd)
 
 - [x] **ADR-007 P5c-1 完了**を前提として、real L1 input (UIA Focus Changed event) が ring 経由で bridge → engine-perception に流れる (D1-2 PR で達成、`docs/adr-008-d1-2-plan.md`)
 - [x] **`src/l3_bridge/focus_pump.rs`** が `EventRing` broadcast subscribe → decode → `engine_perception::FocusInputHandle::push_focus()` で動作 (root owns integration、parent-side subscribe で spawn 直後の race 解消、`source_event_id` / `timestamp_source` 必ず保持)
-- [ ] 1 view が incremental に更新される (`current_focused_element`) — **D1-3 で実装**
-- [ ] unit test pass (partial-order 含む) — **D1-4 で view 経由 assert 追加**
+- [x] 1 view が incremental に更新される (`current_focused_element`) — **D1-3 で実装 (本 PR)**
+- [x] unit test pass (partial-order 含む) — D1-3 in-file unit + D1-4 integration `crates/engine-perception/tests/d1_minimum.rs` で assert (32 + 11 全 pass)
 - [ ] bench で TS 版より latency 1/10 (real L1 input ベース、synthetic ではない) — **D1-5 で実施**
-- [x] CI green、`npm run build:rs` / `npm test` 回帰なし、`check:rs-workspace` で engine-perception 含む — D1-2 PR で確認済 (cargo test 60 全 pass / vitest 2434 pass + 1 既知 timing flake)
+- [x] CI green、`npm run build:rs` / `npm test` 回帰なし、`check:rs-workspace` で engine-perception 含む — 本 PR 時点 cargo test 32 (engine-perception) + 11 (root l3_bridge `--no-default-features`) pass / vitest 2435 pass / 28 skip
 - [ ] D1-6 完了 (ドキュメント / メモリ整合) — D1-5 完了後
 
 ---

--- a/docs/adr-008-d1-plan.md
+++ b/docs/adr-008-d1-plan.md
@@ -142,7 +142,7 @@ desktop-touch-mcp/
   - `shutdown_with_pending_events_drains` — 50 events pending でも 2s 以内に shutdown
   - `five_cycle_spawn_run_shutdown` — stress (state leak 検出)
   - `ui_element_ref_projection_is_lossy` — pivot field 漏洩防止 compile-time check
-- [x] **watermark caveat**: 全 push test は target event の後に「pump event」(wallclock_ms +200ms) を 1 件入れて frontier を target を超えて進める (default `DESKTOP_TOUCH_WATERMARK_SHIFT_MS=100ms` semantics に合わせた deterministic test 設計)
+- [x] **watermark caveat**: pump event (wallclock_ms +200ms) を入れる test は frontier を deterministic に進めるため。さらに **PR #91 P2 review** で `worker_loop` の idle 分岐に **idle frontier advance** を実装 — `last_event_anchor (wallclock_ms, Instant)` から real elapsed 時間で `latest_wallclock_ms` を projection、watermark 自動進行。real L1 capture が quiescent でも最新 focus event が view に materialise される (`quiescent_focus_eventually_materialises` test で pin)
 
 ### D1-5: bench harness (PR 4)
 - [ ] `benches/d1_view_latency.rs` 新規 (criterion crate ベース、または simple `#[bench]`)

--- a/docs/adr-008-reactive-perception-engine.md
+++ b/docs/adr-008-reactive-perception-engine.md
@@ -312,7 +312,7 @@ pub trait DataflowAccelerator: Send + Sync {
 
 | Phase | 完了基準 |
 |---|---|
-| D1 | 1 view が incremental に更新、bench で TS 版より latency 1/10 |
+| D1 | 1 view が incremental に更新、bench で TS 版より latency 1/10 — view (`current_focused_element`) は **D1-3 で実装完了** (`crates/engine-perception/src/views/current_focused_element.rs`、PR #91 想定)、bench は **D1-5 で実施** |
 | D2 | 既存 `desktop_state` を全部 view 経由に置換、tool 結果が同一 (回帰なし) |
 | D3 | `state_at(now-2s)` で過去 state が引ける、p95 latency < 5ms |
 | D4 | lens 再計算が fixed-point で settle、無限ループ自動検出 (max iter cap) |

--- a/docs/views-catalog.md
+++ b/docs/views-catalog.md
@@ -68,11 +68,11 @@ ADR-008 D2 は「主要 view 4 つを declarative に実装」を完了基準に
 
 ### 3.1 D1: 最小成立 (1 view)
 
-| view 名 | category | input | output (Rust struct) | consumer | SLO | phase |
-|---|---|---|---|---|---|---|
-| `current_focused_element` | state | `UiaFocusChanged` events from L1 | `UiElementRef { name, automation_id, control_type, window_title }` | L4 envelope.data (desktop_state) | p99 < 1ms | D1 |
+| view 名 | category | input | output (Rust struct) | consumer | SLO | phase | status |
+|---|---|---|---|---|---|---|---|
+| `current_focused_element` | state | `UiaFocusChanged` events from L1 | `UiElementRef { name, automation_id, control_type, window_title }` | L4 envelope.data (desktop_state) | p99 < 1ms | D1 | **Implemented (D1-3)** |
 
-> **D1-2 実装状況 (2026-04-30)**: pipeline 配線は完了 (`src/l3_bridge/focus_pump.rs` + `crates/engine-perception/src/input.rs`)。L1 ring の broadcast 経由で `UiaFocusChanged` event が timely InputSession に届き、`source_event_id` (北極星 N1) と watermark advance (北極星 N2) も実装済。**operator graph 本体 (`current_focused_element` view 自体)** は D1-3 で `crates/engine-perception/src/views/current_focused_element.rs` を新設して追加予定。SLO p99 < 1ms / `Implemented` 表記は D1-3 完了時に flip。
+> **D1-3 実装完了 (2026-04-30)**: operator graph 本体を `crates/engine-perception/src/views/current_focused_element.rs` に新設。`map(FocusEvent → (hwnd, ((wallclock, sub), UiElementRef)))` → `reduce(per-hwnd last-by-time)` → `inspect(diff bookkeeping)` → `Arc<RwLock<HashMap<u64, BTreeMap<UiElementRef, i64>>>>` 読み取り API (`get(hwnd)` / `snapshot()` / `len()` / `is_empty()`)。pivot 4 フィールド (`source_event_id` / `wallclock_ms` / `sub_ordinal` / `timestamp_source`) は output から除外し L4 envelope 側で別途搬送。SLO p99 < 1ms の bench 計測は **D1-5** で実施 (本書 §8 / `docs/adr-008-d1-plan.md` D1-5)。
 
 ### 3.2 D2: 主要 view 4 つ (本書の主スコープ)
 

--- a/docs/views-catalog.md
+++ b/docs/views-catalog.md
@@ -72,7 +72,11 @@ ADR-008 D2 は「主要 view 4 つを declarative に実装」を完了基準に
 |---|---|---|---|---|---|---|---|
 | `current_focused_element` | state | `UiaFocusChanged` events from L1 | `UiElementRef { name, automation_id, control_type, window_title }` | L4 envelope.data (desktop_state) | p99 < 1ms | D1 | **Implemented (D1-3)** |
 
-> **D1-3 実装完了 (2026-04-30)**: operator graph 本体を `crates/engine-perception/src/views/current_focused_element.rs` に新設。`map(FocusEvent → (hwnd, ((wallclock, sub), UiElementRef)))` → `reduce(per-hwnd last-by-time)` → `inspect(diff bookkeeping)` → `Arc<RwLock<HashMap<u64, BTreeMap<UiElementRef, i64>>>>` 読み取り API (`get(hwnd)` / `snapshot()` / `len()` / `is_empty()`)。pivot 4 フィールド (`source_event_id` / `wallclock_ms` / `sub_ordinal` / `timestamp_source`) は output から除外し L4 envelope 側で別途搬送。SLO p99 < 1ms の bench 計測は **D1-5** で実施 (本書 §8 / `docs/adr-008-d1-plan.md` D1-5)。
+> **D1-3 実装完了 (2026-04-30)**: operator graph 本体を `crates/engine-perception/src/views/current_focused_element.rs` に新設。`map(FocusEvent → (hwnd, ((wallclock, sub), UiElementRef)))` → `reduce(per-hwnd last-by-time)` → `inspect(diff bookkeeping)` → `Arc<RwLock<HashMap<u64, BTreeMap<UiElementRef, i64>>>>` 読み取り API (`get(hwnd)` / `snapshot()` / `len()` / `is_empty()`)。pivot 4 フィールド (`source_event_id` / `wallclock_ms` / `sub_ordinal` / `timestamp_source`) は output から除外し L4 envelope 側で別途搬送。
+>
+> **idle frontier advance (PR #91 P2 review fix)**: real L1 capture には heartbeat がないため、focus が変化して停止すると watermark が進まず、最新 event が永久に view に出ない問題を発見。`worker_loop` の idle 分岐で `last_event_anchor: (wallclock_ms, Instant)` から real elapsed 時間を加算して `latest_wallclock_ms` を projection、watermark を進めるように変更 (`crates/engine-perception/src/input.rs::worker_loop`)。これで quiescent focus も view に materialise される。production の monotone real-time wallclock では legitimate な後続 event を back-dated 扱いにすることはない。
+>
+> SLO p99 < 1ms の bench 計測は **D1-5** で実施 (本書 §8 / `docs/adr-008-d1-plan.md` D1-5)。
 
 ### 3.2 D2: 主要 view 4 つ (本書の主スコープ)
 

--- a/src/l3_bridge/mod.rs
+++ b/src/l3_bridge/mod.rs
@@ -38,6 +38,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use engine_perception::input::{spawn_perception_worker, FocusInputHandle, L1Sink, PerceptionWorker};
+use engine_perception::views::current_focused_element::CurrentFocusedElementView;
 
 use crate::l1_capture::ensure_l1;
 
@@ -47,22 +48,27 @@ use self::focus_pump::FocusPump;
 /// L1 ring (`ensure_l1()`).
 ///
 /// Order is critical (Codex v1 P2-2 / v3 P1):
-///   1. Spawn the perception worker (cmd channel up).
+///   1. Spawn the perception worker (cmd channel up, view handle ready).
 ///   2. Take a clone of the L1 ring `Arc`.
 ///   3. Spawn the pump LAST — its `spawn()` does the parent-side
 ///      `subscribe(...)` synchronously, so by the time this helper
 ///      returns, the subscription is registered with the ring and
 ///      a caller can `ring.push(...)` without losing events.
 ///
-/// Returns `(worker, pump)`. Drop or [`shutdown_perception_pipeline_for_test`]
-/// in pump → worker order.
-pub(crate) fn spawn_perception_pipeline_for_test(
-) -> (PerceptionWorker, FocusInputHandle, FocusPump) {
-    let (worker, handle) = spawn_perception_worker();
+/// Returns `(worker, handle, view, pump)`. The `view` is the
+/// `current_focused_element` reader-side handle (D1-3). Drop or
+/// [`shutdown_perception_pipeline_for_test`] in pump → worker order.
+pub(crate) fn spawn_perception_pipeline_for_test() -> (
+    PerceptionWorker,
+    FocusInputHandle,
+    CurrentFocusedElementView,
+    FocusPump,
+) {
+    let (worker, handle, view) = spawn_perception_worker();
     let ring = ensure_l1().ring.clone();
     let sink: Arc<dyn L1Sink> = Arc::new(handle.clone());
     let pump = FocusPump::spawn(ring, sink);
-    (worker, handle, pump)
+    (worker, handle, view, pump)
 }
 
 /// Shut down a pipeline started by
@@ -170,10 +176,19 @@ mod lifecycle_tests {
             }),
             window_title: format!("LifecycleWin{}", cycle),
         };
+        // 200ms-spaced wallclocks (per seq) so the input's watermark
+        // advances past earlier seqs after the later ones land — the
+        // default 100ms watermark shift means events whose
+        // wallclock_ms is within 100ms of the latest stay below the
+        // frontier and are not yet released by the dataflow. With a
+        // 200ms gap, seq 0 and 1 get released after 3 pushes; seq 2
+        // sits at the frontier and is not asserted on.
         let internal = InternalEvent {
             envelope_version: 1,
             event_id: 0,
-            wallclock_ms: 1_800_000_000_000 + cycle as u64 * 1000 + seq as u64,
+            wallclock_ms: 1_800_000_000_000
+                + cycle as u64 * 10_000
+                + seq as u64 * 200,
             sub_ordinal: 0,
             timestamp_source: TimestampSource::StdTime as u8,
             kind: EventKind::UiaFocusChanged as u16,
@@ -240,8 +255,9 @@ mod lifecycle_tests {
         for cycle in 0..5u32 {
             // (1) spawn the engine-perception worker (real timely +
             // InputSession; we'll observe its processed_count to
-            // confirm cmds crossed into the dataflow path).
-            let (worker, handle) = engine_perception::input::spawn_perception_worker();
+            // confirm cmds crossed into the dataflow path; the view
+            // exposes the materialised current_focused_element state).
+            let (worker, handle, view) = engine_perception::input::spawn_perception_worker();
 
             // (2) spawn pump wired to a TeeSink that BOTH forwards
             // into the worker (handle.push_focus) AND captures for
@@ -300,6 +316,39 @@ mod lifecycle_tests {
             );
             assert_eq!(worker.processed_count(), 3, "cycle {} processed", cycle);
 
+            // (4c) D1-3 view assertion — the dataflow's reduce + inspect
+            // updated the view's per-hwnd state. With 200ms-spaced
+            // wallclocks (see push_focus_to_ring), seq 0 and 1 fall
+            // strictly below the input's watermark after seq 2's push
+            // (frontier = latest_wallclock - 100ms shift); seq 2 itself
+            // sits at the frontier and is not yet released. Wait for
+            // seq=0's hwnd to appear in the view.
+            let h0 = 0xD000_u64 + cycle as u64 * 16;
+            let h1 = 0xD000_u64 + cycle as u64 * 16 + 1;
+            let view_for_wait = view.clone();
+            let h0_settled = {
+                let deadline = Instant::now() + Duration::from_millis(500);
+                let mut got = view_for_wait.get(h0);
+                while Instant::now() < deadline {
+                    got = view_for_wait.get(h0);
+                    if got.is_some() {
+                        break;
+                    }
+                    std::thread::sleep(Duration::from_millis(5));
+                }
+                got
+            };
+            let elem = h0_settled
+                .unwrap_or_else(|| panic!("cycle {}: view.get(h0) must return live row", cycle));
+            assert_eq!(elem.window_title, format!("LifecycleWin{}", cycle));
+            assert_eq!(elem.name, format!("Cyc{}Seq{}", cycle, 0));
+            // h1 is also released (its wallclock is 200ms before
+            // seq=2, watermark crosses it).
+            let elem1 = view
+                .get(h1)
+                .unwrap_or_else(|| panic!("cycle {}: view.get(h1) must return live row", cycle));
+            assert_eq!(elem1.name, format!("Cyc{}Seq{}", cycle, 1));
+
             // Drop the original handle so its tx clone is released;
             // sink still holds its own clone, so the worker channel
             // stays alive until pump shutdown drops the sink.
@@ -341,13 +390,15 @@ mod lifecycle_tests {
         let ring = crate::l1_capture::ensure_l1().ring.clone();
         let baseline = ring.subscriber_count();
 
-        let (worker, _handle, pump) = spawn_perception_pipeline_for_test();
+        let (worker, _handle, view, pump) = spawn_perception_pipeline_for_test();
         assert!(
             ring.subscriber_count() >= baseline + 1,
             "spawn must add at least one subscriber slot (baseline={}, after_spawn={})",
             baseline,
             ring.subscriber_count()
         );
+        // No events pushed → view stays empty.
+        assert!(view.is_empty(), "fresh pipeline view should be empty");
         shutdown_perception_pipeline_for_test(worker, pump).expect("shutdown clean");
         // The helper's own slot must be gone. Other concurrent
         // lifecycle tests may have added/removed slots in parallel,

--- a/src/l3_bridge/mod.rs
+++ b/src/l3_bridge/mod.rs
@@ -319,35 +319,46 @@ mod lifecycle_tests {
             // (4c) D1-3 view assertion — the dataflow's reduce + inspect
             // updated the view's per-hwnd state. With 200ms-spaced
             // wallclocks (see push_focus_to_ring), seq 0 and 1 fall
-            // strictly below the input's watermark after seq 2's push
-            // (frontier = latest_wallclock - 100ms shift); seq 2 itself
-            // sits at the frontier and is not yet released. Wait for
-            // seq=0's hwnd to appear in the view.
+            // strictly below the input's watermark immediately after
+            // seq 2's push (frontier = latest_wallclock - 100ms
+            // shift). seq 2 itself starts at the frontier and is
+            // released slightly later by idle-advance (PR #91 P2).
+            // Wait for all 3 to appear.
             let h0 = 0xD000_u64 + cycle as u64 * 16;
             let h1 = 0xD000_u64 + cycle as u64 * 16 + 1;
+            let h2 = 0xD000_u64 + cycle as u64 * 16 + 2;
             let view_for_wait = view.clone();
-            let h0_settled = {
+            let all_settled = {
                 let deadline = Instant::now() + Duration::from_millis(500);
-                let mut got = view_for_wait.get(h0);
+                let mut got = false;
                 while Instant::now() < deadline {
-                    got = view_for_wait.get(h0);
-                    if got.is_some() {
+                    if view_for_wait.get(h0).is_some()
+                        && view_for_wait.get(h1).is_some()
+                        && view_for_wait.get(h2).is_some()
+                    {
+                        got = true;
                         break;
                     }
                     std::thread::sleep(Duration::from_millis(5));
                 }
                 got
             };
-            let elem = h0_settled
-                .unwrap_or_else(|| panic!("cycle {}: view.get(h0) must return live row", cycle));
-            assert_eq!(elem.window_title, format!("LifecycleWin{}", cycle));
-            assert_eq!(elem.name, format!("Cyc{}Seq{}", cycle, 0));
-            // h1 is also released (its wallclock is 200ms before
-            // seq=2, watermark crosses it).
-            let elem1 = view
-                .get(h1)
-                .unwrap_or_else(|| panic!("cycle {}: view.get(h1) must return live row", cycle));
+            assert!(
+                all_settled,
+                "cycle {}: view did not settle 3 hwnds (idle-advance): \
+                 h0={:?} h1={:?} h2={:?}",
+                cycle,
+                view.get(h0).map(|e| e.name),
+                view.get(h1).map(|e| e.name),
+                view.get(h2).map(|e| e.name),
+            );
+            let elem0 = view.get(h0).expect("h0 live");
+            assert_eq!(elem0.window_title, format!("LifecycleWin{}", cycle));
+            assert_eq!(elem0.name, format!("Cyc{}Seq{}", cycle, 0));
+            let elem1 = view.get(h1).expect("h1 live");
             assert_eq!(elem1.name, format!("Cyc{}Seq{}", cycle, 1));
+            let elem2 = view.get(h2).expect("h2 live");
+            assert_eq!(elem2.name, format!("Cyc{}Seq{}", cycle, 2));
 
             // Drop the original handle so its tx clone is released;
             // sink still holds its own clone, so the worker channel


### PR DESCRIPTION
## Summary

Implements the first materialised view in ADR-008 D1 — the `current_focused_element` state view. Builds on the D1-2 L1 → engine-perception adapter (PR #90) by wiring a timely + differential-dataflow operator graph onto the `FocusEvent` collection.

- **Operator graph**: `events.map → reduce(per-hwnd last-by-(wallclock_ms, sub_ordinal)) → inspect`
- **Read API**: `view.get(hwnd) / snapshot() / len() / is_empty()` (`Arc<RwLock<HashMap<u64, BTreeMap<UiElementRef, i64>>>>` — diff-sum bookkeeping for retraction/assertion ordering convergence)
- **Output shape**: `UiElementRef { name, automation_id, control_type, window_title }` per `docs/views-catalog.md` §3.1
- Pivot fields (`source_event_id`, `wallclock_ms`, `sub_ordinal`, `timestamp_source`) deliberately excluded — L4 envelope carries those (北極星 N1)
- `spawn_perception_worker()` signature: 2-tuple → 3-tuple `(PerceptionWorker, FocusInputHandle, CurrentFocusedElementView)`

## D1-4 tests

| 範囲 | 件数 |
|---|---|
| views/current_focused_element.rs in-file unit | 6 |
| tests/d1_minimum.rs integration | 9 |
| root l3_bridge lifecycle (view assertion 追加) | 2 (既存強化) |

D1-4 spec 必須項目: ✅ event inject → view 反映 / ✅ partial-order test (reverse wallclock convergent) / ✅ shutdown deadlock-free / ✅ 5-cycle stress

## Test results

- `cargo test -p engine-perception` → **32/32 pass** (23 lib + 9 integration)
- `cargo test --lib --no-default-features l3_bridge` → **11/11 pass**
- `npm run test:capture` → **2435/2435 pass + 28 skip** (vs D1-2 baseline 2434, regression 0; +1 は flaky benchmark-gates が今回 green)

## Opus review (強制命令 3)

致命的 0 件、merge 可能と評定。Merge 前修正:
1. ✅ `crates/engine-perception/src/input.rs` module docstring を 3-tuple 表記に修正
2. ✅ `apply_diff` に `debug_assert!(new >= 0)` 追加 (DD diff invariant 違反防御、負エントリ leak 防止)

D1-5/D2 follow-up (本 PR scope 外): transient stale read 強化 / tie-breaker `>` vs `>=` semantics 明示 / hwnd 死活遷移 view-経由 test / starvation 再評価 (`parking_lot::RwLock` or `arc-swap`) / bench で SETTLE_TIMEOUT 妥当性検証 / L4 envelope 側 pivot 搬送経路の実装。

## Watermark caveat

D1-2 の `worker_loop` は `latest_wallclock_ms - 100ms` で frontier を進めるため、最新 push は frontier 上に留まり release されません。D1-4 全 integration test は target event の後に「pump event」(wallclock_ms +200ms) を追加で 1 件 inject して frontier を target を超えて進める設計。`src/l3_bridge/mod.rs::push_focus_to_ring` の wallclock 間隔も 1ms → 200ms に変更 (元の 5-cycle leak 検出意図は維持)。

## Acceptance status

`docs/adr-008-d1-plan.md` §11 D1 acceptance:
- [x] 1 view が incremental に更新 (本 PR)
- [x] unit test pass (partial-order 含む) (本 PR)
- [ ] bench で TS 版より latency 1/10 (**D1-5 で実施、本 PR scope 外**)

`docs/views-catalog.md` §3.1: `Implemented (D1-3)` flip 済。

## Test plan

- [x] CI workspace check (`check:rs-workspace`) green
- [x] CI cargo test (`cargo test -p engine-perception` + root l3_bridge) green
- [x] CI vitest (`npm test`) green
- [x] Codex / AI multi-reviewer 確認 (重要 PR なので Codex + Gemini)

🤖 Generated with [Claude Code](https://claude.com/claude-code)