### PR TITLE
chore(build-rs): auto-populate node.lib from node-gyp cache (Windows preflight)

### DIFF
--- a/docs/build-rs-followups.md
+++ b/docs/build-rs-followups.md
@@ -1,0 +1,47 @@
+# build-rs followups
+
+`scripts/build-rs.mjs` および `build.rs` 周辺の永続的 follow-up（CLAUDE.md §9 準拠：残件は memory ではなく docs に書く）。
+
+## 起源
+
+- PR #125（chore/build-rs-node-lib-preflight）— Windows MSVC host で `node.lib` 不在時に node-gyp cache から自動 populate する preflight を `scripts/build-rs.mjs` に追加。
+- Opus Round 1 review で識別された P2 / P3 のうち、本 PR scope 外に倒した項目を本 doc に永続化。
+
+## Follow-up items
+
+### F1. `build.rs` に `cargo:rerun-if-changed=node.lib` を追加（P2、別 PR）
+
+**Why:** 現状 `build.rs` は `node.lib` 自体を tracking していない。preflight が初回 build で `node.lib` を配置 → cargo は問題なく link するが、ユーザが手で `node.lib` を削除して再生成するシナリオで cargo が incremental cache のまま再 link をスキップする可能性。
+
+**How to apply:** `build.rs:13-26` の Windows ブランチに `println!("cargo:rerun-if-changed={manifest_dir}/node.lib");` を追加（msvc / gnu 両方）。最小 1 行 PR。
+
+**Trigger:** ユーザから「`node.lib` を入れ替えても build が更新されない」型 issue が出たら優先度上げ。それまでは defer 可。
+
+### F2. CI workflow の `Fetch node.lib for MSVC linking` step 削除（P3、別 PR）
+
+**Why:** `.github/workflows/ci.yml:65-79` と `.github/workflows/release.yml` の `Fetch node.lib` step は PR #125 の preflight 導入後 **冗長**（`npm run build:rs` 内部で同等処理が走る）。重複は将来的に node-gyp install の引数（`--target` / `--yes`）が片側だけ更新される drift リスクの温床。
+
+**How to apply:** 両 workflow から `Fetch node.lib for MSVC linking` step を削除し、`npm run build:rs` (or `build:rs:debug`) 単独で完結することをローカル + CI dry-run で確認。
+
+**注意:** preflight は MSVC のみ対応。CI が gnu host で走る将来 plan があるなら本 follow-up は保留。現状 CI/release は windows-latest msvc 一択なので削除して安全。
+
+### F3. `@napi-rs/cli` silent skip の upstream root cause 調査（P2、別 PR / issue）
+
+**Why:** PR #125 は症状治療（preflight で `node.lib` を repo root に置く）であり、`@napi-rs/cli` v3.6.2 が clean clone で `node.lib` の download を silent に no-op する根本原因は未解明。
+
+**How to apply:**
+1. `@napi-rs/cli` v3.6.2 → 最新 (3.7+ 等) で再現するか確認
+2. CLI source を読み、Windows host での node.lib fetch path を辿る（`packages/cli/src/api/build.ts` 周辺、推定）
+3. 必要なら `napi-rs/napi-rs` リポに reproducer 付き issue を立てる
+4. upstream で fix されたら本 PR の preflight を縮小 / 撤去（preflight comment block の `@napi-rs/cli download path can silently no-op` 記述を更新）
+
+**Trigger:** napi-rs/cli の major update を入れるタイミング、または「Windows clean clone で build:rs が落ちる」型 issue が他リポでも報告された段階。
+
+## 関連リンク
+
+- PR #125: https://github.com/Harusame64/desktop-touch-mcp/pull/125
+- `scripts/build-rs.mjs` preflight 実装
+- `build.rs:13-26` MSVC / GNU 分岐
+- `.github/workflows/ci.yml:65-79` 既存 CI fetch step
+- `docs/ocr-quality-improvement-plan.md:40-44` 旧手動手順（PR #125 で更新済）
+- `docs/v1-release-readiness-review.md:85` build.rs 観点（PR #125 で更新済）

--- a/docs/ocr-quality-improvement-plan.md
+++ b/docs/ocr-quality-improvement-plan.md
@@ -39,8 +39,8 @@
 
 ### ビルド環境補記
 
-- Rust napi ビルド（`npm run build:rs`）には `node.lib` が必要。
-  初回は `npx node-gyp install` でダウンロードし `C:\Users\<user>\AppData\Local\node-gyp\Cache\<version>\x64\node.lib` をプロジェクトルートにコピーしてから実行。
+- Rust napi ビルド（`npm run build:rs`）には `node.lib` が必要。Windows MSVC host では `scripts/build-rs.mjs` の preflight が `%LOCALAPPDATA%\node-gyp\Cache\<version>\<arch>\node.lib` から repo root へ自動コピーする（cache が空なら `npx --yes node-gyp install --target=<version>` を先に発火）。
+- 手動の `npx node-gyp install` + `cp` は不要（PR #125 で自動化）。GNU host だけは `libnode.a` 別経路が必要なため preflight が skip + warn する。
 - `node.lib` は `.gitignore` 対象なのでリポジトリには含まれない。
 
 ### フェーズ 2 完了判定（実績）

--- a/docs/v1-release-readiness-review.md
+++ b/docs/v1-release-readiness-review.md
@@ -82,7 +82,7 @@ V2 は Phase 4b dogfood で main merge 済 (PR #34、`072b1db`) ですが、Phas
 - **`native-rs-engine`** UIA bindings — koffi 削除済み (napi-rs に統合)? それとも残留? (Phase 1 §1.5 引継ぎで言及あり)
 - **`native-rs-engine`** perception sensors (Rust 側) — TS 側 sensor 群との重複・整合性
 - **`src/engine/vision-gpu/backend.ts`** ↔ Rust 接続 — Vulkan / CUDA / DirectML の lane warmup race、`PocVisualBackend` のフェイルセーフ動作 (Tier ∞)
-- **`build.rs`** — node.lib 取得 (windows-latest CI で `node-gyp install` 必要、memory `feedback_ci_node_lib.md` 引継ぎ)
+- **`build.rs`** — node.lib 取得 (windows-latest CI で `node-gyp install` 必要、memory `feedback_ci_node_lib.md` 引継ぎ。dev side は PR #125 で `scripts/build-rs.mjs` preflight に自動化済)
 - **Rust テスト** — `cargo check` / `cargo test` / `cargo clippy` の状況、CI 統合
 
 ### 3.5. D — TS↔Rust 境界観点

--- a/scripts/build-rs.mjs
+++ b/scripts/build-rs.mjs
@@ -30,7 +30,7 @@
 // a useful signal.
 
 import { spawnSync } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -81,6 +81,60 @@ function detectHostTriple() {
   return pieces.slice(-4).join("-");
 }
 
+// On Windows, `napi-build` emits `cargo:rustc-link-search=<repo root>` so the
+// linker looks for `node.lib` there — but napi-build does NOT download the lib
+// itself. The @napi-rs/cli download path can silently no-op on a fresh clone
+// (empty %LOCALAPPDATA%\node-gyp\Cache, no `node.lib` in repo root), which
+// surfaces as `LNK1181: 入力ファイル 'node.lib' を開けません` deep inside the
+// link stage. Populate `node.lib` from the node-gyp cache here, running
+// `npx node-gyp install` first if the cache is empty.
+function ensureNodeLibOnWindows(triple) {
+  if (process.platform !== "win32") return;
+  const repoNodeLib = join(ROOT, "node.lib");
+  if (existsSync(repoNodeLib)) return;
+  const localAppData = process.env.LOCALAPPDATA;
+  if (!localAppData) {
+    console.error("[build-rs] LOCALAPPDATA env not set; cannot locate node-gyp cache.");
+    process.exit(1);
+  }
+  const arch = archFromTriple(triple);
+  const cachedNodeLib = join(
+    localAppData,
+    "node-gyp",
+    "Cache",
+    process.versions.node,
+    arch,
+    "node.lib",
+  );
+  if (!existsSync(cachedNodeLib)) {
+    console.log(
+      `[build-rs] node.lib missing from repo root and node-gyp cache; running 'npx node-gyp install'`,
+    );
+    const npx = process.platform === "win32" ? "npx.cmd" : "npx";
+    const r = spawnSync(npx, ["node-gyp", "install"], {
+      stdio: "inherit",
+      cwd: ROOT,
+    });
+    if (r.status !== 0 || !existsSync(cachedNodeLib)) {
+      console.error(`[build-rs] node-gyp install did not produce ${cachedNodeLib}`);
+      process.exit(1);
+    }
+  }
+  copyFileSync(cachedNodeLib, repoNodeLib);
+  console.log(`[build-rs] populated ${repoNodeLib} from node-gyp cache`);
+}
+
+// node-gyp Cache layout: <ver>/<arch>/node.lib where arch ∈ {x64, ia32, arm64}.
+// Prefer the rustup target triple (cross-compile aware); fall back to host arch.
+function archFromTriple(triple) {
+  if (triple?.startsWith("x86_64")) return "x64";
+  if (triple?.startsWith("aarch64")) return "arm64";
+  if (triple?.startsWith("i686")) return "ia32";
+  if (process.arch === "arm64") return "arm64";
+  if (process.arch === "ia32") return "ia32";
+  return "x64";
+}
+
 const args = process.argv.slice(2);
 const release = args.includes("--release");
 const passthrough = args.filter((a) => a !== "--release" && a !== "--debug");
@@ -105,13 +159,16 @@ function restore() {
   }
 }
 
-// ── 2. Run `napi build` ─────────────────────────────────────────────────────
+// ── 2. Preflight (Windows only) ─────────────────────────────────────────────
+const triple = detectHostTriple();
+ensureNodeLibOnWindows(triple);
+
+// ── 3. Run `napi build` ─────────────────────────────────────────────────────
 // Invoke the napi CLI's JS entry directly with `node`. Going through
 // `npx`/`npx.cmd` requires `shell: true` (DEP0190 on Node ≥ 22), and the
 // shell lookup is brittle across MSYS bash / pwsh / cmd / GitHub Actions
 // runners. Calling node with an absolute path is portable and explicit.
 const napiCli = join(ROOT, "node_modules", "@napi-rs", "cli", "dist", "cli.js");
-const triple = detectHostTriple();
 const targetArgs = triple ? ["--target", triple] : [];
 if (triple) {
   console.log(`[build-rs] detected rustup toolchain triple: ${triple}`);

--- a/scripts/build-rs.mjs
+++ b/scripts/build-rs.mjs
@@ -90,17 +90,20 @@ function detectHostTriple() {
 // Populate `node.lib` from the node-gyp cache, running `npx node-gyp install`
 // first if the cache is empty.
 //
-// GNU host is intentionally skipped: `build.rs` requires `libnode.a` (generated
-// from node.exe exports via dlltool) on gnu, not `node.lib`. Auto-populating
-// `node.lib` there would produce a "silent miss-rescue" — file appears, but
-// link still fails. CI/release flows are MSVC-only; gnu is a developer
-// preference and out of scope here.
+// GNU / GNU-LLVM hosts are intentionally skipped: `build.rs` requires
+// `libnode.a` (generated from node.exe exports via dlltool) on those targets,
+// not `node.lib`. Auto-populating `node.lib` there would produce a "silent
+// miss-rescue" — file appears, but link still fails. `gnullvm` is the LLVM
+// MinGW toolchain (rustc reports `CARGO_CFG_TARGET_ENV=gnu` for it, so
+// `build.rs` routes it to the libnode.a branch correctly); we mirror that
+// here. CI/release flows are MSVC-only; gnu/gnullvm is a developer preference
+// and out of scope.
 function ensureNodeLibOnWindows(triple) {
   if (process.platform !== "win32") return;
-  if (triple?.endsWith("-gnu")) {
+  if (triple?.endsWith("-gnu") || triple?.endsWith("-gnullvm")) {
     console.warn(
-      "[build-rs] gnu host detected; preflight handles MSVC node.lib only. " +
-        "GNU target needs libnode.a generated separately (see build.rs).",
+      `[build-rs] ${triple} host detected; preflight handles MSVC node.lib only. ` +
+        "GNU/GNU-LLVM target needs libnode.a generated separately (see build.rs).",
     );
     return;
   }

--- a/scripts/build-rs.mjs
+++ b/scripts/build-rs.mjs
@@ -81,15 +81,29 @@ function detectHostTriple() {
   return pieces.slice(-4).join("-");
 }
 
-// On Windows, `napi-build` emits `cargo:rustc-link-search=<repo root>` so the
-// linker looks for `node.lib` there — but napi-build does NOT download the lib
-// itself. The @napi-rs/cli download path can silently no-op on a fresh clone
-// (empty %LOCALAPPDATA%\node-gyp\Cache, no `node.lib` in repo root), which
-// surfaces as `LNK1181: 入力ファイル 'node.lib' を開けません` deep inside the
-// link stage. Populate `node.lib` from the node-gyp cache here, running
-// `npx node-gyp install` first if the cache is empty.
+// On Windows MSVC, `build.rs` emits `cargo:rustc-link-search=<repo root>` +
+// `cargo:rustc-link-lib=node` so the linker looks for `node.lib` at the repo
+// root — but napi-build does NOT download the lib itself, and the @napi-rs/cli
+// download path can silently no-op on a fresh clone (empty
+// %LOCALAPPDATA%\node-gyp\Cache, no `node.lib` in repo root). The result is
+// `LNK1181: 入力ファイル 'node.lib' を開けません` deep inside the link stage.
+// Populate `node.lib` from the node-gyp cache, running `npx node-gyp install`
+// first if the cache is empty.
+//
+// GNU host is intentionally skipped: `build.rs` requires `libnode.a` (generated
+// from node.exe exports via dlltool) on gnu, not `node.lib`. Auto-populating
+// `node.lib` there would produce a "silent miss-rescue" — file appears, but
+// link still fails. CI/release flows are MSVC-only; gnu is a developer
+// preference and out of scope here.
 function ensureNodeLibOnWindows(triple) {
   if (process.platform !== "win32") return;
+  if (triple?.endsWith("-gnu")) {
+    console.warn(
+      "[build-rs] gnu host detected; preflight handles MSVC node.lib only. " +
+        "GNU target needs libnode.a generated separately (see build.rs).",
+    );
+    return;
+  }
   const repoNodeLib = join(ROOT, "node.lib");
   if (existsSync(repoNodeLib)) return;
   const localAppData = process.env.LOCALAPPDATA;
@@ -98,20 +112,26 @@ function ensureNodeLibOnWindows(triple) {
     process.exit(1);
   }
   const arch = archFromTriple(triple);
+  const nodeVer = process.versions.node;
   const cachedNodeLib = join(
     localAppData,
     "node-gyp",
     "Cache",
-    process.versions.node,
+    nodeVer,
     arch,
     "node.lib",
   );
   if (!existsSync(cachedNodeLib)) {
     console.log(
-      `[build-rs] node.lib missing from repo root and node-gyp cache; running 'npx node-gyp install'`,
+      `[build-rs] node.lib missing from repo root and node-gyp cache; running 'npx --yes node-gyp install --target=${nodeVer}'`,
     );
     const npx = process.platform === "win32" ? "npx.cmd" : "npx";
-    const r = spawnSync(npx, ["node-gyp", "install"], {
+    // `--target=<ver>` pins the download to the running Node's version so the
+    // post-install lookup at `<ver>/<arch>/node.lib` finds it. Without it,
+    // node-gyp picks its own default (often a different version), the cache
+    // path mismatches, and we'd false-positive the "did not produce" branch.
+    // CI does the same (.github/workflows/ci.yml).
+    const r = spawnSync(npx, ["--yes", "node-gyp", "install", `--target=${nodeVer}`], {
       stdio: "inherit",
       cwd: ROOT,
     });
@@ -126,6 +146,8 @@ function ensureNodeLibOnWindows(triple) {
 
 // node-gyp Cache layout: <ver>/<arch>/node.lib where arch ∈ {x64, ia32, arm64}.
 // Prefer the rustup target triple (cross-compile aware); fall back to host arch.
+// Only meaningful when the caller has already confirmed Windows + non-gnu;
+// `ensureNodeLibOnWindows` is the only caller and gates both checks.
 function archFromTriple(triple) {
   if (triple?.startsWith("x86_64")) return "x64";
   if (triple?.startsWith("aarch64")) return "arm64";


### PR DESCRIPTION
## Summary

- `scripts/build-rs.mjs` に Windows preflight を追加。`node.lib` が repo root に無い場合 `%LOCALAPPDATA%\node-gyp\Cache\<ver>\<arch>\node.lib` から自動コピー、cache も空なら `npx node-gyp install` を発火させてから再試行。
- 既存の `napi build` 呼び出しと `index.d.ts` / `index.js` snapshot/restore の振る舞いは変更なし。Linux / macOS では preflight は no-op（`process.platform !== "win32"` で早期 return）。

## Why

clean clone + `npm run build:rs` で `LNK1181: 入力ファイル 'node.lib' を開けません` で死ぬ事象に今日遭遇。原因は napi-build が `cargo:rustc-link-search=<repo root>` を出すだけで `node.lib` 本体は CLI 側でダウンロードされる前提なのに、そのダウンロードが silent で no-op になるケースがあるため。手動で `npx node-gyp install` してから cache の `node.lib` を repo root にコピー、で復旧したので、その手順を build script に内蔵し DX を改善する。

## Test plan

- [x] `rm node.lib && npm run build:rs` がローカル成功（ログに `[build-rs] populated ... from node-gyp cache` が出てから cargo link 完走、`Finished release profile` で終わる）
- [x] node.lib が既に repo root に存在する状態で `npm run build:rs` を流して preflight が早期 return することを確認（既存挙動と差分なし）
- [ ] 非 Windows 環境では preflight が no-op になる（`process.platform !== "win32"` の早期 return、コードレビューで確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)