### PR TITLE
feat(expansion): clipboard commit wrapper (L5 envelope)

### DIFF
--- a/src/stub-tool-catalog.ts
+++ b/src/stub-tool-catalog.ts
@@ -627,6 +627,13 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
           "properties": {
             "action": {
               "const": "read"
+            },
+            "include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
             }
           },
           "additionalProperties": false,
@@ -644,6 +651,13 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
               "description": "Text to place on the clipboard",
               "type": "string",
               "maxLength": 100000
+            },
+            "include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
             }
           },
           "additionalProperties": false,

--- a/src/tools/clipboard.ts
+++ b/src/tools/clipboard.ts
@@ -5,6 +5,8 @@ import { promisify } from "node:util";
 import { ok } from "./_types.js";
 import type { ToolResult } from "./_types.js";
 import { failWith } from "./_errors.js";
+import { withRichNarration } from "./_narration.js";
+import { makeCommitWrapper, withEnvelopeIncludeForUnion } from "./_envelope.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -93,13 +95,57 @@ export const clipboardHandler = async (args: ClipboardArgs): Promise<import("./_
 // Registration
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * Walking skeleton expansion phase swimlane 1 (L5 commit tool wrapper):
+ * `clipboard` is wrapped via `makeCommitWrapper` (lease-less commit variant
+ * — `leaseValidator` omitted; clipboard read/write are OS-level idempotent
+ * actions without a lease 4-tuple, mirroring the S6 `click_element` PoC and
+ * the PR #123 `keyboard` wrap pattern).
+ *
+ * `withRichNarration` (inner) → `makeCommitWrapper` (outer) composition
+ * matches `keyboardRegistrationHandler` (`keyboard.ts:1038`) and
+ * `clickElementRegistrationHandler` (`ui-elements.ts:372`):
+ *   - withRichNarration enriches the handler's ToolResult (post.* hooks)
+ *   - makeCommitWrapper handles L1 ToolCallStarted/Completed push +
+ *     envelope assembly + compat hoist + tool_call_id seq
+ *
+ * `windowTitleKey` is omitted because clipboard has no window-scoped target
+ * (read/write hit the OS clipboard regardless of foreground window). This
+ * mirrors the same omission in the click_element/keyboard families when a
+ * tool has no positional/window target — withRichNarration falls through
+ * to `withPostState` only (the rich-narrate UIA-diff path is unreachable
+ * since narrate isn't in the clipboard schema).
+ *
+ * Module-scope export so `run_macro` (`TOOL_REGISTRY.clipboard` in
+ * `macro.ts`) shares the same wrapped instance (PR #112 shared
+ * registration handler pattern, strip risk prevention).
+ *
+ * Trunk pattern conformance: engine-perception layer 改変ゼロ
+ * (expansion-pr-guard.yml + check-expansion-disjoint.mjs)、handler internal
+ * logic + Zod schema + 戻り値 shape 不変 (ADR-010 §1.5)。
+ */
+export const clipboardRegistrationSchema = withEnvelopeIncludeForUnion(clipboardSchema);
+
+export const clipboardRegistrationHandler = makeCommitWrapper(
+  withRichNarration(
+    "clipboard",
+    clipboardHandler as (args: Record<string, unknown>) => Promise<ToolResult>,
+    {},
+  ) as (args: Record<string, unknown>) => Promise<ToolResult>,
+  "clipboard",
+  {
+    // leaseValidator omitted = lease-less commit variant
+    // getSessionId / argsSummary / clock も default 利用 = mechanical コピー最小
+  },
+);
+
 export function registerClipboardTools(server: McpServer): void {
   server.registerTool(
     "clipboard",
     {
       description: "Read or write the Windows clipboard. action='read' returns current text content (empty string if non-text). action='write' replaces clipboard with given text. Caveats: Non-text clipboard payloads (images, files) return empty string on read. Overwrites existing clipboard content on write.",
-      inputSchema: clipboardSchema,
+      inputSchema: clipboardRegistrationSchema,
     },
-    clipboardHandler
+    clipboardRegistrationHandler as typeof clipboardHandler
   );
 }

--- a/src/tools/macro.ts
+++ b/src/tools/macro.ts
@@ -23,7 +23,7 @@ import { mouseClickHandler, mouseClickRegistrationSchema, mouseClickRegistration
 // Keyboard dispatcher (Phase 2)
 import { keyboardHandler, keyboardRegistrationSchema, keyboardRegistrationHandler } from "./keyboard.js";
 // Clipboard dispatcher (Phase 2)
-import { clipboardHandler, clipboardSchema } from "./clipboard.js";
+import { clipboardHandler, clipboardRegistrationSchema, clipboardRegistrationHandler } from "./clipboard.js";
 // Window
 import {
   focusWindowHandler, focusWindowSchema,
@@ -150,7 +150,11 @@ const TOOL_REGISTRY: Record<string, ToolEntry> = {
   // server.tool 経路と同 instance を共有 (PR #112 shared registration handler
   // pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
   keyboard:             { schema: keyboardRegistrationSchema,          handler: keyboardRegistrationHandler as typeof keyboardHandler },
-  clipboard:            { schema: clipboardSchema,                     handler: clipboardHandler },
+  // Walking skeleton expansion swimlane 1 (L5 commit wrapper): use the
+  // module-scope wrapped handler from clipboard.ts so run_macro 経路は
+  // server.tool 経路と同 instance を共有 (PR #112 shared registration handler
+  // pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
+  clipboard:            { schema: clipboardRegistrationSchema,         handler: clipboardRegistrationHandler as typeof clipboardHandler },
   // Action — window/scroll/terminal dispatchers (Phase 2)
   window_dock:          { schema: windowDockSchema,                    handler: windowDockHandler },
   scroll:               { schema: scrollSchema,                        handler: scrollDispatchHandler },

--- a/tests/unit/expansion-clipboard-wrapper.test.ts
+++ b/tests/unit/expansion-clipboard-wrapper.test.ts
@@ -1,0 +1,168 @@
+/**
+ * expansion-clipboard-wrapper.test.ts — walking skeleton expansion phase
+ * swimlane 1 (L5 commit tool wrapper) contract test.
+ *
+ * Pins the bit-equal contract for `clipboard` wrap via `makeCommitWrapper`
+ * per `docs/walking-skeleton-expansion-plan.md` §3 (30 分タイムアタック
+ * template) — mechanical copy of PR #123 keyboard wrap pattern
+ * (`tests/unit/expansion-keyboard-wrapper.test.ts`), the discriminatedUnion
+ * (3b) sibling for OS-level read/write actions without a window target.
+ *
+ * Trunk contract conformance:
+ *   - L5 wrapper のみで mechanical コピー成立 (engine-perception layer 改変ゼロ)
+ *   - lease 不在 commit variant (`leaseValidator` 省略、OS-level idempotent)
+ *   - run_macro 経路と server.registerTool 経路で同 instance 共有
+ *     (PR #112 shared registration handler pattern)
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  makeCommitWrapper,
+  defaultL1Emitter,
+  buildCausedBy,
+  buildBasedOn,
+  _resetHistoryBuffersForTest,
+  _resetToolCallSeqForTest,
+  type CommitL1Emitter,
+  type ViewSnapshot,
+} from "../../src/tools/_envelope.js";
+
+function resetAll(): void {
+  _resetHistoryBuffersForTest();
+  _resetToolCallSeqForTest();
+}
+
+function makeViewSnapshot(): ViewSnapshot {
+  return {
+    focus: { hwnd: null, elementName: "test-element" },
+    dirtyRectsByMonitor: new Map([[0, 1]]),
+    latestEventId: 100n,
+    queryWallclockMs: Date.now(),
+  };
+}
+
+// ── E1: clipboard wrap → L1 ToolCallStarted/Completed event 記録 ─────────────
+
+describe("expansion swimlane 1 (clipboard): wrap → L1 events recorded (lease 不在 variant)", () => {
+  it("makeCommitWrapper flow 通過、ToolCallStarted/Completed 両 event push、lease_token undefined", async () => {
+    resetAll();
+    const events: Array<{ kind: "started" | "completed"; tool: string; leaseToken?: unknown }> = [];
+    const fakeEmitter: CommitL1Emitter = {
+      pushStarted: ({ tool, sessionId, toolCallId, leaseToken }) => {
+        events.push({ kind: "started", tool, leaseToken });
+        // history buffer も seed (E3 buildCausedBy 動作確認用)
+        defaultL1Emitter.pushStarted({
+          tool,
+          argsJson: "{}",
+          sessionId,
+          toolCallId,
+          leaseToken,
+        });
+      },
+      pushCompleted: ({ tool, elapsedMs, ok, errorCode, sessionId, toolCallId }) => {
+        events.push({ kind: "completed", tool });
+        defaultL1Emitter.pushCompleted({
+          tool,
+          elapsedMs,
+          ok,
+          errorCode,
+          sessionId,
+          toolCallId,
+        });
+      },
+    };
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"data":{"text":"hello"}}' }],
+    });
+    // Lease 不在 commit variant: leaseValidator omitted (clipboard read/write are
+    // OS-level idempotent without a lease 4-tuple, sub-plan §3.1 line 153
+    // expansion 30 分 template、PR #123 keyboard pattern mechanical copy)
+    const wrapped = makeCommitWrapper(handler, "clipboard", {
+      l1Emitter: fakeEmitter,
+    });
+    const result = await wrapped({
+      action: "read",
+    } as Record<string, unknown>);
+    // Started + Completed 両 event push されている
+    expect(events).toHaveLength(2);
+    expect(events[0].kind).toBe("started");
+    expect(events[0].tool).toBe("clipboard");
+    // lease 不在 variant のため lease_token undefined
+    expect(events[0].leaseToken).toBeUndefined();
+    expect(events[1].kind).toBe("completed");
+    expect(events[1].tool).toBe("clipboard");
+    expect(result.content).toBeDefined();
+  });
+});
+
+// ── E2: include 未指定時 raw shape return (既存 raw client 互換) ─────────────
+
+describe("expansion swimlane 1 (clipboard): include 未指定時 raw shape return", () => {
+  it("default 経路 → envelope shape を hoist して raw client 互換", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"text":"hello"}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "clipboard", {});
+    const result = await wrapped({
+      action: "read",
+    } as Record<string, unknown>);
+    const text = (result.content[0] as { text: string }).text;
+    const parsed = JSON.parse(text);
+    // _version 不在 = raw shape (compat hoist で envelope flatten)
+    expect(parsed._version).toBeUndefined();
+    expect(parsed.ok).toBe(true);
+    expect(parsed.text).toBe("hello");
+  });
+});
+
+// ── E3: include=causal 経路 → caused_by.your_last_action = "clipboard(...)" ──
+
+describe("expansion swimlane 1 (clipboard): include=causal で caused_by.your_last_action に clipboard 記録", () => {
+  it("clipboard wrap → history buffer に entry → buildCausedBy で your_last_action = clipboard(...)", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "clipboard", {
+      getSessionId: () => "sessCB",
+    });
+    await wrapped({
+      action: "write",
+      text: "x",
+    } as Record<string, unknown>);
+    // history buffer に entry が記録されているか確認
+    const causedBy = buildCausedBy("sessCB", makeViewSnapshot());
+    expect(causedBy).toBeDefined();
+    expect(causedBy?.your_last_action).toContain("clipboard");
+    expect(causedBy?.tool_call_id).toMatch(/^sessCB:\d+$/);
+    // based_on も並列で動作確認
+    const basedOn = buildBasedOn("sessCB", makeViewSnapshot());
+    expect(basedOn).toBeDefined();
+    // events は string[] (u64 decimal) で JSON-safe
+    if (basedOn?.events && basedOn.events.length > 0) {
+      expect(typeof basedOn.events[0]).toBe("string");
+    }
+  });
+});
+
+// ── E4: trunk completion contract: L5 wrapper のみで mechanical copy 成立 ────
+
+describe("expansion swimlane 1 (clipboard): trunk completion contract — mechanical copy", () => {
+  it("S5 contract が clipboard wrap でそのまま機能 (lease validator omit のみで lease 不在 variant)", async () => {
+    resetAll();
+    const handler = vi.fn(async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    }));
+    const wrapped = makeCommitWrapper(handler, "clipboard", {
+      // sub-plan §3.1: getSessionId / argsSummary / clock も default 利用
+      // = mechanical コピー最小、leaseValidator のみ omit
+    });
+    const result = await wrapped({
+      action: "read",
+    } as Record<string, unknown>);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(result.content).toBeDefined();
+    // L1 emitter は default で動作 (production では nativeL1 push、test では history buffer のみ)
+  });
+});


### PR DESCRIPTION
## Summary

`clipboard` を `makeCommitWrapper` で wrap (lease-less commit variant)。S6 click_element PoC pattern + PR #123 keyboard 準拠 (sub-plan §3 30 分タイムアタック template、discriminatedUnion 3b family)。

## scope

- `src/tools/clipboard.ts`: module-scope `clipboardRegistrationHandler` + `clipboardRegistrationSchema = withEnvelopeIncludeForUnion(clipboardSchema)` export、`server.registerTool` の `inputSchema` を `clipboardRegistrationSchema` に切替、handler を `clipboardRegistrationHandler` に切替。`withRichNarration` 内側 (windowTitleKey 省略 — clipboard is OS-level、no window-scoped target) → `makeCommitWrapper` 外側。
- `src/tools/macro.ts`: `TOOL_REGISTRY.clipboard.schema` を `clipboardRegistrationSchema` に切替 + handler を shared instance に切替 (PR #112 shared registration handler pattern、strip risk 防止)。`z.object()` ラップは discriminatedUnion 系のため不要 (sub-plan §3.1 step 4)。
- `tests/unit/expansion-clipboard-wrapper.test.ts`: 4 contract tests (E1: L1 ToolCallStarted/Completed events recorded、E2: include 未指定時 raw shape return、E3: include=causal で `your_last_action = "clipboard(...)"`、E4: trunk completion contract mechanical copy) — PR #123 keyboard wrapper test pattern mechanical copy。
- `src/stub-tool-catalog.ts`: `npm run check:stub-catalog` で再生成された差分 (`include` field 追加分、2 variants)。

## trunk contract conformance check

- engine-perception layer 改変ゼロ (expansion-pr-guard.yml + check-expansion-disjoint.mjs)
- run_macro 経路同 instance 共有 (PR #112 pattern)
- handler internal logic + Zod schema + 戻り値 shape 不変 (ADR-010 §1.5)

## Test plan

- [x] \`npm run build\` (tsc) green
- [x] \`npm run check:stub-catalog\` (再生成 diff を本 PR に commit)
- [x] \`npm run test:unit\` 全 131 file / 2351 tests pass (新 test 4 件含む)
- [ ] CI Linux (\`npm run build\` / \`npm run test:unit\` / \`npm run check:stub-catalog\` / \`expansion-pr-guard.yml\`) で trunk lock layer 改変ゼロ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)