### PR TITLE
feat(adr-007 P5c-2): DXGI dirty rect → L1 ring emit

### DIFF
--- a/docs/adr-007-p5c-2-plan.md
+++ b/docs/adr-007-p5c-2-plan.md
@@ -21,7 +21,7 @@ F. **payload `DirtyRectPayload` 充足** (既に `src/l1_capture/payload.rs:48` 
 
 ### 1.2 本 sub-plan で扱わない (carry-over)
 
-- **secondary monitor 対応** (親 plan §10 OQ #3): 本 sub-plan は **primary monitor (`output_index = 0`) のみ emit**、secondary monitor は OQ #3 で別 phase
+- **secondary monitor 専用機能** (親 plan §10 OQ #3): per-output 並行 thread / per-monitor 専用 view / secondary monitor 検出ロジック等の高度機能は OQ #3 で別 phase。**ただし** 既存 `spawn(output_index)` で受け取った output index を payload `monitor_index` に正しく載せること自体は本 PR の責務 (Codex P1-Codex-3、2026-05-01 確定 — 「carry-over」を理由に既存 multi-monitor 経路を破壊する regression は出さない、北極星整合)
 - **Tier dispatch / cascade** (親 plan §1.1 G + ADR-008 D5): P5c-2 は emit のみ、Tier 別 backend dispatch は D5 carry-over
 - **`DirtyRect` event の rate throttling** (親 plan §11.4 / R4): scroll と違い dirty rect は frame 駆動で本来 60Hz 上限。明示的 rate limit は不要、ただし ring 飽和時の `drop_count` 監視は P5c 全体共通の責務として §6 で扱う
 - **`dirty_rects_aggregate` view 実装**: ADR-008 PR-ε (D2-C) で別 PR、本 PR はあくまで emit
@@ -201,7 +201,7 @@ fn acquire_dirty_rects(ctx, timeout_ms, ring: &Arc<EventRing>, enable_l1_emit: &
 |---|---|---|
 | 1 | option B (always-on consumer thread) への pivot 是非 — v2 kill switch 状態で emit 不在が production 課題化するか | P5c-2 merge 後、ADR-008 D2-C `dirty_rects_aggregate` view の bench 結果を踏まえ Opus 判断 |
 | ~~2~~ | ~~`benches/l1_capture.rs::bench_dirty_rect_60hz` を本 PR で enable するか別 PR (P5c-2-bench) で carry-over するか~~ | **Resolved (Opus 判断、2026-05-01)**: 別 PR (`P5c-2-bench`) で carry-over 採用。理由: 親 §11.4 acceptance に bench 含まれず、本 PR scope を「emit + integration test」に絞る方が PR #94/#95 の Codex round 多発教訓 (sub-batch 切り効果) と整合 |
-| 3 | secondary monitor 対応 (親 plan §10 OQ #3) | 別 phase、production 需要があれば着手 |
+| 3 | secondary monitor の **高度機能** (per-output 並行 thread / per-monitor 専用 view / detection logic) — 親 plan §10 OQ #3 | 別 phase、production 需要があれば着手。**注**: `spawn(output_index)` 経由の output index を payload `monitor_index` に正しく載せること自体は本 PR で実装済 (§3.1 / Codex P1-Codex-3 fix、2026-05-01)。本 OQ は **新機能** の追加 (= 既存 multi-monitor 経路の正しい扱いとは別軸) を carry-over する意味 |
 | ~~4~~ | ~~`frame_index` を duplication thread ローカル AtomicU64 にするか、L1 ring 全体共通の monotonic counter にするか~~ | **Resolved (Opus 判断、2026-05-01、§3.1 反映済)**: duplication thread ローカル `Arc<AtomicU64>` を採用、frame 単位採番 (1 frame で N rect が同 `frame_index` を共有)。理由: views-catalog §3.2 が `summary { count, total_area }` を frame 単位で aggregate する仕様で、`frame_index` は「同 frame の rect を束ねるキー」として必須、event_id (event 単位、ring 全体共通) では役割が違うため代替不可 |
 
 ---

--- a/src/duplication/thread.rs
+++ b/src/duplication/thread.rs
@@ -174,7 +174,22 @@ fn run_loop(
                         access_lost_count = 0;
                         Ok(rects)
                     }
-                    other => other,
+                    other => {
+                        // Codex P2-Codex-1: a non-AccessLost error
+                        // (e.g. `DuplicationError::Other(_)` from a
+                        // transient device/driver hiccup) breaks the
+                        // "consecutive AccessLost" chain just as much
+                        // as a successful frame does. If we left the
+                        // counter alone, an `Err(Other)` between two
+                        // AccessLost runs could trip the threshold on
+                        // the second AccessLost even though the failures
+                        // weren't consecutive — false Failure events,
+                        // contract violation. Reset on every
+                        // non-AccessLost outcome so the counter only
+                        // tracks unbroken AccessLost streaks.
+                        access_lost_count = 0;
+                        other
+                    }
                 };
                 let _ = reply.send(result);
             }
@@ -397,6 +412,13 @@ mod tests {
                 // returns errors (TIMEOUT, ACCESS_LOST). Don't fail
                 // the test on these; just skip.
                 eprintln!("skipping enable-half: DXGI Next returned Err");
+                // Codex P2-Codex-2: `DuplicationHandle` has no `Drop`
+                // cleanup, so an early return without sending `Stop`
+                // leaves the duplication thread alive for the rest of
+                // the test process — subsequent DXGI tests can hit
+                // resource contention. Send Stop here so the thread
+                // tears down before we exit.
+                let _ = handle.tx.send(DuplicationCmd::Stop);
                 return;
             }
         };

--- a/src/duplication/thread.rs
+++ b/src/duplication/thread.rs
@@ -136,6 +136,12 @@ fn run_loop(
     enable_l1_emit: Arc<AtomicBool>,
     frame_index: Arc<AtomicU64>,
 ) {
+    // `output_index` is also the monitor identifier the emit fork
+    // stamps onto each `DirtyRectPayload`. The same value already
+    // drives `create_context` above; reusing it here keeps the
+    // `spawn(output_index)` argument the single source of truth for
+    // which monitor a payload describes (Codex P1-Codex-3, 2026-05-01).
+    let monitor_index = output_index;
     // P5c-2: AccessLost spam suppression. Push exactly one Failure event
     // when DXGI's access-lost cycle exceeds 5 consecutive failures, then
     // stay quiet until a successful frame resets the counter. Mirrors the
@@ -153,6 +159,7 @@ fn run_loop(
                     &ring,
                     &enable_l1_emit,
                     &frame_index,
+                    monitor_index,
                 );
                 // On ACCESS_LOST, attempt to re-create the context on this thread.
                 let result = match result {
@@ -224,6 +231,7 @@ fn acquire_dirty_rects(
     ring: &Arc<EventRing>,
     enable_l1_emit: &Arc<AtomicBool>,
     frame_index: &Arc<AtomicU64>,
+    monitor_index: u32,
 ) -> Result<Vec<DirtyRect>, DuplicationError> {
     unsafe {
         let mut frame_info = DXGI_OUTDUPL_FRAME_INFO::default();
@@ -277,15 +285,21 @@ fn acquire_dirty_rects(
         // P5c-2: emit fork. One `EventKind::DirtyRect` envelope per rect,
         // all sharing the same `frame_index` so the D2-C
         // `dirty_rects_aggregate` view can group them per frame
-        // (views-catalog §3.2 `summary { count, total_area }`). `monitor_index`
-        // is hard-coded to 0 — secondary monitors stay carry-over per
-        // sub-plan §10 OQ #3.
+        // (views-catalog §3.2 `summary { count, total_area }`).
+        // `monitor_index` is propagated from the `spawn(output_index)`
+        // argument so secondary-monitor subscriptions
+        // (`DirtyRectSubscription::new(Some(1))` and friends) stamp
+        // their payloads with their actual output index, not the hard-
+        // coded primary (Codex P1-Codex-3, 2026-05-01). Per-output
+        // *features* (per-monitor parallel threads, dedicated views)
+        // remain carry-over per sub-plan §10 OQ #3 — just the labelling
+        // is fixed here.
         if enable_l1_emit.load(Ordering::Relaxed) && !dirty_rects.is_empty() {
             let frame_idx = frame_index.fetch_add(1, Ordering::Relaxed);
             for r in &dirty_rects {
                 let payload = DirtyRectPayload {
                     rect: [r.x, r.y, r.width, r.height],
-                    monitor_index: 0,
+                    monitor_index,
                     frame_index: frame_idx,
                 };
                 let event = build_event(

--- a/src/duplication/thread.rs
+++ b/src/duplication/thread.rs
@@ -1,4 +1,6 @@
 use crossbeam_channel::{bounded, Receiver, Sender};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
 use std::{mem, slice, thread};
 
 use windows::Win32::{
@@ -11,6 +13,16 @@ use windows::Win32::{
 use super::device::{create_context, DuplicationContext};
 use super::types::{DirtyRect, DuplicationError, OutputBounds};
 
+// P5c-2: L1 ring emit. `build_event` / `make_failure_event` /
+// `encode_payload` / `EventKind` / `DirtyRectPayload` are crate-private
+// helpers; `EventRing` is `pub` re-exported. The narrow `Arc<EventRing>`
+// borrow keeps L1Inner privacy clean (P5c-1 same shape, see
+// `src/uia/event_handlers/focus.rs:41-44`).
+use crate::l1_capture::{
+    build_event, encode_payload, ensure_l1, make_failure_event, DirtyRectPayload, EventKind,
+    EventRing,
+};
+
 pub enum DuplicationCmd {
     Next {
         timeout_ms: u32,
@@ -22,12 +34,44 @@ pub enum DuplicationCmd {
 pub struct DuplicationHandle {
     pub tx: Sender<DuplicationCmd>,
     pub bounds: OutputBounds,
+    /// Toggles the L1 ring emit fork in [`acquire_dirty_rects`]. Default is
+    /// `true`; tests and graceful-disable paths flip it via
+    /// [`DuplicationHandle::set_l1_emit_enabled`]. Storing the `Arc` on the
+    /// handle (with another clone living on the duplication thread) keeps
+    /// the toggle reachable from the napi side without exposing the field
+    /// through `DirtyRectSubscription` (P5c-2 sub-plan §3.1: napi expose
+    /// は変えない、internal API).
+    pub enable_l1_emit: Arc<AtomicBool>,
+}
+
+impl DuplicationHandle {
+    /// Internal-only toggle for the L1 ring emit fork. Used by Rust
+    /// integration tests and by graceful-disable paths to mute emit
+    /// without tearing the duplication thread down. Not exposed through
+    /// the napi `DirtyRectSubscription` surface.
+    #[allow(dead_code)] // wired up by tests + future graceful-disable callers
+    pub fn set_l1_emit_enabled(&self, enabled: bool) {
+        self.enable_l1_emit.store(enabled, Ordering::Relaxed);
+    }
 }
 
 pub fn spawn(output_index: u32) -> Result<DuplicationHandle, DuplicationError> {
     // Bootstrap channel to propagate init success/failure back to the caller.
     let (boot_tx, boot_rx) = bounded::<Result<OutputBounds, DuplicationError>>(1);
     let (cmd_tx, cmd_rx) = bounded::<DuplicationCmd>(32);
+
+    // P5c-2: L1 ring emit setup. The ring is shared with every other
+    // emitter (P5c-1 focus / future P5c-3/4) via the global L1 slot.
+    // `enable_l1_emit` and `frame_index` are owned by this duplication
+    // thread; `enable_l1_emit` also lives on the returned `DuplicationHandle`
+    // so callers can flip it without touching the thread directly.
+    let ring = ensure_l1().ring.clone();
+    let enable_l1_emit = Arc::new(AtomicBool::new(true));
+    let frame_index = Arc::new(AtomicU64::new(0));
+
+    let ring_for_thread = Arc::clone(&ring);
+    let enable_l1_emit_for_thread = Arc::clone(&enable_l1_emit);
+    let frame_index_for_thread = Arc::clone(&frame_index);
 
     thread::Builder::new()
         .name(format!("desktop-dup-{output_index}"))
@@ -44,12 +88,32 @@ pub fn spawn(output_index: u32) -> Result<DuplicationHandle, DuplicationError> {
                     c
                 }
                 Err(e) => {
+                    // P5c-2: graceful disable on DXGI unavailable. Push exactly
+                    // one Failure event before the thread exits — the boot
+                    // channel signals the caller, but the L1 ring is the
+                    // observability surface for the perception pipeline.
+                    let reason = format!("{:?}", e);
+                    let event = make_failure_event(
+                        "duplication",
+                        "create_context",
+                        &reason,
+                        None,
+                    );
+                    ring_for_thread.push(event);
+
                     let _ = boot_tx.send(Err(e));
                     return;
                 }
             };
 
-            run_loop(&mut ctx, cmd_rx, output_index);
+            run_loop(
+                &mut ctx,
+                cmd_rx,
+                output_index,
+                ring_for_thread,
+                enable_l1_emit_for_thread,
+                frame_index_for_thread,
+            );
         })
         .map_err(|e| DuplicationError::InitFailed(format!("thread spawn: {e}")))?;
 
@@ -57,18 +121,46 @@ pub fn spawn(output_index: u32) -> Result<DuplicationHandle, DuplicationError> {
         .recv()
         .map_err(|e| DuplicationError::InitFailed(format!("boot recv: {e}")))??;
 
-    Ok(DuplicationHandle { tx: cmd_tx, bounds })
+    Ok(DuplicationHandle {
+        tx: cmd_tx,
+        bounds,
+        enable_l1_emit,
+    })
 }
 
-fn run_loop(ctx: &mut DuplicationContext, rx: Receiver<DuplicationCmd>, output_index: u32) {
+fn run_loop(
+    ctx: &mut DuplicationContext,
+    rx: Receiver<DuplicationCmd>,
+    output_index: u32,
+    ring: Arc<EventRing>,
+    enable_l1_emit: Arc<AtomicBool>,
+    frame_index: Arc<AtomicU64>,
+) {
+    // P5c-2: AccessLost spam suppression. Push exactly one Failure event
+    // when DXGI's access-lost cycle exceeds 5 consecutive failures, then
+    // stay quiet until a successful frame resets the counter. Mirrors the
+    // P5c-1 focus handler's "log once, recover quietly" pattern (sub-plan
+    // §3.2 / R4).
+    let mut access_lost_count: u32 = 0;
+
     while let Ok(cmd) = rx.recv() {
         match cmd {
             DuplicationCmd::Stop => break,
             DuplicationCmd::Next { timeout_ms, reply } => {
-                let result = acquire_dirty_rects(ctx, timeout_ms);
+                let result = acquire_dirty_rects(
+                    ctx,
+                    timeout_ms,
+                    &ring,
+                    &enable_l1_emit,
+                    &frame_index,
+                );
                 // On ACCESS_LOST, attempt to re-create the context on this thread.
                 let result = match result {
                     Err(DuplicationError::AccessLost) => {
+                        // Spam suppression lives in a pure helper so the unit
+                        // test in `mod tests` can hit the 5th-call threshold
+                        // without spinning up a real DXGI duplication context.
+                        record_access_lost(&mut access_lost_count, &ring);
                         match create_context(output_index) {
                             Ok(new_ctx) => {
                                 *ctx = new_ctx;
@@ -78,6 +170,10 @@ fn run_loop(ctx: &mut DuplicationContext, rx: Receiver<DuplicationCmd>, output_i
                             Err(e) => Err(e),
                         }
                     }
+                    Ok(rects) => {
+                        access_lost_count = 0;
+                        Ok(rects)
+                    }
                     other => other,
                 };
                 let _ = reply.send(result);
@@ -86,9 +182,33 @@ fn run_loop(ctx: &mut DuplicationContext, rx: Receiver<DuplicationCmd>, output_i
     }
 }
 
+/// Increment the AccessLost counter and push exactly one Failure event
+/// to the L1 ring on the 5th consecutive AccessLost. Subsequent calls
+/// (counter > 5) advance the counter but stay quiet — the caller is
+/// expected to reset `*counter` to 0 on the next successful frame.
+///
+/// Pure helper so [`tests::access_lost_5th_call_pushes_exactly_one_failure`]
+/// can hit the threshold without constructing a `DuplicationContext`
+/// (which holds a DXGI interface and can't be mocked without hardware).
+fn record_access_lost(counter: &mut u32, ring: &Arc<EventRing>) {
+    *counter = counter.saturating_add(1);
+    if *counter == 5 {
+        let event = make_failure_event(
+            "duplication",
+            "AcquireNextFrame",
+            "AccessLost: 5 consecutive failures",
+            None,
+        );
+        ring.push(event);
+    }
+}
+
 fn acquire_dirty_rects(
     ctx: &DuplicationContext,
     timeout_ms: u32,
+    ring: &Arc<EventRing>,
+    enable_l1_emit: &Arc<AtomicBool>,
+    frame_index: &Arc<AtomicU64>,
 ) -> Result<Vec<DirtyRect>, DuplicationError> {
     unsafe {
         let mut frame_info = DXGI_OUTDUPL_FRAME_INFO::default();
@@ -139,6 +259,196 @@ fn acquire_dirty_rects(
         // ReleaseFrame must always be called after a successful AcquireNextFrame.
         let _ = ctx.duplication.ReleaseFrame();
 
+        // P5c-2: emit fork. One `EventKind::DirtyRect` envelope per rect,
+        // all sharing the same `frame_index` so the D2-C
+        // `dirty_rects_aggregate` view can group them per frame
+        // (views-catalog §3.2 `summary { count, total_area }`). `monitor_index`
+        // is hard-coded to 0 — secondary monitors stay carry-over per
+        // sub-plan §10 OQ #3.
+        if enable_l1_emit.load(Ordering::Relaxed) && !dirty_rects.is_empty() {
+            let frame_idx = frame_index.fetch_add(1, Ordering::Relaxed);
+            for r in &dirty_rects {
+                let payload = DirtyRectPayload {
+                    rect: [r.x, r.y, r.width, r.height],
+                    monitor_index: 0,
+                    frame_index: frame_idx,
+                };
+                let event = build_event(
+                    EventKind::DirtyRect as u16,
+                    encode_payload(&payload),
+                    None,
+                    None,
+                );
+                ring.push(event);
+            }
+        }
+
         Ok(dirty_rects)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::l1_capture::EventRing;
+    use std::time::{Duration, Instant};
+
+    /// Test 3 (sub-plan §3.3) — AccessLost spam suppression.
+    ///
+    /// `record_access_lost` is the pure helper extracted from `run_loop`'s
+    /// AccessLost branch. We can't construct a real `DuplicationContext`
+    /// without DXGI hardware, so the spam-suppression invariant
+    /// (exactly 1 Failure event per 5 consecutive AccessLost calls) is
+    /// pinned at the helper level instead. The integration in `run_loop`
+    /// is a single line call site, so the helper test fully covers the
+    /// behaviour the sub-plan §3.2 requires.
+    #[test]
+    fn access_lost_5th_call_pushes_exactly_one_failure() {
+        let ring = Arc::new(EventRing::new(1024));
+        let mut counter = 0u32;
+
+        // Calls 1..=4: counter increments, no push.
+        for _ in 0..4 {
+            record_access_lost(&mut counter, &ring);
+        }
+        assert_eq!(counter, 4);
+        let after_4 = ring.poll(0, 16);
+        assert_eq!(
+            after_4.len(),
+            0,
+            "no Failure event expected before the 5th call"
+        );
+
+        // Call 5: counter == 5 → exactly one Failure event.
+        record_access_lost(&mut counter, &ring);
+        assert_eq!(counter, 5);
+        let after_5 = ring.poll(0, 16);
+        assert_eq!(after_5.len(), 1);
+        assert_eq!(after_5[0].kind, EventKind::Failure as u16);
+
+        // Calls 6..=10: counter keeps incrementing but the helper stays
+        // quiet — the caller is the one that resets the counter on a
+        // successful frame.
+        for _ in 0..5 {
+            record_access_lost(&mut counter, &ring);
+        }
+        assert_eq!(counter, 10);
+        let after_10 = ring.poll(0, 16);
+        assert_eq!(
+            after_10.len(),
+            0,
+            "drained to 0 by the after_5 poll, no further pushes expected"
+        );
+    }
+
+    /// Test 1+2 (sub-plan §3.3) — emit fork enable / disable round-trip
+    /// against real DXGI hardware. Skipped (returns early) on hosts where
+    /// `spawn(0)` fails (RDP, headless CI, no GPU output, …) so the suite
+    /// still passes off-host.
+    ///
+    /// Subscribes to the L1 ring **before** calling `Next` so we observe
+    /// only the events emitted by this duplication thread. Other parallel
+    /// tests pushing to the same global ring are filtered out via the
+    /// `EventKind::DirtyRect` kind check; we never assert on absolute
+    /// counts of unrelated event kinds.
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn dxgi_emit_fork_enable_disable_roundtrip() {
+        // 1) Try to spawn — skip the test entirely if DXGI is unavailable.
+        let handle = match spawn(0) {
+            Ok(h) => h,
+            Err(_) => {
+                eprintln!(
+                    "skipping dxgi_emit_fork_enable_disable_roundtrip: \
+                     no DXGI output available (likely RDP / headless / no GPU)"
+                );
+                return;
+            }
+        };
+
+        // 2) Subscribe to the global ring so we see events without
+        //    competing with any other consumer that polls.
+        let ring = ensure_l1().ring.clone();
+        let sub = ring.subscribe(4096);
+
+        // 3) Drain any pre-existing snapshots (other tests, P5c-1
+        //    focus events from session start, etc.).
+        while sub.try_recv().is_ok() {}
+
+        // ── Emit ON (default) ────────────────────────────────────────
+        // Issue a Next cmd, capture its rect-count reply, and count the
+        // DirtyRect events that landed in our subscription within a
+        // short drain window. The two should match.
+        let (reply_tx, reply_rx) = bounded(1);
+        handle
+            .tx
+            .send(DuplicationCmd::Next {
+                timeout_ms: 100,
+                reply: reply_tx,
+            })
+            .expect("send Next while DXGI thread is alive");
+        let returned = reply_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("DXGI thread reply within 2s");
+        let returned_count = match returned {
+            Ok(rects) => rects.len(),
+            Err(_) => {
+                // AcquireNextFrame on an idle desktop legitimately
+                // returns errors (TIMEOUT, ACCESS_LOST). Don't fail
+                // the test on these; just skip.
+                eprintln!("skipping enable-half: DXGI Next returned Err");
+                return;
+            }
+        };
+
+        // Drain the subscription for ~250ms — enough for the emit fork
+        // to have completed for this Next call.
+        let drain_until = Instant::now() + Duration::from_millis(250);
+        let mut emit_count_enabled = 0;
+        while Instant::now() < drain_until {
+            match sub.recv_timeout(Duration::from_millis(20)) {
+                Ok(env) if env.kind == EventKind::DirtyRect as u16 => emit_count_enabled += 1,
+                Ok(_) => {} // unrelated event from another emitter
+                Err(_) => break,
+            }
+        }
+        assert_eq!(
+            emit_count_enabled, returned_count,
+            "with emit enabled, every returned rect should produce one DirtyRect envelope"
+        );
+
+        // ── Emit OFF ─────────────────────────────────────────────────
+        handle.set_l1_emit_enabled(false);
+        let (reply_tx2, reply_rx2) = bounded(1);
+        handle
+            .tx
+            .send(DuplicationCmd::Next {
+                timeout_ms: 100,
+                reply: reply_tx2,
+            })
+            .expect("send second Next while DXGI thread is alive");
+        let _ = reply_rx2
+            .recv_timeout(Duration::from_secs(2))
+            .expect("DXGI thread reply within 2s");
+
+        // Drain again — there must be zero DirtyRect events even if the
+        // frame produced rects.
+        let drain_until2 = Instant::now() + Duration::from_millis(250);
+        let mut emit_count_disabled = 0;
+        while Instant::now() < drain_until2 {
+            match sub.recv_timeout(Duration::from_millis(20)) {
+                Ok(env) if env.kind == EventKind::DirtyRect as u16 => emit_count_disabled += 1,
+                Ok(_) => {}
+                Err(_) => break,
+            }
+        }
+        assert_eq!(
+            emit_count_disabled, 0,
+            "with emit disabled, no DirtyRect envelopes should land on the ring"
+        );
+
+        // Stop the duplication thread cleanly so the test process tears
+        // down without a lingering background loop.
+        let _ = handle.tx.send(DuplicationCmd::Stop);
     }
 }

--- a/src/l1_capture/payload.rs
+++ b/src/l1_capture/payload.rs
@@ -45,9 +45,9 @@ pub struct UiaFocusChangedPayload {
     pub window_title: String,
 }
 
-/// Payload for `EventKind::DirtyRect` (=0). Emitted by P5c-2.
+/// Payload for `EventKind::DirtyRect` (=0). Emitted by P5c-2 from
+/// `src/duplication/thread.rs::acquire_dirty_rects`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[allow(dead_code)] // P5c-2 emit
 pub struct DirtyRectPayload {
     /// `[x, y, w, h]`, virtual-screen pixels.
     pub rect: [i32; 4],

--- a/src/l1_capture/payload.rs
+++ b/src/l1_capture/payload.rs
@@ -52,7 +52,15 @@ pub struct DirtyRectPayload {
     /// `[x, y, w, h]`, virtual-screen pixels.
     pub rect: [i32; 4],
     pub monitor_index: u32,
-    /// DXGI frame counter.
+    /// Frame counter shared by all rects emitted from the same DXGI frame.
+    /// Incremented only when the emit fork runs (i.e. `enable_l1_emit`
+    /// is on **and** the frame produced at least one dirty rect), so
+    /// gaps are expected: disabled emit, empty frames, and frames whose
+    /// rects landed via the napi pull path while emit was off all skip
+    /// the counter. Use this strictly for grouping rects from the same
+    /// DXGI frame (D2-C `dirty_rects_aggregate` view's per-frame
+    /// `summary { count, total_area }` key) — not as a count of total
+    /// DXGI frames produced by the duplication thread.
     pub frame_index: u64,
 }
 


### PR DESCRIPTION
## Summary

ADR-008 D2-C0 §3.bis ledger L1 trigger PR。`docs/adr-007-p5c-2-plan.md` (PR #101 で merged) の sub-plan §3.1〜§3.3 を実装。

emit fork を既存 DXGI pull path 内 (`acquire_dirty_rects`) に追加、`DuplicationContext` 無改修 (R6 整合)。pure helper `record_access_lost` 抽出で AccessLost spam 抑制を testability 込みで実装。

## 実装内容

### `src/duplication/thread.rs` (+~310 line)
- **`run_loop` signature 拡張**: `ring: Arc<EventRing>` / `enable_l1_emit: Arc<AtomicBool>` / `frame_index: Arc<AtomicU64>` 3 引数追加 (sub-plan §3.1 / R6 整合)
- **`acquire_dirty_rects` emit fork**: `Vec<DirtyRect>` 構築完了後、enable + 非空なら `frame_index.fetch_add(1)` で frame 単位採番、各 rect を `EventKind::DirtyRect` envelope として `ring.push`
- **`DuplicationHandle::set_l1_emit_enabled(bool)`**: internal-only toggle API、`DirtyRectSubscription` napi expose は無改修
- **`spawn` で DXGI 利用不可時 1 度だけ Failure event push**: graceful disable 経路強化
- **`record_access_lost` pure helper**: 5 連続 AccessLost で 1 度のみ Failure event push、`run_loop` から呼出 (testability + 抽象化)

### `src/l1_capture/payload.rs` (-2 line)
- `DirtyRectPayload` の `#[allow(dead_code)] // P5c-2 emit` marker 削除 (P5c-2 emit が landing したため不要、強制命令 7「仕組みで対応」整合 — dead_code lint が「emit 漏れ」の compile-time signal として機能)

### `src/duplication/thread.rs` `#[cfg(test)] mod tests` (+~145 line)
2 件の test、両方 pass:

1. **`access_lost_5th_call_pushes_exactly_one_failure`** (no DXGI required):
   - Fresh `EventRing::new(1024)` に対し `record_access_lost` を 10 回呼出
   - 1〜4 回目: counter 増加、push なし
   - 5 回目: counter==5、Failure event 1 件 push (kind 検証)
   - 6〜10 回目: counter 増加、push なし

2. **`dxgi_emit_fork_enable_disable_roundtrip`** (real DXGI、`#[cfg(target_os = "windows")]`):
   - `spawn(0)` 失敗時 (RDP / headless CI / no GPU) は早期 return で skip
   - 成功時: subscribe → `Next` cmd → 戻り値 rect 数と subscription 受信 DirtyRect 数が一致を assert
   - `set_l1_emit_enabled(false)` 後の `Next` で DirtyRect 受信 0 を assert
   - 終了時 `Stop` cmd で thread 後片付け

## Push 6 ガード結果 (全 pass)

| ガード | 結果 |
|---|---|
| `cargo check --workspace` | ✅ clean (warnings 6 件、全て pre-existing) |
| `cargo test -p engine-perception` | ✅ 47 pass (37 lib + 10 integration) |
| `npm run check:napi-safe` | ✅ |
| `npm run check:native-types` | ✅ 46 exports |
| `npm run build` (tsc) | ✅ clean |
| `npm run check:stub-catalog` | ✅ (CRLF warning のみ、実 diff 0) |

## Local test 検証

```bash
cargo test -p desktop-touch-engine --no-default-features --lib duplication::thread::tests
# 2 passed; 0 failed
```

\`--no-default-features\` で vision-gpu を除外 — vision-gpu 配下の florence2/paddleocr に **pre-existing** な 4 test compile errors あり (`memory/feedback_cargo_test_integration.md` 記録)、本 PR scope 外。production build (\`cargo check --workspace\`) は default features で clean。

## sub-plan §7 acceptance 達成度

### 親 plan §11.4
- [x] 画面変化で \`EventKind::DirtyRect\` event が ring push (test 2 で実 DXGI 経由検証)
- [x] 既存 napi polling と並行動作可 (TS pull 経路無干渉、reply は従来通り)
- [x] DXGI 利用不可環境で graceful disable (\`create_context\` Err 経路で Failure event 1 度のみ + thread 終了)

### sub-plan §7.2 追加 acceptance
- [x] \`enable_l1_emit = false\` で emit 停止 (test 2 disable 後)
- [x] AccessLost 5 連続で Failure event 1 件のみ (test 1)
- [x] \`#[allow(dead_code)] // P5c-2 emit\` marker 削除、cargo check で dead_code warning 0
- [x] cargo test --workspace 全 pass (no-default-features 限定、vision-gpu pre-existing 既知)
- [x] \`npm run check:napi-safe\` / \`check:native-types\` / \`check:stub-catalog\` 全 pass
- [ ] **Opus phase-boundary review** (強制命令 3): 本 PR review で実施

## Open Questions (sub-plan §10、carry-over)

- **OQ #1** (option B pivot 是非): merge 後 D2-C view bench 結果を待つ
- **OQ #3** (secondary monitor): primary only 維持、別 phase
- **OQ #2 / #4**: Resolved (本 PR で確定実装)

## 次 step (post-merge)

1. ADR-008 D2 plan §3.bis ledger L1 verification 列を「**Resolved (PR #本 PR)**」に更新 (D2-G phase または本 PR merge 後の次 PR)
2. **PR-ε (D2-C \`dirty_rects_aggregate\` view)** 着手 (Opus 判断「prerequisite 先行案」に従う)
3. 並行で **D2-D plan** (\`semantic_event_stream\` skeleton + FocusMoved seed) 起草

🤖 Generated with [Claude Code](https://claude.com/claude-code)