### PR TITLE
feat(expansion): focus_window commit wrapper (L5 envelope)

### DIFF
--- a/src/stub-tool-catalog.ts
+++ b/src/stub-tool-catalog.ts
@@ -732,6 +732,13 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
           "default": 9222,
           "minimum": 1,
           "maximum": 65535
+        },
+        "include": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
         }
       },
       "additionalProperties": false,

--- a/src/tools/macro.ts
+++ b/src/tools/macro.ts
@@ -26,7 +26,9 @@ import { keyboardHandler, keyboardRegistrationSchema, keyboardRegistrationHandle
 import { clipboardHandler, clipboardRegistrationSchema, clipboardRegistrationHandler } from "./clipboard.js";
 // Window
 import {
-  focusWindowHandler, focusWindowSchema,
+  focusWindowHandler,
+  focusWindowRegistrationSchema,
+  focusWindowRegistrationHandler,
   // V1 fallback (only reachable when DESKTOP_TOUCH_DISABLE_FUKUWARAI_V2=1).
   getWindowsHandler, getWindowsSchema,
 } from "./window.js";
@@ -147,7 +149,11 @@ const TOOL_REGISTRY: Record<string, ToolEntry> = {
   mouse_click:          { schema: z.object(mouseClickRegistrationSchema), handler: mouseClickRegistrationHandler as typeof mouseClickHandler },
   mouse_drag:           { schema: z.object(mouseDragSchema),           handler: mouseDragHandler },
   click_element:        { schema: z.object(clickElementRegistrationSchema), handler: clickElementRegistrationHandler as typeof clickElementHandler },
-  focus_window:         { schema: z.object(focusWindowSchema),         handler: focusWindowHandler },
+  // Walking skeleton expansion swimlane 1 (L5 commit wrapper): use the
+  // module-scope wrapped handler from window.ts so run_macro 経路は
+  // server.tool 経路と同 instance を共有 (PR #112 shared registration handler
+  // pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
+  focus_window:         { schema: z.object(focusWindowRegistrationSchema), handler: focusWindowRegistrationHandler as typeof focusWindowHandler },
   // Action — text/clipboard dispatchers (Phase 2)
   // Walking skeleton expansion swimlane 1 (L5 commit wrapper): use the
   // module-scope wrapped handler from keyboard.ts so run_macro 経路は

--- a/src/tools/window.ts
+++ b/src/tools/window.ts
@@ -7,6 +7,8 @@ import { updateWindowCache } from "../engine/window-cache.js";
 import { listTabs, activateTab, DEFAULT_CDP_PORT } from "../engine/cdp-bridge.js";
 import type { ToolResult } from "./_types.js";
 import { failWith } from "./_errors.js";
+import { withRichNarration } from "./_narration.js";
+import { makeCommitWrapper, withEnvelopeIncludeSchema } from "./_envelope.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Schemas
@@ -146,6 +148,43 @@ export const focusWindowHandler = async ({
 // Registration
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * Walking skeleton expansion phase swimlane 1 (L5 commit tool wrapper):
+ * `focus_window` is wrapped via `makeCommitWrapper` (lease-less commit
+ * variant — `leaseValidator` omitted; focus_window is title-driven without
+ * a lease 4-tuple, mirroring PR #121 mouse_click raw shape pattern).
+ *
+ * `withRichNarration` (inner) → `makeCommitWrapper` (outer):
+ *   - withRichNarration enriches the handler's ToolResult with post.* state
+ *     (rich-narrate UIA-diff path is unreachable since `narrate` isn't in
+ *     the focus_window schema — falls through to withPostState only)
+ *   - makeCommitWrapper handles L1 ToolCallStarted/Completed push +
+ *     envelope assembly + compat hoist + tool_call_id seq
+ *
+ * `windowTitleKey: "title"` mirrors the focus_window arg shape (the partial
+ * window title is passed as `title`, not `windowTitle`, unique among the
+ * commit family — sub-plan §3.1 step 4 "windowTitleKey is the literal field
+ * name of the target window title in this tool's schema").
+ *
+ * Module-scope export so `run_macro` (`TOOL_REGISTRY.focus_window` in
+ * `macro.ts`) shares the same wrapped instance (PR #112 shared
+ * registration handler pattern, strip risk prevention).
+ *
+ * Trunk pattern conformance: engine-perception layer 改変ゼロ
+ * (expansion-pr-guard.yml + check-expansion-disjoint.mjs)、handler internal
+ * logic + Zod schema + 戻り値 shape 不変 (ADR-010 §1.5)。
+ */
+export const focusWindowRegistrationSchema = withEnvelopeIncludeSchema(focusWindowSchema);
+
+export const focusWindowRegistrationHandler = makeCommitWrapper(
+  withRichNarration("focus_window", focusWindowHandler, { windowTitleKey: "title" }) as (args: Record<string, unknown>) => Promise<ToolResult>,
+  "focus_window",
+  {
+    // leaseValidator omitted = lease-less commit variant
+    // getSessionId / argsSummary / clock も default 利用 = mechanical コピー最小
+  },
+);
+
 export function registerWindowTools(server: McpServer): void {
   // Phase 4: get_windows / get_active_window privatized — handlers retained
   // as internal exports. desktop_discover returns the windows list (with
@@ -156,7 +195,7 @@ export function registerWindowTools(server: McpServer): void {
   server.tool(
     "focus_window",
     "Bring a window to the foreground by partial title match (case-insensitive). Use when a tool does not accept a windowTitle param, or when you need to switch focus before a sequence of actions. Use chromeTabUrlContains to activate a specific Chrome/Edge tab by URL substring before focusing — only the active tab's title appears in the windows list. If CDP is unavailable, chromeTabUrlContains is silently skipped — check response.hints.warnings. Returns WindowNotFound if no match exists; call desktop_discover to see available titles. Caveats: On some apps focus may be immediately stolen back (modal dialogs, UAC prompts) — verify with desktop_state after focusing.",
-    focusWindowSchema,
-    focusWindowHandler
+    focusWindowRegistrationSchema,
+    focusWindowRegistrationHandler as typeof focusWindowHandler
   );
 }

--- a/tests/unit/expansion-focus-window-wrapper.test.ts
+++ b/tests/unit/expansion-focus-window-wrapper.test.ts
@@ -1,0 +1,166 @@
+/**
+ * expansion-focus-window-wrapper.test.ts — walking skeleton expansion phase
+ * swimlane 1 (L5 commit tool wrapper) contract test.
+ *
+ * Pins the bit-equal contract for `focus_window` wrap via `makeCommitWrapper`
+ * per `docs/walking-skeleton-expansion-plan.md` §3 (30 分タイムアタック
+ * template) — mechanical copy of PR #121 mouse_click wrap pattern
+ * (`tests/unit/expansion-mouse-click-wrapper.test.ts`), the raw shape (3a)
+ * family for title-driven window focus.
+ *
+ * Trunk contract conformance:
+ *   - L5 wrapper のみで mechanical コピー成立 (engine-perception layer 改変ゼロ)
+ *   - lease 不在 commit variant (`leaseValidator` 省略、title-driven focus)
+ *   - run_macro 経路と server.tool 経路で同 instance 共有
+ *     (PR #112 shared registration handler pattern)
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  makeCommitWrapper,
+  defaultL1Emitter,
+  buildCausedBy,
+  buildBasedOn,
+  _resetHistoryBuffersForTest,
+  _resetToolCallSeqForTest,
+  type CommitL1Emitter,
+  type ViewSnapshot,
+} from "../../src/tools/_envelope.js";
+
+function resetAll(): void {
+  _resetHistoryBuffersForTest();
+  _resetToolCallSeqForTest();
+}
+
+function makeViewSnapshot(): ViewSnapshot {
+  return {
+    focus: { hwnd: null, elementName: "test-element" },
+    dirtyRectsByMonitor: new Map([[0, 1]]),
+    latestEventId: 100n,
+    queryWallclockMs: Date.now(),
+  };
+}
+
+// ── E1: focus_window wrap → L1 ToolCallStarted/Completed event 記録 ──────────
+
+describe("expansion swimlane 1 (focus_window): wrap → L1 events recorded (lease 不在 variant)", () => {
+  it("makeCommitWrapper flow 通過、ToolCallStarted/Completed 両 event push、lease_token undefined", async () => {
+    resetAll();
+    const events: Array<{ kind: "started" | "completed"; tool: string; leaseToken?: unknown }> = [];
+    const fakeEmitter: CommitL1Emitter = {
+      pushStarted: ({ tool, sessionId, toolCallId, leaseToken }) => {
+        events.push({ kind: "started", tool, leaseToken });
+        defaultL1Emitter.pushStarted({
+          tool,
+          argsJson: "{}",
+          sessionId,
+          toolCallId,
+          leaseToken,
+        });
+      },
+      pushCompleted: ({ tool, elapsedMs, ok, errorCode, sessionId, toolCallId }) => {
+        events.push({ kind: "completed", tool });
+        defaultL1Emitter.pushCompleted({
+          tool,
+          elapsedMs,
+          ok,
+          errorCode,
+          sessionId,
+          toolCallId,
+        });
+      },
+    };
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"focused":"Notepad","region":{"x":0,"y":0,"width":800,"height":600}}' }],
+    });
+    // Lease 不在 commit variant: leaseValidator omitted (focus_window is
+    // title-driven without a lease 4-tuple, sub-plan §3.1 line 153 expansion
+    // 30 分 template、PR #121 mouse_click pattern mechanical copy)
+    const wrapped = makeCommitWrapper(handler, "focus_window", {
+      l1Emitter: fakeEmitter,
+    });
+    const result = await wrapped({
+      title: "Notepad",
+    } as Record<string, unknown>);
+    // Started + Completed 両 event push されている
+    expect(events).toHaveLength(2);
+    expect(events[0].kind).toBe("started");
+    expect(events[0].tool).toBe("focus_window");
+    // lease 不在 variant のため lease_token undefined
+    expect(events[0].leaseToken).toBeUndefined();
+    expect(events[1].kind).toBe("completed");
+    expect(events[1].tool).toBe("focus_window");
+    expect(result.content).toBeDefined();
+  });
+});
+
+// ── E2: include 未指定時 raw shape return (既存 raw client 互換) ─────────────
+
+describe("expansion swimlane 1 (focus_window): include 未指定時 raw shape return", () => {
+  it("default 経路 → envelope shape を hoist して raw client 互換", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"focused":"Notepad"}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "focus_window", {});
+    const result = await wrapped({
+      title: "Notepad",
+    } as Record<string, unknown>);
+    const text = (result.content[0] as { text: string }).text;
+    const parsed = JSON.parse(text);
+    // _version 不在 = raw shape (compat hoist で envelope flatten)
+    expect(parsed._version).toBeUndefined();
+    expect(parsed.ok).toBe(true);
+    expect(parsed.focused).toBe("Notepad");
+  });
+});
+
+// ── E3: include=causal 経路 → caused_by.your_last_action = "focus_window(...)" ─
+
+describe("expansion swimlane 1 (focus_window): include=causal で caused_by.your_last_action に focus_window 記録", () => {
+  it("focus_window wrap → history buffer に entry → buildCausedBy で your_last_action = focus_window(...)", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "focus_window", {
+      getSessionId: () => "sessFW",
+    });
+    await wrapped({
+      title: "Notepad",
+    } as Record<string, unknown>);
+    // history buffer に entry が記録されているか確認
+    const causedBy = buildCausedBy("sessFW", makeViewSnapshot());
+    expect(causedBy).toBeDefined();
+    expect(causedBy?.your_last_action).toContain("focus_window");
+    expect(causedBy?.tool_call_id).toMatch(/^sessFW:\d+$/);
+    // based_on も並列で動作確認
+    const basedOn = buildBasedOn("sessFW", makeViewSnapshot());
+    expect(basedOn).toBeDefined();
+    // events は string[] (u64 decimal) で JSON-safe
+    if (basedOn?.events && basedOn.events.length > 0) {
+      expect(typeof basedOn.events[0]).toBe("string");
+    }
+  });
+});
+
+// ── E4: trunk completion contract: L5 wrapper のみで mechanical copy 成立 ────
+
+describe("expansion swimlane 1 (focus_window): trunk completion contract — mechanical copy", () => {
+  it("S5 contract が focus_window wrap でそのまま機能 (lease validator omit のみで lease 不在 variant)", async () => {
+    resetAll();
+    const handler = vi.fn(async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    }));
+    const wrapped = makeCommitWrapper(handler, "focus_window", {
+      // sub-plan §3.1: getSessionId / argsSummary / clock も default 利用
+      // = mechanical コピー最小、leaseValidator のみ omit
+    });
+    const result = await wrapped({
+      title: "Notepad",
+    } as Record<string, unknown>);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(result.content).toBeDefined();
+    // L1 emitter は default で動作 (production では nativeL1 push、test では history buffer のみ)
+  });
+});


### PR DESCRIPTION
## Summary

`focus_window` を `makeCommitWrapper` で wrap (lease-less commit variant)。PR #121 mouse_click 同型 pattern (sub-plan §3 30 分タイムアタック template、raw shape 3a family)。

## scope

- `src/tools/window.ts`: module-scope `focusWindowRegistrationHandler` + `focusWindowRegistrationSchema = withEnvelopeIncludeSchema(focusWindowSchema)` export、`server.tool` の 3rd arg を `focusWindowRegistrationSchema` に切替、handler を `focusWindowRegistrationHandler` に切替。`withRichNarration` 内側 (windowTitleKey: \"title\" — focus_window の field 名は `title`、`windowTitle` ではない、commit family 内で唯一) → `makeCommitWrapper` 外側。
- `src/tools/macro.ts`: `TOOL_REGISTRY.focus_window.schema` を `z.object(focusWindowRegistrationSchema)` に切替 + handler を shared instance に切替 (PR #112 shared registration handler pattern、strip risk 防止)。
- `tests/unit/expansion-focus-window-wrapper.test.ts`: 4 contract tests (E1: L1 ToolCallStarted/Completed events、E2: include 未指定時 raw shape return、E3: include=causal で `your_last_action = \"focus_window(...)\"`、E4: trunk completion contract mechanical copy) — PR #121 mouse_click wrapper test pattern mechanical copy。
- `src/stub-tool-catalog.ts`: `npm run check:stub-catalog` で再生成された差分 (`include` field 追加分)。

## trunk contract conformance check

- engine-perception layer 改変ゼロ (`npm run check:expansion-disjoint` OK + expansion-pr-guard.yml)
- run_macro 経路同 instance 共有 (PR #112 pattern)
- handler internal logic + Zod schema + 戻り値 shape 不変 (ADR-010 §1.5)

## Test plan

- [x] \`npm run build\` (tsc) green
- [x] \`npm run check:stub-catalog\` (再生成 diff を本 PR に commit)
- [x] \`npm run check:expansion-disjoint\` OK (trunk lock paths 4 untouched)
- [x] \`npx vitest run tests/unit/expansion-focus-window-wrapper.test.ts\` 4/4 pass
- [ ] CI Linux で trunk lock layer 改変ゼロ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)