### PR TITLE
fix(codeql #108): suppress trivial-conditional in desktop-state.ts:707

### DIFF
--- a/src/tools/desktop-state.ts
+++ b/src/tools/desktop-state.ts
@@ -702,9 +702,15 @@ const desktopStateCausedByProjector = async (
   }
 
   // L1 ring 末尾 event_id (OQ #5 既存 binding reuse、新規不要)
+  // Note: line 657 early return guarantees `nativeL1 != null` here, so the
+  // outer `nativeL1 &&` check is omitted (CodeQL alert #108
+  // `js/trivial-conditional` 構造的修正, PR fix/codeql-108-trivial-conditional).
+  // The `typeof` check on the optional `l1GetCaptureStats` method is retained
+  // as defence against binding shape drift (e.g. partial native binding
+  // loaded on non-Windows / pre-P5a binary).
   let latestEventId: bigint | undefined;
   try {
-    if (nativeL1 && typeof nativeL1.l1GetCaptureStats === "function") {
+    if (typeof nativeL1.l1GetCaptureStats === "function") {
       const stats = nativeL1.l1GetCaptureStats();
       latestEventId = stats.eventIdHighWater;
     }


### PR DESCRIPTION
## Summary

Fix GitHub Code Scanning alert **#108** (`js/trivial-conditional`, severity: warning) at `src/tools/desktop-state.ts:707`.

- Alert URL: https://github.com/Harusame64/desktop-touch-mcp/security/code-scanning/108
- Message: *"This use of variable 'nativeL1' always evaluates to true."*
- Resolution path: **structural removal** (Option A) — drop the redundant `nativeL1 &&` operand.

| Alert | severity | rule | file:line | resolution |
|---|---|---|---|---|
| #108 | warning | `js/trivial-conditional` | `src/tools/desktop-state.ts:707` | structural removal of trivial operand |

## Root cause

`computeProjectorInputs` early-returns at line 657:

```ts
if (!nativeL1 || typeof nativeL1.l1GetCaptureStats !== "function") {
  return { forceDegraded: true };
}
```

…so by the time control flow reaches line 707, CodeQL flow analysis correctly proves that `nativeL1` cannot be null/undefined. The outer operand `nativeL1 &&` in `if (nativeL1 && typeof nativeL1.l1GetCaptureStats === "function")` is therefore trivially true and warrants the alert.

## Fix option chosen: A (structural removal)

Drop only the trivially-true `nativeL1 &&` operand. Keep the `typeof nativeL1.l1GetCaptureStats === "function"` check as defence-in-depth against binding shape drift (e.g. a partial native binding loaded on non-Windows or against a pre-P5a binary that omits the L1 capture-stats method). Add an inline comment above the `if` referencing the line-657 narrowing guarantee so a future reader does not re-add the defensive operand.

### Why not Option B (inline `// codeql[...]` suppress)

PR #120 round 2 established that inline `// codeql[js/...]` suppress comments are **not supported** by current GitHub-hosted CodeQL — that syntax is legacy LGTM platform (sunset 2022-12) and does **not** flip alerts to `fixed`. Structural removal is the only path that reliably resolves the alert on re-scan.

### Why not Option C (replace the `nativeL1` operand with a sub-property check)

The original intent was a plain null guard, not a sub-property predicate. Sub-property checks are already covered by the retained `typeof … === "function"` clause on the optional `l1GetCaptureStats` method.

## Test plan

- [x] `npm run build` (tsc) — OK, regression 0
- [x] Relevant unit tests pass — `desktop-state-causal-include` / `desktop-state-envelope` / `desktop-state-focus-builder`, 76 tests pass
- [ ] CodeQL re-scan after merge: `gh api repos/Harusame64/desktop-touch-mcp/code-scanning/alerts/108 --jq .state` → expect `open → fixed` flip (triggered by `.github/workflows/codeql.yml` on push to main)
- [ ] Opus phase-boundary review (production code change → §3.3 Step 1 required)
- [ ] Codex review (production code change → §3.3 Step 2 required per CLAUDE.md §3.2 教訓)

## Scope discipline

Single-alert single-file fix. Disjoint from PR #120 (alerts #109/#110), no functional behavior change — only removes a provably-true conditional operand whose removal is permitted by an upstream early-return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)