### PR TITLE
fix(adr-008 D2-C): post-merge Round 4 — Opus R2 P2×2 + P3×2 follow-ups

### DIFF
--- a/crates/engine-perception/src/input.rs
+++ b/crates/engine-perception/src/input.rs
@@ -1189,8 +1189,25 @@ mod tests {
         // to advance past 0xCC's wallclock so 0xCC also materialises
         // in the per-hwnd view (otherwise 0xCC sits at the frontier
         // and only idle-advance projects past it via real-time elapsed).
-        // 5_000ms-jump ensures watermark covers all earlier events
-        // even with shift_ms=100 default and idle-advance latency.
+        //
+        // **Why +5_000ms specifically** (Opus PR #108 Round 2 P3-B):
+        //   - default WATERMARK_SHIFT_MS = 100ms → watermark = max_wc - 100
+        //   - DD's reduce + arrange_by_key + inspect chain over the
+        //     5-tuple operator graph (focus_view + latest_focus +
+        //     dirty_rects shared scope) needs several `worker.step()`
+        //     activations to settle for the latest events
+        //   - lifecycle test uses 200ms spacing without an explicit
+        //     pump because L1 ring → focus_pump → handle latency
+        //     naturally spaces events out (~50ms+ recv_timeout cycle);
+        //     the in-crate test pushes via `handle.push_focus` directly
+        //     so events arrive in a single batch, requiring an explicit
+        //     pump to drive watermark forward
+        //   - +5_000ms gives ~25× margin over the 200ms event spacing,
+        //     comfortable against jitter from `step_until_idle` cap (32)
+        //     and idle-advance recv_timeout cycle (1ms default)
+        //   - 1_000ms or smaller observed flaky on slower CI runners
+        //     during pre-Round 2 iteration; 5_000ms eliminated all
+        //     flake without inflating test wall time
         handle.push_focus(make_focus_event_with_hwnd(0xDD, wc_base + 5_000, 0));
 
         // Counter 分離確認 (Codex P2-B): focus 4 件、dirty rect 2 件

--- a/crates/engine-perception/src/views/dirty_rects_aggregate.rs
+++ b/crates/engine-perception/src/views/dirty_rects_aggregate.rs
@@ -210,19 +210,39 @@ impl DirtyRectsAggregateView {
 
         // ── Step 1: update the per-(key, count_value) diff sum ────
         let counts = g.by_key.entry(key).or_default();
-        let new_diff = counts.get(&count_value).copied().unwrap_or(0) + diff;
-        // Defensive: a negative diff sum shouldn't occur under DD's
-        // diff invariants (every retraction matches a prior
+        let prior = counts.get(&count_value).copied().unwrap_or(0);
+        let new_diff = prior + diff;
+
+        // **Late retraction for evicted/never-asserted (key, count_value)**
+        // (Opus PR #108 Round 2 P2-A): the cap eviction in Step 3
+        // can remove `(monitor, frame)` from `by_key` after a prior
+        // assertion landed (late-older-arrival path). A subsequent
+        // DD reduce retraction for the same key/value then lands on
+        // an empty BTreeMap, with `prior == 0` and `diff < 0` ⇒
+        // `new_diff == -1`. The pre-Round 4 shape panicked in debug
+        // builds on this `debug_assert!` even though the retraction
+        // is semantically a no-op (the data is gone). Drop silently
+        // and clean up the BTreeMap entry created by `entry().or_default()`.
+        if prior == 0 && diff < 0 {
+            if counts.is_empty() {
+                g.by_key.remove(&key);
+            }
+            return;
+        }
+        // Defensive: any other negative diff sum shouldn't occur under
+        // DD's diff invariants (every retraction matches a prior
         // assertion, even if observed out-of-order). Surface the bug
         // in debug builds without panicking — same posture as
         // `current_focused_element::apply_diff`.
         debug_assert!(
             new_diff >= 0,
-            "negative diff sum at (monitor={}, frame={}, count_value={}): {}",
+            "negative diff sum at (monitor={}, frame={}, count_value={}): {} (prior={}, diff={})",
             monitor_index,
             frame_index,
             count_value,
             new_diff,
+            prior,
+            diff,
         );
         if new_diff <= 0 {
             counts.remove(&count_value);
@@ -463,6 +483,39 @@ mod tests {
         v.apply_count(0, 1, 5, 1);
         assert_eq!(v.get(0, 1), Some(5));
         assert_eq!(v.live_frame_count(0), 1);
+    }
+
+    #[test]
+    fn apply_count_late_older_arrival_followed_by_retraction_does_not_panic() {
+        // **Opus PR #108 Round 2 P2-A regression**: late-older arrival
+        // path evicts `(monitor, frame)` from `by_key` after a prior
+        // assertion (cap full + new frame is the new min). A subsequent
+        // DD reduce retraction for the same `(key, count_value)` then
+        // lands on an empty BTreeMap, with `prior == 0` and `diff < 0`
+        // ⇒ `new_diff == -1`. Pre-Round 4 shape panicked in debug builds
+        // on `debug_assert!(new_diff >= 0)`. Round 4 fix drops such
+        // retractions silently (the data is already gone via eviction).
+        let v = DirtyRectsAggregateView::new();
+        // Fill the per-monitor live cap with frames 1..=CAP.
+        for fi in 1..=(PER_MONITOR_FRAME_CAP as u64) {
+            v.apply_count(0, fi, 1, 1);
+        }
+        assert_eq!(v.live_frame_count(0), PER_MONITOR_FRAME_CAP);
+        // Late older arrival = frame 0. Cap eviction picks min = 0
+        // (the just-inserted frame), removes it from both
+        // live_frames_by_monitor and by_key.
+        v.apply_count(0, 0, 1, 1);
+        assert!(v.get(0, 0).is_none(), "frame 0 evicted (late-older drop)");
+        // Now DD reduce fires retraction for the just-evicted (0, 0,
+        // count_value=1). Pre-Round 4: panic. Round 4: silent drop.
+        v.apply_count(0, 0, 1, -1);
+        // View state unchanged — the retraction is a no-op for an
+        // already-evicted key. Surviving frames 1..=CAP intact.
+        assert!(v.get(0, 0).is_none());
+        assert_eq!(v.live_frame_count(0), PER_MONITOR_FRAME_CAP);
+        for fi in 1..=(PER_MONITOR_FRAME_CAP as u64) {
+            assert_eq!(v.get(0, fi), Some(1), "frame {} survived eviction sequence", fi);
+        }
     }
 
     #[test]

--- a/docs/adr-008-d2-c-followups.md
+++ b/docs/adr-008-d2-c-followups.md
@@ -1,0 +1,141 @@
+# ADR-008 D2-C — post-merge follow-ups
+
+PR #108 (S2 walking skeleton trunk impl、merged 2026-05-01 `7986838`) の
+**post-merge follow-ups** を集約する永続 docs (CLAUDE.md 強制命令 9: 残件は
+memory ではなく docs/)。
+
+Round 1 (Opus + Codex)、Round 2 (Opus re-review)、User review、Round 4
+post-merge correction PR で順次反映。完了した item は strikethrough +
+**Resolved** 化、carry-over 対象は OQ として永続化。
+
+## 1. Resolved (post-merge correction PRs)
+
+### 1.1 ~~Round 2 P2-A: late-older arrival post-eviction retraction panic~~
+
+**Resolved** in Round 4 PR (post-merge): `dirty_rects_aggregate.rs::apply_count`
+で `prior == 0 && diff < 0` の場合に silently drop、`debug_assert!` を
+回避。`apply_count_late_older_arrival_followed_by_retraction_does_not_panic`
+test で regression pin。
+
+### 1.2 ~~Round 2 P2-B: `processedCount` focus-only docs sync~~
+
+**Resolved** in Round 4 PR: `index.d.ts` + `src/engine/native-types.ts` の
+`NativeViewFocusedPipelineStatus.processedCount` JSDoc に
+「**Focus-only since S2 D2-C** (Codex round 1 P2-B): dirty-rect traffic
+uses separate counter」を明記。Caller の誤解 (focus-pipeline activity vs
+all-event count) を防ぐ。
+
+### 1.3 ~~Round 2 P3-B: G2-3 test `wc_base + 5_000` pump rationale~~
+
+**Resolved** in Round 4 PR: `crates/engine-perception/src/input.rs` の G2-3
+test pump event に「Why +5_000ms specifically」コメント拡張。
+WATERMARK_SHIFT_MS=100 + DD 5-tuple operator graph settle latency +
+batched-vs-trickled push pattern + flake margin の根拠を明記。
+
+### 1.4 ~~Round 1 → Round 2 → Round 3 (User review) findings 全反映~~
+
+PR #108 head merged shape: Round 1 + Round 2 + Round 3 (User P2 type
+contract) で計 11 findings (Opus P1×2 + P2×4 + P3×3 + Codex P2×2 +
+User P2×1) を 3 round で 1 PR に集約 land。`docs/adr-008-d2-c-plan.md`
+§2.3 + sub-plan 全段で bit-equal sync。
+
+## 2. Open Questions (carry-over to expansion / S6)
+
+### 2.1 OQ #4 (Round 2 P3-A): test helper unification
+
+`crates/engine-perception/src/input.rs::tests` の **2 つの make_event helper**:
+
+- `make_event(source_event_id, wallclock_ms, sub_ordinal)`: pre-S2、`hwnd: 0x1234`
+  ハードコード (per-hwnd diversity 不要なテスト用、17 箇所で使用)
+- `make_focus_event_with_hwnd(hwnd, wallclock_ms, sub_ordinal)`: S2 G2-3
+  追加、per-hwnd 多様性必要なテスト用
+
+両者の存在は **API 重複** で、将来 test 増えたときに「どちらを使うか」判断が
+分散する。統一案:
+
+- **(a)** `make_event` の第 1 引数を `hwnd` に変更 (rename `source_event_id`
+  → `hwnd`、source_event_id は新たに自動採番) → 既存 17 callers の意味的
+  再解釈が必要 (source_event_id 値は意味的には任意なので影響軽微)
+- **(b)** `make_event` を `make_focus_event_with_hwnd(0x1234, ...)` に
+  delegating fn 化 → backward compat 維持しつつ helper 1 本に collapse
+- **(c)** carry-over (現状維持)、test 増加で再評価
+
+**推奨**: (b) — backward compat + DRY、Round 4 と分離して別 PR で吸収可能。
+**着手 timing**: walking skeleton trunk 完了 (S6) 後の expansion phase 初期、
+あるいは S3 (envelope wrapper) impl で focus event 多様性 test が追加で
+必要になったタイミング (どちらが先でも OK)。
+
+### 2.2 OQ #5 (Round 2 P3-C): 3-leg shutdown helper macro / OQ
+
+`PerceptionPipeline::shutdown_with_timeout` の 3-leg concurrent polling
+shape は将来 5/6 leg (例: window_pump、scroll_pump 追加時) で scale すると
+boilerplate 増加。
+
+- **(a)** macro_rules!化 (`shutdown_legs!(self, timeout, [pump, dirty_pump,
+  worker])`) で leg list を引数にして展開
+- **(b)** trait `Shutdownable { fn signal_shutdown(&self); fn join_with_timeout(&self, Duration) -> Result<(), &'static str>; }`
+  + slice ベース concurrent polling generic helper
+- **(c)** 現状の 3-leg ハードコード維持 (新 leg 追加時に 1 行 edit で対応)
+
+**推奨**: (b) — 拡張性 + テスタビリティ、ただし pump trait 化は L3 bridge
+内側 abstraction 増加で慎重判断必要。**着手 timing**: 4 leg 目を追加する
+PR (P5c-3 window_pump or P5c-4 scroll_pump) と同時、別 PR で先行リファクタ
+する判断は不要。
+
+### 2.3 OQ #6 (Round 2 P2-2 carry-over): `last_event_anchor` cmd_kind trace
+
+worker_loop の `last_event_anchor: Option<(u64, Instant)>` 共有変数が
+focus と dirty rect 両方で更新される。trace 観点では「どの cmd 経由で
+更新されたか」が log に出ないため、production debug 時に分析しにくい。
+
+- **(a)** `eprintln!` の anchor update site に `cmd_kind: "focus" | "dirty_rect"`
+  field 追加 (運用観点 trace 拡張、code shape 不変)
+- **(b)** `last_event_anchor` を `(u64, Instant, AnchorSource)` 3-tuple
+  に拡張、production telemetry に source も expose
+- **(c)** 現状維持 (両 cmd の wallclock_ms は monotone と契約)
+
+**推奨**: (a) — production debug 体験向上、impl side effect なし。**着手
+timing**: 別 PR、optional。
+
+### 2.4 OQ #7 (Round 2 P3-A from R1): `decode_dirty_rect_event` arc shape
+
+`src/l3_bridge/dirty_rect_pump.rs::decode_dirty_rect_event` の引数は
+`&AtomicU64` direct ref、`focus_pump.rs::decode_focus_event` は
+`&AtomicU64` (after_none_skip + decode_failures 2 atomics) で挙動同等
+だが arg shape 微差。mechanical コピー徹底観点で focus_pump 同型化推奨
+(carry-over)。
+
+## 3. 4 Round summary (本 PR まとめ)
+
+| Round | Reviewer | Findings | Apply commit |
+|---|---|---|---|
+| 1 | Opus phase-boundary | P1×2 + P2×4 + P3×3 (Conditionally Approved) | a6d30a0 |
+| 1 | Codex auto | P2×2 | a6d30a0 |
+| 2 | Opus re-review | P1 ゼロ + P2×2 + P3×2 (Conditionally Approved) | post-merge follow-up PR |
+| 3 | User | P2×1 (latest field type/runtime mismatch) | 9a1fe5e |
+
+User merged after Round 3 (head `9a1fe5e` → squash-merged as `7986838`)。
+Round 2 Opus P2-A/P2-B + P3-A/P3-B + P3-C は本 follow-up doc + Round 4 PR
+で吸収。
+
+## 4. Lessons captured (memory candidate)
+
+- **TypeScript type 契約と runtime behavior の mismatch** (PR #108 User P2):
+  napi-rs `Option::None` for nested struct field is **omitted** (key
+  absent), not `null`. Pre-existing patterns (`NativeFocusedElement.automationId`
+  with `string | null`) may have the same gap. Surface via runtime smoke
+  tests with `'field' in result` assertion.
+
+- **Late-older arrival cap eviction race** (PR #108 Opus Round 2 P2-A):
+  diff bookkeeping pattern (`current_focused_element` template) doesn't
+  natively handle cap eviction wiping `by_key` entries underneath
+  ongoing DD reduce retraction streams. Soft-clamp negative diff sums
+  with prior == 0 to drop silent. Add test for assert + evict + retract
+  triplet to guard against regression.
+
+- **Counter contamination across cmd types** (PR #108 Codex P2-B):
+  shared `processed_count` across `Cmd::PushFocus` and `Cmd::PushDirtyRect`
+  contaminates focus-pipeline telemetry. Per-cmd counters + dedicated
+  napi-exposed status struct prevents masking of focus health regressions.
+  Apply same pattern to future cmd variants (Window / Scroll / etc.) at
+  introduction time.

--- a/index.d.ts
+++ b/index.d.ts
@@ -300,6 +300,13 @@ export interface NativeViewFocusedPipelineStatus {
   /** `true` when the slot's pipeline has had a failed shutdown
    * (Codex review v9 P2-17). Callers should fall back to UIA. */
   poisoned: boolean
+  /** Cumulative `Cmd::PushFocus` count the worker has dequeued and
+   * run through `update_at` + `flush`. **Focus-only since S2 D2-C**
+   * (Codex round 1 P2-B): `Cmd::PushDirtyRect` traffic is tracked
+   * on a separate Rust-side counter (`PerceptionWorker::processed_dirty_rect_count`)
+   * to keep this focus-pipeline telemetry isolated from dirty-rect
+   * traffic. Pre-S2 it counted all events (mixed). 0 when the
+   * pipeline is not yet initialized. */
   processedCount: bigint
 }
 

--- a/src/engine/native-types.ts
+++ b/src/engine/native-types.ts
@@ -71,6 +71,12 @@ export interface NativeViewFocusedPipelineStatus {
   /** `true` when the slot's pipeline has had a failed shutdown
    * (Codex review v9 P2-17). Callers should fall back to UIA. */
   poisoned: boolean
+  /** Cumulative `Cmd::PushFocus` count. **Focus-only since S2 D2-C**
+   * (Codex PR #108 round 1 P2-B): dirty-rect traffic uses a separate
+   * Rust-side counter (`PerceptionWorker::processed_dirty_rect_count`).
+   * Do NOT use this as overall pipeline activity gauge — it explicitly
+   * excludes dirty-rect events to keep focus-pipeline telemetry
+   * isolated. */
   processedCount: bigint
 }
 


### PR DESCRIPTION
## Summary

PR #108 (S2 walking skeleton trunk impl、merged 2026-05-01 `7986838`) の **post-merge correction**。Opus phase-boundary Round 2 re-review 結果 (Conditionally Approved、P1 ゼロ + P2×2 + P3×2) を反映する独立 PR (PR #107 同 pattern、新運用モード `feedback_autonomous_phase_transition.md` の post-PR review iteration)。

## P2 (must fix、debug-build correctness)

### P2-A: late-older arrival post-eviction retraction panic

`apply_count` で late-older 経路 (cap full + 新 frame が新 min) → `by_key` evicted 直後 DD reduce が同 key/value retraction fire ⇒ `prior == 0 && diff < 0` ⇒ `new_diff == -1` ⇒ `debug_assert!` panic。

**Fix**: silent drop for `prior == 0 && diff < 0`、+ regression test `apply_count_late_older_arrival_followed_by_retraction_does_not_panic` で assert+evict+retract triplet pin。

### P2-B: `processedCount` focus-only docs sync

`index.d.ts` + `src/engine/native-types.ts` の JSDoc に「**Focus-only since S2 D2-C** (Codex round 1 P2-B): dirty-rect traffic uses separate counter」を追記、caller の誤解防止。

## P3 (nice to have)

- **P3-A**: `make_event` vs `make_focus_event_with_hwnd` helper unification を **`docs/adr-008-d2-c-followups.md` §2.1 OQ #4** で永続化 (3 案 + 推奨 + 着手 timing)
- **P3-B**: G2-3 test `wc_base + 5_000` pump magic number の rationale コメント拡張 (WATERMARK_SHIFT_MS + 5-tuple settle latency + batched push + flake margin)
- **P3-C** (Round 1 P3 carry-over): shutdown 3-leg helper macro / trait OQ を §2.2 OQ #5 で永続化
- (Round 1 P2-2 carry-over): `last_event_anchor` cmd_kind trace を §2.3 OQ #6
- (Round 1 P3-2 carry-over): `decode_dirty_rect_event` arc shape を §2.4 OQ #7

## 新規 docs

`docs/adr-008-d2-c-followups.md` 新設 (~150 line): post-merge follow-ups 集約 + Resolved 化 + 4 OQ + 4-round review summary + 3 lessons captured。CLAUDE.md §9 整合。

## 6-guard 全 pass

- ✅ `cargo check --workspace` clean
- ✅ `cargo test -p engine-perception --lib` **47/47 pass** (+1 from main: P2-A regression)
- ✅ `cargo test -p desktop-touch-engine --no-default-features --lib l3_bridge` **25/25 pass**
- ✅ npm 4 guards + tsc all OK
- ✅ vitest G2-4 Node smoke 2/2 pass

## CLAUDE.md 強制命令整合

| 強制命令 | 整合 |
|---|---|
| §3.3 (PR review loop) | 4 round 反復、AI 単独 sweep 盲点を post-PR review で吸収 |
| §3.1 (4 SSOT bit-equal) | impl + sub-plan + index.d.ts + native-types.ts + followups doc で sync |
| §3.2 (PR #102 教訓延長) | TS type 契約 vs runtime mismatch も既存 API 振る舞い破壊軸 |
| §7 (仕組みで対応) | silent-drop で structurally tolerate + regression test pin |
| §8 | feature branch + PR |
| §9 | 残件 4 OQ を docs/ 永続化 |

## Test plan

- [x] cargo + npm 6-guard 全 pass
- [x] P2-A regression test pin
- [x] **Codex auto-review** (新 PR で auto-trigger)
- [ ] User merge 判断 → S3 (envelope wrapper) autonomous 着手

🤖 Generated with [Claude Code](https://claude.com/claude-code)