### PR TITLE
feat(expansion): mouse_click commit wrapper (L5 envelope)

### DIFF
--- a/docs/walking-skeleton-expansion-plan.md
+++ b/docs/walking-skeleton-expansion-plan.md
@@ -83,12 +83,19 @@ trunk lock layer 改変なしで mechanical コピーで進められるのは sw
    **Why**: MCP SDK の `server.tool` + `run_macro` 内 `entry.schema.parse(args)` は両方 Zod 経由、Zod object parse は unknown key を strip する。`include` field は base schema に存在しないため、injection なしでは `include:["causal"]` / `include:["envelope"]` が消失し `makeCommitWrapper` の peek+strip が空振りして per-call envelope opt-in が **silently raw fallback** する (PR #112 P1-1 / PR #117 click_element 既存 bug / PR #121 mouse_click Codex P2 と全て同型)。
 4. **module-scope export** (`{tool}RegistrationHandler` 命名)、`run_macro` 経路 (`TOOL_REGISTRY.{tool}` in `macro.ts`) も同 instance に切替 (PR #112 shared registration handler pattern、strip risk 防止)
 5. **unit test 1 件追加** (envelope shape return + L1 ToolCallStarted/Completed event 確認)
-6. **push + PR 起票**:
+6. **stub catalog 再生成 必須** (★ Opus PR #121 Round 2 P2-NEW-1 反映、CLAUDE.md §7 仕組みで対応):
+   ```bash
+   npm run check:stub-catalog
+   ```
+   `withEnvelopeIncludeSchema` で `include` field が schema に追加されると `src/stub-tool-catalog.ts` の generated entry にも `include` property が追加される。`check:stub-catalog` は `node scripts/generate-stub-tool-catalog.mjs && git diff --exit-code src/stub-tool-catalog.ts` で diff があれば exit 1。
+
+   diff があれば `src/stub-tool-catalog.ts` を本 PR に commit する (CI build job が同 check を Linux 環境で実行するため、ローカル forget は CI で機械的に検出されるが、push 前にローカル確認すれば 1 回の round 短縮)。
+7. **push + PR 起票**:
    - PR title に "expansion" 含有 (例: "expansion: mouse_click commit wrapper")
    - label に `expansion` 付与 (workflow trigger 用)
    - `expansion-pr-guard.yml` が trunk lock layer 改変なしを enforce
-7. **Opus 1 round** (trunk pattern conformance 軸) + **Codex 補助 review**
-8. **merge** (Opus 指摘ゼロ + Codex P1 ゼロ)
+8. **Opus 1 round** (trunk pattern conformance 軸) + **Codex 補助 review**
+9. **merge** (Opus 指摘ゼロ + Codex P1 ゼロ)
 
 ### 3.2 PR description template
 
@@ -102,6 +109,7 @@ trunk lock layer 改変なしで mechanical コピーで進められるのは sw
 - `src/tools/{file}.ts`: module-scope `{tool}RegistrationHandler` + `{tool}RegistrationSchema = withEnvelopeIncludeSchema({tool}Schema)` export、`server.tool` 3rd arg を `{tool}RegistrationSchema` に切替
 - `src/tools/macro.ts`: `TOOL_REGISTRY.{tool}.schema` を `z.object({tool}RegistrationSchema)` に切替 + handler を shared instance に切替
 - `tests/unit/{tool}-wrapper.test.ts`: envelope shape return + L1 event 確認 (1 件)
+- `src/stub-tool-catalog.ts`: `npm run check:stub-catalog` で再生成された差分 (`include` field 追加分)
 
 ## trunk contract conformance check
 

--- a/docs/walking-skeleton-expansion-plan.md
+++ b/docs/walking-skeleton-expansion-plan.md
@@ -70,14 +70,25 @@ trunk lock layer 改変なしで mechanical コピーで進められるのは sw
    - query tool: `makeQueryWrapper(handler, "tool_name", { /* options */ })`
    - lease 必須 commit: `leaseValidator` + `extractLeaseToken` を渡す (S4 desktop_act 先例)
    - lease 不在 commit: `leaseValidator` 省略 (S6 click_element 先例)
-3. **module-scope export** (`{tool}RegistrationHandler` 命名)、`run_macro` 経路 (`TOOL_REGISTRY.{tool}` in `macro.ts`) も同 instance に切替 (PR #112 shared registration handler pattern、strip risk 防止)
-4. **unit test 1 件追加** (envelope shape return + L1 ToolCallStarted/Completed event 確認)
-5. **push + PR 起票**:
+3. **`{tool}RegistrationSchema` 必須 export** (★ Codex PR #121 P2 + Opus PR #121 P2-1 反映、PR #117 land 後の同型 production bug を仕組みで防止):
+   ```typescript
+   import { makeCommitWrapper, withEnvelopeIncludeSchema } from "./_envelope.js";
+
+   export const {tool}RegistrationSchema = withEnvelopeIncludeSchema({tool}Schema);
+   ```
+   この `{tool}RegistrationSchema` を **以下 2 経路の両方で参照する** (片方だけ忘れると `include` arg が silently strip される):
+   - `server.tool("{tool}", desc, {tool}RegistrationSchema, {tool}RegistrationHandler)` (MCP server 直接登録)
+   - `TOOL_REGISTRY.{tool} = { schema: z.object({tool}RegistrationSchema), handler: {tool}RegistrationHandler ... }` (macro.ts、`run_macro` 経路)
+
+   **Why**: MCP SDK の `server.tool` + `run_macro` 内 `entry.schema.parse(args)` は両方 Zod 経由、Zod object parse は unknown key を strip する。`include` field は base schema に存在しないため、injection なしでは `include:["causal"]` / `include:["envelope"]` が消失し `makeCommitWrapper` の peek+strip が空振りして per-call envelope opt-in が **silently raw fallback** する (PR #112 P1-1 / PR #117 click_element 既存 bug / PR #121 mouse_click Codex P2 と全て同型)。
+4. **module-scope export** (`{tool}RegistrationHandler` 命名)、`run_macro` 経路 (`TOOL_REGISTRY.{tool}` in `macro.ts`) も同 instance に切替 (PR #112 shared registration handler pattern、strip risk 防止)
+5. **unit test 1 件追加** (envelope shape return + L1 ToolCallStarted/Completed event 確認)
+6. **push + PR 起票**:
    - PR title に "expansion" 含有 (例: "expansion: mouse_click commit wrapper")
    - label に `expansion` 付与 (workflow trigger 用)
    - `expansion-pr-guard.yml` が trunk lock layer 改変なしを enforce
-6. **Opus 1 round** (trunk pattern conformance 軸) + **Codex 補助 review**
-7. **merge** (Opus 指摘ゼロ + Codex P1 ゼロ)
+7. **Opus 1 round** (trunk pattern conformance 軸) + **Codex 補助 review**
+8. **merge** (Opus 指摘ゼロ + Codex P1 ゼロ)
 
 ### 3.2 PR description template
 
@@ -88,8 +99,8 @@ trunk lock layer 改変なしで mechanical コピーで進められるのは sw
 
 ## scope
 
-- `src/tools/{file}.ts`: module-scope `{tool}RegistrationHandler` export
-- `src/tools/macro.ts`: `TOOL_REGISTRY.{tool}` を shared instance に切替
+- `src/tools/{file}.ts`: module-scope `{tool}RegistrationHandler` + `{tool}RegistrationSchema = withEnvelopeIncludeSchema({tool}Schema)` export、`server.tool` 3rd arg を `{tool}RegistrationSchema` に切替
+- `src/tools/macro.ts`: `TOOL_REGISTRY.{tool}.schema` を `z.object({tool}RegistrationSchema)` に切替 + handler を shared instance に切替
 - `tests/unit/{tool}-wrapper.test.ts`: envelope shape return + L1 event 確認 (1 件)
 
 ## trunk contract conformance check

--- a/src/stub-tool-catalog.ts
+++ b/src/stub-tool-catalog.ts
@@ -601,6 +601,13 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
         "fixId": {
           "description": "Approve a pending suggestedFix (one-shot, 15s TTL).",
           "type": "string"
+        },
+        "include": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
         }
       },
       "additionalProperties": false,
@@ -996,6 +1003,13 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
         "fixId": {
           "description": "One-shot fix approval ID. If a previous mouse_click returned a suggestedFix, pass that fixId here to approve it. The server revalidates the fix and executes with corrected args. fixId expires in 15 seconds and can only be used once.",
           "type": "string"
+        },
+        "include": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
         }
       },
       "additionalProperties": false,

--- a/src/tools/macro.ts
+++ b/src/tools/macro.ts
@@ -15,7 +15,7 @@ import { assertKeyComboSafe } from "../utils/key-safety.js";
 // Screenshot
 import { screenshotHandler, screenshotSchema } from "./screenshot.js";
 // Mouse
-import { mouseClickHandler, mouseClickSchema, mouseClickRegistrationHandler, mouseDragHandler, mouseDragSchema } from "./mouse.js";
+import { mouseClickHandler, mouseClickRegistrationSchema, mouseClickRegistrationHandler, mouseDragHandler, mouseDragSchema } from "./mouse.js";
 // Keyboard dispatcher (Phase 2)
 import { keyboardHandler, keyboardSchema } from "./keyboard.js";
 // Clipboard dispatcher (Phase 2)
@@ -31,7 +31,7 @@ import { windowDockHandler, windowDockSchema } from "./window-dock.js";
 // UI elements (click_element always public after Phase 4; the next two are
 // V1 fallbacks only reachable when DESKTOP_TOUCH_DISABLE_FUKUWARAI_V2=1).
 import {
-  clickElementHandler, clickElementSchema, clickElementRegistrationHandler,
+  clickElementHandler, clickElementRegistrationSchema, clickElementRegistrationHandler,
   getUiElementsHandler, getUiElementsSchema,
   setElementValueHandler, setElementValueSchema,
 } from "./ui-elements.js";
@@ -131,9 +131,9 @@ const TOOL_REGISTRY: Record<string, ToolEntry> = {
   desktop_state:        { schema: z.object(desktopStateRegistrationSchema), handler: desktopStateRegistrationHandler as any },
   screenshot:           { schema: z.object(screenshotSchema),          handler: screenshotHandler },
   // Action — native
-  mouse_click:          { schema: z.object(mouseClickSchema),          handler: mouseClickRegistrationHandler as typeof mouseClickHandler },
+  mouse_click:          { schema: z.object(mouseClickRegistrationSchema), handler: mouseClickRegistrationHandler as typeof mouseClickHandler },
   mouse_drag:           { schema: z.object(mouseDragSchema),           handler: mouseDragHandler },
-  click_element:        { schema: z.object(clickElementSchema),        handler: clickElementRegistrationHandler as typeof clickElementHandler },
+  click_element:        { schema: z.object(clickElementRegistrationSchema), handler: clickElementRegistrationHandler as typeof clickElementHandler },
   focus_window:         { schema: z.object(focusWindowSchema),         handler: focusWindowHandler },
   // Action — text/clipboard dispatchers (Phase 2)
   keyboard:             { schema: keyboardSchema,                      handler: keyboardHandler },

--- a/src/tools/macro.ts
+++ b/src/tools/macro.ts
@@ -15,7 +15,7 @@ import { assertKeyComboSafe } from "../utils/key-safety.js";
 // Screenshot
 import { screenshotHandler, screenshotSchema } from "./screenshot.js";
 // Mouse
-import { mouseClickHandler, mouseClickSchema, mouseDragHandler, mouseDragSchema } from "./mouse.js";
+import { mouseClickHandler, mouseClickSchema, mouseClickRegistrationHandler, mouseDragHandler, mouseDragSchema } from "./mouse.js";
 // Keyboard dispatcher (Phase 2)
 import { keyboardHandler, keyboardSchema } from "./keyboard.js";
 // Clipboard dispatcher (Phase 2)
@@ -131,7 +131,7 @@ const TOOL_REGISTRY: Record<string, ToolEntry> = {
   desktop_state:        { schema: z.object(desktopStateRegistrationSchema), handler: desktopStateRegistrationHandler as any },
   screenshot:           { schema: z.object(screenshotSchema),          handler: screenshotHandler },
   // Action — native
-  mouse_click:          { schema: z.object(mouseClickSchema),          handler: mouseClickHandler },
+  mouse_click:          { schema: z.object(mouseClickSchema),          handler: mouseClickRegistrationHandler as typeof mouseClickHandler },
   mouse_drag:           { schema: z.object(mouseDragSchema),           handler: mouseDragHandler },
   click_element:        { schema: z.object(clickElementSchema),        handler: clickElementRegistrationHandler as typeof clickElementHandler },
   focus_window:         { schema: z.object(focusWindowSchema),         handler: focusWindowHandler },

--- a/src/tools/mouse.ts
+++ b/src/tools/mouse.ts
@@ -13,6 +13,7 @@ import { ok } from "./_types.js";
 import type { ToolResult } from "./_types.js";
 import { failWith } from "./_errors.js";
 import { withRichNarration, narrateParam } from "./_narration.js";
+import { makeCommitWrapper } from "./_envelope.js";
 import { detectFocusLoss } from "./_focus.js";
 import { evaluatePreToolGuards, buildEnvelopeFor } from "../engine/perception/registry.js";
 import { runActionGuard, isAutoGuardEnabled } from "./_action-guard.js";
@@ -688,6 +689,32 @@ export const getCursorPositionHandler = async (): Promise<ToolResult> => {
 // Registration
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * Walking skeleton expansion phase swimlane 1 (L5 commit tool wrapper):
+ * `mouse_click` is wrapped via `makeCommitWrapper` (lease-less commit
+ * variant — no lease 4-tuple validation, fixed-coordinate click).
+ * Mechanical copy of PR #117 `clickElementRegistrationHandler` pattern
+ * (`docs/walking-skeleton-expansion-plan.md` §3 30-minute time-attack
+ * template, sub-plan §1.1 G).
+ *
+ * `withRichNarration` (inner) → `makeCommitWrapper` (outer):
+ *   - withRichNarration enriches the handler's ToolResult (`hints.diff` 等)
+ *   - makeCommitWrapper handles L1 ToolCallStarted/Completed push +
+ *     envelope assembly + compat hoist + tool_call_id seq
+ *
+ * Module-scope export so `run_macro` (`TOOL_REGISTRY.mouse_click` in
+ * `macro.ts`) shares the same wrapped instance (PR #112 shared
+ * registration handler pattern, strip risk prevention).
+ */
+export const mouseClickRegistrationHandler = makeCommitWrapper(
+  withRichNarration("mouse_click", mouseClickHandler, { windowTitleKey: "windowTitle" }) as (args: Record<string, unknown>) => Promise<ToolResult>,
+  "mouse_click",
+  {
+    // leaseValidator omitted = lease-less commit variant
+    // getSessionId / argsSummary / clock も default 利用 = mechanical コピー最小
+  },
+);
+
 export function registerMouseTools(server: McpServer): void {
   // Phase 4: mouse_move privatized — hover-trigger UIs are rare in practice.
   // mouseMoveHandler retained as internal export for tests / future facade.
@@ -696,7 +723,7 @@ export function registerMouseTools(server: McpServer): void {
     "mouse_click",
     "Click at screen coordinates. Normally pass windowTitle so the server auto-guards the click (verifies target identity, foreground, coordinate is inside the target rect) and returns post.perception without a confirmation screenshot. origin+scale from dotByDot=true screenshots are converted to screen coords before guarding. doubleClick:true for double-click; tripleClick:true for triple-click (selects a full line of text). Prefer click_element (UIA) for native apps, prefer browser_click for Chrome. Examples: mouse_click({windowTitle:'Notepad', x:200, y:150}) // guarded — post.perception.status='ok'. mouse_click({x:100, y:100}) // unguarded — post.perception.status='unguarded'. If a guard failure returns a suggestedFix, pass its fixId to approve the fix: mouse_click({fixId:'fix-...'}) // one-shot, expires in 15s. lensId is optional and only for advanced pinned-target workflows; omit it for normal use. Caveats: origin+scale are meaningful ONLY with dotByDot=true screenshot responses.",
     mouseClickSchema,
-    withRichNarration("mouse_click", mouseClickHandler, { windowTitleKey: "windowTitle" })
+    mouseClickRegistrationHandler as typeof mouseClickHandler
   );
   server.tool("mouse_drag", "Click and drag from (startX, startY) to (endX, endY) holding the left mouse button — for sliders, drag-and-drop, canvas drawing, and window resizing. Pass windowTitle so the server auto-guards the start coordinate and returns post.perception. Examples: mouse_drag({windowTitle:'Notepad', startX:50, startY:50, endX:200, endY:200}). lensId is optional and only for advanced pinned-target workflows. Caveats: Left button only. Both start and endpoint are guarded. Cross-window and desktop drags are blocked by default — pass allowCrossWindowDrag:true to confirm intent.", mouseDragSchema, withRichNarration("mouse_drag", mouseDragHandler, { windowTitleKey: "windowTitle" }));
   // scroll tool removed in Phase 2b (family merge) — registered via scroll(action='raw') in scroll.ts

--- a/src/tools/mouse.ts
+++ b/src/tools/mouse.ts
@@ -13,7 +13,7 @@ import { ok } from "./_types.js";
 import type { ToolResult } from "./_types.js";
 import { failWith } from "./_errors.js";
 import { withRichNarration, narrateParam } from "./_narration.js";
-import { makeCommitWrapper } from "./_envelope.js";
+import { makeCommitWrapper, withEnvelopeIncludeSchema } from "./_envelope.js";
 import { detectFocusLoss } from "./_focus.js";
 import { evaluatePreToolGuards, buildEnvelopeFor } from "../engine/perception/registry.js";
 import { runActionGuard, isAutoGuardEnabled } from "./_action-guard.js";
@@ -715,6 +715,22 @@ export const mouseClickRegistrationHandler = makeCommitWrapper(
   },
 );
 
+/**
+ * Registration-time schema with `include?: string[]` injected via
+ * `withEnvelopeIncludeSchema` so per-call envelope opt-in
+ * (`include:["envelope"]` / `include:["causal"]` / `include:["raw"]`)
+ * survives the MCP SDK's `z.object(schema).parse(args)` step.
+ *
+ * Both registration paths must use this injected schema:
+ *   1. `server.tool("mouse_click", desc, mouseClickRegistrationSchema, ...)`
+ *   2. `TOOL_REGISTRY.mouse_click = { schema: z.object(mouseClickRegistrationSchema), ... }`
+ *
+ * Without injection, Zod's default object parse strips unknown keys and
+ * `include` is removed before `makeCommitWrapper` can peek it
+ * (Codex PR #121 P2 + PR #112 / PR #117 同型 risk pattern).
+ */
+export const mouseClickRegistrationSchema = withEnvelopeIncludeSchema(mouseClickSchema);
+
 export function registerMouseTools(server: McpServer): void {
   // Phase 4: mouse_move privatized — hover-trigger UIs are rare in practice.
   // mouseMoveHandler retained as internal export for tests / future facade.
@@ -722,7 +738,7 @@ export function registerMouseTools(server: McpServer): void {
   server.tool(
     "mouse_click",
     "Click at screen coordinates. Normally pass windowTitle so the server auto-guards the click (verifies target identity, foreground, coordinate is inside the target rect) and returns post.perception without a confirmation screenshot. origin+scale from dotByDot=true screenshots are converted to screen coords before guarding. doubleClick:true for double-click; tripleClick:true for triple-click (selects a full line of text). Prefer click_element (UIA) for native apps, prefer browser_click for Chrome. Examples: mouse_click({windowTitle:'Notepad', x:200, y:150}) // guarded — post.perception.status='ok'. mouse_click({x:100, y:100}) // unguarded — post.perception.status='unguarded'. If a guard failure returns a suggestedFix, pass its fixId to approve the fix: mouse_click({fixId:'fix-...'}) // one-shot, expires in 15s. lensId is optional and only for advanced pinned-target workflows; omit it for normal use. Caveats: origin+scale are meaningful ONLY with dotByDot=true screenshot responses.",
-    mouseClickSchema,
+    mouseClickRegistrationSchema,
     mouseClickRegistrationHandler as typeof mouseClickHandler
   );
   server.tool("mouse_drag", "Click and drag from (startX, startY) to (endX, endY) holding the left mouse button — for sliders, drag-and-drop, canvas drawing, and window resizing. Pass windowTitle so the server auto-guards the start coordinate and returns post.perception. Examples: mouse_drag({windowTitle:'Notepad', startX:50, startY:50, endX:200, endY:200}). lensId is optional and only for advanced pinned-target workflows. Caveats: Left button only. Both start and endpoint are guarded. Cross-window and desktop drags are blocked by default — pass allowCrossWindowDrag:true to confirm intent.", mouseDragSchema, withRichNarration("mouse_drag", mouseDragHandler, { windowTitleKey: "windowTitle" }));

--- a/src/tools/ui-elements.ts
+++ b/src/tools/ui-elements.ts
@@ -11,7 +11,7 @@ import { buildHintsForTitle } from "../engine/identity-tracker.js";
 import { evaluatePreToolGuards, buildEnvelopeFor } from "../engine/perception/registry.js";
 import { runActionGuard, isAutoGuardEnabled, validateAndPrepareFix, consumeFix } from "./_action-guard.js";
 import { resolveWindowTarget } from "./_resolve-window.js";
-import { makeCommitWrapper } from "./_envelope.js";
+import { makeCommitWrapper, withEnvelopeIncludeSchema } from "./_envelope.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Schemas
@@ -378,6 +378,22 @@ export const clickElementRegistrationHandler = makeCommitWrapper(
   },
 );
 
+/**
+ * Registration-time schema with `include?: string[]` injected via
+ * `withEnvelopeIncludeSchema` so per-call envelope opt-in
+ * (`include:["envelope"]` / `include:["causal"]` / `include:["raw"]`)
+ * survives the MCP SDK's `z.object(schema).parse(args)` step.
+ *
+ * Without injection, Zod's default object parse strips unknown keys and
+ * `include` is removed before `makeCommitWrapper` can peek it
+ * (PR #112 P1-1 / Codex PR #121 P2 同型 risk pattern). PR #117 で land
+ * された click_element wrap が schema injection を欠いていたため、
+ * `run_macro({tool:"click_element", args:{include:["causal"]}})` が
+ * silently raw fallback する production bug を内包していた。本 PR で
+ * mouse_click 同梱 fix として解消 (Opus PR #121 Round 1 P1-2 反映)。
+ */
+export const clickElementRegistrationSchema = withEnvelopeIncludeSchema(clickElementSchema);
+
 export function registerUiElementTools(server: McpServer): void {
   // Phase 4: get_ui_elements privatized — handler retained as internal export.
   // desktop_discover returns the actionable[] entity list (with name / role /
@@ -387,7 +403,7 @@ export function registerUiElementTools(server: McpServer): void {
   server.tool(
     "click_element",
     "Invoke a UI element by name or automationId via UIA InvokePattern — no screen coordinates needed. The server auto-guards using windowTitle (verifies identity, foreground, modal) and returns post.perception.status. Prefer over mouse_click for buttons, menu items, and links in native Windows apps. Use desktop_discover first to discover automationIds. Pass fixId from a suggestedFix to re-target after window identity drift. lensId is optional for advanced pinned-lens use. Caveats: Requires InvokePattern — some custom controls do not expose it; fall back to mouse_click in that case.",
-    clickElementSchema,
+    clickElementRegistrationSchema,
     clickElementRegistrationHandler as typeof clickElementHandler
   );
 

--- a/tests/unit/mouse-click-commit-wrapper.test.ts
+++ b/tests/unit/mouse-click-commit-wrapper.test.ts
@@ -1,0 +1,142 @@
+/**
+ * mouse-click-commit-wrapper.test.ts — expansion swimlane 1 contract test
+ * (mouse_click lease 不在 commit variant、walking skeleton expansion phase
+ * の最初の本格 PR、`docs/walking-skeleton-expansion-plan.md` §3 30-minute
+ * time-attack template 適用例).
+ *
+ * Pins the bit-equal contract for `mouse_click` wrap via `makeCommitWrapper`
+ * — mechanical copy of `tests/unit/click-element-commit-wrapper.test.ts`
+ * (PR #117 G6 contract test、tool name のみ置換).
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  makeCommitWrapper,
+  defaultL1Emitter,
+  buildCausedBy,
+  buildBasedOn,
+  _resetHistoryBuffersForTest,
+  _resetToolCallSeqForTest,
+  type CommitL1Emitter,
+  type ViewSnapshot,
+} from "../../src/tools/_envelope.js";
+
+function resetAll(): void {
+  _resetHistoryBuffersForTest();
+  _resetToolCallSeqForTest();
+}
+
+function makeViewSnapshot(): ViewSnapshot {
+  return {
+    focus: { hwnd: null, elementName: "test-element" },
+    dirtyRectsByMonitor: new Map([[0, 1]]),
+    latestEventId: 100n,
+    queryWallclockMs: Date.now(),
+  };
+}
+
+// ── expansion-1: mouse_click wrap → L1 ToolCallStarted/Completed event 記録 ────
+
+describe("expansion-1: mouse_click wrap → L1 events recorded (lease 不在 variant)", () => {
+  it("makeCommitWrapper flow 通過、ToolCallStarted/Completed 両 event push、lease_token undefined", async () => {
+    resetAll();
+    const events: Array<{ kind: "started" | "completed"; tool: string; leaseToken?: unknown }> = [];
+    const fakeEmitter: CommitL1Emitter = {
+      pushStarted: ({ tool, sessionId, toolCallId, leaseToken }) => {
+        events.push({ kind: "started", tool, leaseToken });
+        defaultL1Emitter.pushStarted({
+          tool,
+          argsJson: "{}",
+          sessionId,
+          toolCallId,
+          leaseToken,
+        });
+      },
+      pushCompleted: ({ tool, elapsedMs, ok, errorCode, sessionId, toolCallId }) => {
+        events.push({ kind: "completed", tool });
+        defaultL1Emitter.pushCompleted({
+          tool,
+          elapsedMs,
+          ok,
+          errorCode,
+          sessionId,
+          toolCallId,
+        });
+      },
+    };
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"data":{"clicked":{"x":100,"y":200}}}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "mouse_click", {
+      l1Emitter: fakeEmitter,
+    });
+    const result = await wrapped({ x: 100, y: 200 } as Record<string, unknown>);
+    expect(events).toHaveLength(2);
+    expect(events[0].kind).toBe("started");
+    expect(events[0].tool).toBe("mouse_click");
+    expect(events[0].leaseToken).toBeUndefined();
+    expect(events[1].kind).toBe("completed");
+    expect(events[1].tool).toBe("mouse_click");
+    expect(result.content).toBeDefined();
+  });
+});
+
+// ── expansion-2: 既存 raw client 互換 (compat hoist) ──────────────────────────
+
+describe("expansion-2: include 未指定時 raw shape return (既存 raw client 互換)", () => {
+  it("default 経路 → envelope shape を hoist して raw client 互換", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"clicked":{"x":50,"y":60}}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "mouse_click", {});
+    const result = await wrapped({} as Record<string, unknown>);
+    const text = (result.content[0] as { text: string }).text;
+    const parsed = JSON.parse(text);
+    expect(parsed._version).toBeUndefined();
+    expect(parsed.ok).toBe(true);
+    expect(parsed.clicked).toEqual({ x: 50, y: 60 });
+  });
+});
+
+// ── expansion-3: include=causal 経路 → caused_by.your_last_action = "mouse_click(...)" ──
+
+describe("expansion-3: include=causal で caused_by.your_last_action に mouse_click 記録", () => {
+  it("mouse_click wrap → history buffer に entry → buildCausedBy で your_last_action = mouse_click(...)", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "mouse_click", {
+      getSessionId: () => "sessA",
+    });
+    await wrapped({ x: 200, y: 300 } as Record<string, unknown>);
+    const causedBy = buildCausedBy("sessA", makeViewSnapshot());
+    expect(causedBy).toBeDefined();
+    expect(causedBy?.your_last_action).toContain("mouse_click");
+    expect(causedBy?.tool_call_id).toMatch(/^sessA:\d+$/);
+    const basedOn = buildBasedOn("sessA", makeViewSnapshot());
+    expect(basedOn).toBeDefined();
+    if (basedOn?.events && basedOn.events.length > 0) {
+      expect(typeof basedOn.events[0]).toBe("string");
+    }
+  });
+});
+
+// ── expansion contract: mechanical copy from S6 click_element PoC works ────
+
+describe("expansion contract: makeCommitWrapper mechanical copy works for mouse_click", () => {
+  it("S5/S6 contract が mouse_click wrap でそのまま機能 (lease validator omit のみ)", async () => {
+    resetAll();
+    const handler = vi.fn(async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    }));
+    const wrapped = makeCommitWrapper(handler, "mouse_click", {
+      // walking-skeleton-expansion-plan.md §3 30-minute time-attack:
+      // getSessionId / argsSummary / clock も default 利用、leaseValidator のみ omit
+    });
+    const result = await wrapped({ x: 1, y: 2 } as Record<string, unknown>);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(result.content).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Walking skeleton expansion phase の **swimlane 1 (L5 commit tool wrapper)** 最初の本格 PR。`docs/walking-skeleton-expansion-plan.md` §3 30-minute time-attack template の最初の適用例。PR #117 `clickElementRegistrationHandler` pattern の **mechanical コピー** (lease 不在 commit variant、固定座標 click)。

## scope

- `src/tools/mouse.ts`: `mouseClickRegistrationHandler` + `mouseClickRegistrationSchema = withEnvelopeIncludeSchema(mouseClickSchema)` module-scope export、`server.tool` 切替
- `src/tools/ui-elements.ts`: **PR #117 land 後の click_element 同型 schema injection 漏れを本 PR 同梱 fix** (`clickElementRegistrationSchema` export + `server.tool` 切替、Opus Round 1 P1-2)
- `src/tools/macro.ts`: `TOOL_REGISTRY.mouse_click` + `TOOL_REGISTRY.click_element` を `*RegistrationSchema` 経由に切替 + handler を shared instance に (PR #112 shared registration handler pattern)
- `docs/walking-skeleton-expansion-plan.md`: §3.1 着手手順に `{tool}RegistrationSchema` 必須 export step を追加 (Opus Round 1 P2-1、CLAUDE.md §7 仕組みで対応)
- `tests/unit/mouse-click-commit-wrapper.test.ts`: 4 test (L1 events / raw shape compat / caused_by / mechanical copy contract)

## trunk contract conformance check

- engine-perception layer 改変ゼロ (`expansion-pr-guard.yml` + `check-expansion-disjoint.mjs`)
- run_macro 経路同 instance 共有 (PR #112 pattern)
- handler internal logic + Zod schema + 戻り値 shape 不変 (ADR-010 §1.5)

---

## Review iteration ledger

### Codex Round 1 (commit `e183af9`)
- **P2** (`src/tools/macro.ts:134`): `mouse_click` の TOOL_REGISTRY entry が古い `mouseClickSchema` を使用、`run_macro({tool:"mouse_click", args:{include:["causal"]}})` で Zod が `include` を strip → `makeCommitWrapper` peek 失敗 → silently raw fallback。

### Opus Round 1 (commit `e183af9`、判定: Changes Requested)
- **P1-1**: Codex P2 と同型、production bug。本 commit `3de9795` で fix 済 (`mouseClickRegistrationSchema` export + 両経路切替)。
- **P1-2** (`src/tools/ui-elements.ts:390` + `src/tools/macro.ts:136`): **PR #117 land 後の click_element 同型 strip bug**。Opus 判断: 選択肢 1+3 併用 (本 PR 同梱 fix + template 改訂)。CLAUDE.md §3.2 解釈として「carry-over = 新機能の別 phase 倒し意味、既存 production bug は対象外」、PR #102 P5c-2 同型 judgment 盲点回避。本 commit で fix 済。
- **P2-1** (`docs/walking-skeleton-expansion-plan.md` §3): template に schema injection step 欠落 → 3 連続同型 bug 再発の構造的盲点。本 commit で §3.1 step 3 + §3.2 template 同期更新。CLAUDE.md §7 仕組みで対応 + §3.1 複数表 fact 整合に整合。
- **P2-2** (PR description): 「最新 commit で fix 済」表現が事実と乖離 → 本 description 全面更新で解消。
- **P3 carry-over**: schema injection 経路の共通 contract test (`tests/unit/macro-include-passthrough.test.ts`) は全 expansion tool 共通 helper として別 PR で 1 度だけ起票。

### 次 step
- Opus Round 2 review 起動 → P1+P2 ゼロ確認 → squash merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)