### PR TITLE
docs(walking-skeleton): G1 gate decision — 継続 (S2 着手 GO)

### DIFF
--- a/docs/walking-skeleton-trunk-selection.md
+++ b/docs/walking-skeleton-trunk-selection.md
@@ -472,7 +472,7 @@ expansion フェーズ:
 
 | Gate | date | decision | rationale | scope shrink 内容 |
 |---|---|---|---|---|
-| G1 | (S1 PR merge 時に追記) | (継続 / shrink) | (...) | (S2 の dirty rect view を count-only にさらに絞る等) |
+| G1 | 2026-05-01 (PR #105 `4f912c3` merged) | **継続** | `build_*(focus_stream) -> (Arranged, View)` signature 統一が DD 0.23 actual API で成立 (impl PR #105 で実証、cargo check + 37 unit + 19 integration test 全 pass、bench regression 0)。`Arranged<'scope, ...>` の closure 外持ち出し試行は型 system で static error (Codex v2 P2-9 確認)。`spawn_perception_worker` 戻り値 4-tuple 不変 + 既存 production-pipeline lifecycle 経路 8 test 無修正で pass = 既存 caller 破壊 0。S2 `build_dirty_rects_aggregate` が同 template を mechanical コピー可能 (sub-plan §3.3 と shape integral)。Opus round 1 P1×2 + P2×4 + P3×3 → Round 2 全反映、Codex round 1 clean。Round 2 Opus re-review pending (本 G1 判定 commit 時点)、code shape 不変なので新規 P1 確率低 | (なし、S2 (D2-C) 着手は trunk 計画通り 200-300 line / 3-4 日見積、shrink 不要) |
 | G2 | (S2 PR merge 時に追記) | (継続 / shrink) | (...) | (S3-S5 の envelope / caused_by を最小 field に削る等) |
 | G3 | (S4 PR merge 時に追記) | (継続 / shrink) | (...) | (S5 を in-memory buffer + 直近 1 件のみに固定する等) |
 


### PR DESCRIPTION
## Summary

ADR-008 D2-E0 walking skeleton S1 impl PR #105 (`4f912c3`) merged 2026-05-01。`docs/adr-008-d2-e0-plan.md` §3.6 D2-E0-6 + sub-plan §1.1 G acceptance に従い、`docs/walking-skeleton-trunk-selection.md` Appendix C 末尾に G1 判定結果を append (永続化、CLAUDE.md §9)。

## G1 判定: 継続 (scope shrink なし)

`docs/walking-skeleton-trunk-selection.md` §4 S1 完了基準 (line 184-188) 全項目 pass:

1. ✅ 既存 D1/D2-A/D2-B integration test 全 pass (37 unit + 19 integration)
2. ✅ 新 scope で `current_focused_element` 回帰なし
3. ✅ Gate G1: D2-E0 refactor 後、複数 view を S2 で同 scope に置ける形
   - `build_*(focus_stream) -> (Arranged, View)` signature が DD 0.23 actual API で成立 (PR #105 で実証)
   - `Arranged<'scope, ...>` の closure 外持ち出し試行は型 system で static error (Codex v2 P2-9 確認)
   - S2 `build_dirty_rects_aggregate` が同 template を mechanical コピー可能 (D2-C sub-plan §3.3 と shape integral)

## 後続: S2 (PR-ε D2-C count-only `dirty_rects_aggregate` impl)

- `crates/engine-perception/src/views/dirty_rects_aggregate.rs` 新設 (count-only view + minimal getter)
- `src/l3_bridge/dirty_rect_pump.rs` 新設 (focus_pump.rs 同型、PR #102 DXGI dirty rect emit を input 化)
- `spawn_perception_worker` closure 内 `let _ = cfe_arranged;` 削除 → S2 entrypoint marker comment 通りに `dirty_rects_aggregate::build_*` 呼出に置き換え (PR #105 input.rs に詳細手順 comment 記載済)
- napi `view_get_dirty_rects(monitor_index)` 新設、`monitor_index` field を payload から落とさない (CLAUDE.md §3.2 PR #102 教訓)
- G2 contract test 4 件 (Rust 3 + Node smoke 1)、bench regression guard
- 200-300 line / 3-4 日見積 (D2-C sub-plan §4 + walking-skeleton §4.1)

## Test plan

- [x] G1 判定を Appendix C に永続化
- [x] sub-plan §3.6 acceptance 整合
- [x] User merge → S2 (PR-ε D2-C impl) 着手 GO

🤖 Generated with [Claude Code](https://claude.com/claude-code)