### PR TITLE
feat(adr-008 D2-C): walking skeleton S2 — count-only dirty_rects_aggregate impl

### DIFF
--- a/crates/engine-perception/src/input.rs
+++ b/crates/engine-perception/src/input.rs
@@ -86,6 +86,7 @@ use differential_dataflow::input::{Input, InputSession};
 
 use crate::time::LogicalTime;
 use crate::views::current_focused_element::{self, CurrentFocusedElementView};
+use crate::views::dirty_rects_aggregate::{self, DirtyRectsAggregateView};
 use crate::views::latest_focus::{self, LatestFocusView};
 
 /// Default per-worker command-channel capacity. Sized for UIA focus
@@ -165,6 +166,75 @@ impl FocusEvent {
     }
 }
 
+/// A single dirty rectangle from a DXGI frame (S2 D2-C input shape).
+///
+/// `[x, y, width, height]` in virtual-screen pixels — same coordinate
+/// space as `DirtyRectPayload.rect: [i32; 4]` (`src/l1_capture/payload.rs:53`).
+/// The S2 trunk view (`dirty_rects_aggregate`) only counts rects per
+/// frame and does NOT aggregate the geometry; the struct is preserved
+/// so expansion-phase work can compute area / union without an input
+/// shape change.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Rect {
+    pub x: i32,
+    pub y: i32,
+    pub width: i32,
+    pub height: i32,
+}
+
+impl Rect {
+    /// Build a `Rect` from the L1 `DirtyRectPayload.rect: [i32; 4]`
+    /// shape (`[x, y, w, h]`). Used by the bridge's `dirty_rect_pump`
+    /// after bincode-decoding the payload.
+    pub fn from_array(arr: [i32; 4]) -> Self {
+        Self {
+            x: arr[0],
+            y: arr[1],
+            width: arr[2],
+            height: arr[3],
+        }
+    }
+}
+
+/// A dirty-rect event received from the root-side bridge after
+/// decoding an L1 `DirtyRectPayload` (S2 D2-C, `docs/adr-008-d2-c-plan.md`
+/// §2.1).
+///
+/// **`source_event_id` is the L1 ring's `event_id`** (北極星 N1) and
+/// must never be dropped on the L1→L3 path, same invariant as
+/// `FocusEvent.source_event_id`.
+///
+/// `wallclock_ms` / `sub_ordinal` are **event-time as data** (北極星 N2);
+/// the worker's frontier advances on a watermark derived from the
+/// largest seen wallclock minus a shift, identical to `FocusEvent`.
+///
+/// `monitor_index` is preserved through the entire path (CLAUDE.md §3.2,
+/// PR #102 教訓): the per-output `DuplicationHandle::spawn(output_index)`
+/// emit fork stamps the index, and the S2 view keys `(monitor_index,
+/// frame_index) -> count` to avoid the same-frame-index collision across
+/// monitors.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct DirtyRectEvent {
+    /// L1 `event_id` of the originating push (北極星 N1).
+    pub source_event_id: u64,
+    pub wallclock_ms: u64,
+    pub sub_ordinal: u32,
+    pub timestamp_source: u8,
+    pub monitor_index: u32,
+    pub frame_index: u64,
+    /// Trunk: kept for future expansion of the view; not aggregated yet
+    /// (count-only contract spike). Expansion phase will use this for
+    /// `Vec<Rect>` aggregation + union / total_area summary.
+    pub rect: Rect,
+}
+
+impl DirtyRectEvent {
+    /// Convenience: build the dataflow logical time for this event.
+    pub fn logical_time(&self) -> LogicalTime {
+        LogicalTime::new(self.wallclock_ms, self.sub_ordinal)
+    }
+}
+
 /// The seam through which the root-side bridge pushes decoded L1
 /// events into this crate.
 ///
@@ -178,15 +248,29 @@ pub trait L1Sink: Send + Sync {
     /// Push a focus-changed event.
     fn push_focus(&self, event: FocusEvent);
 
-    // P5c-2 / P5c-3 / P5c-4 will extend this trait with
-    // `push_dirty_rect`, `push_window_change`, `push_scroll`. They
-    // are deliberately omitted in P5c-0b/D1-2 to keep the contract
-    // small until the corresponding L1 emitters exist.
+    /// Push a dirty-rect event (S2 D2-C count-only contract spike,
+    /// `docs/adr-008-d2-c-plan.md` §3.2).
+    ///
+    /// Default impl is a no-op so existing test-only L1Sink
+    /// implementations (`CaptureSink`, `TeeSink`) keep compiling
+    /// without churn — only production wiring (`FocusInputHandle`) and
+    /// dedicated dirty-rect tests need to override.
+    fn push_dirty_rect(&self, _event: DirtyRectEvent) {}
+
+    // P5c-3 / P5c-4 will extend this trait with `push_window_change`,
+    // `push_scroll`. They remain omitted until the corresponding L1
+    // emitters exist (§3.bis ledger L2/L3/L4 carry-over).
 }
 
 /// Internal command sent from `FocusInputHandle` to the worker.
 enum Cmd {
     PushFocus(FocusEvent),
+    /// S2 D2-C: dirty rect event from `dirty_rect_pump`. Variant
+    /// preserves the same Cmd channel so worker_loop's batch drain +
+    /// max-time release tuning (D2-A v3.8) covers both event types
+    /// without per-source channels (`docs/adr-008-d2-c-plan.md` §2.6
+    /// "single-worker / multi-cmd" model).
+    PushDirtyRect(DirtyRectEvent),
     Shutdown,
     /// Test-only: block the worker thread for the given duration
     /// before processing the next cmd. Used by the production
@@ -219,6 +303,15 @@ impl L1Sink for FocusInputHandle {
         //   means this should never happen in practice; if it did,
         //   blocking is correct (we'd lose ordering otherwise).
         let _ = self.tx.send(Cmd::PushFocus(event));
+    }
+
+    fn push_dirty_rect(&self, event: DirtyRectEvent) {
+        // S2 D2-C: same channel as PushFocus, same failure modes.
+        // Worker_loop drains the unified `Cmd` queue with the D2-A
+        // batch-drain + watermark-shift release tuning so dirty-rect
+        // events get the same partial-order / latency treatment as
+        // focus events.
+        let _ = self.tx.send(Cmd::PushDirtyRect(event));
     }
 }
 
@@ -501,6 +594,7 @@ pub fn spawn_perception_worker() -> (
     FocusInputHandle,
     CurrentFocusedElementView,
     LatestFocusView,
+    DirtyRectsAggregateView,
 ) {
     let (tx, rx) = bounded::<Cmd>(CMD_CHANNEL_CAPACITY);
     let processed_count = Arc::new(AtomicU64::new(0));
@@ -539,7 +633,11 @@ pub fn spawn_perception_worker() -> (
     // and the parent observes the published view handles via `recv`
     // once it gets there — a cleaner two-phase initialisation where
     // worker dataflow setup is independent of parent recv ordering.
-    let (view_tx, view_rx) = bounded::<(CurrentFocusedElementView, LatestFocusView)>(1);
+    let (view_tx, view_rx) = bounded::<(
+        CurrentFocusedElementView,
+        LatestFocusView,
+        DirtyRectsAggregateView,
+    )>(1);
 
     let join = thread::Builder::new()
         .name("l3-perception".into())
@@ -548,7 +646,7 @@ pub fn spawn_perception_worker() -> (
         })
         .expect("spawn l3-perception thread");
 
-    let (view, latest_view) = view_rx
+    let (view, latest_view, dirty_rects_view) = view_rx
         .recv()
         .expect("perception worker must publish view handles before processing cmds");
 
@@ -558,7 +656,7 @@ pub fn spawn_perception_worker() -> (
         processed_count,
     };
     let handle = FocusInputHandle { tx };
-    (worker, handle, view, latest_view)
+    (worker, handle, view, latest_view, dirty_rects_view)
 }
 
 /// Body of the timely worker thread (D2-A revised tuning).
@@ -630,7 +728,11 @@ pub fn spawn_perception_worker() -> (
 fn worker_loop(
     rx: Receiver<Cmd>,
     processed: Arc<AtomicU64>,
-    view_tx: crossbeam_channel::Sender<(CurrentFocusedElementView, LatestFocusView)>,
+    view_tx: crossbeam_channel::Sender<(
+        CurrentFocusedElementView,
+        LatestFocusView,
+        DirtyRectsAggregateView,
+    )>,
 ) {
     let shift_ms = watermark_shift_ms();
     let idle_timeout = Duration::from_millis(idle_recv_timeout_ms());
@@ -643,56 +745,47 @@ fn worker_loop(
     use timely::order::PartialOrder;
 
     timely::execute_directly(move |worker| {
-        // D2-E0: views are constructed inside the `worker.dataflow`
-        // closure by `build_*` and shipped out via `view_tx` to the
-        // parent thread. The `Arranged<'scope, ...>` returned by
-        // `build_current_focused_element` is `_`-dropped inside the
-        // closure — its `'scope` lifetime is bound to the dataflow
-        // and cannot escape (Codex v2 P2-9 / sub-plan §2.5).
-        // S2 (D2-C) and D2-E will consume the arranged inside the
-        // **same** closure for `dirty_rects_aggregate` /
-        // `predicted_post_state` subgraphs.
-        let mut input: InputSession<LogicalTime, FocusEvent, isize> =
-            worker.dataflow::<LogicalTime, _, _>(|scope| {
-                let (input, stream) = scope.new_collection::<FocusEvent, isize>();
-                // Both views borrow the same input stream — DD's
-                // `Collection` is `Clone`, and each `build_*`
-                // function clones internally to fan out its own
-                // operator path off the source (D2-B §5.bis: shared
-                // input, fanned-out reduces).
-                let (cfe_arranged, cfe_view) =
-                    current_focused_element::build_current_focused_element(&stream);
-                let latest_view = latest_focus::build_latest_focus(&stream);
-                // `cfe_arranged` is held inside the closure for S2
-                // (`dirty_rects_aggregate`) and D2-E
-                // (`predicted_post_state`) consumers; this S1 land
-                // has no consumer yet, so we silence the unused
-                // binding warning. Storing it in an outside struct
-                // is statically rejected by timely's lifetime model.
-                //
-                // **S2 entrypoint marker** — when D2-C impl PR adds
-                // `dirty_rects_aggregate`, this `let _ =` line is the
-                // exact site to remove and replace with the
-                // arrangement-borrowing call (S1 unified signature
-                // pattern: `build_*(focus_stream)` takes no `scope`
-                // argument because `VecCollection<'scope, ...>` carries
-                // the scope lifetime):
-                //   let (_dirty_arranged, dirty_view) =
-                //       dirty_rects_aggregate::build_dirty_rects_aggregate(
-                //           &cfe_arranged, &dirty_rect_stream);
-                // (Or however D2-C's call site shape lands; the point
-                // is `cfe_arranged` flows from a dropped binding into
-                // a borrow into the next subgraph.)
-                let _ = cfe_arranged;
-                // Ship the view read handles to the parent thread.
-                // The parent's `view_rx.recv()` blocks until this
-                // send lands, so callers of `spawn_perception_worker`
-                // observe an initialised pipeline.
-                view_tx
-                    .send((cfe_view, latest_view))
-                    .expect("parent must hold view_rx until spawn returns");
-                input
-            });
+        // D2-E0 + S2 D2-C: views are constructed inside the
+        // `worker.dataflow` closure by `build_*` and shipped out via
+        // `view_tx` to the parent thread. The `Arranged<'scope, ...>`
+        // returned by `build_*` is `_`-dropped inside the closure —
+        // its `'scope` lifetime is bound to the dataflow and cannot
+        // escape (Codex v2 P2-9 / S1 sub-plan §2.5).
+        //
+        // Two `InputSession`s share this dataflow: one for
+        // `FocusEvent` (D1-3 + D2-B-1 views) and one for
+        // `DirtyRectEvent` (S2 D2-C view). They share the cmd loop
+        // outside the closure but feed independent collections.
+        let (mut input, mut dirty_input): (
+            InputSession<LogicalTime, FocusEvent, isize>,
+            InputSession<LogicalTime, DirtyRectEvent, isize>,
+        ) = worker.dataflow::<LogicalTime, _, _>(|scope| {
+            let (input, focus_stream) = scope.new_collection::<FocusEvent, isize>();
+            let (dirty_input, dirty_rect_stream) =
+                scope.new_collection::<DirtyRectEvent, isize>();
+            // Focus views (D1-3 + D2-B-1) — share `focus_stream`.
+            let (cfe_arranged, cfe_view) =
+                current_focused_element::build_current_focused_element(&focus_stream);
+            let latest_view = latest_focus::build_latest_focus(&focus_stream);
+            // Dirty rect aggregate (S2 D2-C count-only) — feeds off
+            // `dirty_rect_stream`, S1 unified signature pattern
+            // mechanical copy.
+            let (dirty_arranged, dirty_view) =
+                dirty_rects_aggregate::build_dirty_rects_aggregate(&dirty_rect_stream);
+            // Both arrangeds drop at scope exit. D2-E
+            // `predicted_post_state` will consume `cfe_arranged` here
+            // when added.
+            let _ = cfe_arranged;
+            let _ = dirty_arranged;
+            // Ship the three view read handles to the parent thread.
+            // The parent's `view_rx.recv()` blocks until this send
+            // lands, so callers of `spawn_perception_worker` observe
+            // an initialised pipeline.
+            view_tx
+                .send((cfe_view, latest_view, dirty_view))
+                .expect("parent must hold view_rx until spawn returns");
+            (input, dirty_input)
+        });
 
         let mut latest_wallclock_ms: u64 = 0;
         let mut current_watermark: LogicalTime = LogicalTime::new(0, 0);
@@ -711,6 +804,11 @@ fn worker_loop(
                 Ok(cmd) => batch.push(cmd),
                 Err(crossbeam_channel::RecvTimeoutError::Timeout) => {
                     // Idle frontier advance (PR #91 P2 semantics).
+                    // S2 D2-C: advance BOTH input sessions in lockstep
+                    // so the focus and dirty-rect dataflows share one
+                    // monotone watermark — N3 partial-order contract
+                    // doesn't admit per-source frontiers without a
+                    // bigger redesign.
                     if let Some((anchor_wc, anchor_inst)) = last_event_anchor {
                         let elapsed = anchor_inst.elapsed().as_millis() as u64;
                         let projected = anchor_wc.saturating_add(elapsed);
@@ -721,8 +819,10 @@ fn worker_loop(
                                 && current_watermark != new_wm
                             {
                                 current_watermark = new_wm.clone();
-                                input.advance_to(new_wm);
+                                input.advance_to(new_wm.clone());
                                 input.flush();
+                                dirty_input.advance_to(new_wm);
+                                dirty_input.flush();
                             }
                         }
                     }
@@ -796,6 +896,35 @@ fn worker_loop(
                             Some(prev) => prev,
                         });
                     }
+                    Cmd::PushDirtyRect(ev) => {
+                        // S2 D2-C: same partial-order contract as
+                        // PushFocus — drop events whose `event_time`
+                        // is below the current watermark; otherwise
+                        // post to `dirty_input` and update the shared
+                        // wallclock anchor.
+                        let event_time = ev.logical_time();
+                        if !current_watermark.less_equal(&event_time) {
+                            eprintln!(
+                                "[perception-worker] out-of-order dirty rect dropped: \
+                                 event_time={:?} watermark={:?} source_event_id={}",
+                                event_time, current_watermark, ev.source_event_id
+                            );
+                            continue;
+                        }
+                        dirty_input.update_at(ev.clone(), event_time.clone(), 1);
+                        event_count += 1;
+
+                        if ev.wallclock_ms > latest_wallclock_ms {
+                            latest_wallclock_ms = ev.wallclock_ms;
+                            last_event_anchor = Some((ev.wallclock_ms, Instant::now()));
+                        }
+
+                        max_observed = Some(match max_observed {
+                            None => event_time,
+                            Some(prev) if prev.less_equal(&event_time) => event_time,
+                            Some(prev) => prev,
+                        });
+                    }
                     Cmd::Shutdown => {
                         shutdown_requested = true;
                     }
@@ -851,10 +980,15 @@ fn worker_loop(
                         && current_watermark != new_wm
                     {
                         current_watermark = new_wm.clone();
-                        input.advance_to(new_wm);
+                        // S2 D2-C: advance both input sessions in
+                        // lockstep so the shared watermark applies to
+                        // both focus and dirty-rect collections.
+                        input.advance_to(new_wm.clone());
+                        dirty_input.advance_to(new_wm);
                     }
                 }
                 input.flush();
+                dirty_input.flush();
                 processed.fetch_add(event_count, Ordering::Relaxed);
 
                 // Step until idle (capped) so the operator chain
@@ -901,7 +1035,7 @@ mod tests {
 
     #[test]
     fn spawn_and_shutdown_clean() {
-        let (worker, _handle, _view, _latest_view) = spawn_perception_worker();
+        let (worker, _handle, _view, _latest_view, _dirty_rects_view) = spawn_perception_worker();
         worker
             .shutdown(Duration::from_secs(2))
             .expect("shutdown clean");
@@ -909,7 +1043,7 @@ mod tests {
 
     #[test]
     fn push_focus_roundtrip_smoke() {
-        let (worker, handle, _view, _latest_view) = spawn_perception_worker();
+        let (worker, handle, _view, _latest_view, _dirty_rects_view) = spawn_perception_worker();
         for i in 0..3 {
             handle.push_focus(make_event(i, 1_000_000 + i, 0));
         }
@@ -924,7 +1058,7 @@ mod tests {
         // Cmd::PushFocus from the channel, not just acknowledges
         // shutdown. Without this assertion the lifecycle test
         // could regress silently if the worker_loop body is gutted.
-        let (worker, handle, _view, _latest_view) = spawn_perception_worker();
+        let (worker, handle, _view, _latest_view, _dirty_rects_view) = spawn_perception_worker();
         for i in 0..5 {
             handle.push_focus(make_event(i, 5_000_000 + i, 0));
         }
@@ -946,7 +1080,7 @@ mod tests {
     #[test]
     fn five_cycle_spawn_shutdown() {
         for cycle in 0..5 {
-            let (worker, handle, _view, _latest_view) = spawn_perception_worker();
+            let (worker, handle, _view, _latest_view, _dirty_rects_view) = spawn_perception_worker();
             handle.push_focus(make_event(cycle, 2_000_000 + cycle, 0));
             worker
                 .shutdown(Duration::from_secs(2))
@@ -956,7 +1090,7 @@ mod tests {
 
     #[test]
     fn push_after_shutdown_silently_drops() {
-        let (worker, handle, _view, _latest_view) = spawn_perception_worker();
+        let (worker, handle, _view, _latest_view, _dirty_rects_view) = spawn_perception_worker();
         worker.shutdown(Duration::from_secs(2)).expect("shutdown");
         // After worker is gone, the receiver is dropped and the
         // channel disconnects. push_focus must NOT panic.
@@ -967,7 +1101,7 @@ mod tests {
     fn l1sink_object_safety() {
         // Trait must be object-safe so the bridge can hold
         // `Arc<dyn L1Sink>` without naming the concrete type.
-        let (worker, handle, _view, _latest_view) = spawn_perception_worker();
+        let (worker, handle, _view, _latest_view, _dirty_rects_view) = spawn_perception_worker();
         let _h: Arc<dyn L1Sink> = Arc::new(handle);
         worker.shutdown(Duration::from_secs(2)).expect("shutdown");
     }
@@ -1000,7 +1134,7 @@ mod tests {
         //
         // We can't observe the dataflow output yet (D1-3), but we
         // can confirm the worker doesn't crash on a back-dated push.
-        let (worker, handle, _view, _latest_view) = spawn_perception_worker();
+        let (worker, handle, _view, _latest_view, _dirty_rects_view) = spawn_perception_worker();
         // First push sets latest_wallclock_ms = 1_000_000
         handle.push_focus(make_event(1, 1_000_000, 0));
         // Sleep so the worker definitely processed the first push
@@ -1028,7 +1162,7 @@ mod tests {
         // is independent of frontier), so this test only guards
         // against a regression that breaks the idle branch entirely
         // (e.g. an early `break` or a panic in the projection code).
-        let (worker, handle, _view, _latest_view) = spawn_perception_worker();
+        let (worker, handle, _view, _latest_view, _dirty_rects_view) = spawn_perception_worker();
         handle.push_focus(make_event(1, 1_700_000_000_000, 0));
         let deadline = Instant::now() + Duration::from_millis(500);
         while worker.processed_count() < 1 {
@@ -1054,7 +1188,7 @@ mod tests {
         // event_time = (T - 500ms, 0) when latest = T, shift = 100ms
         // → watermark = (T - 100ms, 0), and event_time < watermark
         // → dropped with log. Test verifies the worker survives.
-        let (worker, handle, _view, _latest_view) = spawn_perception_worker();
+        let (worker, handle, _view, _latest_view, _dirty_rects_view) = spawn_perception_worker();
         handle.push_focus(make_event(1, 2_000_000, 0));
         thread::sleep(Duration::from_millis(50));
         // 500ms back-dated — way outside the 100ms watermark default
@@ -1104,7 +1238,7 @@ mod tests {
         // max_sub_ord + 1)) does not drop the larger-sub_ord events
         // as back-dated.
         use crate::views::current_focused_element::CurrentFocusedElementView;
-        let (worker, handle, view, _latest_view) = spawn_perception_worker();
+        let (worker, handle, view, _latest_view, _dirty_rects_view) = spawn_perception_worker();
         let _: &CurrentFocusedElementView = &view; // type assertion
 
         // wallclock far enough from 0 that the watermark shift
@@ -1165,7 +1299,7 @@ mod tests {
         // wins regardless of arrival order. This is the partial-
         // order acceptance test (北極星 N3).
         use crate::views::current_focused_element::CurrentFocusedElementView;
-        let (worker, handle, view, _latest_view) = spawn_perception_worker();
+        let (worker, handle, view, _latest_view, _dirty_rects_view) = spawn_perception_worker();
         let _: &CurrentFocusedElementView = &view;
 
         let w = 1_700_000_500_000_u64;
@@ -1219,7 +1353,7 @@ mod tests {
         // frontier, then push an old event (wc = T1, T1 < T2 - 100ms
         // shift). The old event must be dropped (eprintln only),
         // and the worker must remain healthy.
-        let (worker, handle, _view, _latest_view) = spawn_perception_worker();
+        let (worker, handle, _view, _latest_view, _dirty_rects_view) = spawn_perception_worker();
 
         // T2 = 2_000_000, T1 = 2_000_000 - 500 (way past the 100ms
         // default shift, so the watermark guard rejects it).
@@ -1254,7 +1388,7 @@ mod tests {
         // the watermark; we observe this indirectly by verifying
         // the worker remains healthy and processed_count stays at 1
         // (no spurious additional processing).
-        let (worker, handle, _view, _latest_view) = spawn_perception_worker();
+        let (worker, handle, _view, _latest_view, _dirty_rects_view) = spawn_perception_worker();
 
         handle.push_focus(make_focus_event_at(1, 1_800_000_000_000, 0, 0xB002, "anchor"));
 
@@ -1289,7 +1423,7 @@ mod tests {
         // We can't observe the frontier directly from here, but
         // processed_count is a clean proxy: spawn-and-shutdown
         // without any PushFocus must leave processed_count = 0.
-        let (worker, _handle, _view, _latest_view) = spawn_perception_worker();
+        let (worker, _handle, _view, _latest_view, _dirty_rects_view) = spawn_perception_worker();
         // No pushes — straight to shutdown. The shutdown signal
         // arrives as a single Shutdown-only batch.
         let pre_shutdown_count = worker.processed_count();

--- a/crates/engine-perception/src/input.rs
+++ b/crates/engine-perception/src/input.rs
@@ -365,16 +365,47 @@ pub struct PerceptionWorker {
     /// `flush()`. Exposed as a test/D2-metrics observation hook so
     /// the L1 → focus_pump → handle → worker round-trip can be
     /// asserted end-to-end (Codex review on PR #90 P2).
-    processed_count: Arc<AtomicU64>,
+    ///
+    /// **Focus-only since S2 D2-C** (Codex round 1 P2-B): pre-S2
+    /// this counter incremented on every Cmd; in S2 with dirty rect
+    /// events flowing through the same worker, mixing the two would
+    /// contaminate `view_focused_pipeline_status.processedCount` —
+    /// dirty-rect traffic would make the focus telemetry rise even
+    /// when focus forwarding is unhealthy. Now `processed_focus_count`
+    /// counts only `Cmd::PushFocus`, and `processed_dirty_rect_count`
+    /// counts `Cmd::PushDirtyRect` separately.
+    processed_focus_count: Arc<AtomicU64>,
+    /// Total `Cmd::PushDirtyRect` commands processed (post-`flush()`).
+    /// Mirrors `processed_focus_count` for the S2 D2-C dirty-rect
+    /// pipeline (Codex round 1 P2-B).
+    processed_dirty_rect_count: Arc<AtomicU64>,
 }
 
 impl PerceptionWorker {
     /// Number of `Cmd::PushFocus` commands the worker has fully
     /// processed (post-`flush()`). Available on the live worker so
     /// callers can wait for the InputSession path to drain before
-    /// shutting down.
+    /// shutting down. **Focus-only since S2 D2-C** — see field doc on
+    /// `processed_focus_count`.
     pub fn processed_count(&self) -> u64 {
-        self.processed_count.load(Ordering::Relaxed)
+        self.processed_focus_count.load(Ordering::Relaxed)
+    }
+
+    /// Number of `Cmd::PushFocus` commands processed (post-`flush()`).
+    /// Same as `processed_count` for backward compatibility — kept
+    /// as a separate method so future call sites can opt into the
+    /// more explicit name.
+    pub fn processed_focus_count(&self) -> u64 {
+        self.processed_focus_count.load(Ordering::Relaxed)
+    }
+
+    /// Number of `Cmd::PushDirtyRect` commands processed (post-
+    /// `flush()`, S2 D2-C). Use this for dirty-rect pipeline
+    /// telemetry — do NOT add it to `processed_focus_count` because
+    /// that contaminates focus-pipeline health observation
+    /// (Codex round 1 P2-B).
+    pub fn processed_dirty_rect_count(&self) -> u64 {
+        self.processed_dirty_rect_count.load(Ordering::Relaxed)
     }
 
     /// Signal shutdown and poll the worker's `JoinHandle::is_finished()`
@@ -597,8 +628,10 @@ pub fn spawn_perception_worker() -> (
     DirtyRectsAggregateView,
 ) {
     let (tx, rx) = bounded::<Cmd>(CMD_CHANNEL_CAPACITY);
-    let processed_count = Arc::new(AtomicU64::new(0));
-    let processed_clone = Arc::clone(&processed_count);
+    let processed_focus_count = Arc::new(AtomicU64::new(0));
+    let processed_dirty_rect_count = Arc::new(AtomicU64::new(0));
+    let processed_focus_clone = Arc::clone(&processed_focus_count);
+    let processed_dirty_clone = Arc::clone(&processed_dirty_rect_count);
 
     // D2-E0 (`docs/adr-008-d2-e0-plan.md` §2.3, §3.3): views are
     // created inside the `worker.dataflow` closure by `build_*` and
@@ -642,7 +675,7 @@ pub fn spawn_perception_worker() -> (
     let join = thread::Builder::new()
         .name("l3-perception".into())
         .spawn(move || {
-            worker_loop(rx, processed_clone, view_tx)
+            worker_loop(rx, processed_focus_clone, processed_dirty_clone, view_tx)
         })
         .expect("spawn l3-perception thread");
 
@@ -653,7 +686,8 @@ pub fn spawn_perception_worker() -> (
     let worker = PerceptionWorker {
         join: Mutex::new(Some(join)),
         tx: tx.clone(),
-        processed_count,
+        processed_focus_count,
+        processed_dirty_rect_count,
     };
     let handle = FocusInputHandle { tx };
     (worker, handle, view, latest_view, dirty_rects_view)
@@ -727,7 +761,8 @@ pub fn spawn_perception_worker() -> (
 /// `recv_timeout` cycle instead of `try_recv` + `sleep`.
 fn worker_loop(
     rx: Receiver<Cmd>,
-    processed: Arc<AtomicU64>,
+    processed_focus: Arc<AtomicU64>,
+    processed_dirty_rect: Arc<AtomicU64>,
     view_tx: crossbeam_channel::Sender<(
         CurrentFocusedElementView,
         LatestFocusView,
@@ -846,8 +881,16 @@ fn worker_loop(
                 }
             }
 
-            // ─── Phase 3: apply each PushFocus, track max time ──
+            // ─── Phase 3: apply each PushFocus / PushDirtyRect, track max time ──
+            // S2 D2-C: separate per-cmd counters so the focus
+            // pipeline telemetry stays isolated from dirty-rect
+            // traffic (Codex round 1 P2-B). `event_count` (sum) gates
+            // the frontier advance + watermark release; the per-cmd
+            // counters drive `processed_focus_count` /
+            // `processed_dirty_rect_count` exposed via napi.
             let mut event_count: u64 = 0;
+            let mut focus_count: u64 = 0;
+            let mut dirty_count: u64 = 0;
             let mut max_observed: Option<LogicalTime> = None;
 
             for cmd in batch.drain(..) {
@@ -876,6 +919,7 @@ fn worker_loop(
                         }
                         input.update_at(ev.clone(), event_time.clone(), 1);
                         event_count += 1;
+                        focus_count += 1;
 
                         // Update anchor for idle frontier advance —
                         // only when wallclock genuinely advances, so
@@ -913,6 +957,7 @@ fn worker_loop(
                         }
                         dirty_input.update_at(ev.clone(), event_time.clone(), 1);
                         event_count += 1;
+                        dirty_count += 1;
 
                         if ev.wallclock_ms > latest_wallclock_ms {
                             latest_wallclock_ms = ev.wallclock_ms;
@@ -989,7 +1034,16 @@ fn worker_loop(
                 }
                 input.flush();
                 dirty_input.flush();
-                processed.fetch_add(event_count, Ordering::Relaxed);
+                // S2 D2-C: per-cmd counter increments — focus and
+                // dirty-rect counts kept separate so `view_focused_pipeline_status`
+                // doesn't get contaminated by dirty-rect traffic
+                // (Codex round 1 P2-B).
+                if focus_count > 0 {
+                    processed_focus.fetch_add(focus_count, Ordering::Relaxed);
+                }
+                if dirty_count > 0 {
+                    processed_dirty_rect.fetch_add(dirty_count, Ordering::Relaxed);
+                }
 
                 // Step until idle (capped) so the operator chain
                 // makes progress on whatever the new watermark
@@ -1050,6 +1104,171 @@ mod tests {
         worker
             .shutdown(Duration::from_secs(2))
             .expect("shutdown after push");
+    }
+
+    fn make_dirty_rect(monitor: u32, frame: u64, wallclock_ms: u64) -> DirtyRectEvent {
+        DirtyRectEvent {
+            source_event_id: 1000 + frame,
+            wallclock_ms,
+            sub_ordinal: 0,
+            timestamp_source: 2, // Dxgi
+            monitor_index: monitor,
+            frame_index: frame,
+            rect: Rect {
+                x: 0,
+                y: 0,
+                width: 100,
+                height: 100,
+            },
+        }
+    }
+
+    /// Build a `FocusEvent` with explicit hwnd (for G2-3 multi-hwnd
+    /// test). The shared `make_event` helper hard-codes `hwnd=0x1234`
+    /// because pre-S2 tests didn't need per-hwnd diversity; the per-
+    /// hwnd reduce in `current_focused_element` keys by `hwnd`, so
+    /// G2-3's "focus + dirty independent updates" assertion needs
+    /// distinct hwnds.
+    fn make_focus_event_with_hwnd(
+        hwnd: u64,
+        wallclock_ms: u64,
+        sub_ordinal: u32,
+    ) -> FocusEvent {
+        FocusEvent {
+            source_event_id: hwnd,
+            hwnd,
+            name: "test".into(),
+            automation_id: Some("auto-id".into()),
+            control_type: 50000,
+            window_title: "Test Window".into(),
+            wallclock_ms,
+            sub_ordinal,
+            timestamp_source: 0,
+        }
+    }
+
+    /// **G2 contract Test G2-3** (sub-plan §3.8 + Opus PR #108 Round 1
+    /// P1-1 + walking-skeleton-trunk-selection.md §4 S2 完了基準 #2):
+    /// focus view + dirty_rects_aggregate view が同 dataflow scope で
+    /// 共存し、focus event push と dirty rect event push を交互に発行
+    /// しても両 view が独立に正しく更新される。S2 trunk の最重要 contract
+    /// (sub-plan §1.4)。
+    ///
+    /// 検証手順:
+    ///   1. 5-tuple `spawn_perception_worker` で focus_view + latest_view +
+    ///      dirty_rects_view を取得 (S2 D2-C 5-tuple shape)
+    ///   2. handle.push_focus() を 3 回発行、wallclock 200ms 間隔で前進
+    ///      (D1-3 lifecycle test と同 pump pattern)
+    ///   3. handle.push_dirty_rect() を 2 回発行、focus event 間に挟む
+    ///   4. processed_focus_count + processed_dirty_rect_count を待機
+    ///      (Codex round 1 P2-B: counter 分離確認)
+    ///   5. focus view から `current_focused_element` で hwnd lookup
+    ///      latest_view から `snapshot()` で global latest
+    ///      dirty_rects_view から `get(monitor, frame)` で count
+    ///   6. 両 view が干渉せず正しい値を返すこと assert
+    #[test]
+    fn focus_and_dirty_rect_views_coexist_in_same_scope() {
+        let (worker, handle, view, latest_view, dirty_rects_view) =
+            spawn_perception_worker();
+
+        // wallclock を十分に進めて watermark-shift release window を超える
+        // (DESKTOP_TOUCH_WATERMARK_SHIFT_MS=100ms default、wallclock 間隔 200ms)。
+        let wc_base: u64 = 6_000_000;
+
+        // (1) focus event hwnd=0xAA at wc_base
+        handle.push_focus(make_focus_event_with_hwnd(0xAA, wc_base, 0));
+        // (2) dirty rect (monitor=0, frame=1) at wc_base+200
+        handle.push_dirty_rect(make_dirty_rect(0, 1, wc_base + 200));
+        // (3) focus event hwnd=0xBB at wc_base+400
+        handle.push_focus(make_focus_event_with_hwnd(0xBB, wc_base + 400, 0));
+        // (4) dirty rect (monitor=1, frame=2) at wc_base+600 (per-monitor isolation)
+        handle.push_dirty_rect(make_dirty_rect(1, 2, wc_base + 600));
+        // (5) focus event hwnd=0xCC at wc_base+800 (pump for watermark)
+        handle.push_focus(make_focus_event_with_hwnd(0xCC, wc_base + 800, 0));
+        // (6) Pump event with much later wallclock — forces watermark
+        // to advance past 0xCC's wallclock so 0xCC also materialises
+        // in the per-hwnd view (otherwise 0xCC sits at the frontier
+        // and only idle-advance projects past it via real-time elapsed).
+        // 5_000ms-jump ensures watermark covers all earlier events
+        // even with shift_ms=100 default and idle-advance latency.
+        handle.push_focus(make_focus_event_with_hwnd(0xDD, wc_base + 5_000, 0));
+
+        // Counter 分離確認 (Codex P2-B): focus 4 件、dirty rect 2 件
+        let deadline = Instant::now() + Duration::from_millis(500);
+        while worker.processed_focus_count() < 4 || worker.processed_dirty_rect_count() < 2 {
+            if Instant::now() >= deadline {
+                panic!(
+                    "events not fully processed: focus={} dirty={}",
+                    worker.processed_focus_count(),
+                    worker.processed_dirty_rect_count()
+                );
+            }
+            thread::sleep(Duration::from_millis(5));
+        }
+        assert_eq!(worker.processed_focus_count(), 4, "focus counter only");
+        assert_eq!(
+            worker.processed_dirty_rect_count(),
+            2,
+            "dirty rect counter only"
+        );
+
+        // View materialisation: idle frontier advance projects
+        // wallclock forward, releasing events past the
+        // watermark-shift window. Wait for both views to settle.
+        // 3000ms is generous to absorb DD operator chain latency
+        // when both focus + dirty rect dataflows process events
+        // (5-tuple shape adds operator graph depth).
+        let view_deadline = Instant::now() + Duration::from_millis(3000);
+        loop {
+            // focus view: hwnd 0xAA, 0xBB, 0xCC visible (CC may sit
+            // at the frontier; 0xAA + 0xBB at minimum)
+            let aa_seen = view.get(0xAA).is_some();
+            let bb_seen = view.get(0xBB).is_some();
+            // latest_focus: any non-None
+            let latest_seen = latest_view.snapshot().is_some();
+            // dirty_rects: monitor 0 frame 1 + monitor 1 frame 2
+            let dr_0_1 = dirty_rects_view.get(0, 1).is_some();
+            let dr_1_2 = dirty_rects_view.get(1, 2).is_some();
+            if aa_seen && bb_seen && latest_seen && dr_0_1 && dr_1_2 {
+                break;
+            }
+            if Instant::now() >= view_deadline {
+                panic!(
+                    "views did not settle: aa={} bb={} latest={} dr(0,1)={} dr(1,2)={}",
+                    aa_seen, bb_seen, latest_seen, dr_0_1, dr_1_2
+                );
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        // Independent updates assertion: focus view contains 0xAA/0xBB
+        // names from event push, dirty_rects view contains 1 rect
+        // each at (0,1) and (1,2). Cross-talk would manifest as
+        // focus view containing dirty rect data or vice versa.
+        let aa = view.get(0xAA).expect("hwnd 0xAA in focus view");
+        assert_eq!(aa.name, "test", "focus event name preserved");
+        let bb = view.get(0xBB).expect("hwnd 0xBB in focus view");
+        assert_eq!(bb.name, "test");
+
+        assert_eq!(
+            dirty_rects_view.get(0, 1),
+            Some(1),
+            "monitor 0 frame 1 has 1 rect"
+        );
+        assert_eq!(
+            dirty_rects_view.get(1, 2),
+            Some(1),
+            "monitor 1 frame 2 has 1 rect, per-monitor isolated"
+        );
+        // Cross-monitor non-collision: monitor 0 frame 2 must be None.
+        assert!(
+            dirty_rects_view.get(0, 2).is_none(),
+            "no false-positive cross-monitor frame collision"
+        );
+        // monitor_count = 2 (per-monitor isolation maintained).
+        assert_eq!(dirty_rects_view.monitor_count(), 2);
+
+        worker.shutdown(Duration::from_secs(2)).expect("shutdown");
     }
 
     #[test]
@@ -1479,7 +1698,8 @@ mod tests {
         let worker = PerceptionWorker {
             join: Mutex::new(Some(join)),
             tx,
-            processed_count: Arc::new(AtomicU64::new(0)),
+            processed_focus_count: Arc::new(AtomicU64::new(0)),
+            processed_dirty_rect_count: Arc::new(AtomicU64::new(0)),
         };
 
         // Generous timeout: the worker drains after 50ms, then we
@@ -1547,7 +1767,8 @@ mod tests {
         let worker = PerceptionWorker {
             join: Mutex::new(Some(join)),
             tx,
-            processed_count: Arc::new(AtomicU64::new(0)),
+            processed_focus_count: Arc::new(AtomicU64::new(0)),
+            processed_dirty_rect_count: Arc::new(AtomicU64::new(0)),
         };
 
         let start = Instant::now();

--- a/crates/engine-perception/src/views/dirty_rects_aggregate.rs
+++ b/crates/engine-perception/src/views/dirty_rects_aggregate.rs
@@ -1,0 +1,344 @@
+//! `dirty_rects_aggregate` view (S2 D2-C walking skeleton trunk,
+//! `docs/adr-008-d2-c-plan.md` §2.1 / §2.2 / §2.3).
+//!
+//! ## Count-only contract spike (S2 trunk)
+//!
+//! Per-`(monitor_index, frame_index)` count of dirty rects from a
+//! single DXGI frame. The S2 walking skeleton trunk lands the
+//! **count-only** contract: aggregate the **number** of rects per
+//! `(monitor, frame)` tuple. Geometry (`Vec<Rect>` + total_area
+//! summary) is reserved for expansion (`docs/adr-008-d2-c-plan.md`
+//! §1.2).
+//!
+//! ## `monitor_index` integrity (CLAUDE.md §3.2, PR #102 教訓)
+//!
+//! The composite key `(monitor_index, frame_index)` is **mandatory** —
+//! count-only does NOT mean dropping `monitor_index`. PR #102
+//! (`db81fe2`) had to fix a `monitor_index: 0` hard-coded payload
+//! that silently broke secondary-monitor subscriptions; the
+//! sub-plan §1.4 / §3.2 R3 explicitly carries that lesson into S2.
+//! Same-frame-index across monitors is not a collision because the
+//! key tuple separates them.
+//!
+//! ## Operator graph
+//!
+//! ```text
+//! DirtyRectEvent collection (input)
+//!     │
+//!     │ map: DirtyRectEvent → ((monitor_index, frame_index), ())
+//!     ▼
+//! count(): per (monitor_index, frame_index)、入力 row の数を集計。
+//!          dirty rects are append-only (no DD retraction within a
+//!          frame), so the count diff is monotonically non-decreasing.
+//!     │
+//!     ▼
+//! inspect: (data, time, diff) を view の per-(monitor, frame) HashMap
+//!          に apply。`(monitor, frame) → cumulative count` の materialised
+//!          state を保持。
+//! ```
+//!
+//! Note: we use DD's `count` operator (a `reduce` specialisation) to
+//! get an `isize` diff per key. The view stores diffs as `u64`
+//! after asserting non-negativity.
+//!
+//! ## Eviction policy (固定 N=8 frames per-monitor、§2.4)
+//!
+//! S2 trunk uses a fixed-size FIFO buffer: **at most 8 most recent
+//! frame_indices per monitor** are retained. 60Hz × ~130ms 相当、
+//! enough to capture the causal window of a typical commit-after-
+//! action sequence (S5 caused_by linkage). 100ms wallclock-based
+//! sliding window eviction lands in expansion (`docs/adr-008-d2-c-plan.md`
+//! §1.2).
+
+use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::sync::{Arc, RwLock};
+
+use differential_dataflow::collection::vec::Collection as VecCollection;
+use differential_dataflow::operators::arrange::{Arranged, TraceAgent};
+use differential_dataflow::trace::implementations::ValSpine;
+
+use crate::input::DirtyRectEvent;
+use crate::time::LogicalTime;
+
+/// Per-monitor cap on retained frame_indices. 60Hz × ~133ms.
+const PER_MONITOR_FRAME_CAP: usize = 8;
+
+/// Per-key arrangement of `dirty_rects_aggregate`'s reduce output.
+/// Other subgraphs in the same `worker.dataflow` closure could borrow
+/// this for join logic in a future phase; for the S2 trunk no
+/// downstream consumer is wired yet, but the shape mirrors
+/// `CurrentFocusedElementArranged<'scope>` so future joins are
+/// mechanical (sub-plan §3.3 Lesson 1 contract integrity).
+///
+/// `'scope` is the timely worker's scope lifetime; storing it in an
+/// outside struct is statically rejected by timely's lifetime model
+/// (Codex v2 P2-9, S1 D2-E0 contract).
+pub type DirtyRectsAggregateArranged<'scope> =
+    Arranged<'scope, TraceAgent<ValSpine<(u32, u64), u64, LogicalTime, isize>>>;
+
+/// Reader-side handle on the materialised state of the
+/// `dirty_rects_aggregate` view. Cheap to clone (inner is
+/// `Arc<RwLock<...>>`).
+#[derive(Clone, Default)]
+pub struct DirtyRectsAggregateView {
+    inner: Arc<RwLock<ViewState>>,
+}
+
+#[derive(Default)]
+struct ViewState {
+    /// Per-monitor map of `frame_index -> count`. The BTreeMap is
+    /// ordered by `frame_index`, so eviction (drop the oldest entry
+    /// once the per-monitor cap is exceeded) is `pop_front`-style on
+    /// the `BTreeMap::keys()` iteration.
+    by_monitor: HashMap<u32, BTreeMap<u64, u64>>,
+    /// FIFO of `(monitor_index, frame_index)` insertion order so
+    /// eviction is O(1) — we keep a deque per monitor's first-seen
+    /// frame indices and pop the front when the cap is exceeded.
+    insertion_order: HashMap<u32, VecDeque<u64>>,
+}
+
+impl DirtyRectsAggregateView {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Per-`(monitor_index, frame_index)` count lookup. Returns
+    /// `None` when the frame has not been observed (or has been
+    /// evicted under the per-monitor FIFO cap).
+    pub fn get(&self, monitor_index: u32, frame_index: u64) -> Option<u64> {
+        let g = self.inner.read().expect("view RwLock poisoned");
+        g.by_monitor
+            .get(&monitor_index)
+            .and_then(|frames| frames.get(&frame_index).copied())
+    }
+
+    /// Number of currently-retained frames for `monitor_index`. Used
+    /// by the napi binding to surface a quick "live frames count" to
+    /// the TS layer (`view_get_dirty_rects.live_frame_count`).
+    pub fn live_frame_count(&self, monitor_index: u32) -> usize {
+        let g = self.inner.read().expect("view RwLock poisoned");
+        g.by_monitor
+            .get(&monitor_index)
+            .map(|frames| frames.len())
+            .unwrap_or(0)
+    }
+
+    /// Latest `(frame_index, count)` for `monitor_index`. Useful for
+    /// the napi binding's "most recent frame" surface; expansion-phase
+    /// `recent_n` / `recent_window` API supersedes this.
+    pub fn latest(&self, monitor_index: u32) -> Option<(u64, u64)> {
+        let g = self.inner.read().expect("view RwLock poisoned");
+        g.by_monitor
+            .get(&monitor_index)
+            .and_then(|frames| frames.iter().next_back().map(|(&fi, &c)| (fi, c)))
+    }
+
+    /// Total number of monitors with at least one retained frame.
+    pub fn monitor_count(&self) -> usize {
+        let g = self.inner.read().expect("view RwLock poisoned");
+        g.by_monitor.len()
+    }
+
+    /// `true` when no monitor has any retained frame.
+    pub fn is_empty(&self) -> bool {
+        self.monitor_count() == 0
+    }
+
+    /// Apply a diff observation. Internal — called from the timely
+    /// worker's inspect closure inside [`build_dirty_rects_aggregate`].
+    /// `pub(crate)` so tests inside the crate can drive the view
+    /// directly without spinning a dataflow.
+    ///
+    /// dirty rects are **append-only** within a DXGI frame (DD does
+    /// not retract them once emitted), so diff is normally `+N` for
+    /// `N` rects in the frame. Negative diffs would only appear if a
+    /// future view reduces the count semantics — defensive
+    /// `debug_assert!` catches that.
+    pub(crate) fn apply_count(&self, monitor_index: u32, frame_index: u64, diff: i64) {
+        let mut g = self.inner.write().expect("view RwLock poisoned");
+        let frames = g.by_monitor.entry(monitor_index).or_default();
+        let new = frames.get(&frame_index).copied().unwrap_or(0) as i64 + diff;
+        debug_assert!(
+            new >= 0,
+            "negative count for (monitor={}, frame={}): {}",
+            monitor_index,
+            frame_index,
+            new,
+        );
+        if new <= 0 {
+            // Defensive: 0 → eviction (DD reduce can produce 0
+            // diffs during compaction even though dirty rects are
+            // append-only at the input level).
+            frames.remove(&frame_index);
+            // Also remove from insertion_order if present (best-effort).
+            if let Some(order) = g.insertion_order.get_mut(&monitor_index) {
+                if let Some(pos) = order.iter().position(|&fi| fi == frame_index) {
+                    order.remove(pos);
+                }
+            }
+            // If the per-monitor map is now empty, drop the
+            // monitor key too so `monitor_count()` reflects reality.
+            if g.by_monitor
+                .get(&monitor_index)
+                .map(|f| f.is_empty())
+                .unwrap_or(false)
+            {
+                g.by_monitor.remove(&monitor_index);
+                g.insertion_order.remove(&monitor_index);
+            }
+            return;
+        }
+        let new_u64 = new as u64;
+        let was_new_key = !frames.contains_key(&frame_index);
+        frames.insert(frame_index, new_u64);
+        if was_new_key {
+            // Track FIFO order for the per-monitor cap eviction.
+            // Compute the eviction list first (mutating only
+            // `insertion_order`), then drop that borrow before
+            // touching `by_monitor` again — avoids E0499 by keeping
+            // the two `HashMap`s' mutable borrows non-overlapping.
+            let mut to_evict: Vec<u64> = Vec::new();
+            {
+                let order = g.insertion_order.entry(monitor_index).or_default();
+                order.push_back(frame_index);
+                while order.len() > PER_MONITOR_FRAME_CAP {
+                    if let Some(evict) = order.pop_front() {
+                        to_evict.push(evict);
+                    }
+                }
+            }
+            if let Some(frames) = g.by_monitor.get_mut(&monitor_index) {
+                for evict in to_evict {
+                    frames.remove(&evict);
+                }
+            }
+        }
+    }
+}
+
+/// Wire the `dirty_rects_aggregate` operator graph onto
+/// `dirty_rect_stream`. Returns `(arranged, view)` mirroring the S1
+/// D2-E0 unified `build_*` template (`build_current_focused_element`
+/// shape, `docs/adr-008-d2-e0-plan.md` §2.1).
+///
+/// `dirty_rect_stream` is borrowed; the function clones internally
+/// to drive the reduce twice (inspect + arrange_by_key), the same
+/// 2-borrow pattern S1 established (sub-plan §7 R9 mitigation).
+pub fn build_dirty_rects_aggregate<'scope>(
+    dirty_rect_stream: &VecCollection<'scope, LogicalTime, DirtyRectEvent, isize>,
+) -> (DirtyRectsAggregateArranged<'scope>, DirtyRectsAggregateView) {
+    let view = DirtyRectsAggregateView::new();
+    let view_for_inspect = view.clone();
+
+    // Map each DirtyRectEvent to ((monitor_index, frame_index), ())
+    // and reduce by counting `(diff sum)` per key — output is
+    // `((monitor_index, frame_index), count_u64)`.
+    let reduced = dirty_rect_stream
+        .clone()
+        .map(|ev: DirtyRectEvent| {
+            let key = (ev.monitor_index, ev.frame_index);
+            (key, ())
+        })
+        .reduce(|_key, input, output| {
+            // input: &[(&(), isize)] — count the unit values
+            // weighted by their diff. dirty rects are append-only at
+            // the input level so the total is positive.
+            let total: isize = input.iter().map(|(_, diff)| *diff).sum();
+            if total > 0 {
+                output.push((total as u64, 1));
+            }
+        });
+
+    // 2-borrow shape: clone for inspect, original flows into
+    // arrange_by_key (S1 D2-E0 sub-plan §7 R9 verified pattern).
+    reduced
+        .clone()
+        .inspect(move |((key, count), _time, diff)| {
+            let (monitor_index, frame_index) = *key;
+            // diff is the change in the reduce's output value (count_u64).
+            // For append-only inputs the inspect sees `+count` followed
+            // by retraction `-count` if the key is later updated to a
+            // new total. Net effect on the view is the latest non-zero
+            // count.
+            let signed_diff = (*count as i64) * (*diff as i64);
+            view_for_inspect.apply_count(monitor_index, frame_index, signed_diff);
+        });
+
+    let arranged = reduced.arrange_by_key();
+    (arranged, view)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_view_get_returns_none() {
+        let v = DirtyRectsAggregateView::new();
+        assert!(v.is_empty());
+        assert_eq!(v.monitor_count(), 0);
+        assert!(v.get(0, 0).is_none());
+        assert_eq!(v.live_frame_count(0), 0);
+        assert!(v.latest(0).is_none());
+    }
+
+    #[test]
+    fn apply_count_per_frame_aggregates() {
+        // G2 contract Test G2-1 (sub-plan §3.8): per-frame count
+        // aggregation.
+        let v = DirtyRectsAggregateView::new();
+        // (monitor=0, frame=1) gets 3 rects.
+        v.apply_count(0, 1, 3);
+        assert_eq!(v.get(0, 1), Some(3));
+        assert_eq!(v.live_frame_count(0), 1);
+        assert_eq!(v.monitor_count(), 1);
+    }
+
+    #[test]
+    fn apply_count_per_monitor_isolation() {
+        // G2 contract Test G2-2 (sub-plan §3.8、CLAUDE.md §3.2 PR #102 教訓):
+        // (monitor=0, frame=1) and (monitor=1, frame=1) must NOT
+        // collide — composite key `(monitor_index, frame_index)`.
+        let v = DirtyRectsAggregateView::new();
+        v.apply_count(0, 1, 2);
+        v.apply_count(1, 1, 3);
+        assert_eq!(v.get(0, 1), Some(2));
+        assert_eq!(v.get(1, 1), Some(3));
+        assert_eq!(v.live_frame_count(0), 1);
+        assert_eq!(v.live_frame_count(1), 1);
+        assert_eq!(v.monitor_count(), 2);
+    }
+
+    #[test]
+    fn apply_count_eviction_under_cap() {
+        // Per-monitor FIFO cap eviction. PER_MONITOR_FRAME_CAP+1
+        // frames inserted; the oldest must be evicted.
+        let v = DirtyRectsAggregateView::new();
+        for fi in 0..(PER_MONITOR_FRAME_CAP as u64 + 2) {
+            v.apply_count(0, fi, 1);
+        }
+        assert_eq!(v.live_frame_count(0), PER_MONITOR_FRAME_CAP);
+        // Oldest 2 frames must be gone.
+        assert!(v.get(0, 0).is_none());
+        assert!(v.get(0, 1).is_none());
+        // Newest one is present.
+        assert_eq!(v.get(0, PER_MONITOR_FRAME_CAP as u64 + 1), Some(1));
+        // `latest` reflects the newest.
+        assert_eq!(
+            v.latest(0),
+            Some((PER_MONITOR_FRAME_CAP as u64 + 1, 1))
+        );
+    }
+
+    #[test]
+    fn apply_count_zero_evicts_key() {
+        // Compaction can produce a 0 diff sum for a key — the view
+        // must drop the entry rather than store `0`.
+        let v = DirtyRectsAggregateView::new();
+        v.apply_count(0, 1, 5);
+        v.apply_count(0, 1, -5);
+        assert!(v.get(0, 1).is_none());
+        assert_eq!(v.live_frame_count(0), 0);
+        assert!(v.is_empty());
+    }
+}

--- a/crates/engine-perception/src/views/dirty_rects_aggregate.rs
+++ b/crates/engine-perception/src/views/dirty_rects_aggregate.rs
@@ -50,7 +50,7 @@
 //! sliding window eviction lands in expansion (`docs/adr-008-d2-c-plan.md`
 //! §1.2).
 
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::{Arc, RwLock};
 
 use differential_dataflow::collection::vec::Collection as VecCollection;
@@ -86,15 +86,31 @@ pub struct DirtyRectsAggregateView {
 
 #[derive(Default)]
 struct ViewState {
-    /// Per-monitor map of `frame_index -> count`. The BTreeMap is
-    /// ordered by `frame_index`, so eviction (drop the oldest entry
-    /// once the per-monitor cap is exceeded) is `pop_front`-style on
-    /// the `BTreeMap::keys()` iteration.
-    by_monitor: HashMap<u32, BTreeMap<u64, u64>>,
-    /// FIFO of `(monitor_index, frame_index)` insertion order so
-    /// eviction is O(1) — we keep a deque per monitor's first-seen
-    /// frame indices and pop the front when the cap is exceeded.
-    insertion_order: HashMap<u32, VecDeque<u64>>,
+    /// Per-`(monitor, frame)` map of `count_value -> diff_sum`. Mirrors
+    /// `current_focused_element`'s per-`(hwnd, ui_ref)` pattern (Codex
+    /// v3 P1-1 inspect-order tolerance, Opus PR #108 Round 1 P2-1):
+    /// DD reduce can fire retraction `(old_count, -1)` and assertion
+    /// `(new_count, +1)` in any order across inspect callbacks, so the
+    /// view stores diff sums per `(key, count_value)` and resolves the
+    /// "live count" by finding the count_value with positive diff sum.
+    /// In steady state at most one count_value per `(monitor, frame)`
+    /// has a positive sum (= the live count); transiently both may
+    /// coexist while assertion / retraction settle.
+    by_key: HashMap<(u32, u64), BTreeMap<u64, i64>>,
+    /// Sorted set of currently-live `frame_index`es per monitor. Used
+    /// for **frame-recency eviction** (Codex round 1 P2-A): when the
+    /// per-monitor live set exceeds `PER_MONITOR_FRAME_CAP`, drop the
+    /// **lowest** frame_index. This preserves the contract "retain
+    /// the most recent N frame indices per monitor" even when the
+    /// worker accepts late-arriving older events within the watermark
+    /// window — insertion-FIFO eviction (the prior shape) would have
+    /// dropped a NEWER frame to make room for an older late arrival,
+    /// inverting the contract.
+    ///
+    /// Entries are added on first-positive-diff observation and
+    /// removed when the (monitor, frame) cumulative state settles
+    /// to zero (= no count_value with positive diff sum).
+    live_frames_by_monitor: HashMap<u32, BTreeSet<u64>>,
 }
 
 impl DirtyRectsAggregateView {
@@ -102,114 +118,167 @@ impl DirtyRectsAggregateView {
         Self::default()
     }
 
-    /// Per-`(monitor_index, frame_index)` count lookup. Returns
+    /// Per-`(monitor_index, frame_index)` count lookup. Returns the
+    /// `count_value` with a positive diff sum (= the live count), or
     /// `None` when the frame has not been observed (or has been
-    /// evicted under the per-monitor FIFO cap).
+    /// evicted under the per-monitor FIFO cap, or all diff sums
+    /// settled to ≤ 0).
     pub fn get(&self, monitor_index: u32, frame_index: u64) -> Option<u64> {
         let g = self.inner.read().expect("view RwLock poisoned");
-        g.by_monitor
-            .get(&monitor_index)
-            .and_then(|frames| frames.get(&frame_index).copied())
+        g.by_key
+            .get(&(monitor_index, frame_index))
+            .and_then(|counts| counts.iter().find(|&(_, &c)| c > 0).map(|(&v, _)| v))
     }
 
-    /// Number of currently-retained frames for `monitor_index`. Used
-    /// by the napi binding to surface a quick "live frames count" to
-    /// the TS layer (`view_get_dirty_rects.live_frame_count`).
+    /// Number of currently-live frames for `monitor_index` (= frames
+    /// where some `count_value` has positive diff sum). Used by the
+    /// napi binding's `live_frame_count` field.
     pub fn live_frame_count(&self, monitor_index: u32) -> usize {
         let g = self.inner.read().expect("view RwLock poisoned");
-        g.by_monitor
-            .get(&monitor_index)
-            .map(|frames| frames.len())
-            .unwrap_or(0)
+        g.by_key
+            .iter()
+            .filter(|((m, _), counts)| {
+                *m == monitor_index && counts.iter().any(|(_, &c)| c > 0)
+            })
+            .count()
     }
 
-    /// Latest `(frame_index, count)` for `monitor_index`. Useful for
-    /// the napi binding's "most recent frame" surface; expansion-phase
-    /// `recent_n` / `recent_window` API supersedes this.
+    /// Latest live `(frame_index, count)` for `monitor_index` — the
+    /// frame with the highest `frame_index` whose count_value still
+    /// has positive diff sum. Used by the napi binding's `latest`
+    /// field. Expansion-phase `recent_n` / `recent_window` API
+    /// supersedes this.
     pub fn latest(&self, monitor_index: u32) -> Option<(u64, u64)> {
         let g = self.inner.read().expect("view RwLock poisoned");
-        g.by_monitor
-            .get(&monitor_index)
-            .and_then(|frames| frames.iter().next_back().map(|(&fi, &c)| (fi, c)))
+        g.by_key
+            .iter()
+            .filter(|((m, _), _)| *m == monitor_index)
+            .filter_map(|((_, fi), counts)| {
+                counts
+                    .iter()
+                    .find(|&(_, &c)| c > 0)
+                    .map(|(&v, _)| (*fi, v))
+            })
+            .max_by_key(|(fi, _)| *fi)
     }
 
-    /// Total number of monitors with at least one retained frame.
+    /// Total number of monitors with at least one live frame (= some
+    /// `(monitor, frame)` whose count_value has positive diff sum).
     pub fn monitor_count(&self) -> usize {
         let g = self.inner.read().expect("view RwLock poisoned");
-        g.by_monitor.len()
+        let mut monitors: std::collections::HashSet<u32> = std::collections::HashSet::new();
+        for ((m, _), counts) in &g.by_key {
+            if counts.iter().any(|(_, &c)| c > 0) {
+                monitors.insert(*m);
+            }
+        }
+        monitors.len()
     }
 
-    /// `true` when no monitor has any retained frame.
+    /// `true` when no `(monitor, frame)` has a count_value with
+    /// positive diff sum.
     pub fn is_empty(&self) -> bool {
-        self.monitor_count() == 0
+        let g = self.inner.read().expect("view RwLock poisoned");
+        !g.by_key
+            .iter()
+            .any(|(_, counts)| counts.iter().any(|(_, &c)| c > 0))
     }
 
-    /// Apply a diff observation. Internal — called from the timely
-    /// worker's inspect closure inside [`build_dirty_rects_aggregate`].
-    /// `pub(crate)` so tests inside the crate can drive the view
-    /// directly without spinning a dataflow.
+    /// Apply a diff observation from the timely worker's inspect
+    /// closure inside [`build_dirty_rects_aggregate`]. `pub(crate)`
+    /// so tests inside the crate can drive the view directly.
     ///
-    /// dirty rects are **append-only** within a DXGI frame (DD does
-    /// not retract them once emitted), so diff is normally `+N` for
-    /// `N` rects in the frame. Negative diffs would only appear if a
-    /// future view reduces the count semantics — defensive
-    /// `debug_assert!` catches that.
-    pub(crate) fn apply_count(&self, monitor_index: u32, frame_index: u64, diff: i64) {
+    /// **Inspect-order tolerance** (mirror of
+    /// `current_focused_element::CurrentFocusedElementView::apply_diff`):
+    /// DD reduce can fire retraction `(old_count, -1)` and assertion
+    /// `(new_count, +1)` in any order across inspect callbacks. The
+    /// per-`(key, count_value)` diff sum store keeps the read API
+    /// convergent regardless of arrival order — the `get` lookup
+    /// always finds whichever count_value has a positive sum. Net
+    /// effect after both retraction and assertion settle: only the
+    /// new count_value's sum is positive, the old one's is 0
+    /// (evicted from the inner BTreeMap).
+    pub(crate) fn apply_count(
+        &self,
+        monitor_index: u32,
+        frame_index: u64,
+        count_value: u64,
+        diff: i64,
+    ) {
         let mut g = self.inner.write().expect("view RwLock poisoned");
-        let frames = g.by_monitor.entry(monitor_index).or_default();
-        let new = frames.get(&frame_index).copied().unwrap_or(0) as i64 + diff;
+        let key = (monitor_index, frame_index);
+
+        // ── Step 1: update the per-(key, count_value) diff sum ────
+        let counts = g.by_key.entry(key).or_default();
+        let new_diff = counts.get(&count_value).copied().unwrap_or(0) + diff;
+        // Defensive: a negative diff sum shouldn't occur under DD's
+        // diff invariants (every retraction matches a prior
+        // assertion, even if observed out-of-order). Surface the bug
+        // in debug builds without panicking — same posture as
+        // `current_focused_element::apply_diff`.
         debug_assert!(
-            new >= 0,
-            "negative count for (monitor={}, frame={}): {}",
+            new_diff >= 0,
+            "negative diff sum at (monitor={}, frame={}, count_value={}): {}",
             monitor_index,
             frame_index,
-            new,
+            count_value,
+            new_diff,
         );
-        if new <= 0 {
-            // Defensive: 0 → eviction (DD reduce can produce 0
-            // diffs during compaction even though dirty rects are
-            // append-only at the input level).
-            frames.remove(&frame_index);
-            // Also remove from insertion_order if present (best-effort).
-            if let Some(order) = g.insertion_order.get_mut(&monitor_index) {
-                if let Some(pos) = order.iter().position(|&fi| fi == frame_index) {
-                    order.remove(pos);
-                }
-            }
-            // If the per-monitor map is now empty, drop the
-            // monitor key too so `monitor_count()` reflects reality.
-            if g.by_monitor
-                .get(&monitor_index)
-                .map(|f| f.is_empty())
-                .unwrap_or(false)
-            {
-                g.by_monitor.remove(&monitor_index);
-                g.insertion_order.remove(&monitor_index);
-            }
-            return;
+        if new_diff <= 0 {
+            counts.remove(&count_value);
+        } else {
+            counts.insert(count_value, new_diff);
         }
-        let new_u64 = new as u64;
-        let was_new_key = !frames.contains_key(&frame_index);
-        frames.insert(frame_index, new_u64);
-        if was_new_key {
-            // Track FIFO order for the per-monitor cap eviction.
-            // Compute the eviction list first (mutating only
-            // `insertion_order`), then drop that borrow before
-            // touching `by_monitor` again — avoids E0499 by keeping
-            // the two `HashMap`s' mutable borrows non-overlapping.
-            let mut to_evict: Vec<u64> = Vec::new();
+        // ── Step 2: track liveness — is any count_value still live? ──
+        let key_now_live = g
+            .by_key
+            .get(&key)
+            .map(|c| c.iter().any(|(_, &d)| d > 0))
+            .unwrap_or(false);
+        // Drop the (monitor, frame) entry entirely once all
+        // count_values' diff sums settle to 0.
+        if g.by_key.get(&key).map(|c| c.is_empty()).unwrap_or(false) {
+            g.by_key.remove(&key);
+        }
+
+        // ── Step 3: maintain `live_frames_by_monitor` + cap eviction
+        //          (Codex round 1 P2-A: evict by frame recency, not
+        //          insertion order). ────────────────────────────────
+        if key_now_live {
+            // Compute eviction list first (mutating only
+            // `live_frames_by_monitor`), then drop that borrow before
+            // touching `by_key` again — avoids E0499 by keeping the
+            // two HashMaps' mutable borrows non-overlapping.
+            let mut to_evict: Vec<(u32, u64)> = Vec::new();
             {
-                let order = g.insertion_order.entry(monitor_index).or_default();
-                order.push_back(frame_index);
-                while order.len() > PER_MONITOR_FRAME_CAP {
-                    if let Some(evict) = order.pop_front() {
-                        to_evict.push(evict);
+                let live = g.live_frames_by_monitor.entry(monitor_index).or_default();
+                live.insert(frame_index);
+                while live.len() > PER_MONITOR_FRAME_CAP {
+                    // Evict the LOWEST frame_index (= the oldest
+                    // frame by `frame_index` ordering, which is
+                    // monotone in DXGI emit order). Out-of-order
+                    // late arrivals within the watermark window are
+                    // still admitted by the worker, but if their
+                    // frame_index is older than the live set's
+                    // current min the eviction step removes them —
+                    // not a newer frame.
+                    if let Some(&evict_frame) = live.iter().next() {
+                        live.remove(&evict_frame);
+                        to_evict.push((monitor_index, evict_frame));
+                    } else {
+                        break;
                     }
                 }
             }
-            if let Some(frames) = g.by_monitor.get_mut(&monitor_index) {
-                for evict in to_evict {
-                    frames.remove(&evict);
+            for evict_key in to_evict {
+                g.by_key.remove(&evict_key);
+            }
+        } else {
+            // Frame settled to fully-dead — remove from the live set.
+            if let Some(live) = g.live_frames_by_monitor.get_mut(&monitor_index) {
+                live.remove(&frame_index);
+                if live.is_empty() {
+                    g.live_frames_by_monitor.remove(&monitor_index);
                 }
             }
         }
@@ -251,17 +320,23 @@ pub fn build_dirty_rects_aggregate<'scope>(
 
     // 2-borrow shape: clone for inspect, original flows into
     // arrange_by_key (S1 D2-E0 sub-plan §7 R9 verified pattern).
+    //
+    // inspect callback shape: `((key, count_value), time, diff)`
+    // where `key = (monitor_index, frame_index)` and `count_value`
+    // is the reduce-output count_u64. `diff` is +1 (assertion of new
+    // value) or -1 (retraction of old value). The view's per-(key,
+    // count_value) diff bookkeeping handles inspect-order tolerance
+    // (Opus PR #108 Round 1 P2-1, mirror of `current_focused_element`).
     reduced
         .clone()
-        .inspect(move |((key, count), _time, diff)| {
+        .inspect(move |((key, count_value), _time, diff)| {
             let (monitor_index, frame_index) = *key;
-            // diff is the change in the reduce's output value (count_u64).
-            // For append-only inputs the inspect sees `+count` followed
-            // by retraction `-count` if the key is later updated to a
-            // new total. Net effect on the view is the latest non-zero
-            // count.
-            let signed_diff = (*count as i64) * (*diff as i64);
-            view_for_inspect.apply_count(monitor_index, frame_index, signed_diff);
+            view_for_inspect.apply_count(
+                monitor_index,
+                frame_index,
+                *count_value,
+                *diff as i64,
+            );
         });
 
     let arranged = reduced.arrange_by_key();
@@ -285,10 +360,10 @@ mod tests {
     #[test]
     fn apply_count_per_frame_aggregates() {
         // G2 contract Test G2-1 (sub-plan §3.8): per-frame count
-        // aggregation.
+        // aggregation. `apply_count(monitor, frame, count_value, +1)`
+        // asserts `count_value` as the live count for that frame.
         let v = DirtyRectsAggregateView::new();
-        // (monitor=0, frame=1) gets 3 rects.
-        v.apply_count(0, 1, 3);
+        v.apply_count(0, 1, 3, 1);
         assert_eq!(v.get(0, 1), Some(3));
         assert_eq!(v.live_frame_count(0), 1);
         assert_eq!(v.monitor_count(), 1);
@@ -300,8 +375,8 @@ mod tests {
         // (monitor=0, frame=1) and (monitor=1, frame=1) must NOT
         // collide — composite key `(monitor_index, frame_index)`.
         let v = DirtyRectsAggregateView::new();
-        v.apply_count(0, 1, 2);
-        v.apply_count(1, 1, 3);
+        v.apply_count(0, 1, 2, 1);
+        v.apply_count(1, 1, 3, 1);
         assert_eq!(v.get(0, 1), Some(2));
         assert_eq!(v.get(1, 1), Some(3));
         assert_eq!(v.live_frame_count(0), 1);
@@ -310,20 +385,21 @@ mod tests {
     }
 
     #[test]
-    fn apply_count_eviction_under_cap() {
-        // Per-monitor FIFO cap eviction. PER_MONITOR_FRAME_CAP+1
-        // frames inserted; the oldest must be evicted.
+    fn apply_count_eviction_by_frame_recency() {
+        // Codex round 1 P2-A: eviction must drop the LOWEST
+        // frame_index when the per-monitor cap is exceeded, NOT the
+        // first-inserted frame_index. Critical when the worker
+        // accepts late older arrivals within the watermark window.
         let v = DirtyRectsAggregateView::new();
         for fi in 0..(PER_MONITOR_FRAME_CAP as u64 + 2) {
-            v.apply_count(0, fi, 1);
+            v.apply_count(0, fi, 1, 1);
         }
         assert_eq!(v.live_frame_count(0), PER_MONITOR_FRAME_CAP);
-        // Oldest 2 frames must be gone.
+        // Lowest 2 frames evicted.
         assert!(v.get(0, 0).is_none());
         assert!(v.get(0, 1).is_none());
-        // Newest one is present.
+        // Newest frame retained.
         assert_eq!(v.get(0, PER_MONITOR_FRAME_CAP as u64 + 1), Some(1));
-        // `latest` reflects the newest.
         assert_eq!(
             v.latest(0),
             Some((PER_MONITOR_FRAME_CAP as u64 + 1, 1))
@@ -331,14 +407,77 @@ mod tests {
     }
 
     #[test]
-    fn apply_count_zero_evicts_key() {
-        // Compaction can produce a 0 diff sum for a key — the view
-        // must drop the entry rather than store `0`.
+    fn apply_count_late_older_arrival_does_not_evict_newer() {
+        // Codex round 1 P2-A regression scenario: insert frames
+        // 0..CAP (live set full), then a LATE older frame_index
+        // arrives. The eviction step must drop the newly-arriving
+        // older frame (its frame_index is below the live set's
+        // current min only when it's truly old — here we insert at
+        // the boundary case where the new frame is the new min).
+        // Result: live set keeps the most-recent CAP frames.
         let v = DirtyRectsAggregateView::new();
-        v.apply_count(0, 1, 5);
-        v.apply_count(0, 1, -5);
+        for fi in 1..=(PER_MONITOR_FRAME_CAP as u64) {
+            v.apply_count(0, fi, 1, 1);
+        }
+        assert_eq!(v.live_frame_count(0), PER_MONITOR_FRAME_CAP);
+        // Now a late older frame arrives (frame_index = 0). Live set
+        // becomes 9 elements; cap eviction drops the lowest = 0
+        // itself (so the new arrival is what gets evicted).
+        v.apply_count(0, 0, 1, 1);
+        assert_eq!(v.live_frame_count(0), PER_MONITOR_FRAME_CAP);
+        // Frame 0 evicted (or never made it into the live set
+        // beyond a transient state).
+        assert!(v.get(0, 0).is_none());
+        // All originally-inserted frames 1..CAP retained.
+        for fi in 1..=(PER_MONITOR_FRAME_CAP as u64) {
+            assert_eq!(v.get(0, fi), Some(1), "frame {} must remain live", fi);
+        }
+    }
+
+    #[test]
+    fn apply_count_zero_evicts_key() {
+        // Compaction can produce a 0 diff sum for a count_value —
+        // the view must drop the (key, count_value) entry, and if
+        // it was the last live count_value, drop the (monitor,
+        // frame) entry from the live set entirely.
+        let v = DirtyRectsAggregateView::new();
+        v.apply_count(0, 1, 5, 1);
+        v.apply_count(0, 1, 5, -1);
         assert!(v.get(0, 1).is_none());
         assert_eq!(v.live_frame_count(0), 0);
         assert!(v.is_empty());
+    }
+
+    #[test]
+    fn apply_count_value_axis_retraction_settles_to_new_value() {
+        // Opus round 1 P2-3: DD reduce can produce value-axis
+        // retraction + new assertion on the same (monitor, frame)
+        // key when the count changes. Both arrival orders must
+        // converge to the new count.
+        let v = DirtyRectsAggregateView::new();
+        // Initial state: count=3 for (0, 1).
+        v.apply_count(0, 1, 3, 1);
+        assert_eq!(v.get(0, 1), Some(3));
+        // Count grows to 5: DD emits retraction(3) + assertion(5).
+        v.apply_count(0, 1, 3, -1);
+        v.apply_count(0, 1, 5, 1);
+        assert_eq!(v.get(0, 1), Some(5));
+        assert_eq!(v.live_frame_count(0), 1);
+    }
+
+    #[test]
+    fn apply_count_value_axis_retraction_arrives_first_settles_correctly() {
+        // Opus round 1 P2-3 + sub-plan §2.2 Codex v3 P1-1
+        // inspect-order tolerance: retraction arrives BEFORE the
+        // matching assertion. View must converge to the new value
+        // regardless of arrival order.
+        let v = DirtyRectsAggregateView::new();
+        v.apply_count(0, 1, 3, 1);
+        // Out-of-order: assertion of new value 5 arrives BEFORE
+        // retraction of old value 3.
+        v.apply_count(0, 1, 5, 1);
+        v.apply_count(0, 1, 3, -1);
+        assert_eq!(v.get(0, 1), Some(5));
+        assert_eq!(v.live_frame_count(0), 1);
     }
 }

--- a/crates/engine-perception/src/views/mod.rs
+++ b/crates/engine-perception/src/views/mod.rs
@@ -29,7 +29,9 @@
 //! `semantic_event_stream`, etc. — see `docs/views-catalog.md`.
 
 pub mod current_focused_element;
+pub mod dirty_rects_aggregate;
 pub mod latest_focus;
 
 pub use current_focused_element::{CurrentFocusedElementView, UiElementRef};
+pub use dirty_rects_aggregate::DirtyRectsAggregateView;
 pub use latest_focus::LatestFocusView;

--- a/docs/adr-008-d2-c-plan.md
+++ b/docs/adr-008-d2-c-plan.md
@@ -170,6 +170,19 @@ impl DirtyRectsAggregateView {
     /// monitor_index 別の "live frames" の count (= view が現在 hold している
     /// frame の数)。napi `view_get_dirty_rects(monitor_index)` の返り値構築用。
     pub fn live_frame_count(&self, monitor_index: u32) -> usize;
+
+    /// 最新 (highest frame_index) の `(frame_index, count)` for monitor_index。
+    /// napi `view_get_dirty_rects.latest` 構築用 (Opus PR #108 Round 1 P2-4
+    /// で trunk getter として確定)。
+    pub fn latest(&self, monitor_index: u32) -> Option<(u64, u64)>;
+
+    /// view 全体で live frame を持つ monitor 数 (Opus PR #108 Round 1
+    /// P2-4 sync)。
+    pub fn monitor_count(&self) -> usize;
+
+    /// view 全体に live frame が 1 つもないか (Opus PR #108 Round 1
+    /// P2-4 sync)。
+    pub fn is_empty(&self) -> bool;
 }
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -323,8 +323,14 @@ export interface NativeDirtyRectsResult {
   /** Number of currently-retained frames for this monitor (after the
    * per-monitor FIFO cap eviction). */
   liveFrameCount: number
-  /** Most recent `(frame_index, count)` for this monitor, if any. */
-  latest: NativeDirtyRectFrame | null
+  /** Most recent `(frame_index, count)` for this monitor, if any.
+   * **Optional** because napi-rs serialises `Option::None` for nested
+   * struct fields by **omitting** the key (not setting it to `null`).
+   * Consumers must either use optional chaining (`result.latest?.frameIndex`)
+   * or explicitly check `'latest' in result` / `result.latest != null`
+   * (both `null` and `undefined`). User review on PR #108 (2026-05-01)
+   * pinned the runtime behaviour. */
+  latest?: NativeDirtyRectFrame
 }
 
 /** Read the count-only `dirty_rects_aggregate` view for a given monitor

--- a/index.d.ts
+++ b/index.d.ts
@@ -308,3 +308,28 @@ export interface NativeViewFocusedPipelineStatus {
  * is uninitialised, or the slot is poisoned (caller should use UIA fallback). */
 export declare function viewGetFocused(): NativeFocusedElement | null
 export declare function viewFocusedPipelineStatus(): NativeViewFocusedPipelineStatus
+
+// ─── L3 perception dirty_rects_aggregate view (S2 D2-C) ──────────────────────
+
+export interface NativeDirtyRectFrame {
+  frameIndex: bigint
+  count: bigint
+}
+
+export interface NativeDirtyRectsResult {
+  /** The `monitor_index` the caller asked for, echoed back so the TS
+   * layer can confirm round-trip integrity (CLAUDE.md §3.2 PR #102 教訓). */
+  monitorIndex: number
+  /** Number of currently-retained frames for this monitor (after the
+   * per-monitor FIFO cap eviction). */
+  liveFrameCount: number
+  /** Most recent `(frame_index, count)` for this monitor, if any. */
+  latest: NativeDirtyRectFrame | null
+}
+
+/** Read the count-only `dirty_rects_aggregate` view for a given monitor
+ * (S2 D2-C count-only contract spike, `docs/adr-008-d2-c-plan.md`).
+ * Returns the per-monitor live-frame count and the latest
+ * `(frame_index, count)`; empty result when the pipeline has no rect
+ * yet, the slot is poisoned, or no rect for the requested monitor. */
+export declare function viewGetDirtyRects(monitorIndex: number): NativeDirtyRectsResult

--- a/index.js
+++ b/index.js
@@ -119,4 +119,7 @@ export const l1ShutdownForTest          = nativeBinding.l1ShutdownForTest;
 export const viewGetFocused             = nativeBinding.viewGetFocused;
 export const viewFocusedPipelineStatus  = nativeBinding.viewFocusedPipelineStatus;
 
+// ─── L3 perception dirty_rects_aggregate view (S2 D2-C) ──────────────────────
+export const viewGetDirtyRects          = nativeBinding.viewGetDirtyRects;
+
 export default nativeBinding;

--- a/src/engine/native-types.ts
+++ b/src/engine/native-types.ts
@@ -74,6 +74,24 @@ export interface NativeViewFocusedPipelineStatus {
   processedCount: bigint
 }
 
+// ─── L3 perception dirty_rects_aggregate view (S2 D2-C) ──────────────────────
+// Returned by `viewGetDirtyRects(monitorIndex)`. Count-only contract spike
+// per `docs/adr-008-d2-c-plan.md` §2.3 / §3.7 — no rect geometry, just a
+// per-`(monitor, frame)` count and the latest frame for the queried monitor.
+
+export interface NativeDirtyRectFrame {
+  frameIndex: bigint
+  count: bigint
+}
+
+export interface NativeDirtyRectsResult {
+  /** The `monitor_index` the caller asked for, echoed back so the TS
+   * layer can confirm round-trip integrity (CLAUDE.md §3.2 PR #102 教訓). */
+  monitorIndex: number
+  liveFrameCount: number
+  latest: NativeDirtyRectFrame | null
+}
+
 export interface NativeFocusAndPointResult {
   focused?: NativeUiaFocusInfo | null
   atPoint?: NativeUiaFocusInfo | null

--- a/src/engine/native-types.ts
+++ b/src/engine/native-types.ts
@@ -89,7 +89,14 @@ export interface NativeDirtyRectsResult {
    * layer can confirm round-trip integrity (CLAUDE.md §3.2 PR #102 教訓). */
   monitorIndex: number
   liveFrameCount: number
-  latest: NativeDirtyRectFrame | null
+  /** Most recent `(frame_index, count)` for this monitor, if any.
+   * **Optional** because napi-rs serialises `Option::None` for nested
+   * struct fields by **omitting** the key (not setting it to `null`).
+   * User review on PR #108 (2026-05-01) pinned the runtime behaviour.
+   * Use optional chaining (`result.latest?.frameIndex`) or
+   * `result.latest != null` (covers both `undefined` from omission
+   * and a hypothetical future `null`). */
+  latest?: NativeDirtyRectFrame
 }
 
 export interface NativeFocusAndPointResult {

--- a/src/l3_bridge/dirty_rect_pump.rs
+++ b/src/l3_bridge/dirty_rect_pump.rs
@@ -1,0 +1,433 @@
+//! Dirty rect event pump: L1 ring → engine-perception input.
+//!
+//! S2 D2-C (`docs/adr-008-d2-c-plan.md` §3.5) sibling of `focus_pump`.
+//! Subscribes to the L1 ring on the parent thread, then spawns a
+//! worker that filters `EventKind::DirtyRect` payloads, decodes them
+//! via bincode, builds a `DirtyRectEvent`, and pushes it through the
+//! shared `L1Sink` into the engine.
+//!
+//! Same lifecycle / shutdown contract as `focus_pump.rs`:
+//! - parent-side `subscribe` (Codex v3 P1)
+//! - retain-on-timeout `JoinHandle` (Codex v6 P1)
+//! - 5-cycle restart safe (test parity with focus_pump's
+//!   `five_cycle_spawn_shutdown`)
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use crate::l1_capture::{
+    DirtyRectPayload, EventKind, EventRing, Subscription, SubscriptionEvent,
+};
+use engine_perception::input::{DirtyRectEvent, L1Sink, Rect};
+
+/// Per-recv timeout. Bounds shutdown latency.
+const RECV_TIMEOUT: Duration = Duration::from_millis(100);
+
+/// Subscription channel capacity. P5c-2 emit fork rate is at most
+/// monitor-refresh-rate × dirty-rects-per-frame ≤ a few hundred / sec
+/// in worst case, so 8192 is ample (mirrors `focus_pump`).
+const SUB_CAPACITY: usize = 8192;
+
+/// L1 → engine-perception dirty rect event pump.
+pub(crate) struct DirtyRectPump {
+    join: Mutex<Option<JoinHandle<()>>>,
+    shutdown: Arc<AtomicBool>,
+    forwarded_count: Arc<AtomicU64>,
+    decode_failure_count: Arc<AtomicU64>,
+}
+
+impl DirtyRectPump {
+    /// Spawn the pump. Mirrors `FocusPump::spawn` exactly: parent-side
+    /// `ring.subscribe(...)` first (Codex v3 P1), then move the
+    /// `Subscription` into the worker.
+    pub(crate) fn spawn(ring: Arc<EventRing>, sink: Arc<dyn L1Sink>) -> Self {
+        let sub: Subscription = ring.subscribe(SUB_CAPACITY);
+
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let forwarded_count = Arc::new(AtomicU64::new(0));
+        let decode_failure_count = Arc::new(AtomicU64::new(0));
+
+        let shutdown_clone = Arc::clone(&shutdown);
+        let forwarded_clone = Arc::clone(&forwarded_count);
+        let decode_failures_clone = Arc::clone(&decode_failure_count);
+
+        let join = thread::Builder::new()
+            .name("l3-dirty-rect-pump".into())
+            .spawn(move || {
+                run(
+                    sub,
+                    sink,
+                    shutdown_clone,
+                    forwarded_clone,
+                    decode_failures_clone,
+                );
+            })
+            .expect("spawn l3-dirty-rect-pump");
+
+        DirtyRectPump {
+            join: Mutex::new(Some(join)),
+            shutdown,
+            forwarded_count,
+            decode_failure_count,
+        }
+    }
+
+    /// Signal shutdown and poll the pump thread's `is_finished()`
+    /// until the deadline. **The `JoinHandle` is retained on timeout**
+    /// (Codex v6 P1), same retain semantics as `FocusPump`.
+    pub(crate) fn shutdown_with_timeout(&self, timeout: Duration) -> Result<(), &'static str> {
+        self.shutdown.store(true, Ordering::SeqCst);
+
+        let deadline = Instant::now() + timeout;
+        let poll_interval = Duration::from_millis(10);
+
+        loop {
+            let finished_or_done = {
+                let mut guard = self.join.lock().unwrap_or_else(|e| e.into_inner());
+                match guard.as_ref() {
+                    Some(h) if h.is_finished() => {
+                        let h = guard.take().expect("just observed Some");
+                        let _ = h.join();
+                        true
+                    }
+                    Some(_) => false,
+                    None => true,
+                }
+            };
+            if finished_or_done {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                return Err("dirty rect pump join timed out");
+            }
+            thread::sleep(poll_interval);
+        }
+    }
+
+    /// Consume-form shutdown — delegates to `shutdown_with_timeout`.
+    pub(crate) fn shutdown(self, timeout: Duration) -> Result<(), &'static str> {
+        self.shutdown_with_timeout(timeout)
+    }
+
+    pub(crate) fn forwarded_count(&self) -> u64 {
+        self.forwarded_count.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn decode_failure_count(&self) -> u64 {
+        self.decode_failure_count.load(Ordering::Relaxed)
+    }
+}
+
+impl Drop for DirtyRectPump {
+    fn drop(&mut self) {
+        // Best-effort signal + best-effort join. Don't block in Drop.
+        self.shutdown.store(true, Ordering::SeqCst);
+        let handle_opt = self
+            .join
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .take();
+        if let Some(h) = handle_opt {
+            let deadline = Instant::now() + Duration::from_secs(2);
+            while !h.is_finished() {
+                if Instant::now() >= deadline {
+                    return;
+                }
+                thread::sleep(Duration::from_millis(10));
+            }
+            let _ = h.join();
+        }
+    }
+}
+
+fn run(
+    sub: Subscription,
+    sink: Arc<dyn L1Sink>,
+    shutdown: Arc<AtomicBool>,
+    forwarded: Arc<AtomicU64>,
+    decode_failures: Arc<AtomicU64>,
+) {
+    loop {
+        if shutdown.load(Ordering::SeqCst) {
+            break;
+        }
+        match sub.recv_timeout(RECV_TIMEOUT) {
+            Ok(env) => {
+                if env.kind != EventKind::DirtyRect as u16 {
+                    continue;
+                }
+                if let Some(ev) = decode_dirty_rect_event(&env, &decode_failures) {
+                    sink.push_dirty_rect(ev);
+                    forwarded.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+            Err(crossbeam_channel::RecvTimeoutError::Timeout) => continue,
+            Err(crossbeam_channel::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+    // sub Drop unsubscribes from the ring automatically.
+}
+
+/// Decode one `SubscriptionEvent` into a `DirtyRectEvent`. Returns
+/// `None` on bincode decode failure (counter incremented). Extracted
+/// as a free function so unit tests can drive the decode path with
+/// synthetic envelopes without spawning the full pump (mirrors
+/// `focus_pump::decode_focus_event`).
+fn decode_dirty_rect_event(
+    env: &SubscriptionEvent,
+    decode_failures: &AtomicU64,
+) -> Option<DirtyRectEvent> {
+    let payload: DirtyRectPayload =
+        match bincode::serde::decode_from_slice(&env.payload, bincode::config::standard()) {
+            Ok((p, _)) => p,
+            Err(_) => {
+                decode_failures.fetch_add(1, Ordering::Relaxed);
+                return None;
+            }
+        };
+    Some(DirtyRectEvent {
+        source_event_id: env.event_id,
+        wallclock_ms: env.wallclock_ms,
+        sub_ordinal: env.sub_ordinal,
+        timestamp_source: env.timestamp_source,
+        monitor_index: payload.monitor_index,
+        frame_index: payload.frame_index,
+        rect: Rect::from_array(payload.rect),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::Mutex as StdMutex;
+
+    use crate::l1_capture::{encode_payload, DirtyRectPayload, EventRing, TimestampSource};
+    use engine_perception::input::{DirtyRectEvent, FocusEvent};
+
+    /// Capture-only `L1Sink` for tests.
+    struct CaptureSink {
+        events: StdMutex<Vec<DirtyRectEvent>>,
+    }
+
+    impl CaptureSink {
+        fn new() -> Self {
+            Self {
+                events: StdMutex::new(Vec::new()),
+            }
+        }
+        fn snapshot(&self) -> Vec<DirtyRectEvent> {
+            self.events.lock().unwrap().clone()
+        }
+    }
+
+    impl L1Sink for CaptureSink {
+        fn push_focus(&self, _event: FocusEvent) {
+            // Not relevant for dirty-rect tests.
+        }
+        fn push_dirty_rect(&self, event: DirtyRectEvent) {
+            self.events.lock().unwrap().push(event);
+        }
+    }
+
+    fn make_ring() -> Arc<EventRing> {
+        Arc::new(EventRing::new(1024))
+    }
+
+    fn make_dirty_rect_event(
+        ring: &EventRing,
+        monitor_index: u32,
+        frame_index: u64,
+        rect: [i32; 4],
+        wallclock_ms: u64,
+    ) -> u64 {
+        let payload = DirtyRectPayload {
+            rect,
+            monitor_index,
+            frame_index,
+        };
+        let payload_bytes = encode_payload(&payload);
+        let internal = crate::l1_capture::InternalEvent {
+            envelope_version: 1,
+            event_id: 0,
+            wallclock_ms,
+            sub_ordinal: 0,
+            timestamp_source: TimestampSource::Dxgi as u8,
+            kind: EventKind::DirtyRect as u16,
+            payload: payload_bytes,
+            session_id: None,
+            tool_call_id: None,
+        };
+        ring.push(internal)
+    }
+
+    fn wait_for<F: Fn(&CaptureSink) -> bool>(
+        sink: &CaptureSink,
+        timeout: Duration,
+        predicate: F,
+    ) -> bool {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if predicate(sink) {
+                return true;
+            }
+            thread::sleep(Duration::from_millis(5));
+        }
+        predicate(sink)
+    }
+
+    #[test]
+    fn forwards_dirty_rect_to_sink() {
+        let ring = make_ring();
+        let sink = Arc::new(CaptureSink::new());
+        let pump = DirtyRectPump::spawn(Arc::clone(&ring), sink.clone() as Arc<dyn L1Sink>);
+
+        let event_id =
+            make_dirty_rect_event(&ring, 0, 1, [10, 20, 30, 40], 1_700_000_000_000);
+
+        assert!(
+            wait_for(&sink, Duration::from_millis(500), |s| s.snapshot().len() == 1),
+            "expected 1 forwarded dirty rect, got {}",
+            sink.snapshot().len()
+        );
+
+        let events = sink.snapshot();
+        let ev = &events[0];
+        assert_eq!(ev.source_event_id, event_id, "N1 source_event_id pivot");
+        assert_eq!(ev.monitor_index, 0);
+        assert_eq!(ev.frame_index, 1);
+        assert_eq!(ev.rect.x, 10);
+        assert_eq!(ev.rect.y, 20);
+        assert_eq!(ev.rect.width, 30);
+        assert_eq!(ev.rect.height, 40);
+        assert_eq!(ev.timestamp_source, TimestampSource::Dxgi as u8);
+        assert_eq!(pump.forwarded_count(), 1);
+        assert_eq!(pump.decode_failure_count(), 0);
+
+        pump.shutdown(Duration::from_secs(2)).expect("shutdown");
+    }
+
+    #[test]
+    fn monitor_index_propagates_correctly() {
+        // CLAUDE.md §3.2 PR #102 教訓: monitor_index must NOT be
+        // hard-coded or dropped on the L1→L3 path.
+        let ring = make_ring();
+        let sink = Arc::new(CaptureSink::new());
+        let pump = DirtyRectPump::spawn(Arc::clone(&ring), sink.clone() as Arc<dyn L1Sink>);
+
+        make_dirty_rect_event(&ring, 0, 1, [0, 0, 100, 100], 1_700_000_000_000);
+        make_dirty_rect_event(&ring, 1, 1, [0, 0, 200, 200], 1_700_000_000_001);
+
+        assert!(wait_for(&sink, Duration::from_millis(500), |s| s.snapshot().len() == 2));
+
+        let events = sink.snapshot();
+        assert_eq!(events[0].monitor_index, 0);
+        assert_eq!(events[1].monitor_index, 1);
+        assert_eq!(events[0].rect.width, 100);
+        assert_eq!(events[1].rect.width, 200);
+
+        pump.shutdown(Duration::from_secs(2)).expect("shutdown");
+    }
+
+    #[test]
+    fn skips_non_dirty_rect_events() {
+        // Non-DirtyRect kind (e.g. UiaFocusChanged) must not forward.
+        let ring = make_ring();
+        let sink = Arc::new(CaptureSink::new());
+        let pump = DirtyRectPump::spawn(Arc::clone(&ring), sink.clone() as Arc<dyn L1Sink>);
+
+        let internal = crate::l1_capture::InternalEvent {
+            envelope_version: 1,
+            event_id: 0,
+            wallclock_ms: 1_700_000_000_000,
+            sub_ordinal: 0,
+            timestamp_source: TimestampSource::StdTime as u8,
+            kind: EventKind::Heartbeat as u16,
+            payload: vec![],
+            session_id: None,
+            tool_call_id: None,
+        };
+        ring.push(internal);
+        thread::sleep(Duration::from_millis(150));
+
+        assert_eq!(sink.snapshot().len(), 0);
+        assert_eq!(pump.forwarded_count(), 0);
+        assert_eq!(pump.decode_failure_count(), 0);
+
+        pump.shutdown(Duration::from_secs(2)).expect("shutdown");
+    }
+
+    #[test]
+    fn decode_failure_increments_counter() {
+        let ring = make_ring();
+        let sink = Arc::new(CaptureSink::new());
+        let pump = DirtyRectPump::spawn(Arc::clone(&ring), sink.clone() as Arc<dyn L1Sink>);
+
+        // Invalid bincode payload under DirtyRect kind.
+        let internal = crate::l1_capture::InternalEvent {
+            envelope_version: 1,
+            event_id: 0,
+            wallclock_ms: 1_700_000_000_000,
+            sub_ordinal: 0,
+            timestamp_source: TimestampSource::Dxgi as u8,
+            kind: EventKind::DirtyRect as u16,
+            payload: vec![0xff, 0xff, 0xff],
+            session_id: None,
+            tool_call_id: None,
+        };
+        ring.push(internal);
+        thread::sleep(Duration::from_millis(150));
+
+        assert_eq!(sink.snapshot().len(), 0);
+        assert_eq!(pump.decode_failure_count(), 1);
+        assert_eq!(pump.forwarded_count(), 0);
+
+        pump.shutdown(Duration::from_secs(2)).expect("shutdown");
+    }
+
+    #[test]
+    fn shutdown_within_2s() {
+        let ring = make_ring();
+        let sink = Arc::new(CaptureSink::new());
+        let pump = DirtyRectPump::spawn(Arc::clone(&ring), sink as Arc<dyn L1Sink>);
+        let start = Instant::now();
+        pump.shutdown(Duration::from_secs(2)).expect("shutdown");
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "shutdown should be fast (no events to drain)"
+        );
+    }
+
+    #[test]
+    fn five_cycle_spawn_shutdown() {
+        let ring = make_ring();
+
+        for cycle in 0..5 {
+            let sink = Arc::new(CaptureSink::new());
+            let pump =
+                DirtyRectPump::spawn(Arc::clone(&ring), sink.clone() as Arc<dyn L1Sink>);
+            make_dirty_rect_event(
+                &ring,
+                cycle as u32,
+                cycle as u64,
+                [0, 0, 10, 10],
+                1_700_000_000_000 + cycle as u64,
+            );
+            assert!(
+                wait_for(&sink, Duration::from_millis(500), |s| s.snapshot().len() == 1),
+                "cycle {} expected 1 forwarded dirty rect",
+                cycle
+            );
+            pump.shutdown(Duration::from_secs(2))
+                .unwrap_or_else(|e| panic!("cycle {} shutdown failed: {}", cycle, e));
+            assert_eq!(
+                ring.subscriber_count(),
+                0,
+                "cycle {}: subscriber slot must be cleared on Drop",
+                cycle
+            );
+        }
+    }
+}

--- a/src/l3_bridge/mod.rs
+++ b/src/l3_bridge/mod.rs
@@ -32,6 +32,7 @@
 
 #![allow(dead_code)]
 
+pub(crate) mod dirty_rect_pump;
 pub(crate) mod focus_pump;
 
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -49,10 +50,12 @@ use crate::win32::safety::napi_safe_call;
 
 use engine_perception::input::{spawn_perception_worker, FocusInputHandle, L1Sink, PerceptionWorker};
 use engine_perception::views::current_focused_element::CurrentFocusedElementView;
+use engine_perception::views::dirty_rects_aggregate::DirtyRectsAggregateView;
 use engine_perception::views::latest_focus::LatestFocusView;
 
 use crate::l1_capture::ensure_l1;
 
+use self::dirty_rect_pump::DirtyRectPump;
 use self::focus_pump::FocusPump;
 
 /// Test helper: spawn the full perception pipeline on the existing
@@ -75,11 +78,12 @@ pub(crate) fn spawn_perception_pipeline_for_test() -> (
     CurrentFocusedElementView,
     FocusPump,
 ) {
-    // D2-B-1: spawn_perception_worker now returns 4 elements
-    // (latest_focus_view added). Existing test callers don't need
-    // the latest_focus_view, so we drop it here. Production
-    // `spawn_pipeline_inner` keeps it on `PerceptionPipeline`.
-    let (worker, handle, view, _latest_view) = spawn_perception_worker();
+    // D2-B-1 → S2 D2-C: spawn_perception_worker now returns 5 elements
+    // (latest_focus_view added in D2-B-1, dirty_rects_view added in
+    // S2 D2-C). Existing test callers don't need the latest/dirty
+    // views, so we drop them here. Production `spawn_pipeline_inner`
+    // keeps them on `PerceptionPipeline`.
+    let (worker, handle, view, _latest_view, _dirty_rects_view) = spawn_perception_worker();
     let ring = ensure_l1().ring.clone();
     let sink: Arc<dyn L1Sink> = Arc::new(handle.clone());
     let pump = FocusPump::spawn(ring, sink);
@@ -173,9 +177,19 @@ pub struct PerceptionPipeline {
     /// this one because the focused element's HWND is not always
     /// the foreground-window HWND (Codex v3 P1-4).
     pub latest_focus_view: LatestFocusView,
+    /// Per-`(monitor_index, frame_index)` count view of DXGI dirty
+    /// rects (S2 D2-C count-only contract spike,
+    /// `docs/adr-008-d2-c-plan.md`). Read via the napi binding
+    /// `view_get_dirty_rects(monitor_index)`.
+    pub dirty_rects_view: DirtyRectsAggregateView,
     pub handle: FocusInputHandle,
     worker: PerceptionWorker,
     pump: FocusPump,
+    /// Dirty-rect pump: `EventKind::DirtyRect` → engine-perception
+    /// `DirtyRectEvent` (S2 D2-C, `docs/adr-008-d2-c-plan.md` §3.5).
+    /// Mirrors `FocusPump`'s shape so the lifecycle (5-cycle restart,
+    /// retain-on-timeout shutdown, slot poisoning) is identical.
+    dirty_rect_pump: DirtyRectPump,
     /// Set when `shutdown_with_timeout` returns `Err` from either leg
     /// (Codex review v8 P2-16). A poisoned pipeline has lost the
     /// retain-on-timeout safety: at minimum the pump has signalled
@@ -210,25 +224,60 @@ impl PerceptionPipeline {
     /// `ensure_perception_pipeline()` checks it and evicts the slot
     /// instead of handing out a half-stopped pipeline.
     pub fn shutdown_with_timeout(&self, timeout: Duration) -> Result<(), &'static str> {
-        let half = timeout / 2;
-        let pump_result = self.pump.shutdown_with_timeout(half);
-        // Attempt the worker leg even if the pump failed — its
-        // JoinHandle is retained on Err either way, so a retry
-        // path can still complete it.
-        let worker_result = self.worker.shutdown_with_timeout(half);
+        // S2 D2-C: 3 legs (focus_pump, dirty_rect_pump, worker). Each
+        // leg's `shutdown_with_timeout` first sets its `AtomicBool`
+        // shutdown flag synchronously, then polls `is_finished()` until
+        // its deadline. To prevent the 3-leg total wall time from
+        // ballooning past the caller's `timeout` (the
+        // `ensure_perception_pipeline` poison-eviction retry only
+        // budgets 100ms), we **pre-signal all 3 legs with timeout=0**
+        // (each call sets the flag in microseconds and returns Err on
+        // the immediate deadline) so all 3 worker threads start
+        // winding down at roughly the same wall-clock instant. Then
+        // we poll all 3 concurrently with a shared deadline,
+        // returning Ok the moment all 3 report finished.
+        //
+        // Why this matters: `FocusPump` and `DirtyRectPump` use
+        // `recv_timeout(100ms)` so a pump can be mid-recv when signal
+        // fires and must wait up to 100ms to wake. With 3 sequential
+        // polls of timeout/3, neither pump can reliably exit in 33ms
+        // and the pipeline gets falsely poisoned (test
+        // `shutdown_timeout_failure_poisons_slot_and_evicts_on_next_ensure`).
+        // Concurrent polling lets all 3 threads race against one
+        // shared 100ms deadline, matching pre-D2-C 2-leg semantics.
+        let _ = self.pump.shutdown_with_timeout(Duration::ZERO);
+        let _ = self.dirty_rect_pump.shutdown_with_timeout(Duration::ZERO);
+        let _ = self.worker.shutdown_with_timeout(Duration::ZERO);
 
-        match (pump_result, worker_result) {
-            (Ok(()), Ok(())) => Ok(()),
-            (Err(e), _) | (_, Err(e)) => {
-                // Either leg's failure means the pipeline is no
-                // longer fully live: pump.shutdown stored `true` on
-                // its own shutdown AtomicBool before polling, so
-                // even if the pump's JoinHandle was retained, its
-                // forwarder thread is winding down. Mark poisoned
-                // so `ensure_perception_pipeline()` can evict.
-                self.poisoned.store(true, Ordering::SeqCst);
-                Err(e)
+        let deadline = std::time::Instant::now() + timeout;
+        let poll_interval = Duration::from_millis(10);
+        loop {
+            // Each leg's `shutdown_with_timeout(Duration::ZERO)` is a
+            // poll: it returns Ok if the JoinHandle has been taken
+            // (already joined, or finished and just-joined inside
+            // the call), Err otherwise. Idempotent — repeated calls
+            // are cheap.
+            let p_done = self.pump.shutdown_with_timeout(Duration::ZERO).is_ok();
+            let d_done = self.dirty_rect_pump.shutdown_with_timeout(Duration::ZERO).is_ok();
+            let w_done = self.worker.shutdown_with_timeout(Duration::ZERO).is_ok();
+            if p_done && d_done && w_done {
+                return Ok(());
             }
+            if std::time::Instant::now() >= deadline {
+                // Any leg still alive → poison. Mark and return the
+                // first reason in priority order (pump, dirty_pump,
+                // worker) for diagnostic clarity.
+                self.poisoned.store(true, Ordering::SeqCst);
+                let reason = if !p_done {
+                    "focus pump join timed out"
+                } else if !d_done {
+                    "dirty rect pump join timed out"
+                } else {
+                    "worker join timed out"
+                };
+                return Err(reason);
+            }
+            std::thread::sleep(poll_interval);
         }
     }
 
@@ -265,7 +314,12 @@ static PERCEPTION_SLOT: OnceLock<Mutex<Option<Arc<PerceptionPipeline>>>> = OnceL
 /// pipeline is marked poisoned (one or both legs are no longer
 /// live, see `PerceptionPipeline::is_poisoned`). On the next
 /// `ensure_perception_pipeline()` call we attempt **one best-effort
-/// short-timeout retry** (100ms). The slot is then handled by the
+/// short-timeout retry** (250ms — enlarged from the pre-S2 100ms to
+/// accommodate the 3-leg shutdown introduced in S2 D2-C; pumps use
+/// `recv_timeout(100ms)` so a worst-case wakeup adds up to 100ms per
+/// pump, and the concurrent-poll shape in
+/// `PerceptionPipeline::shutdown_with_timeout` lets all 3 race
+/// against the shared deadline). The slot is then handled by the
 /// outcome of that retry:
 ///
 ///   - **Retry succeeded** → both threads have joined, the slot can
@@ -300,7 +354,7 @@ pub fn ensure_perception_pipeline() -> Arc<PerceptionPipeline> {
             // previous attempt. The leg(s) still holding handles
             // resume polling.
             if existing
-                .shutdown_with_timeout(Duration::from_millis(100))
+                .shutdown_with_timeout(Duration::from_millis(250))
                 .is_ok()
             {
                 // Clean — both legs are gone. Clear the slot; the
@@ -391,16 +445,20 @@ pub(crate) fn shutdown_perception_pipeline_for_test(
 /// pump in the same order as `spawn_perception_pipeline_for_test` so
 /// the parent-side `subscribe(...)` runs synchronously (Codex v3 P1).
 fn spawn_pipeline_inner() -> PerceptionPipeline {
-    let (worker, handle, view, latest_focus_view) = spawn_perception_worker();
+    let (worker, handle, view, latest_focus_view, dirty_rects_view) =
+        spawn_perception_worker();
     let ring = ensure_l1().ring.clone();
     let sink: Arc<dyn L1Sink> = Arc::new(handle.clone());
-    let pump = FocusPump::spawn(ring, sink);
+    let pump = FocusPump::spawn(ring.clone(), sink.clone());
+    let dirty_rect_pump = DirtyRectPump::spawn(ring, sink);
     PerceptionPipeline {
         view,
         latest_focus_view,
+        dirty_rects_view,
         handle,
         worker,
         pump,
+        dirty_rect_pump,
         poisoned: AtomicBool::new(false),
     }
 }
@@ -522,6 +580,83 @@ pub fn view_focused_pipeline_status() -> napi::Result<NativeViewFocusedPipelineS
             }
         };
         Ok(status)
+    })
+}
+
+// ─── napi-exposed dirty_rects_aggregate read API (S2 D2-C) ────────────────
+//
+// `view_get_dirty_rects(monitor_index)` is the S2 D2-C trunk's count-only
+// getter (`docs/adr-008-d2-c-plan.md` §3.7 D2-C-6). The shape matches
+// the sub-plan §2.3 minimal getter spec: `(live_frame_count, latest)`
+// where `latest` is `Option<(frame_index, count)>`. **`monitor_index`
+// is preserved on the response** as a sanity field so callers can
+// confirm the index they asked for round-trips correctly (CLAUDE.md
+// §3.2 PR #102 教訓 + sub-plan §1.4 北極星整合).
+
+/// Read shape returned to napi callers from [`view_get_dirty_rects`].
+/// Matches `docs/adr-008-d2-c-plan.md` §2.3 minimal getter spec.
+#[napi(object)]
+pub struct NativeDirtyRectsResult {
+    /// The `monitor_index` the caller asked for, echoed back so the
+    /// TS layer can confirm round-trip integrity (CLAUDE.md §3.2 PR
+    /// #102 教訓: never drop / hard-code monitor_index).
+    pub monitor_index: u32,
+    /// Number of currently-retained frames for this monitor (after
+    /// the per-monitor FIFO cap eviction in
+    /// `DirtyRectsAggregateView`).
+    pub live_frame_count: u32,
+    /// Most recent `(frame_index, count)` for this monitor, if any.
+    /// `None` when no dirty rect has been observed (or all retained
+    /// frames evicted).
+    pub latest: Option<NativeDirtyRectFrame>,
+}
+
+#[napi(object)]
+pub struct NativeDirtyRectFrame {
+    pub frame_index: BigInt,
+    pub count: BigInt,
+}
+
+/// Read the count-only `dirty_rects_aggregate` view for a given
+/// monitor (S2 D2-C count-only contract spike). Returns the per-
+/// monitor live-frame count and the latest `(frame_index, count)`.
+///
+/// First call lazily spawns the perception pipeline
+/// (`ensure_perception_pipeline`). Returns an empty result
+/// (`live_frame_count = 0`, `latest = None`) when:
+///
+///   - the perception pipeline has never received a dirty rect event,
+///   - the slot is poisoned (a previous shutdown attempt failed),
+///     in which case the caller should rely on the UIA / Tier 0
+///     fallback path,
+///   - or no rect has been emitted for the requested `monitor_index`.
+///
+/// Wrapped in `napi_safe_call` per ADR-007 §3.4 — any panic in the
+/// pipeline init / view read path turns into a typed napi error.
+#[napi]
+pub fn view_get_dirty_rects(monitor_index: u32) -> napi::Result<NativeDirtyRectsResult> {
+    napi_safe_call("view_get_dirty_rects", || {
+        let pipeline = ensure_perception_pipeline();
+        if pipeline.is_poisoned() {
+            return Ok(NativeDirtyRectsResult {
+                monitor_index,
+                live_frame_count: 0,
+                latest: None,
+            });
+        }
+        let live_frame_count = pipeline.dirty_rects_view.live_frame_count(monitor_index) as u32;
+        let latest = pipeline
+            .dirty_rects_view
+            .latest(monitor_index)
+            .map(|(frame_index, count)| NativeDirtyRectFrame {
+                frame_index: BigInt::from(frame_index),
+                count: BigInt::from(count),
+            });
+        Ok(NativeDirtyRectsResult {
+            monitor_index,
+            live_frame_count,
+            latest,
+        })
     })
 }
 
@@ -703,7 +838,7 @@ mod lifecycle_tests {
             // InputSession; we'll observe its processed_count to
             // confirm cmds crossed into the dataflow path; the view
             // exposes the materialised current_focused_element state).
-            let (worker, handle, view, _latest_view) =
+            let (worker, handle, view, _latest_view, _dirty_rects_view) =
                 engine_perception::input::spawn_perception_worker();
 
             // (2) spawn pump wired to a TeeSink that BOTH forwards

--- a/tests/unit/view-get-dirty-rects-smoke.test.ts
+++ b/tests/unit/view-get-dirty-rects-smoke.test.ts
@@ -1,0 +1,73 @@
+/**
+ * tests/unit/view-get-dirty-rects-smoke.test.ts
+ *
+ * **G2 contract Test G2-4** (Opus PR #108 Round 1 P1-2 + sub-plan
+ * `docs/adr-008-d2-c-plan.md` §3.8 D2-C-7 + User feedback 2026-05-01):
+ *
+ * Node-side smoke test for the `viewGetDirtyRects` napi binding (S2
+ * D2-C). Calls the export once and verifies it does NOT throw +
+ * returns an object with the expected shape (`monitorIndex` field
+ * echoed back for round-trip integrity per CLAUDE.md §3.2 PR #102
+ * 教訓).
+ *
+ * **What this catches that compile-time `check:native-types` does
+ * not** (User feedback rationale, sub-plan §0):
+ *   - native binding registration drop (rust→addon symbol miswire)
+ *   - JS export missing from `index.js`
+ *   - runtime symbol mismatch (renamed Rust fn vs index.d.ts decl)
+ *   - pipeline init crash (panicking `ensure_perception_pipeline`)
+ *
+ * **What this does NOT cover** (carry-over to expansion):
+ *   - DXGI live frame rect counts (no real DXGI driver in CI)
+ *   - vitest live integration (Notepad/Edge fixture-based) — sub-plan §1.3
+ */
+
+import { describe, it, expect } from "vitest";
+
+describe("viewGetDirtyRects (G2-4 smoke)", () => {
+  it("returns a NativeDirtyRectsResult shape with monitor_index echoed", async () => {
+    // Dynamic import: the addon is loaded lazily so a missing /
+    // unbuilt `index.node` surfaces as a clear failure here rather
+    // than at module-load time of the entire test suite.
+    const addon = await import("../../index.js");
+
+    // The function must exist on the export (compile-time
+    // `check:native-types` ensures the declaration; this checks the
+    // actual runtime symbol).
+    expect(typeof addon.viewGetDirtyRects).toBe("function");
+
+    // First-call lazy init of the perception pipeline. With no DXGI
+    // events emitted, the result is an empty (but well-formed) shape:
+    //   { monitorIndex: 0, liveFrameCount: 0, latest: null }
+    // The key contract is that the call doesn't throw and the
+    // returned object has the shape the TS layer expects (CLAUDE.md
+    // §3.2 PR #102 教訓: monitor_index round-trip integrity).
+    const result = addon.viewGetDirtyRects(0);
+
+    expect(result).toBeDefined();
+    expect(result.monitorIndex).toBe(0);
+    expect(typeof result.liveFrameCount).toBe("number");
+    // `latest` is `NativeDirtyRectFrame | null | undefined` — napi-rs
+    // serialises `Option::None` as `undefined` (not null) in JS
+    // contexts, so accept both. Smoke-with-no-events case: undefined
+    // / null. With DXGI events flowing: object with frameIndex +
+    // count (vitest live integration scope, sub-plan §1.3 carry-over).
+    expect(
+      result.latest === null ||
+        result.latest === undefined ||
+        (typeof result.latest === "object" &&
+          typeof result.latest.frameIndex === "bigint" &&
+          typeof result.latest.count === "bigint"),
+    ).toBe(true);
+  });
+
+  it("returns the requested monitor_index back even for non-zero indices", async () => {
+    // Per-monitor query smoke (CLAUDE.md §3.2 PR #102 教訓 follow-up):
+    // the binding must NOT hard-code monitor_index=0 in the response.
+    // Even with no rects emitted for monitor=1, the result must echo
+    // the queried index.
+    const addon = await import("../../index.js");
+    const result = addon.viewGetDirtyRects(1);
+    expect(result.monitorIndex).toBe(1);
+  });
+});

--- a/tests/unit/view-get-dirty-rects-smoke.test.ts
+++ b/tests/unit/view-get-dirty-rects-smoke.test.ts
@@ -47,18 +47,28 @@ describe("viewGetDirtyRects (G2-4 smoke)", () => {
     expect(result).toBeDefined();
     expect(result.monitorIndex).toBe(0);
     expect(typeof result.liveFrameCount).toBe("number");
-    // `latest` is `NativeDirtyRectFrame | null | undefined` — napi-rs
-    // serialises `Option::None` as `undefined` (not null) in JS
-    // contexts, so accept both. Smoke-with-no-events case: undefined
-    // / null. With DXGI events flowing: object with frameIndex +
+    // `latest` is **optional** — napi-rs serialises `Option::None`
+    // for a nested struct field by **omitting the key entirely**
+    // (User review on PR #108 2026-05-01 pinned the runtime
+    // behaviour). The TS type uses `latest?: NativeDirtyRectFrame`
+    // to match. With DXGI events flowing: object with frameIndex +
     // count (vitest live integration scope, sub-plan §1.3 carry-over).
     expect(
-      result.latest === null ||
-        result.latest === undefined ||
+      result.latest === undefined ||
+        result.latest === null ||
         (typeof result.latest === "object" &&
           typeof result.latest.frameIndex === "bigint" &&
           typeof result.latest.count === "bigint"),
     ).toBe(true);
+    // Pin the omission-vs-null contract: in the smoke-with-no-events
+    // case the field must be **absent** from the object (not present
+    // with value null). If a future napi-rs upgrade changes the
+    // serialisation to null, this assertion fails and we know to
+    // re-evaluate the TS types (currently `latest?: NativeDirtyRectFrame`
+    // covers both omission and undefined assignment).
+    if (result.liveFrameCount === 0) {
+      expect("latest" in result).toBe(false);
+    }
   });
 
   it("returns the requested monitor_index back even for non-zero indices", async () => {


### PR DESCRIPTION
## Summary

Walking skeleton trunk PR-ε (S2) impl per `docs/adr-008-d2-c-plan.md` (PR #103 + Round 2 follow-up PR #107)。Count-only `(monitor_index, frame_index) -> count` view + dirty_rect_pump + napi binding + production pipeline 5-tuple shape。S1 で確立した `build_*(focus_stream) -> (Arranged, View)` template を mechanical コピーで揃えた contract spike。

新運用モード (memory `feedback_autonomous_phase_transition.md`、user 2026-05-01 認可): phase 移行は Opus 判断 autonomous で着手、user + Codex は post-PR review。

## What changed (~1200 line / 7 files)

- `crates/engine-perception/src/input.rs`: `Rect` + `DirtyRectEvent` 型 + `L1Sink::push_dirty_rect` (default impl `{}`) + `Cmd::PushDirtyRect` variant + `FocusInputHandle::push_dirty_rect` impl + spawn_perception_worker 戻り値 **5-tuple** + worker_loop に 2 つ目の InputSession + dataflow closure 内 `build_dirty_rects_aggregate` 呼出 + Cmd::PushDirtyRect arm (focus と同じ N3 partial-order + watermark-shift + idle frontier advance)
- `crates/engine-perception/src/views/dirty_rects_aggregate.rs` 新設: count-only view + `DirtyRectsAggregateArranged<'scope>` alias + `build_dirty_rects_aggregate(&dirty_rect_stream) -> (Arranged, View)` (S1 R9 2-borrow pattern) + 固定 N=8 frames per-monitor FIFO eviction + 4 unit test
- `src/l3_bridge/dirty_rect_pump.rs` 新設 (`focus_pump.rs` 完全同型): parent-side subscribe + bincode decode + retain-on-timeout shutdown + 6 unit test
- `src/l3_bridge/mod.rs`: `PerceptionPipeline` に `dirty_rects_view` + `dirty_rect_pump` field 追加 + `shutdown_with_timeout` を **3-leg concurrent shutdown** に refactor (pre-signal all 3 → 共有 deadline polling) + `ensure_perception_pipeline` retry budget 100→250ms 拡張 + `view_get_dirty_rects(monitor_index)` napi binding 新設
- `index.d.ts` + `src/engine/native-types.ts`: `NativeDirtyRectFrame` + `NativeDirtyRectsResult` 型同期 (47 napi exports)

## CLAUDE.md 強制命令整合

| 強制命令 | 整合 |
|---|---|
| §3 + §3.3 | Opus + Codex 両 review post-PR auto-trigger (production code 改修 PR 必須) |
| §3.1 | sub-plan / impl / index.d.ts / native-types.ts の 4 SSOT で shape (`monitor_index` field 維持、count-only output、5-tuple) bit-equal |
| §3.2 (PR #102 教訓) | `monitor_index` を全経路で保持、ハードコード禁止、payload echo + napi result echo + view `(monitor, frame)` 複合 key |
| §7 | 3-leg concurrent shutdown を構造で拡張可能 |
| §8 | feature branch + PR |
| §9 | G1 gate は PR #106 で永続化済 |

## 6-guard 全 pass

- ✅ `cargo check --workspace` clean
- ✅ `cargo test -p engine-perception --lib` **42/42 pass**
- ✅ `cargo test -p desktop-touch-engine --no-default-features --lib l3_bridge` **25/25 pass** (focus_pump 9 + lifecycle 2 + production_pipeline_lifecycle 8 + **dirty_rect_pump 6**)
- ✅ `npm run check:napi-safe` OK
- ✅ `npm run check:native-types` OK (**47 Rust exports**)
- ✅ `npm run check:stub-catalog` OK
- ✅ `npm run build` (tsc) OK

## G2 contract status

| # | walking-skeleton §4 S2 目標 | 本 PR 状態 |
|---|---|---|
| 1 | DXGI emit を入力に view が更新される | ✅ Rust `apply_count_per_frame_aggregates` test (sub-plan §3.8 G2-1) |
| 2 | `monitor_index` field 維持 | ✅ Rust `apply_count_per_monitor_isolation` test (G2-2) + dirty_rect_pump `monitor_index_propagates_correctly` test |
| 3 | napi export TS 側から呼べる | ✅ compile-time `check:native-types` 47 exports + `view_get_dirty_rects` declared |
| 4 | focus + dirty rects 共存 (G2-3) | ⏳ Rust mock-based test 本 PR carry-over (review findings 反映で追加 follow-up commit、または別 PR) |
| 5 | Node smoke (G2-4) | ⏳ `tests/unit/view-get-dirty-rects-smoke.test.ts` 本 PR carry-over (vitest 追加 follow-up) |

## Test plan

- [x] Rust + npm 6-guard 全 pass
- [x] **Opus phase-boundary review** (CLAUDE.md §3.3 Step 1)
- [x] **Codex auto-review** (CLAUDE.md §3.2 dual-reviewer)
- [x] G2-3 / G2-4 contract test を follow-up commit/PR で追加
- [x] User merge → G2 ゲート判定 → walking-skeleton Appendix C append → S3 着手 (envelope minimal wrapper)

## Schedule for option C (carry-over)

User 2026-05-01 確認: option C (parking_lot::Condvar signal-driven worker_loop) は **trunk 完了 (S6) 後の expansion phase 初期** で独立 swimlane として着手 (`view_update_latency` SLO `<1ms` 達成は contract spike phase の責務外、`docs/walking-skeleton-trunk-selection.md` §3.2 整合)。S6 で起こす `docs/walking-skeleton-expansion-plan.md` に option C を明示。

🤖 Generated with [Claude Code](https://claude.com/claude-code)