### PR TITLE
docs(adr-008): track plan H1/intro carry-over for D2-G

### DIFF
--- a/docs/adr-008-d2-plan.md
+++ b/docs/adr-008-d2-plan.md
@@ -776,7 +776,8 @@ D1 `current_focused_element` view は `hwnd` を key にした per-hwnd state (f
 ### D2-G: ドキュメント整合 + メモリ更新 (PR 14)
 
 - [ ] `docs/views-catalog.md` §3.2 を実装した view ごとに `Implemented + Benched` flip + 実測値追記
-- [ ] **ADR-008 §8 D2 行を「focus path 完了、modal / attention は D4 carry-over」明記**で更新
+- [ ] **ADR-008 §8 D2 行を「focus path 完了、modal / attention は D4 carry-over」明記**で更新 (※ PR #99 で先行更新済、D2-G では最終確定文言で再確認のみ)
+- [ ] **本 plan H1 タイトル (L1) を「主要 view 3 + 1 carry-over」表記に更新** (D2-C0 ゲート確定 PR #99 で 4 → 3 縮小、§intro L16 も同様)。これは plan 内ローカル枠組み記述で SSOT (§3.2 / §4 / §8 / §11.1) ではないため D2-C0 PR #99 では先行更新せず carry-over、D2-G で最終整合
 - [ ] 本 plan §11 Acceptance を全 [x] flip
 - [ ] `docs/adr-008-d1-followups.md` の対応項目を Resolved 化 (§3.5 のみ carry-over)
 - [ ] memory `project_adr008_d2_done.md` 新規 + `MEMORY.md` index 更新
@@ -1207,7 +1208,7 @@ D2-E0 / D2-E と整合: **`Arranged` を外部 struct に保持せず、同 `wor
 - [ ] cargo test --workspace 全 pass、追加 unit + integration test 全 pass
 - [ ] vitest `npm run test:capture` 0 regression
 - [ ] 各 phase 完了で **Opus phase-boundary review** 実施、指摘ゼロまで反復 (強制命令 3)
-- [ ] D2-G で docs / memory 整合: views-catalog §3.2 の Implemented view 全て flip、ADR-008 §8 D2 を「focus path 完了、modal/attention は D4 carry-over」明記、D1-followups §3 を Resolved 化 (§3.5 除く)
+- [ ] D2-G で docs / memory 整合: views-catalog §3.2 の Implemented view 全て flip、ADR-008 §8 D2 を「focus path 完了、modal/attention は D4 carry-over」明記 (※ PR #99 で先行済、最終確定文言で再確認のみ)、本 plan H1 タイトル (L1) + §intro (L16) の「主要 view 4」古文言を 3 + 1 carry-over 表記に更新、D1-followups §3 を Resolved 化 (§3.5 除く)
 
 ---
 


### PR DESCRIPTION
## Summary

PR #99 (D2-C0 ゲート) の closure follow-up。round 4 review が plan H1 タイトル / §intro に古い「主要 view 4」表記が残ることを発見、本 PR で **D2-G phase で書き換える** よう明示追跡 entry を追加。

scope は小さく (3 行追加 / 2 行修正)、`docs/adr-008-d2-plan.md` のみ変更。

## なぜ PR #99 内で済ませなかったか

PR #99 round 4 reviewer が指摘した通り、これは **plan 内ローカル枠組み記述で SSOT ではない**:
- SSOT 表 (§3.2 / §4 / §8 / §11.1): PR #99 で 4 表 bit-equal 整合済
- H1 タイトル / §intro: plan 全体の枠組み引用、D2-G で書き換える前提が plan §1.3 / §11.5 で既に rule 化済

SSOT を round 2/3 で完結させたため、本 entry は scope 拡大を避けて D2-G 着手時に拾うべき carry-over として明示追跡。

## 追加した checklist 項目

`docs/adr-008-d2-plan.md`:
- **§D2-G**: 「本 plan H1 タイトル (L1) を「主要 view 3 + 1 carry-over」表記に更新 (D2-C0 ゲート確定 PR #99 で 4 → 3 縮小、§intro L16 も同様)」
- **§11.5**: D2-G summary line に H1 / §intro 更新を追記
- 既存 §D2-G の ADR-008 §8 D2 行更新タスクには「※ PR #99 で先行更新済、D2-G では最終確定文言で再確認のみ」注釈追加 (D2-G phase で重複作業を避けるため)

## Companion: local-only `CLAUDE.md` 強制命令 3 update

**[B 案]** Opus 判断力盲点 pattern (round 2 で「過渡的表記妥当」と誤判定 → user 補正、round 3 で同型盲点 §8 見落とし) の仕組み化を、`CLAUDE.md` 強制命令 3 のサブセクション「ADR/plan 複数表 fact 整合チェックリスト」として記載しました。**ただし `CLAUDE.md` は \`d5cbd40\` で gitignored** (project owner 判断「local dev workflow file」) なので、本 PR には含まれません。User の local 環境のみで反映される governance 改訂です。

中身: ADR / 大きめ plan の同じ事実が複数の表 / 見出し / phase 表 / acceptance 表に散在する場合、1 箇所修正したら docs 全 section grep で同期確認するチェック手順 (4 step) を Opus review プロンプトに必ず組み込む、というルール。memory `feedback_north_star_reconciliation.md` (北極星照合) と並ぶ Opus 判断補強層として位置付け。

## Test plan
- [x] `git log --oneline -- CLAUDE.md` で gitignored 状態を確認 (本 PR に CLAUDE.md は含まれないことを Verify 済)
- [x] §D2-G / §11.5 entry が既存 D2-G タスク (ADR-008 §8 / views-catalog flip / D1-followups Resolved 化) と整合
- [x] 本 PR は governance / docs only、production code 触らず — Opus phase-boundary review は不要 (PR #99 で D2-C0 phase 完結済、本 PR は post-phase clean-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)