### PR TITLE
feat(adr-008 D2-B-1): latest_focus view + napi binding view_get_focused

### DIFF
--- a/crates/engine-perception/benches/d1_view_latency.rs
+++ b/crates/engine-perception/benches/d1_view_latency.rs
@@ -255,7 +255,7 @@ fn populate_view(
 }
 
 fn bench_view_get_hit(c: &mut Criterion) {
-    let (worker, handle, view) = spawn_perception_worker();
+    let (worker, handle, view, _latest_view) = spawn_perception_worker();
     populate_view(&handle, &view, HWND_LIVE, Duration::from_millis(500));
 
     // D2-A-3: capture iteration elapsed for percentile reporting.
@@ -303,7 +303,7 @@ fn bench_view_get_hit(c: &mut Criterion) {
 }
 
 fn bench_view_get_miss(c: &mut Criterion) {
-    let (worker, handle, view) = spawn_perception_worker();
+    let (worker, handle, view, _latest_view) = spawn_perception_worker();
     populate_view(&handle, &view, HWND_LIVE, Duration::from_millis(500));
 
     let samples: Mutex<Vec<Duration>> =
@@ -398,7 +398,7 @@ fn bench_view_update_latency(c: &mut Criterion) {
     // We deliberately do NOT override `WATERMARK_SHIFT_MS` here so the
     // bench reflects the production worker's behaviour.
 
-    let (worker, handle, view) = spawn_perception_worker();
+    let (worker, handle, view, _latest_view) = spawn_perception_worker();
 
     // Prime: drive a first event through and wait for the view to
     // materialise, so subsequent iterations measure pure update

--- a/crates/engine-perception/src/input.rs
+++ b/crates/engine-perception/src/input.rs
@@ -65,12 +65,14 @@
 //!
 //! ## Lifecycle
 //!
-//! [`spawn_perception_worker`] returns
-//! `(PerceptionWorker, FocusInputHandle, CurrentFocusedElementView)`.
-//! Drop the handle (or all clones thereof) and call
-//! `PerceptionWorker::shutdown(timeout)` to stop the thread. The view
-//! handle (D1-3) is independent of the worker's lifetime — it remains
-//! readable after shutdown but stops receiving updates.
+//! [`spawn_perception_worker`] returns a 4-tuple
+//! `(PerceptionWorker, FocusInputHandle, CurrentFocusedElementView,
+//! LatestFocusView)` (D2-B-1: `LatestFocusView` added in
+//! `docs/adr-008-d2-plan.md` §5.bis). Drop the handle (or all clones
+//! thereof) and call `PerceptionWorker::shutdown(timeout)` to stop
+//! the thread. Both view handles are independent of the worker's
+//! lifetime — they remain readable after shutdown but stop
+//! receiving updates.
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -84,6 +86,7 @@ use differential_dataflow::input::{Input, InputSession};
 
 use crate::time::LogicalTime;
 use crate::views::current_focused_element::{self, CurrentFocusedElementView};
+use crate::views::latest_focus::{self, LatestFocusView};
 
 /// Default per-worker command-channel capacity. Sized for UIA focus
 /// rate (< 10 events/sec under human use); the bridge sleeps for at
@@ -472,27 +475,47 @@ fn max_steps_per_cmd() -> usize {
         .unwrap_or(DEFAULT_MAX_STEPS_PER_CMD)
 }
 
-/// Spawn the timely worker thread + return a triple
-/// `(PerceptionWorker, FocusInputHandle, CurrentFocusedElementView)`.
+/// Spawn the timely worker thread + return a 4-tuple
+/// `(PerceptionWorker, FocusInputHandle, CurrentFocusedElementView, LatestFocusView)`.
 ///
 /// The worker owns the `differential_dataflow::input::InputSession`
 /// and the dataflow graph; the handle is the bridge's seam
-/// (`Arc::new(handle): Arc<dyn L1Sink>`); the view is the read-only
-/// reader-side of the `current_focused_element` materialised state
-/// (D1-3). The view handle is created on the parent thread and cloned
-/// into the worker so the dataflow's inspect callback can write to it.
-pub fn spawn_perception_worker(
-) -> (PerceptionWorker, FocusInputHandle, CurrentFocusedElementView) {
+/// (`Arc::new(handle): Arc<dyn L1Sink>`).
+///
+/// **Two view handles are returned** (D2-B / `docs/adr-008-d2-plan.md`
+/// §5.bis):
+///
+/// - `CurrentFocusedElementView` — per-hwnd state (D1-3, retained).
+/// - `LatestFocusView` — singleton-key state, "latest globally
+///   focused element". Production `desktop_state.ts` reads this one
+///   because the focused element's `hwnd` is not always equal to the
+///   foreground-window hwnd (Codex v3 P1-4).
+///
+/// Both views are cloned into the same `worker.dataflow(|scope| ...)`
+/// closure so they share a single input collection — the raw event
+/// stream is processed once and fanned out into two reduces. View
+/// handles created on the parent thread, cloned into the worker so
+/// inspect callbacks can write through.
+pub fn spawn_perception_worker() -> (
+    PerceptionWorker,
+    FocusInputHandle,
+    CurrentFocusedElementView,
+    LatestFocusView,
+) {
     let (tx, rx) = bounded::<Cmd>(CMD_CHANNEL_CAPACITY);
     let processed_count = Arc::new(AtomicU64::new(0));
     let processed_clone = Arc::clone(&processed_count);
 
     let view = CurrentFocusedElementView::new();
+    let latest_view = LatestFocusView::new();
     let view_for_worker = view.clone();
+    let latest_view_for_worker = latest_view.clone();
 
     let join = thread::Builder::new()
         .name("l3-perception".into())
-        .spawn(move || worker_loop(rx, processed_clone, view_for_worker))
+        .spawn(move || {
+            worker_loop(rx, processed_clone, view_for_worker, latest_view_for_worker)
+        })
         .expect("spawn l3-perception thread");
 
     let worker = PerceptionWorker {
@@ -501,7 +524,7 @@ pub fn spawn_perception_worker(
         processed_count,
     };
     let handle = FocusInputHandle { tx };
-    (worker, handle, view)
+    (worker, handle, view, latest_view)
 }
 
 /// Body of the timely worker thread (D2-A revised tuning).
@@ -574,6 +597,7 @@ fn worker_loop(
     rx: Receiver<Cmd>,
     processed: Arc<AtomicU64>,
     view: CurrentFocusedElementView,
+    latest_view: LatestFocusView,
 ) {
     let shift_ms = watermark_shift_ms();
     let idle_timeout = Duration::from_millis(idle_recv_timeout_ms());
@@ -593,7 +617,12 @@ fn worker_loop(
         let mut input: InputSession<LogicalTime, FocusEvent, isize> =
             worker.dataflow::<LogicalTime, _, _>(|scope| {
                 let (input, stream) = scope.new_collection::<FocusEvent, isize>();
-                current_focused_element::build(stream, view.clone());
+                // Both views consume the same input stream — DD's
+                // `Collection` is `Clone`, so each `build` call
+                // chains its own operator path off the same source
+                // (D2-B §5.bis: shared input, fanned-out reduces).
+                current_focused_element::build(stream.clone(), view.clone());
+                latest_focus::build(stream, latest_view.clone());
                 input
             });
 
@@ -804,7 +833,7 @@ mod tests {
 
     #[test]
     fn spawn_and_shutdown_clean() {
-        let (worker, _handle, _view) = spawn_perception_worker();
+        let (worker, _handle, _view, _latest_view) = spawn_perception_worker();
         worker
             .shutdown(Duration::from_secs(2))
             .expect("shutdown clean");
@@ -812,7 +841,7 @@ mod tests {
 
     #[test]
     fn push_focus_roundtrip_smoke() {
-        let (worker, handle, _view) = spawn_perception_worker();
+        let (worker, handle, _view, _latest_view) = spawn_perception_worker();
         for i in 0..3 {
             handle.push_focus(make_event(i, 1_000_000 + i, 0));
         }
@@ -827,7 +856,7 @@ mod tests {
         // Cmd::PushFocus from the channel, not just acknowledges
         // shutdown. Without this assertion the lifecycle test
         // could regress silently if the worker_loop body is gutted.
-        let (worker, handle, _view) = spawn_perception_worker();
+        let (worker, handle, _view, _latest_view) = spawn_perception_worker();
         for i in 0..5 {
             handle.push_focus(make_event(i, 5_000_000 + i, 0));
         }
@@ -849,7 +878,7 @@ mod tests {
     #[test]
     fn five_cycle_spawn_shutdown() {
         for cycle in 0..5 {
-            let (worker, handle, _view) = spawn_perception_worker();
+            let (worker, handle, _view, _latest_view) = spawn_perception_worker();
             handle.push_focus(make_event(cycle, 2_000_000 + cycle, 0));
             worker
                 .shutdown(Duration::from_secs(2))
@@ -859,7 +888,7 @@ mod tests {
 
     #[test]
     fn push_after_shutdown_silently_drops() {
-        let (worker, handle, _view) = spawn_perception_worker();
+        let (worker, handle, _view, _latest_view) = spawn_perception_worker();
         worker.shutdown(Duration::from_secs(2)).expect("shutdown");
         // After worker is gone, the receiver is dropped and the
         // channel disconnects. push_focus must NOT panic.
@@ -870,7 +899,7 @@ mod tests {
     fn l1sink_object_safety() {
         // Trait must be object-safe so the bridge can hold
         // `Arc<dyn L1Sink>` without naming the concrete type.
-        let (worker, handle, _view) = spawn_perception_worker();
+        let (worker, handle, _view, _latest_view) = spawn_perception_worker();
         let _h: Arc<dyn L1Sink> = Arc::new(handle);
         worker.shutdown(Duration::from_secs(2)).expect("shutdown");
     }
@@ -903,7 +932,7 @@ mod tests {
         //
         // We can't observe the dataflow output yet (D1-3), but we
         // can confirm the worker doesn't crash on a back-dated push.
-        let (worker, handle, _view) = spawn_perception_worker();
+        let (worker, handle, _view, _latest_view) = spawn_perception_worker();
         // First push sets latest_wallclock_ms = 1_000_000
         handle.push_focus(make_event(1, 1_000_000, 0));
         // Sleep so the worker definitely processed the first push
@@ -931,7 +960,7 @@ mod tests {
         // is independent of frontier), so this test only guards
         // against a regression that breaks the idle branch entirely
         // (e.g. an early `break` or a panic in the projection code).
-        let (worker, handle, _view) = spawn_perception_worker();
+        let (worker, handle, _view, _latest_view) = spawn_perception_worker();
         handle.push_focus(make_event(1, 1_700_000_000_000, 0));
         let deadline = Instant::now() + Duration::from_millis(500);
         while worker.processed_count() < 1 {
@@ -957,7 +986,7 @@ mod tests {
         // event_time = (T - 500ms, 0) when latest = T, shift = 100ms
         // → watermark = (T - 100ms, 0), and event_time < watermark
         // → dropped with log. Test verifies the worker survives.
-        let (worker, handle, _view) = spawn_perception_worker();
+        let (worker, handle, _view, _latest_view) = spawn_perception_worker();
         handle.push_focus(make_event(1, 2_000_000, 0));
         thread::sleep(Duration::from_millis(50));
         // 500ms back-dated — way outside the 100ms watermark default
@@ -1007,7 +1036,7 @@ mod tests {
         // max_sub_ord + 1)) does not drop the larger-sub_ord events
         // as back-dated.
         use crate::views::current_focused_element::CurrentFocusedElementView;
-        let (worker, handle, view) = spawn_perception_worker();
+        let (worker, handle, view, _latest_view) = spawn_perception_worker();
         let _: &CurrentFocusedElementView = &view; // type assertion
 
         // wallclock far enough from 0 that the watermark shift
@@ -1068,7 +1097,7 @@ mod tests {
         // wins regardless of arrival order. This is the partial-
         // order acceptance test (北極星 N3).
         use crate::views::current_focused_element::CurrentFocusedElementView;
-        let (worker, handle, view) = spawn_perception_worker();
+        let (worker, handle, view, _latest_view) = spawn_perception_worker();
         let _: &CurrentFocusedElementView = &view;
 
         let w = 1_700_000_500_000_u64;
@@ -1122,7 +1151,7 @@ mod tests {
         // frontier, then push an old event (wc = T1, T1 < T2 - 100ms
         // shift). The old event must be dropped (eprintln only),
         // and the worker must remain healthy.
-        let (worker, handle, _view) = spawn_perception_worker();
+        let (worker, handle, _view, _latest_view) = spawn_perception_worker();
 
         // T2 = 2_000_000, T1 = 2_000_000 - 500 (way past the 100ms
         // default shift, so the watermark guard rejects it).
@@ -1157,7 +1186,7 @@ mod tests {
         // the watermark; we observe this indirectly by verifying
         // the worker remains healthy and processed_count stays at 1
         // (no spurious additional processing).
-        let (worker, handle, _view) = spawn_perception_worker();
+        let (worker, handle, _view, _latest_view) = spawn_perception_worker();
 
         handle.push_focus(make_focus_event_at(1, 1_800_000_000_000, 0, 0xB002, "anchor"));
 
@@ -1192,7 +1221,7 @@ mod tests {
         // We can't observe the frontier directly from here, but
         // processed_count is a clean proxy: spawn-and-shutdown
         // without any PushFocus must leave processed_count = 0.
-        let (worker, _handle, _view) = spawn_perception_worker();
+        let (worker, _handle, _view, _latest_view) = spawn_perception_worker();
         // No pushes — straight to shutdown. The shutdown signal
         // arrives as a single Shutdown-only batch.
         let pre_shutdown_count = worker.processed_count();

--- a/crates/engine-perception/src/views/latest_focus.rs
+++ b/crates/engine-perception/src/views/latest_focus.rs
@@ -1,0 +1,251 @@
+//! `latest_focus` view (ADR-008 D2-B / `docs/adr-008-d2-plan.md` §5.bis).
+//!
+//! Singleton-key last-by-time reduction over the same [`FocusEvent`]
+//! collection that feeds `current_focused_element`. Produces 0 or 1
+//! "latest focused element globally" row regardless of which `hwnd`
+//! emitted the event.
+//!
+//! ## Why this is separate from `current_focused_element`
+//!
+//! `current_focused_element` is keyed by `hwnd` so callers can ask
+//! "what's focused inside this specific window?". Production
+//! `desktop_state.ts`, however, exposes one global focused element —
+//! and the focused element's `hwnd` (`UiElementRef::hwnd`) is not
+//! always the foreground window's `hwnd` (a child / control HWND, or
+//! the unresolved 0 sentinel from `focus_pump`, can populate it). A
+//! `view_get_focused(activeHwnd)` lookup against the per-hwnd view
+//! therefore misses in production-frequent cases (Codex v3 P1-4).
+//!
+//! `latest_focus` reduces the same input stream under the singleton
+//! key `()`, so the produced row is the latest focus regardless of
+//! which `hwnd` carried it. Both views share one input collection
+//! (wired in `spawn_perception_worker` via the same `worker.dataflow`
+//! closure), so memory growth is bounded — the raw event stream is
+//! processed once and fanned out into two reduces.
+//!
+//! ## Operator graph
+//!
+//! ```text
+//! FocusEvent collection
+//!     │
+//!     │ map: FocusEvent → ((), (LogicalTime, UiElementRef))
+//!     ▼
+//! reduce(): pick the (ts, ui_ref) whose ts is largest among values
+//!           with positive accumulated diff. Output ((ts, ui_ref), +1).
+//!     │
+//!     ▼
+//! inspect: apply (data, time, diff) to the view's BTreeMap-of-
+//!          (LogicalTime, UiElementRef) → diff-sum (Codex v3 P1-1
+//!          inspect-order tolerance pattern).
+//! ```
+//!
+//! ## Diff bookkeeping with `LogicalTime` in the key (Codex v3 P1-1)
+//!
+//! DD's reduce inspect callback can fire the retraction of an old
+//! winner before the assertion of a new winner (the order is not
+//! guaranteed within a single time step). If the materialised state
+//! were just `Option<UiElementRef>` set/cleared on each callback,
+//! a stale `None` could be observed between the retraction and the
+//! assertion, and a late retraction could even reset to `None` after
+//! the new value was already in place.
+//!
+//! Mirroring `current_focused_element`'s defence, `LatestFocusView`
+//! stores diff sums per `(LogicalTime, UiElementRef)` and resolves
+//! the public read by reverse-walking the `BTreeMap` and returning
+//! the first entry whose diff sum is positive. Convergence is
+//! independent of inspect arrival order. The `LogicalTime` in the
+//! key is what makes "largest ts wins" work across out-of-order
+//! callbacks — without it the materialised state would lose the
+//! discriminator (Codex v4 P2-13 reduce output shape).
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, RwLock};
+
+use differential_dataflow::collection::vec::Collection as VecCollection;
+
+use super::current_focused_element::UiElementRef;
+use crate::input::FocusEvent;
+use crate::time::LogicalTime;
+
+/// Reader-side handle on the materialised state of `latest_focus`.
+/// Cheap to clone (inner is `Arc<RwLock<...>>`).
+#[derive(Clone, Default)]
+pub struct LatestFocusView {
+    inner: Arc<RwLock<LatestFocusState>>,
+}
+
+#[derive(Default)]
+struct LatestFocusState {
+    /// Diff-sum bookkeeping keyed by `(LogicalTime, UiElementRef)`.
+    /// `BTreeMap`'s lexicographic ordering plus `LogicalTime`'s lex
+    /// ordering means iterating from the back finds the largest-ts
+    /// live entry; ties on ts (which the L1 invariant says cannot
+    /// happen) would tie-break by `UiElementRef`'s derived `Ord`.
+    counts: BTreeMap<(LogicalTime, UiElementRef), i64>,
+}
+
+impl LatestFocusView {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Latest globally-focused element, if any. `None` when no event
+    /// has yet been released by the dataflow's reduce + watermark.
+    pub fn snapshot(&self) -> Option<UiElementRef> {
+        let g = self.inner.read().expect("LatestFocusView RwLock poisoned");
+        g.counts
+            .iter()
+            .rev()
+            .find_map(|((_, ui_ref), &c)| if c > 0 { Some(ui_ref.clone()) } else { None })
+    }
+
+    /// Number of `(LogicalTime, UiElementRef)` keys with a positive
+    /// diff sum. In a quiescent state (after retractions settle) this
+    /// is 0 or 1; transiently during a focus change it can be 2.
+    pub fn len(&self) -> usize {
+        let g = self.inner.read().expect("LatestFocusView RwLock poisoned");
+        g.counts.values().filter(|&&c| c > 0).count()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Apply a diff observation. Internal — called from the timely
+    /// worker's inspect closure inside [`build`]. `pub(crate)` so
+    /// tests inside the crate can exercise the bookkeeping directly.
+    pub(crate) fn apply_diff(&self, ts: LogicalTime, value: UiElementRef, diff: i64) {
+        let mut g = self.inner.write().expect("LatestFocusView RwLock poisoned");
+        let key = (ts, value);
+        let new = g.counts.get(&key).copied().unwrap_or(0) + diff;
+        debug_assert!(
+            new >= 0,
+            "negative diff sum in latest_focus, ts={:?} new={}",
+            key.0,
+            new
+        );
+        if new <= 0 {
+            g.counts.remove(&key);
+        } else {
+            g.counts.insert(key, new);
+        }
+    }
+}
+
+/// Wire the `latest_focus` operator graph onto `events`. Same
+/// caller-creates-view-ahead pattern as `current_focused_element::build`.
+pub fn build<'scope>(
+    events: VecCollection<'scope, LogicalTime, FocusEvent, isize>,
+    view: LatestFocusView,
+) {
+    let view_for_inspect = view;
+
+    events
+        .map(|ev: FocusEvent| {
+            let ts = ev.logical_time();
+            let value = UiElementRef::from_event(&ev);
+            // Singleton key `()`. The reduce sees one collection
+            // worth of values and picks the largest-ts live one.
+            ((), (ts, value))
+        })
+        .reduce(|_unit, input, output| {
+            let mut best: Option<&(LogicalTime, UiElementRef)> = None;
+            for (val_ref, diff) in input.iter() {
+                if *diff <= 0 {
+                    continue;
+                }
+                let cand: &(LogicalTime, UiElementRef) = *val_ref;
+                match best {
+                    None => best = Some(cand),
+                    Some(b) if cand.0 > b.0 => best = Some(cand),
+                    _ => {}
+                }
+            }
+            if let Some((ts, ui_ref)) = best {
+                output.push(((ts.clone(), ui_ref.clone()), 1));
+            }
+        })
+        .inspect(move |((unit_and_value, _time, diff)): &(((), (LogicalTime, UiElementRef)), LogicalTime, isize)| {
+            // The reduce output is keyed by `()` so DD lifts the row
+            // into `((), (ts, ui_ref))`. We destructure here.
+            let (_unit, (ts, ui_ref)) = unit_and_value;
+            view_for_inspect.apply_diff(ts.clone(), ui_ref.clone(), *diff as i64);
+        });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ts(wc: u64, sub: u32) -> LogicalTime {
+        LogicalTime::new(wc, sub)
+    }
+
+    fn ref_(name: &str) -> UiElementRef {
+        UiElementRef {
+            name: name.into(),
+            automation_id: None,
+            control_type: 50000,
+            window_title: "Win".into(),
+        }
+    }
+
+    #[test]
+    fn empty_view_snapshot_returns_none() {
+        let v = LatestFocusView::new();
+        assert!(v.is_empty());
+        assert_eq!(v.snapshot(), None);
+    }
+
+    #[test]
+    fn apply_diff_returns_largest_ts_live() {
+        let v = LatestFocusView::new();
+        v.apply_diff(ts(100, 0), ref_("a"), 1);
+        v.apply_diff(ts(200, 0), ref_("b"), 1);
+        // Both live; reverse-walk picks the larger-ts entry.
+        assert_eq!(v.snapshot().unwrap().name, "b");
+    }
+
+    #[test]
+    fn retraction_first_then_assertion_settles() {
+        // Codex v3 P1-1 inspect-order tolerance: retraction can
+        // arrive before the matching assertion. The view must still
+        // converge to the assertion.
+        let v = LatestFocusView::new();
+        v.apply_diff(ts(100, 0), ref_("old"), 1);
+        // Now focus moves: retraction of "old" arrives BEFORE the
+        // assertion of "new".
+        v.apply_diff(ts(100, 0), ref_("old"), -1);
+        v.apply_diff(ts(200, 0), ref_("new"), 1);
+        assert_eq!(v.snapshot().unwrap().name, "new");
+    }
+
+    #[test]
+    fn assertion_first_then_retraction_settles() {
+        let v = LatestFocusView::new();
+        v.apply_diff(ts(100, 0), ref_("old"), 1);
+        // Assertion of new value arrives FIRST, then retraction of
+        // old. The view must end up with "new".
+        v.apply_diff(ts(200, 0), ref_("new"), 1);
+        v.apply_diff(ts(100, 0), ref_("old"), -1);
+        assert_eq!(v.snapshot().unwrap().name, "new");
+    }
+
+    #[test]
+    fn full_retraction_evicts() {
+        let v = LatestFocusView::new();
+        v.apply_diff(ts(100, 0), ref_("a"), 1);
+        v.apply_diff(ts(100, 0), ref_("a"), -1);
+        assert!(v.is_empty());
+        assert_eq!(v.snapshot(), None);
+    }
+
+    #[test]
+    fn same_wallclock_different_sub_ordinal_picks_higher_sub() {
+        let v = LatestFocusView::new();
+        v.apply_diff(ts(100, 0), ref_("a"), 1);
+        v.apply_diff(ts(100, 5), ref_("b"), 1);
+        // Higher sub_ordinal at the same wallclock wins.
+        assert_eq!(v.snapshot().unwrap().name, "b");
+    }
+}

--- a/crates/engine-perception/src/views/latest_focus.rs
+++ b/crates/engine-perception/src/views/latest_focus.rs
@@ -165,7 +165,7 @@ pub fn build<'scope>(
                 output.push(((ts.clone(), ui_ref.clone()), 1));
             }
         })
-        .inspect(move |((unit_and_value, _time, diff)): &(((), (LogicalTime, UiElementRef)), LogicalTime, isize)| {
+        .inspect(move |(unit_and_value, _time, diff): &(((), (LogicalTime, UiElementRef)), LogicalTime, isize)| {
             // The reduce output is keyed by `()` so DD lifts the row
             // into `((), (ts, ui_ref))`. We destructure here.
             let (_unit, (ts, ui_ref)) = unit_and_value;

--- a/crates/engine-perception/src/views/mod.rs
+++ b/crates/engine-perception/src/views/mod.rs
@@ -14,5 +14,7 @@
 //! `docs/views-catalog.md`.
 
 pub mod current_focused_element;
+pub mod latest_focus;
 
 pub use current_focused_element::{CurrentFocusedElementView, UiElementRef};
+pub use latest_focus::LatestFocusView;

--- a/crates/engine-perception/tests/d1_minimum.rs
+++ b/crates/engine-perception/tests/d1_minimum.rs
@@ -97,7 +97,7 @@ fn wait_for_view<F: Fn(&CurrentFocusedElementView) -> bool>(
 
 #[test]
 fn single_focus_event_appears_in_view() {
-    let (worker, handle, view) = spawn_perception_worker();
+    let (worker, handle, view, _latest_view) = spawn_perception_worker();
     let base = 1_700_000_000_000u64;
 
     // Event we want to verify (target).
@@ -138,7 +138,7 @@ fn quiescent_focus_eventually_materialises() {
     // (500ms) is well past the 100ms watermark shift plus
     // worker-step jitter (~1ms per loop), so idle-advance has many
     // opportunities to fire before the timeout.
-    let (worker, handle, view) = spawn_perception_worker();
+    let (worker, handle, view, _latest_view) = spawn_perception_worker();
     let base = 1_700_000_000_000u64;
 
     handle.push_focus(focus_event(1, 0xCAFE, base, "QuiescentEdit", "QuiescentApp"));
@@ -163,7 +163,7 @@ fn quiescent_focus_eventually_materialises() {
 fn last_by_time_per_hwnd() {
     // Three events on the same hwnd, in wallclock-increasing order.
     // The view must converge to the LATEST (highest wallclock_ms).
-    let (worker, handle, view) = spawn_perception_worker();
+    let (worker, handle, view, _latest_view) = spawn_perception_worker();
     let base = 1_700_000_000_000u64;
     let hwnd = 0xCAFE_u64;
 
@@ -200,7 +200,7 @@ fn out_of_order_events_settle_to_latest_by_time() {
     // means both events land within the watermark window of each
     // other — neither is dropped. The view must still pick the one
     // with the higher wallclock_ms (last-by-time semantics).
-    let (worker, handle, view) = spawn_perception_worker();
+    let (worker, handle, view, _latest_view) = spawn_perception_worker();
     let base = 1_700_000_000_000u64;
     let hwnd = 0xCAFE_u64;
 
@@ -241,7 +241,7 @@ fn far_back_dated_event_dropped() {
     // BELOW the frontier and is dropped by the worker_loop guard.
     // Test verifies the worker does NOT crash on such an event and
     // the view continues to reflect the in-window event.
-    let (worker, handle, view) = spawn_perception_worker();
+    let (worker, handle, view, _latest_view) = spawn_perception_worker();
     let base = 1_700_000_000_000u64;
     let hwnd = 0xCAFE_u64;
 
@@ -271,7 +271,7 @@ fn far_back_dated_event_dropped() {
 
 #[test]
 fn multiple_hwnds_tracked_independently() {
-    let (worker, handle, view) = spawn_perception_worker();
+    let (worker, handle, view, _latest_view) = spawn_perception_worker();
     let base = 1_700_000_000_000u64;
 
     push_all(
@@ -311,7 +311,7 @@ fn shutdown_without_events_is_clean() {
     // deadlock しない". Even with no events ever pushed, the worker
     // must shut down within the timeout — the cmd channel handles
     // Cmd::Shutdown synchronously.
-    let (worker, _handle, view) = spawn_perception_worker();
+    let (worker, _handle, view, _latest_view) = spawn_perception_worker();
     assert!(view.is_empty());
     let start = Instant::now();
     worker
@@ -329,7 +329,7 @@ fn shutdown_with_pending_events_drains() {
     // settle, calling shutdown must still drain cleanly (the worker
     // pumps remaining cmds before honouring Cmd::Shutdown — see
     // worker_loop's try_recv loop). No deadlock.
-    let (worker, handle, _view) = spawn_perception_worker();
+    let (worker, handle, _view, _latest_view) = spawn_perception_worker();
     let base = 1_700_000_000_000u64;
     for i in 0..50 {
         handle.push_focus(focus_event(
@@ -353,7 +353,7 @@ fn five_cycle_spawn_run_shutdown() {
     // Mirrors the L1 worker / focus_pump 5-cycle tests; flushes any
     // hidden state leak across cycles.
     for cycle in 0..5u64 {
-        let (worker, handle, view) = spawn_perception_worker();
+        let (worker, handle, view, _latest_view) = spawn_perception_worker();
         let base = 1_700_000_000_000u64 + cycle * 1_000_000;
         handle.push_focus(focus_event(
             1,

--- a/docs/adr-008-d2-plan.md
+++ b/docs/adr-008-d2-plan.md
@@ -1,6 +1,6 @@
 # ADR-008 D2 — 主要 view 4 つ + desktop_state focus path view 経由置換プラン
 
-- Status: **Draft v3.11 (起草中、Opus、2026-04-30) — D2-A 実装完了、Codex review v1〜v13 反映済、Opus phase-boundary review (D2-0 + D2-A phase) 完了**
+- Status: **Draft v3.12 (起草中、Opus、2026-04-30) — D2-A 完了 + D2-B-1 (latest_focus view + napi binding) 実装着手、Codex review v1〜v13 反映済**
 - Date: 2026-04-30
 - Authors: Claude (Opus, max effort) — `desktop-touch-mcp`
 - 親 ADR: `docs/adr-008-reactive-perception-engine.md` §4 D2 / §8 D2
@@ -250,6 +250,36 @@ PR #95 v3.10 push 後の Codex round 13 で P1 + P2:
 **cargo test (v3.11)**:
 - `cargo test -p engine-perception` (default 並列モード、env race fix 後) で integration 含む 41 全 pass
 - env race の構造的解消で `--test-threads=1` 前提 CI も不要
+
+### v3.12 (D2-B-1 latest_focus view + napi binding 着手、PR-γ、2026-04-30)
+
+D2-A merged (`d5641fd`) を baseline に、D2-B-1 sub-batch を新 feature branch (`feature/adr-008-d2-b-desktop-state-focus`) で実装着手。
+
+**実装範囲 (PR-γ、本 commit)**:
+
+1. **`crates/engine-perception/src/views/latest_focus.rs` 新設** (§5.bis 完全準拠):
+   - singleton-key `()` で reduce、output value 型は `(LogicalTime, UiElementRef)` (Codex v4 P2-13)
+   - materialised state は `BTreeMap<(LogicalTime, UiElementRef), i64>` の diff bookkeeping (Codex v3 P1-1 inspect-order tolerance pattern)
+   - `snapshot()` は `iter().rev().find(c > 0)` で largest-ts live entry 取得
+   - in-file unit test 6 件 (`empty` / `largest_ts_live` / `retraction_first` / `assertion_first` / `full_retraction_evicts` / `same_wallclock_higher_sub`)
+2. **`spawn_perception_worker` を 4-tuple 化** `(PerceptionWorker, FocusInputHandle, CurrentFocusedElementView, LatestFocusView)`、両 view を **同 `worker.dataflow` closure 内** で build (D2-E0 同 scope 設計を踏襲、stream 1 つを fan-out)
+3. **`PerceptionPipeline` に `latest_focus_view: LatestFocusView` field 追加**、`spawn_pipeline_inner` で worker 4-tuple → pipeline 構築
+4. **napi binding 2 件 新設** (`src/l3_bridge/mod.rs`):
+   - `view_get_focused() -> Option<FocusedElementJs>`: `is_poisoned()` check + `latest_focus_view.snapshot()` + `crate::uia::control_type_name(UIA_CONTROLTYPE_ID(...))` で `controlType` を **string 化** (Codex v3 P1-3 bit-equal、既存 UIA bridge と同変換 table 共有 = OQ #11 Resolved)
+   - `view_focused_pipeline_status() -> ViewFocusedPipelineStatusJs`: diagnostics (`initialized` / `poisoned` / `processed_count`)
+5. 既存 callers 26 箇所 (root crate / engine-perception lib + integration / bench) を 4-tuple destructure に更新 (`_latest_view` で受けて影響最小化)
+
+**OQ resolutions**:
+- **OQ #11** (control_type id → string mapping table の在処): `crate::uia::control_type_name` (`src/uia/mod.rs:27`) が既に 40 種マッピング実装済、napi binding で reuse → **Resolved**
+
+**cargo test (PR-γ commit 時点)**:
+- `cargo test --workspace --lib --no-default-features` → 56 (root) + 37 (engine-perception、+6 latest_focus unit test) = **93 pass / 0 fail**
+- `cargo test -p engine-perception` (integration 込み) → 37 lib + 10 integration = **47 pass / 0 fail**
+
+**未着手 (D2-B-2 / D2-B-3 / D2-B-4 別 PR)**:
+- D2-B-2: `desktop_state.ts` focus-only path replacement + `hints.focusedElementSource = "view"` sentinel + bit-equal contract test
+- D2-B-3: `--with-point-query` baseline (`benches/d1_ts_baseline.mjs`)
+- D2-B-4: MCP transport bench (`d2_desktop_state_roundtrip.mjs`、OQ #16 SLO 判断 fact base)
 
 **option C (parking_lot::Condvar 等 signal-driven)** の優先度を上げる:
 - v3.8 の修正で `view_update_latency` p99 の改善幅は更に縮小、SLO 未達は確実

--- a/docs/views-catalog.md
+++ b/docs/views-catalog.md
@@ -96,6 +96,16 @@ ADR-008 D2 は「主要 view 4 つを declarative に実装」を完了基準に
 > - SLO `< 1ms` の表記は **緩和しない** (ユーザー判断)、bench harness は production-相当条件 (`shift=default`、wc 200ms 増分) に確定済 (`crates/engine-perception/benches/d1_view_latency.rs`)
 > - partial-order test 5 件 (`same_wallclock_different_sub_ordinal_all_observed` 等) で N3 acceptance を直接 pin、stuck-worker fixture (`Cmd::BlockForTest`) で OQ #15 (Codex v9 P2-17 retry-fail branch) も Resolved
 
+#### 3.1.bis `latest_focus` view (D2-B-1、PR-γ 着手)
+
+| view 名 | category | input | output | consumer | SLO | phase | status |
+|---|---|---|---|---|---|---|---|
+| `latest_focus` | state (singleton) | (D1 と共有) `UiaFocusChanged` events from L1 (current_focused_element と同 input stream を fan-out) | `Option<UiElementRef>` (logical_time global max の event 1 件) | L4 envelope.data の **production focus path** (`desktop_state.ts` focus-only replacement、Codex v3 P1-4) | lookup p99 < 1ms、update は current_focused_element と同 floor (`shift_ms`) | D2-B-1 | **Implemented (PR-γ 起こし中、2026-04-30)** |
+
+> **D2-B-1 実装 (2026-04-30)**: `crates/engine-perception/src/views/latest_focus.rs` 新設。singleton key `()` で reduce、output value 型 `(LogicalTime, UiElementRef)` (Codex v4 P2-13)、materialised state は `BTreeMap<(LogicalTime, UiElementRef), i64>` の diff bookkeeping (Codex v3 P1-1 inspect-order tolerance)。`spawn_perception_worker` を 4-tuple 化、両 view を同 `worker.dataflow` closure 内で build (D2-E0 同 scope 設計)。
+>
+> napi binding 2 件 (`src/l3_bridge/mod.rs::view_get_focused`, `view_focused_pipeline_status`)。`view_get_focused` は `is_poisoned()` check + `latest_focus_view.snapshot()` + `crate::uia::control_type_name` で `controlType` を string 化 (bit-equal、OQ #11 Resolved)。`desktop_state.ts` 経路結線は D2-B-2 別 PR。
+
 ### 3.2 D2: 主要 view 4 つ (本書の主スコープ)
 
 | view 名 | category | input | output | consumer | SLO | phase |

--- a/index.d.ts
+++ b/index.d.ts
@@ -284,3 +284,27 @@ export declare function l1PushFailure(layer: string, op: string, reason: string,
 export declare function l1PollEvents(sinceEventId: bigint, maxCount: number): NativeEventEnvelope[]
 export declare function l1GetCaptureStats(): NativeCaptureStats
 export declare function l1ShutdownForTest(): void
+
+// ─── L3 perception view (ADR-008 D2-B-1) ─────────────────────────────────────
+
+export interface NativeFocusedElement {
+  name: string
+  automationId: string | null
+  /** Human-readable UIA control type name (e.g. "Button", "Pane", "Edit"). */
+  controlType: string
+  windowTitle: string
+}
+
+export interface NativeViewFocusedPipelineStatus {
+  initialized: boolean
+  /** `true` when the slot's pipeline has had a failed shutdown
+   * (Codex review v9 P2-17). Callers should fall back to UIA. */
+  poisoned: boolean
+  processedCount: bigint
+}
+
+/** Read the latest globally focused element from the perception engine's
+ * `latest_focus` view. Returns `null` when the pipeline has no live row,
+ * is uninitialised, or the slot is poisoned (caller should use UIA fallback). */
+export declare function viewGetFocused(): NativeFocusedElement | null
+export declare function viewFocusedPipelineStatus(): NativeViewFocusedPipelineStatus

--- a/index.js
+++ b/index.js
@@ -115,4 +115,8 @@ export const l1PollEvents               = nativeBinding.l1PollEvents;
 export const l1GetCaptureStats          = nativeBinding.l1GetCaptureStats;
 export const l1ShutdownForTest          = nativeBinding.l1ShutdownForTest;
 
+// ─── L3 perception view (ADR-008 D2-B-1) ─────────────────────────────────────
+export const viewGetFocused             = nativeBinding.viewGetFocused;
+export const viewFocusedPipelineStatus  = nativeBinding.viewFocusedPipelineStatus;
+
 export default nativeBinding;

--- a/src/engine/native-engine.ts
+++ b/src/engine/native-engine.ts
@@ -40,6 +40,8 @@ import type {
   NativeScrollInfo,
   NativeEventEnvelope,
   NativeCaptureStats,
+  NativeFocusedElement,
+  NativeViewFocusedPipelineStatus,
 } from "./native-types.js";
 
 export type * from "./native-types.js";
@@ -314,6 +316,21 @@ export interface NativeL1 {
 export const nativeL1: NativeL1 | null =
   nativeBinding && typeof nativeBinding.l1PushFailure === "function"
     ? (nativeBinding as unknown as NativeL1)
+    : null;
+
+// ─── L3 perception view surface (ADR-008 D2-B-1) ─────────────────────────────
+// Single load point for the `latest_focus` view's read API. `desktop_state.ts`
+// (D2-B-2, next PR) reads `viewGetFocused` first and falls back to UIA when
+// the result is `null` (no live row, uninitialised, or poisoned slot).
+
+export interface NativeViewFocus {
+  viewGetFocused?(): NativeFocusedElement | null;
+  viewFocusedPipelineStatus?(): NativeViewFocusedPipelineStatus;
+}
+
+export const nativeViewFocus: NativeViewFocus | null =
+  nativeBinding && typeof nativeBinding.viewGetFocused === "function"
+    ? (nativeBinding as unknown as NativeViewFocus)
     : null;
 
 if (nativeEngine) {

--- a/src/engine/native-types.ts
+++ b/src/engine/native-types.ts
@@ -52,6 +52,28 @@ export interface NativeUiaFocusInfo {
   value?: string
 }
 
+// ─── L3 perception view (ADR-008 D2-B-1) ─────────────────────────────────────
+// Returned by `viewGetFocused()` (root-level napi export). Mirrors the
+// engine-perception `latest_focus` view's `UiElementRef`, with
+// `controlType` pre-stringified via `crate::uia::control_type_name` so
+// the shape matches the existing `NativeUiaFocusInfo` consumer in
+// `desktop-state.ts` (Codex review v3 P1-3 bit-equal contract).
+
+export interface NativeFocusedElement {
+  name: string
+  automationId: string | null
+  controlType: string
+  windowTitle: string
+}
+
+export interface NativeViewFocusedPipelineStatus {
+  initialized: boolean
+  /** `true` when the slot's pipeline has had a failed shutdown
+   * (Codex review v9 P2-17). Callers should fall back to UIA. */
+  poisoned: boolean
+  processedCount: bigint
+}
+
 export interface NativeFocusAndPointResult {
   focused?: NativeUiaFocusInfo | null
   atPoint?: NativeUiaFocusInfo | null

--- a/src/l3_bridge/mod.rs
+++ b/src/l3_bridge/mod.rs
@@ -45,6 +45,8 @@ use napi::bindgen_prelude::BigInt;
 use napi_derive::napi;
 use windows::Win32::UI::Accessibility::UIA_CONTROLTYPE_ID;
 
+use crate::win32::safety::napi_safe_call;
+
 use engine_perception::input::{spawn_perception_worker, FocusInputHandle, L1Sink, PerceptionWorker};
 use engine_perception::views::current_focused_element::CurrentFocusedElementView;
 use engine_perception::views::latest_focus::LatestFocusView;
@@ -450,21 +452,30 @@ pub struct NativeFocusedElement {
 ///   - or the `latest_focus` view's `snapshot()` has nothing live.
 ///
 /// First call lazily spawns the pipeline (`ensure_perception_pipeline`).
+///
+/// Wrapped in `napi_safe_call` per ADR-007 §3.4 — any panic in the
+/// pipeline init / view read path turns into a typed napi error
+/// instead of unwinding through the addon boundary (which would
+/// take down the Node process).
 #[napi]
-pub fn view_get_focused() -> Option<NativeFocusedElement> {
-    let pipeline = ensure_perception_pipeline();
-    if pipeline.is_poisoned() {
-        return None;
-    }
-    let ui_ref = pipeline.latest_focus_view.snapshot()?;
-    Some(NativeFocusedElement {
-        name: ui_ref.name,
-        automation_id: ui_ref.automation_id,
-        control_type: crate::uia::control_type_name(UIA_CONTROLTYPE_ID(
-            ui_ref.control_type as i32,
-        ))
-        .to_string(),
-        window_title: ui_ref.window_title,
+pub fn view_get_focused() -> napi::Result<Option<NativeFocusedElement>> {
+    napi_safe_call("view_get_focused", || {
+        let pipeline = ensure_perception_pipeline();
+        if pipeline.is_poisoned() {
+            return Ok(None);
+        }
+        let Some(ui_ref) = pipeline.latest_focus_view.snapshot() else {
+            return Ok(None);
+        };
+        Ok(Some(NativeFocusedElement {
+            name: ui_ref.name,
+            automation_id: ui_ref.automation_id,
+            control_type: crate::uia::control_type_name(UIA_CONTROLTYPE_ID(
+                ui_ref.control_type as i32,
+            ))
+            .to_string(),
+            window_title: ui_ref.window_title,
+        }))
     })
 }
 
@@ -486,29 +497,32 @@ pub struct NativeViewFocusedPipelineStatus {
 }
 
 #[napi]
-pub fn view_focused_pipeline_status() -> NativeViewFocusedPipelineStatus {
-    match PERCEPTION_SLOT.get() {
-        None => NativeViewFocusedPipelineStatus {
-            initialized: false,
-            poisoned: false,
-            processed_count: BigInt::from(0u64),
-        },
-        Some(cell) => {
-            let g = cell.lock().unwrap_or_else(|e| e.into_inner());
-            match g.as_ref() {
-                None => NativeViewFocusedPipelineStatus {
-                    initialized: false,
-                    poisoned: false,
-                    processed_count: BigInt::from(0u64),
-                },
-                Some(pipeline) => NativeViewFocusedPipelineStatus {
-                    initialized: true,
-                    poisoned: pipeline.is_poisoned(),
-                    processed_count: BigInt::from(pipeline.worker.processed_count()),
-                },
+pub fn view_focused_pipeline_status() -> napi::Result<NativeViewFocusedPipelineStatus> {
+    napi_safe_call("view_focused_pipeline_status", || {
+        let status = match PERCEPTION_SLOT.get() {
+            None => NativeViewFocusedPipelineStatus {
+                initialized: false,
+                poisoned: false,
+                processed_count: BigInt::from(0u64),
+            },
+            Some(cell) => {
+                let g = cell.lock().unwrap_or_else(|e| e.into_inner());
+                match g.as_ref() {
+                    None => NativeViewFocusedPipelineStatus {
+                        initialized: false,
+                        poisoned: false,
+                        processed_count: BigInt::from(0u64),
+                    },
+                    Some(pipeline) => NativeViewFocusedPipelineStatus {
+                        initialized: true,
+                        poisoned: pipeline.is_poisoned(),
+                        processed_count: BigInt::from(pipeline.worker.processed_count()),
+                    },
+                }
             }
-        }
-    }
+        };
+        Ok(status)
+    })
 }
 
 // ─── 5-cycle lifecycle test (ADR-008 D1-2 §3.6) ────────────────────────

--- a/src/l3_bridge/mod.rs
+++ b/src/l3_bridge/mod.rs
@@ -426,8 +426,12 @@ fn spawn_pipeline_inner() -> PerceptionPipeline {
 /// `automationId`, `type` (string), `windowTitle`. The `value` field
 /// is omitted because the engine doesn't carry it through (UIA
 /// `ValuePattern` reads happen on the JS side).
+///
+/// Naming follows the existing `Native*` convention used elsewhere
+/// in this addon (e.g. `NativeUiaFocusInfo`); the hand-maintained
+/// `index.d.ts` / `index.js` re-exports use the same identifier.
 #[napi(object)]
-pub struct FocusedElementJs {
+pub struct NativeFocusedElement {
     pub name: String,
     pub automation_id: Option<String>,
     /// Human-readable UIA control type name (e.g. "Button", "Pane",
@@ -447,13 +451,13 @@ pub struct FocusedElementJs {
 ///
 /// First call lazily spawns the pipeline (`ensure_perception_pipeline`).
 #[napi]
-pub fn view_get_focused() -> Option<FocusedElementJs> {
+pub fn view_get_focused() -> Option<NativeFocusedElement> {
     let pipeline = ensure_perception_pipeline();
     if pipeline.is_poisoned() {
         return None;
     }
     let ui_ref = pipeline.latest_focus_view.snapshot()?;
-    Some(FocusedElementJs {
+    Some(NativeFocusedElement {
         name: ui_ref.name,
         automation_id: ui_ref.automation_id,
         control_type: crate::uia::control_type_name(UIA_CONTROLTYPE_ID(
@@ -468,7 +472,7 @@ pub fn view_get_focused() -> Option<FocusedElementJs> {
 /// `desktop_state.ts` and `server_status` use this to surface when
 /// the view path is unavailable (so the UIA fallback isn't silent).
 #[napi(object)]
-pub struct ViewFocusedPipelineStatusJs {
+pub struct NativeViewFocusedPipelineStatus {
     /// `true` once `ensure_perception_pipeline` has spawned at least
     /// one pipeline in this process.
     pub initialized: bool,
@@ -482,9 +486,9 @@ pub struct ViewFocusedPipelineStatusJs {
 }
 
 #[napi]
-pub fn view_focused_pipeline_status() -> ViewFocusedPipelineStatusJs {
+pub fn view_focused_pipeline_status() -> NativeViewFocusedPipelineStatus {
     match PERCEPTION_SLOT.get() {
-        None => ViewFocusedPipelineStatusJs {
+        None => NativeViewFocusedPipelineStatus {
             initialized: false,
             poisoned: false,
             processed_count: BigInt::from(0u64),
@@ -492,12 +496,12 @@ pub fn view_focused_pipeline_status() -> ViewFocusedPipelineStatusJs {
         Some(cell) => {
             let g = cell.lock().unwrap_or_else(|e| e.into_inner());
             match g.as_ref() {
-                None => ViewFocusedPipelineStatusJs {
+                None => NativeViewFocusedPipelineStatus {
                     initialized: false,
                     poisoned: false,
                     processed_count: BigInt::from(0u64),
                 },
-                Some(pipeline) => ViewFocusedPipelineStatusJs {
+                Some(pipeline) => NativeViewFocusedPipelineStatus {
                     initialized: true,
                     poisoned: pipeline.is_poisoned(),
                     processed_count: BigInt::from(pipeline.worker.processed_count()),

--- a/src/l3_bridge/mod.rs
+++ b/src/l3_bridge/mod.rs
@@ -38,8 +38,16 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
+// Explicit imports (NOT `use napi::bindgen_prelude::*`) — the glob
+// would shadow `std::result::Result` and break this module's
+// pre-existing `Result<(), &'static str>` shutdown signatures.
+use napi::bindgen_prelude::BigInt;
+use napi_derive::napi;
+use windows::Win32::UI::Accessibility::UIA_CONTROLTYPE_ID;
+
 use engine_perception::input::{spawn_perception_worker, FocusInputHandle, L1Sink, PerceptionWorker};
 use engine_perception::views::current_focused_element::CurrentFocusedElementView;
+use engine_perception::views::latest_focus::LatestFocusView;
 
 use crate::l1_capture::ensure_l1;
 
@@ -65,7 +73,11 @@ pub(crate) fn spawn_perception_pipeline_for_test() -> (
     CurrentFocusedElementView,
     FocusPump,
 ) {
-    let (worker, handle, view) = spawn_perception_worker();
+    // D2-B-1: spawn_perception_worker now returns 4 elements
+    // (latest_focus_view added). Existing test callers don't need
+    // the latest_focus_view, so we drop it here. Production
+    // `spawn_pipeline_inner` keeps it on `PerceptionPipeline`.
+    let (worker, handle, view, _latest_view) = spawn_perception_worker();
     let ring = ensure_l1().ring.clone();
     let sink: Arc<dyn L1Sink> = Arc::new(handle.clone());
     let pump = FocusPump::spawn(ring, sink);
@@ -154,6 +166,11 @@ pub(crate) fn shutdown_spawned_pipeline_for_test(
 /// them as plain fields and delegate `shutdown_with_timeout` directly.
 pub struct PerceptionPipeline {
     pub view: CurrentFocusedElementView,
+    /// Singleton-key "latest globally focused element" view (D2-B-1
+    /// / `docs/adr-008-d2-plan.md` §5.bis). `desktop_state.ts` reads
+    /// this one because the focused element's HWND is not always
+    /// the foreground-window HWND (Codex v3 P1-4).
+    pub latest_focus_view: LatestFocusView,
     pub handle: FocusInputHandle,
     worker: PerceptionWorker,
     pump: FocusPump,
@@ -372,16 +389,121 @@ pub(crate) fn shutdown_perception_pipeline_for_test(
 /// pump in the same order as `spawn_perception_pipeline_for_test` so
 /// the parent-side `subscribe(...)` runs synchronously (Codex v3 P1).
 fn spawn_pipeline_inner() -> PerceptionPipeline {
-    let (worker, handle, view) = spawn_perception_worker();
+    let (worker, handle, view, latest_focus_view) = spawn_perception_worker();
     let ring = ensure_l1().ring.clone();
     let sink: Arc<dyn L1Sink> = Arc::new(handle.clone());
     let pump = FocusPump::spawn(ring, sink);
     PerceptionPipeline {
         view,
+        latest_focus_view,
         handle,
         worker,
         pump,
         poisoned: AtomicBool::new(false),
+    }
+}
+
+// ─── napi-exposed view read API (D2-B-1) ──────────────────────────────────
+//
+// `view_get_focused` is the seam through which `desktop_state.ts`'s
+// focus-only path replacement reads the perception engine's
+// `latest_focus` view. The shape is intentionally identical to the
+// existing UIA `focus.controlType` row in `desktop-state.ts` so the
+// caller can fall through between view and UIA without restructuring
+// — `controlType` is a STRING (e.g. "Button", "Pane"), not the raw
+// `UIA_CONTROLTYPE_ID` u32 the engine stores (Codex v3 P1-3
+// bit-equal contract). The `crate::uia::control_type_name` helper
+// (`src/uia/mod.rs:27`) is the same table the existing UIA bridge
+// uses, so the string mapping is shared.
+//
+// The `view_get_focused` call also honours the production-lifecycle
+// poison flag (Codex v9 P2-17 + v3.6 contract): when the slot is
+// poisoned the napi function returns `None` so the TS caller falls
+// back to UIA-direct rather than serving a half-stopped pipeline.
+
+/// Read shape returned to napi callers from [`view_get_focused`].
+/// Matches `desktop-state.ts`'s existing `ElementInfo` shape: `name`,
+/// `automationId`, `type` (string), `windowTitle`. The `value` field
+/// is omitted because the engine doesn't carry it through (UIA
+/// `ValuePattern` reads happen on the JS side).
+#[napi(object)]
+pub struct FocusedElementJs {
+    pub name: String,
+    pub automation_id: Option<String>,
+    /// Human-readable UIA control type name (e.g. "Button", "Pane",
+    /// "Edit"). Mapped from the engine's raw `UIA_CONTROLTYPE_ID` via
+    /// `crate::uia::control_type_name`.
+    pub control_type: String,
+    pub window_title: String,
+}
+
+/// Read the latest globally focused element from the perception
+/// engine's `latest_focus` view. Returns `None` when:
+///
+///   - the perception pipeline has never received a focus event,
+///   - the slot is poisoned (a previous shutdown attempt failed),
+///     in which case the caller should use the UIA fallback path,
+///   - or the `latest_focus` view's `snapshot()` has nothing live.
+///
+/// First call lazily spawns the pipeline (`ensure_perception_pipeline`).
+#[napi]
+pub fn view_get_focused() -> Option<FocusedElementJs> {
+    let pipeline = ensure_perception_pipeline();
+    if pipeline.is_poisoned() {
+        return None;
+    }
+    let ui_ref = pipeline.latest_focus_view.snapshot()?;
+    Some(FocusedElementJs {
+        name: ui_ref.name,
+        automation_id: ui_ref.automation_id,
+        control_type: crate::uia::control_type_name(UIA_CONTROLTYPE_ID(
+            ui_ref.control_type as i32,
+        ))
+        .to_string(),
+        window_title: ui_ref.window_title,
+    })
+}
+
+/// Diagnostic snapshot of the perception pipeline's runtime state.
+/// `desktop_state.ts` and `server_status` use this to surface when
+/// the view path is unavailable (so the UIA fallback isn't silent).
+#[napi(object)]
+pub struct ViewFocusedPipelineStatusJs {
+    /// `true` once `ensure_perception_pipeline` has spawned at least
+    /// one pipeline in this process.
+    pub initialized: bool,
+    /// `true` when the slot's current pipeline has had a failed
+    /// shutdown (Codex v9 P2-17). Callers should fall back to UIA.
+    pub poisoned: bool,
+    /// Cumulative `Cmd::PushFocus` count the worker has dequeued
+    /// and run through `update_at` + `flush`. 0 when the pipeline
+    /// is not yet initialized.
+    pub processed_count: BigInt,
+}
+
+#[napi]
+pub fn view_focused_pipeline_status() -> ViewFocusedPipelineStatusJs {
+    match PERCEPTION_SLOT.get() {
+        None => ViewFocusedPipelineStatusJs {
+            initialized: false,
+            poisoned: false,
+            processed_count: BigInt::from(0u64),
+        },
+        Some(cell) => {
+            let g = cell.lock().unwrap_or_else(|e| e.into_inner());
+            match g.as_ref() {
+                None => ViewFocusedPipelineStatusJs {
+                    initialized: false,
+                    poisoned: false,
+                    processed_count: BigInt::from(0u64),
+                },
+                Some(pipeline) => ViewFocusedPipelineStatusJs {
+                    initialized: true,
+                    poisoned: pipeline.is_poisoned(),
+                    processed_count: BigInt::from(pipeline.worker.processed_count()),
+                },
+            }
+        }
     }
 }
 
@@ -563,7 +685,8 @@ mod lifecycle_tests {
             // InputSession; we'll observe its processed_count to
             // confirm cmds crossed into the dataflow path; the view
             // exposes the materialised current_focused_element state).
-            let (worker, handle, view) = engine_perception::input::spawn_perception_worker();
+            let (worker, handle, view, _latest_view) =
+                engine_perception::input::spawn_perception_worker();
 
             // (2) spawn pump wired to a TeeSink that BOTH forwards
             // into the worker (handle.push_focus) AND captures for


### PR DESCRIPTION
## Summary

D2-B sub-batch #1 (PR-γ) of the ADR-008 D2 plan: introduces the
`latest_focus` view and the napi `view_get_focused()` binding so
`desktop_state.ts` (next PR, D2-B-2) can read the engine-perception
"latest globally focused element" without going back to UIA.

Builds on PR #94 (D2-0 production lifecycle) and PR #95 (D2-A
worker_loop / N2 contract / OQ #15 stuck-worker test).

## Why

`current_focused_element` is keyed by `hwnd` and the focused
element's HWND is not always the foreground-window HWND (Codex v3
P1-4 / plan §5.bis): child / control HWNDs and the unresolved-0
sentinel can populate it. A `view_get_focused(activeHwnd)` lookup
against the per-hwnd view misses for those — exactly the
production-frequent case `desktop_state.ts` needs to handle.

The new `latest_focus` view reduces the same input stream under
the singleton key `()` and produces 0-or-1 "latest globally
focused element" rows independent of which `hwnd` the focus event
carried.

## Scope (this PR is intentionally small)

Per the post-PR #95 lesson (Codex 9 + 4 rounds across two large
PRs), D2-B is deliberately split into individual sub-batches:

- **This PR (D2-B-1)**: view + napi binding only.
- **Next PR (D2-B-2)**: `desktop_state.ts` focus-only replacement
  + `hints.focusedElementSource = "view"` + bit-equal contract test.
- **D2-B-3**: `--with-point-query` baseline addition.
- **D2-B-4**: MCP transport bench → fact base for the OQ #16
  option C decision.

## Test plan

- [x] `cargo test --workspace --lib --no-default-features` →
  93 passed / 0 failed (56 root + 37 engine-perception, includes
  6 new latest_focus diff-bookkeeping unit tests).
- [x] `cargo test -p engine-perception` (parallel default,
  integration included) → 47 passed / 0 failed
  (`multiple_hwnds_tracked_independently` and the rest of the
  v3.8 watermark suite still pass on the shared input stream).
- [x] `cargo check --workspace` → clean (only pre-existing warnings).
- [ ] CI green on push.
- [ ] Codex bot review on PR.

## Open Questions resolved

**OQ #11**: where does the UIA control-type-id → string mapping
table live? Answer: `crate::uia::control_type_name`
(`src/uia/mod.rs:27`) already covers the 40 control types the UIA
bridge uses. The new napi binding reuses the same helper, so the
`controlType` string emitted from the view matches the existing
`desktop_state.ts` shape exactly — bit-equal contract preserved
(Codex v3 P1-3).

## Highlights for review

- **`latest_focus.rs`** — singleton `()` reduce. Output value type
  is `(LogicalTime, UiElementRef)` so the inspect callback can
  apply diffs into the materialised
  `BTreeMap<(LogicalTime, UiElementRef), i64>`. The 6 in-file
  tests pin the inspect-order tolerance matrix (Codex v3 P1-1
  pattern: retraction-first AND assertion-first both settle).
- **`spawn_perception_worker` is now 4-tuple** —
  `(worker, handle, current_view, latest_view)`. Both views build
  inside the same `worker.dataflow(|scope|...)` closure so they
  fan out from one shared input collection, matching the D2-E0
  same-scope plan. Existing 26 call sites were updated, mostly
  via `_latest_view` to keep the diff minimal.
- **`PerceptionPipeline` adds `latest_focus_view`**. The napi
  binding reads it without spinning a fresh worker.
- **`view_get_focused()` honours `is_poisoned()`**: when the slot
  is poisoned (Codex v9 P2-17), returns `None` so TS falls back
  to UIA direct rather than serving a half-stopped pipeline.
- **`use napi::bindgen_prelude::*` is intentionally avoided**.
  The glob shadows `std::result::Result` and breaks the existing
  `Result<(), &'static str>` shutdown signatures elsewhere in
  this module. Only `BigInt` is explicitly imported.

## Plan

`docs/adr-008-d2-plan.md` is at v3.12 with a new v3.12 section
documenting this sub-batch, the OQ #11 resolution, and the test
counts. `docs/views-catalog.md` adds a §3.1.bis row for
`latest_focus` marked Implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)