### PR TITLE
feat(expansion): keyboard commit wrapper (L5 envelope)

### DIFF
--- a/docs/walking-skeleton-expansion-plan.md
+++ b/docs/walking-skeleton-expansion-plan.md
@@ -70,17 +70,28 @@ trunk lock layer 改変なしで mechanical コピーで進められるのは sw
    - query tool: `makeQueryWrapper(handler, "tool_name", { /* options */ })`
    - lease 必須 commit: `leaseValidator` + `extractLeaseToken` を渡す (S4 desktop_act 先例)
    - lease 不在 commit: `leaseValidator` 省略 (S6 click_element 先例)
-3. **`{tool}RegistrationSchema` 必須 export** (★ Codex PR #121 P2 + Opus PR #121 P2-1 反映、PR #117 land 後の同型 production bug を仕組みで防止):
+3. **`{tool}RegistrationSchema` 必須 export** (★ Codex PR #121 P2 + Opus PR #121 P2-1 + Opus PR #123 keyboard discriminatedUnion 教訓 反映、PR #117 land 後の同型 production bug を仕組みで防止):
+
+   **3a. raw object shape 系** (例: mouse_click / click_element / desktop_state / desktop_act / screenshot):
    ```typescript
    import { makeCommitWrapper, withEnvelopeIncludeSchema } from "./_envelope.js";
 
    export const {tool}RegistrationSchema = withEnvelopeIncludeSchema({tool}Schema);
    ```
-   この `{tool}RegistrationSchema` を **以下 2 経路の両方で参照する** (片方だけ忘れると `include` arg が silently strip される):
-   - `server.tool("{tool}", desc, {tool}RegistrationSchema, {tool}RegistrationHandler)` (MCP server 直接登録)
-   - `TOOL_REGISTRY.{tool} = { schema: z.object({tool}RegistrationSchema), handler: {tool}RegistrationHandler ... }` (macro.ts、`run_macro` 経路)
 
-   **Why**: MCP SDK の `server.tool` + `run_macro` 内 `entry.schema.parse(args)` は両方 Zod 経由、Zod object parse は unknown key を strip する。`include` field は base schema に存在しないため、injection なしでは `include:["causal"]` / `include:["envelope"]` が消失し `makeCommitWrapper` の peek+strip が空振りして per-call envelope opt-in が **silently raw fallback** する (PR #112 P1-1 / PR #117 click_element 既存 bug / PR #121 mouse_click Codex P2 と全て同型)。
+   **3b. discriminatedUnion 系** (例: keyboard / clipboard / window_dock / scroll / terminal / browser_eval、`z.discriminatedUnion("action", [...])` で dispatch する family、★ PR #123 教訓):
+   ```typescript
+   import { makeCommitWrapper, withEnvelopeIncludeForUnion } from "./_envelope.js";
+
+   export const {tool}RegistrationSchema = withEnvelopeIncludeForUnion({tool}Schema);
+   ```
+   `withEnvelopeIncludeSchema` は raw shape (`Record<string, ZodTypeAny>`) のみ受け付け、discriminatedUnion 直適用不可。`withEnvelopeIncludeForUnion` は各 variant の `z.object` に `include` field を merge して新 discriminatedUnion を rebuild する (`src/tools/_envelope.ts` 内定義、ADR-010 P1 expansion phase で導入)。
+
+   どちらの方式でも、`{tool}RegistrationSchema` を **以下 2 経路の両方で参照する** (片方だけ忘れると `include` arg が silently strip される):
+   - `server.tool("{tool}", desc, {tool}RegistrationSchema, {tool}RegistrationHandler)` または `server.registerTool("{tool}", { ..., inputSchema: {tool}RegistrationSchema }, {tool}RegistrationHandler)` (MCP server 直接登録)
+   - `TOOL_REGISTRY.{tool} = { schema: z.object({tool}RegistrationSchema), handler: {tool}RegistrationHandler ... }` (raw shape 系) **または** `{ schema: {tool}RegistrationSchema, handler: ... }` (discriminatedUnion 系、`z.object()` ラップ不要 — union 自体が `ZodTypeAny`) (macro.ts、`run_macro` 経路)
+
+   **Why**: MCP SDK の `server.tool` / `server.registerTool` + `run_macro` 内 `entry.schema.parse(args)` は両方 Zod 経由、Zod object parse は unknown key を strip する。`include` field は base schema に存在しないため、injection なしでは `include:["causal"]` / `include:["envelope"]` が消失し `makeCommitWrapper` の peek+strip が空振りして per-call envelope opt-in が **silently raw fallback** する (PR #112 P1-1 / PR #117 click_element 既存 bug / PR #121 mouse_click Codex P2 / PR #123 keyboard Codex P2 と全て同型、family は raw shape vs discriminatedUnion で helper が分岐するだけ)。
 4. **module-scope export** (`{tool}RegistrationHandler` 命名)、`run_macro` 経路 (`TOOL_REGISTRY.{tool}` in `macro.ts`) も同 instance に切替 (PR #112 shared registration handler pattern、strip risk 防止)
 5. **unit test 1 件追加** (envelope shape return + L1 ToolCallStarted/Completed event 確認)
 6. **stub catalog 再生成 必須** (★ Opus PR #121 Round 2 P2-NEW-1 反映、CLAUDE.md §7 仕組みで対応):

--- a/scripts/generate-stub-tool-catalog.mjs
+++ b/scripts/generate-stub-tool-catalog.mjs
@@ -693,6 +693,40 @@ function parseSchema(src, schemaName) {
     expr = findConstExpression(src, innerName) ?? '';
   }
 
+  // PR #123 follow-up: discriminatedUnion variant injection
+  // `withEnvelopeIncludeForUnion(baseUnion)` — recurse into the
+  // bare-identifier base union, parse each variant's `z.object({...})`,
+  // and append `include?: string[]` to each variant's properties.
+  // Pattern: `withEnvelopeIncludeForUnion(<identifier>)` (single arg, bare name).
+  const unionWrapperMatch = expr.trim().match(
+    /^withEnvelopeIncludeForUnion\s*\(\s*([A-Za-z_$][\w$]*)\s*\)\s*;?\s*$/,
+  );
+  if (unionWrapperMatch) {
+    const innerName = unionWrapperMatch[1];
+    const innerExpr = findConstExpression(src, innerName) ?? '';
+    const unionSchema = parseDiscriminatedUnionSchema(innerExpr);
+    if (unionSchema && Array.isArray(unionSchema.oneOf)) {
+      const includeField = {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+          "Optional response-shape opt-in. " +
+          "`['envelope']` returns the self-documenting envelope " +
+          "(`_version` / `data` / `as_of` / `confidence`). " +
+          "`['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). " +
+          "Default behaviour is raw shape (compat with existing clients).",
+      };
+      for (const variant of unionSchema.oneOf) {
+        if (variant && typeof variant === 'object' && variant.properties) {
+          variant.properties.include = includeField;
+          // include は optional — variant.required に追加しない
+        }
+      }
+      return unionSchema;
+    }
+    return { type: 'object', properties: {}, additionalProperties: true };
+  }
+
   if (!expr.trim().startsWith('{')) return { type: 'object', properties: {}, additionalProperties: true };
   const properties = {};
   const required = [];

--- a/src/stub-tool-catalog.ts
+++ b/src/stub-tool-catalog.ts
@@ -812,6 +812,13 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
             "abortOnFocusLoss": {
               "description": "Focus Leash Phase B: when true, the foreground keystroke send is split into chunks (default 8 chars; override via DTM_LEASH_CHUNK_SIZE env) and the target window's foreground state is verified between chunks. If the user grabs focus mid-stream, the call aborts and returns FocusLostDuringType with context.typed (chars delivered to target) and context.remaining (unsent tail) so the caller can re-focus and retry the unsent portion. Default: true when windowTitle is provided, false otherwise. Has no effect on the clipboard path (atomic Ctrl+V) or the BG (WM_CHAR) path (HWND-targeted, foreground-independent).",
               "type": "boolean"
+            },
+            "include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
             }
           },
           "additionalProperties": false,
@@ -877,6 +884,13 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
             "lensId": {
               "description": "Optional perception lens ID. Guards (safe.keyboardTarget) are evaluated before the key press.",
               "type": "string"
+            },
+            "include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
             }
           },
           "additionalProperties": false,

--- a/src/tools/_envelope.ts
+++ b/src/tools/_envelope.ts
@@ -341,15 +341,63 @@ export function withEnvelopeIncludeSchema<T extends Record<string, ZodTypeAny>>(
     include: z
       .array(z.string())
       .optional()
-      .describe(
-        "Optional response-shape opt-in. " +
-        "`['envelope']` returns the self-documenting envelope " +
-        "(`_version` / `data` / `as_of` / `confidence`). " +
-        "`['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). " +
-        "Default behaviour is raw shape (compat with existing clients).",
-      ),
+      .describe(ENVELOPE_INCLUDE_FIELD_DESCRIPTION),
   } as T & { include: ZodOptional<ZodArray<ZodString>> };
 }
+
+/**
+ * Inject `include?: string[]` into a `z.discriminatedUnion(...)` schema
+ * by extending each variant's object shape and rebuilding the union.
+ *
+ * **Why a separate helper** (Opus PR #123 keyboard worktree report):
+ * `withEnvelopeIncludeSchema` requires a `Record<string, ZodTypeAny>`
+ * (= raw object shape) input, but several tool families
+ * (keyboard / clipboard / window_dock / scroll / terminal / browser_eval)
+ * use `z.discriminatedUnion` to dispatch on an `action` literal. Direct
+ * application of `withEnvelopeIncludeSchema` is impossible — the union
+ * has no flat shape to spread into. This helper extends each variant
+ * object with the same `include` field and rebuilds the discriminator,
+ * preserving the dispatch semantic while making `args.include` survive
+ * the MCP SDK's `z.parse()` step.
+ *
+ * Usage at registration site (sub-plan §3.1 step 3、discriminatedUnion
+ * 系 schema 用):
+ *
+ * ```ts
+ * server.registerTool("keyboard", {
+ *   description,
+ *   inputSchema: withEnvelopeIncludeForUnion(keyboardSchema),
+ * }, makeCommitWrapper(handler, "keyboard", { ... }));
+ * ```
+ *
+ * Type signature is intentionally widened to `ZodTypeAny` because Zod 3.x
+ * does not export the variant tuple type publicly (`ZodDiscriminatedUnion`
+ * has private `options` field with non-exported `ZodObject` element type).
+ * Runtime behaviour is bit-equal with `withEnvelopeIncludeSchema` per
+ * variant: each `z.object` gains `include?: string[]`, the discriminator
+ * is preserved, and the union still dispatches by the same field.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function withEnvelopeIncludeForUnion(union: any): any {
+  const includeField = z
+    .array(z.string())
+    .optional()
+    .describe(ENVELOPE_INCLUDE_FIELD_DESCRIPTION);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const newOptions = (union.options as readonly z.ZodObject<z.ZodRawShape>[]).map(
+    (opt) => opt.extend({ include: includeField }),
+  );
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return z.discriminatedUnion(union.discriminator as string, newOptions as any);
+}
+
+/** Shared description for `include` field across raw-shape and discriminatedUnion injection. */
+const ENVELOPE_INCLUDE_FIELD_DESCRIPTION =
+  "Optional response-shape opt-in. " +
+  "`['envelope']` returns the self-documenting envelope " +
+  "(`_version` / `data` / `as_of` / `confidence`). " +
+  "`['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). " +
+  "Default behaviour is raw shape (compat with existing clients).";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 

--- a/src/tools/keyboard.ts
+++ b/src/tools/keyboard.ts
@@ -24,7 +24,7 @@ import { detectFocusLoss, checkForegroundOnce } from "./_focus.js";
 import { evaluatePreToolGuards, buildEnvelopeFor } from "../engine/perception/registry.js";
 import { runActionGuard, isAutoGuardEnabled, validateAndPrepareFix, consumeFix } from "./_action-guard.js";
 import { resolveWindowTarget } from "./_resolve-window.js";
-import { makeCommitWrapper } from "./_envelope.js";
+import { makeCommitWrapper, withEnvelopeIncludeForUnion } from "./_envelope.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -1015,6 +1015,26 @@ export const keyboardHandler = async (args: KeyboardArgs): Promise<import("./_ty
  * handler internal logic + Zod schema + 戻り値 shape 不変
  * (ADR-010 §1.5)。
  */
+/**
+ * Registration-time schema with `include?: string[]` injected into each
+ * variant of the `z.discriminatedUnion("action", [...])` so per-call
+ * envelope opt-in (`include:["envelope"]` / `include:["causal"]` /
+ * `include:["raw"]`) survives the MCP SDK's `z.parse()` step on both
+ * `server.registerTool` and `run_macro` paths.
+ *
+ * `withEnvelopeIncludeSchema` (raw shape only) is unusable for
+ * discriminatedUnion families (keyboard / clipboard / window_dock /
+ * scroll / terminal / browser_eval). `withEnvelopeIncludeForUnion`
+ * extends every variant object with the `include` field and rebuilds
+ * the discriminator while preserving dispatch semantics.
+ *
+ * Without injection, Zod's default object parse strips unknown keys and
+ * `include` is removed before `makeCommitWrapper` can peek it
+ * (Codex PR #123 P2 + PR #112 P1-1 同型 risk pattern, discriminatedUnion
+ * 系の延長線).
+ */
+export const keyboardRegistrationSchema = withEnvelopeIncludeForUnion(keyboardSchema);
+
 export const keyboardRegistrationHandler = makeCommitWrapper(
   withRichNarration(
     "keyboard",
@@ -1044,8 +1064,8 @@ export function registerKeyboardTools(server: McpServer): void {
           "keyboard({action:'press', keys:'escape', windowTitle:'Dialog'}) → dismiss dialog",
         ],
       }),
-      inputSchema: keyboardSchema,
+      inputSchema: keyboardRegistrationSchema,
     },
-    keyboardRegistrationHandler as (args: Record<string, unknown>) => Promise<import("./_types.js").ToolResult>,
+    keyboardRegistrationHandler as typeof keyboardHandler,
   );
 }

--- a/src/tools/keyboard.ts
+++ b/src/tools/keyboard.ts
@@ -24,6 +24,7 @@ import { detectFocusLoss, checkForegroundOnce } from "./_focus.js";
 import { evaluatePreToolGuards, buildEnvelopeFor } from "../engine/perception/registry.js";
 import { runActionGuard, isAutoGuardEnabled, validateAndPrepareFix, consumeFix } from "./_action-guard.js";
 import { resolveWindowTarget } from "./_resolve-window.js";
+import { makeCommitWrapper } from "./_envelope.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -995,6 +996,38 @@ export const keyboardHandler = async (args: KeyboardArgs): Promise<import("./_ty
 // Registration
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * Walking skeleton expansion phase swimlane 1 (L5 commit tool wrapper):
+ * `keyboard` is wrapped via `makeCommitWrapper` (lease 不在 commit variant —
+ * `leaseValidator` omitted since the public `keyboard` tool is name/keys
+ * driven without a lease 4-tuple, mirroring the S6 `click_element` PoC).
+ * `withRichNarration` (inner) → `makeCommitWrapper` (outer) composition
+ * matches `clickElementRegistrationHandler` (`ui-elements.ts:372`):
+ *   - withRichNarration enriches the handler's ToolResult (`hints.diff` 等)
+ *   - makeCommitWrapper handles L1 ToolCallStarted/Completed push +
+ *     envelope assembly + compat hoist + tool_call_id seq
+ * Module-scope export so `run_macro` (`TOOL_REGISTRY.keyboard` in
+ * `macro.ts`) shares the same wrapped instance (PR #112 shared
+ * registration handler pattern, strip risk prevention).
+ *
+ * Trunk pattern conformance: engine-perception layer 改変ゼロ
+ * (expansion-pr-guard.yml + check-expansion-disjoint.mjs)、
+ * handler internal logic + Zod schema + 戻り値 shape 不変
+ * (ADR-010 §1.5)。
+ */
+export const keyboardRegistrationHandler = makeCommitWrapper(
+  withRichNarration(
+    "keyboard",
+    keyboardHandler as (args: Record<string, unknown>) => Promise<import("./_types.js").ToolResult>,
+    { windowTitleKey: "windowTitle" },
+  ) as (args: Record<string, unknown>) => Promise<import("./_types.js").ToolResult>,
+  "keyboard",
+  {
+    // leaseValidator omitted = lease-less commit variant
+    // getSessionId / argsSummary / clock も default 利用 = mechanical コピー最小
+  },
+);
+
 export function registerKeyboardTools(server: McpServer): void {
   server.registerTool(
     "keyboard",
@@ -1013,6 +1046,6 @@ export function registerKeyboardTools(server: McpServer): void {
       }),
       inputSchema: keyboardSchema,
     },
-    withRichNarration("keyboard", keyboardHandler as (args: Record<string, unknown>) => Promise<import("./_types.js").ToolResult>, { windowTitleKey: "windowTitle" })
+    keyboardRegistrationHandler as (args: Record<string, unknown>) => Promise<import("./_types.js").ToolResult>,
   );
 }

--- a/src/tools/macro.ts
+++ b/src/tools/macro.ts
@@ -17,7 +17,7 @@ import { screenshotHandler, screenshotSchema } from "./screenshot.js";
 // Mouse
 import { mouseClickHandler, mouseClickRegistrationSchema, mouseClickRegistrationHandler, mouseDragHandler, mouseDragSchema } from "./mouse.js";
 // Keyboard dispatcher (Phase 2)
-import { keyboardHandler, keyboardSchema, keyboardRegistrationHandler } from "./keyboard.js";
+import { keyboardHandler, keyboardRegistrationSchema, keyboardRegistrationHandler } from "./keyboard.js";
 // Clipboard dispatcher (Phase 2)
 import { clipboardHandler, clipboardSchema } from "./clipboard.js";
 // Window
@@ -140,7 +140,7 @@ const TOOL_REGISTRY: Record<string, ToolEntry> = {
   // module-scope wrapped handler from keyboard.ts so run_macro 経路は
   // server.tool 経路と同 instance を共有 (PR #112 shared registration handler
   // pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
-  keyboard:             { schema: keyboardSchema,                      handler: keyboardRegistrationHandler as typeof keyboardHandler },
+  keyboard:             { schema: keyboardRegistrationSchema,          handler: keyboardRegistrationHandler as typeof keyboardHandler },
   clipboard:            { schema: clipboardSchema,                     handler: clipboardHandler },
   // Action — window/scroll/terminal dispatchers (Phase 2)
   window_dock:          { schema: windowDockSchema,                    handler: windowDockHandler },

--- a/src/tools/macro.ts
+++ b/src/tools/macro.ts
@@ -17,7 +17,7 @@ import { screenshotHandler, screenshotSchema } from "./screenshot.js";
 // Mouse
 import { mouseClickHandler, mouseClickRegistrationSchema, mouseClickRegistrationHandler, mouseDragHandler, mouseDragSchema } from "./mouse.js";
 // Keyboard dispatcher (Phase 2)
-import { keyboardHandler, keyboardSchema } from "./keyboard.js";
+import { keyboardHandler, keyboardSchema, keyboardRegistrationHandler } from "./keyboard.js";
 // Clipboard dispatcher (Phase 2)
 import { clipboardHandler, clipboardSchema } from "./clipboard.js";
 // Window
@@ -136,7 +136,11 @@ const TOOL_REGISTRY: Record<string, ToolEntry> = {
   click_element:        { schema: z.object(clickElementRegistrationSchema), handler: clickElementRegistrationHandler as typeof clickElementHandler },
   focus_window:         { schema: z.object(focusWindowSchema),         handler: focusWindowHandler },
   // Action — text/clipboard dispatchers (Phase 2)
-  keyboard:             { schema: keyboardSchema,                      handler: keyboardHandler },
+  // Walking skeleton expansion swimlane 1 (L5 commit wrapper): use the
+  // module-scope wrapped handler from keyboard.ts so run_macro 経路は
+  // server.tool 経路と同 instance を共有 (PR #112 shared registration handler
+  // pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
+  keyboard:             { schema: keyboardSchema,                      handler: keyboardRegistrationHandler as typeof keyboardHandler },
   clipboard:            { schema: clipboardSchema,                     handler: clipboardHandler },
   // Action — window/scroll/terminal dispatchers (Phase 2)
   window_dock:          { schema: windowDockSchema,                    handler: windowDockHandler },

--- a/tests/unit/expansion-keyboard-wrapper.test.ts
+++ b/tests/unit/expansion-keyboard-wrapper.test.ts
@@ -1,0 +1,171 @@
+/**
+ * expansion-keyboard-wrapper.test.ts — walking skeleton expansion phase
+ * swimlane 1 (L5 commit tool wrapper) contract test.
+ *
+ * Pins the bit-equal contract for `keyboard` wrap via `makeCommitWrapper`
+ * per `docs/walking-skeleton-expansion-plan.md` §3 (30 分タイムアタック
+ * template) — mechanical copy of S6 `click_element` PoC pattern
+ * (`tests/unit/click-element-commit-wrapper.test.ts`).
+ *
+ * Trunk contract conformance:
+ *   - L5 wrapper のみで mechanical コピー成立 (engine-perception layer 改変ゼロ)
+ *   - lease 不在 commit variant (`leaseValidator` 省略、name/keys 駆動)
+ *   - run_macro 経路と server.tool 経路で同 instance 共有
+ *     (PR #112 shared registration handler pattern)
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  makeCommitWrapper,
+  defaultL1Emitter,
+  buildCausedBy,
+  buildBasedOn,
+  _resetHistoryBuffersForTest,
+  _resetToolCallSeqForTest,
+  type CommitL1Emitter,
+  type ViewSnapshot,
+} from "../../src/tools/_envelope.js";
+
+function resetAll(): void {
+  _resetHistoryBuffersForTest();
+  _resetToolCallSeqForTest();
+}
+
+function makeViewSnapshot(): ViewSnapshot {
+  return {
+    focus: { hwnd: null, elementName: "test-element" },
+    dirtyRectsByMonitor: new Map([[0, 1]]),
+    latestEventId: 100n,
+    queryWallclockMs: Date.now(),
+  };
+}
+
+// ── E1: keyboard wrap → L1 ToolCallStarted/Completed event 記録 ───────────────
+
+describe("expansion swimlane 1 (keyboard): wrap → L1 events recorded (lease 不在 variant)", () => {
+  it("makeCommitWrapper flow 通過、ToolCallStarted/Completed 両 event push、lease_token undefined", async () => {
+    resetAll();
+    const events: Array<{ kind: "started" | "completed"; tool: string; leaseToken?: unknown }> = [];
+    const fakeEmitter: CommitL1Emitter = {
+      pushStarted: ({ tool, sessionId, toolCallId, leaseToken }) => {
+        events.push({ kind: "started", tool, leaseToken });
+        // history buffer も seed (E3 buildCausedBy 動作確認用)
+        defaultL1Emitter.pushStarted({
+          tool,
+          argsJson: "{}",
+          sessionId,
+          toolCallId,
+          leaseToken,
+        });
+      },
+      pushCompleted: ({ tool, elapsedMs, ok, errorCode, sessionId, toolCallId }) => {
+        events.push({ kind: "completed", tool });
+        defaultL1Emitter.pushCompleted({
+          tool,
+          elapsedMs,
+          ok,
+          errorCode,
+          sessionId,
+          toolCallId,
+        });
+      },
+    };
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"data":{"typed":5,"method":"keystroke"}}' }],
+    });
+    // Lease 不在 commit variant: leaseValidator omitted (sub-plan §3.1 line 153
+    // expansion 30 分 template、S6 click_element pattern mechanical copy)
+    const wrapped = makeCommitWrapper(handler, "keyboard", {
+      l1Emitter: fakeEmitter,
+    });
+    const result = await wrapped({
+      action: "type",
+      text: "hello",
+      windowTitle: "Notepad",
+    } as Record<string, unknown>);
+    // Started + Completed 両 event push されている
+    expect(events).toHaveLength(2);
+    expect(events[0].kind).toBe("started");
+    expect(events[0].tool).toBe("keyboard");
+    // lease 不在 variant のため lease_token undefined
+    expect(events[0].leaseToken).toBeUndefined();
+    expect(events[1].kind).toBe("completed");
+    expect(events[1].tool).toBe("keyboard");
+    expect(result.content).toBeDefined();
+  });
+});
+
+// ── E2: include 未指定時 raw shape return (既存 raw client 互換) ─────────────
+
+describe("expansion swimlane 1 (keyboard): include 未指定時 raw shape return", () => {
+  it("default 経路 → envelope shape を hoist して raw client 互換", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"typed":5,"method":"keystroke"}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "keyboard", {});
+    const result = await wrapped({
+      action: "type",
+      text: "hello",
+    } as Record<string, unknown>);
+    const text = (result.content[0] as { text: string }).text;
+    const parsed = JSON.parse(text);
+    // _version 不在 = raw shape (compat hoist で envelope flatten)
+    expect(parsed._version).toBeUndefined();
+    expect(parsed.ok).toBe(true);
+    expect(parsed.typed).toBe(5);
+    expect(parsed.method).toBe("keystroke");
+  });
+});
+
+// ── E3: include=causal 経路 → caused_by.your_last_action = "keyboard(...)" ──
+
+describe("expansion swimlane 1 (keyboard): include=causal で caused_by.your_last_action に keyboard 記録", () => {
+  it("keyboard wrap → history buffer に entry → buildCausedBy で your_last_action = keyboard(...)", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "keyboard", {
+      getSessionId: () => "sessKB",
+    });
+    await wrapped({
+      action: "press",
+      keys: "ctrl+c",
+    } as Record<string, unknown>);
+    // history buffer に entry が記録されているか確認
+    const causedBy = buildCausedBy("sessKB", makeViewSnapshot());
+    expect(causedBy).toBeDefined();
+    expect(causedBy?.your_last_action).toContain("keyboard");
+    expect(causedBy?.tool_call_id).toMatch(/^sessKB:\d+$/);
+    // based_on も並列で動作確認
+    const basedOn = buildBasedOn("sessKB", makeViewSnapshot());
+    expect(basedOn).toBeDefined();
+    // events は string[] (u64 decimal) で JSON-safe
+    if (basedOn?.events && basedOn.events.length > 0) {
+      expect(typeof basedOn.events[0]).toBe("string");
+    }
+  });
+});
+
+// ── E4: trunk completion contract: L5 wrapper のみで mechanical copy 成立 ────
+
+describe("expansion swimlane 1 (keyboard): trunk completion contract — mechanical copy", () => {
+  it("S5 contract が keyboard wrap でそのまま機能 (lease validator omit のみで lease 不在 variant)", async () => {
+    resetAll();
+    const handler = vi.fn(async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    }));
+    const wrapped = makeCommitWrapper(handler, "keyboard", {
+      // sub-plan §3.1: getSessionId / argsSummary / clock も default 利用
+      // = mechanical コピー最小、leaseValidator のみ omit
+    });
+    const result = await wrapped({
+      action: "type",
+      text: "x",
+    } as Record<string, unknown>);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(result.content).toBeDefined();
+    // L1 emitter は default で動作 (production では nativeL1 push、test では history buffer のみ)
+  });
+});


### PR DESCRIPTION
## Summary

walking skeleton expansion phase **swimlane 1 (L5 commit tool wrapper)** の `keyboard` tool wrap PR。PR #117 `clickElementRegistrationHandler` pattern の mechanical コピー (lease 不在 commit variant)。

(初期起票は background agent `a391c5d3fbfe932c2` が実施、user 指示で停止)

## scope

- `src/tools/keyboard.ts`: `keyboardRegistrationHandler` module-scope export
- `src/tools/macro.ts`: `TOOL_REGISTRY.keyboard` を shared instance に切替
- `tests/unit/expansion-keyboard-wrapper.test.ts`: envelope shape + L1 ToolCallStarted/Completed event 確認

## trunk contract conformance

- engine-perception layer 改変ゼロ
- run_macro 経路同 instance 共有 (PR #112 pattern)
- handler internal logic + Zod schema + 戻り値 shape 不変 (ADR-010 §1.5)
- lease 不在 commit variant (PR #117 click_element と同 pattern)

---

## ⏸ 進捗 (2026-05-02、user 指示で並走停止)

### Review 状態

- **Codex Round 1**: ⚠️ **P2 1 件** (line 143、`Preserve include when routing keyboard through run_macro`、PR #121 mouse_click と**同型 P2**)
- **Opus Round 1**: 🟡 **未完了** (background agent 停止)

### 共通発見 (PR #121 + PR #123 同型 P2)

本 PR (keyboard) + PR #121 (mouse_click) で **同型 Codex P2** が出ている。**PR #117 click_element の registry entry でも同型 bug が存在する可能性が高い** (= 既存問題が expansion で顕在化)。

問題: `TOOL_REGISTRY` entry が `z.object(keyboardSchema)` で validate、`run_macro` 経由で `entry.schema.parse(params)` が `include` を strip → wrapper の envelope/causal opt-in が run_macro 経路で機能しない。

根本的修正 option (PR #121 と同):
- (a) `TOOL_REGISTRY` の schema に `withEnvelopeIncludeSchema` を適用
- (b) 各 wrap tool の TOOL_REGISTRY entry で `include: z.array(z.string()).optional()` を追加
- (c) 共通 helper `withRunMacroIncludeSchema` で macro.ts 側で injection

merge 判断 + 根本対処方針は **user 確認待ち** (PR #117 既存 bug の有無 + 修正 scope を含めて再検討必要)。

## 並走 PR (本日 expansion phase 開始)

- PR #121 (swimlane 1 commit、mouse_click): Opus Approved / Codex P2 1 件 (本 PR と同型)
- PR #122 (swimlane 2 query、screenshot): Codex Clean / Opus 未完了
- 本 PR (swimlane 1 commit、keyboard): Opus 未完了 / Codex P2 同型

## 次にすべきこと (user 確認後に再開)

1. PR #117 click_element の TOOL_REGISTRY entry (`src/tools/macro.ts:136`) に同型 bug が存在するか verify
2. 修正方針確定 (上記 (a)/(b)/(c) のいずれか)
3. PR #121 + 本 PR + (必要なら) PR #117 retroactive fix を含む形で修正
4. Opus phase-boundary review 再起動

🤖 Generated with [Claude Code](https://claude.com/claude-code)