### PR TITLE
feat(expansion): mouse_drag commit wrapper (L5 envelope)

### DIFF
--- a/src/stub-tool-catalog.ts
+++ b/src/stub-tool-catalog.ts
@@ -1105,6 +1105,13 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
           "description": "When true, allow drags that start in the title-bar / tab-strip area of a tabbed app (Notepad, Terminal, Edge, Chrome, etc.). Default false — such drags are blocked because they detach the tab into a new window rather than moving the window. Pass true only when you intentionally want to rearrange or detach a tab. Note: active only when auto-guard is enabled (same scope as allowCrossWindowDrag).",
           "type": "boolean",
           "default": false
+        },
+        "include": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
         }
       },
       "additionalProperties": false,

--- a/src/tools/macro.ts
+++ b/src/tools/macro.ts
@@ -19,7 +19,10 @@ import {
   screenshotRegistrationSchema,
 } from "./screenshot.js";
 // Mouse
-import { mouseClickHandler, mouseClickRegistrationSchema, mouseClickRegistrationHandler, mouseDragHandler, mouseDragSchema } from "./mouse.js";
+import {
+  mouseClickHandler, mouseClickRegistrationSchema, mouseClickRegistrationHandler,
+  mouseDragHandler, mouseDragRegistrationSchema, mouseDragRegistrationHandler,
+} from "./mouse.js";
 // Keyboard dispatcher (Phase 2)
 import { keyboardHandler, keyboardRegistrationSchema, keyboardRegistrationHandler } from "./keyboard.js";
 // Clipboard dispatcher (Phase 2)
@@ -145,7 +148,11 @@ const TOOL_REGISTRY: Record<string, ToolEntry> = {
   screenshot:           { schema: z.object(screenshotRegistrationSchema), handler: screenshotRegistrationHandler as typeof screenshotHandler },
   // Action — native
   mouse_click:          { schema: z.object(mouseClickRegistrationSchema), handler: mouseClickRegistrationHandler as typeof mouseClickHandler },
-  mouse_drag:           { schema: z.object(mouseDragSchema),           handler: mouseDragHandler },
+  // Walking skeleton expansion swimlane 1 (L5 commit wrapper): use the
+  // module-scope wrapped handler from mouse.ts so run_macro 経路は
+  // server.tool 経路と同 instance を共有 (PR #112 shared registration handler
+  // pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
+  mouse_drag:           { schema: z.object(mouseDragRegistrationSchema), handler: mouseDragRegistrationHandler as typeof mouseDragHandler },
   click_element:        { schema: z.object(clickElementRegistrationSchema), handler: clickElementRegistrationHandler as typeof clickElementHandler },
   focus_window:         { schema: z.object(focusWindowSchema),         handler: focusWindowHandler },
   // Action — text/clipboard dispatchers (Phase 2)

--- a/src/tools/mouse.ts
+++ b/src/tools/mouse.ts
@@ -731,6 +731,35 @@ export const mouseClickRegistrationHandler = makeCommitWrapper(
  */
 export const mouseClickRegistrationSchema = withEnvelopeIncludeSchema(mouseClickSchema);
 
+/**
+ * Walking skeleton expansion phase swimlane 1 (L5 commit tool wrapper):
+ * `mouse_drag` is wrapped via `makeCommitWrapper` (lease-less commit
+ * variant — no lease 4-tuple validation, fixed-coordinate drag).
+ * Mechanical copy of PR #121 `mouseClickRegistrationHandler` pattern
+ * (`docs/walking-skeleton-expansion-plan.md` §3 30-minute time-attack
+ * template, raw shape 3a family).
+ *
+ * `withRichNarration` (inner) → `makeCommitWrapper` (outer):
+ *   - withRichNarration enriches the handler's ToolResult with post.* state
+ *     (this composition was already in use prior to this PR — preserved)
+ *   - makeCommitWrapper handles L1 ToolCallStarted/Completed push +
+ *     envelope assembly + compat hoist + tool_call_id seq
+ *
+ * Module-scope export so `run_macro` (`TOOL_REGISTRY.mouse_drag` in
+ * `macro.ts`) shares the same wrapped instance (PR #112 shared
+ * registration handler pattern, strip risk prevention).
+ */
+export const mouseDragRegistrationSchema = withEnvelopeIncludeSchema(mouseDragSchema);
+
+export const mouseDragRegistrationHandler = makeCommitWrapper(
+  withRichNarration("mouse_drag", mouseDragHandler, { windowTitleKey: "windowTitle" }) as (args: Record<string, unknown>) => Promise<ToolResult>,
+  "mouse_drag",
+  {
+    // leaseValidator omitted = lease-less commit variant
+    // getSessionId / argsSummary / clock も default 利用 = mechanical コピー最小
+  },
+);
+
 export function registerMouseTools(server: McpServer): void {
   // Phase 4: mouse_move privatized — hover-trigger UIs are rare in practice.
   // mouseMoveHandler retained as internal export for tests / future facade.
@@ -741,7 +770,12 @@ export function registerMouseTools(server: McpServer): void {
     mouseClickRegistrationSchema,
     mouseClickRegistrationHandler as typeof mouseClickHandler
   );
-  server.tool("mouse_drag", "Click and drag from (startX, startY) to (endX, endY) holding the left mouse button — for sliders, drag-and-drop, canvas drawing, and window resizing. Pass windowTitle so the server auto-guards the start coordinate and returns post.perception. Examples: mouse_drag({windowTitle:'Notepad', startX:50, startY:50, endX:200, endY:200}). lensId is optional and only for advanced pinned-target workflows. Caveats: Left button only. Both start and endpoint are guarded. Cross-window and desktop drags are blocked by default — pass allowCrossWindowDrag:true to confirm intent.", mouseDragSchema, withRichNarration("mouse_drag", mouseDragHandler, { windowTitleKey: "windowTitle" }));
+  server.tool(
+    "mouse_drag",
+    "Click and drag from (startX, startY) to (endX, endY) holding the left mouse button — for sliders, drag-and-drop, canvas drawing, and window resizing. Pass windowTitle so the server auto-guards the start coordinate and returns post.perception. Examples: mouse_drag({windowTitle:'Notepad', startX:50, startY:50, endX:200, endY:200}). lensId is optional and only for advanced pinned-target workflows. Caveats: Left button only. Both start and endpoint are guarded. Cross-window and desktop drags are blocked by default — pass allowCrossWindowDrag:true to confirm intent.",
+    mouseDragRegistrationSchema,
+    mouseDragRegistrationHandler as typeof mouseDragHandler
+  );
   // scroll tool removed in Phase 2b (family merge) — registered via scroll(action='raw') in scroll.ts
   // Phase 4: get_cursor_position privatized — handler retained as internal export.
   // Use desktop_state for cursorPos (always present) or desktop_state({includeCursor:true})

--- a/tests/unit/expansion-mouse-drag-wrapper.test.ts
+++ b/tests/unit/expansion-mouse-drag-wrapper.test.ts
@@ -1,0 +1,178 @@
+/**
+ * expansion-mouse-drag-wrapper.test.ts — walking skeleton expansion phase
+ * swimlane 1 (L5 commit tool wrapper) contract test.
+ *
+ * Pins the bit-equal contract for `mouse_drag` wrap via `makeCommitWrapper`
+ * per `docs/walking-skeleton-expansion-plan.md` §3 (30 分タイムアタック
+ * template) — mechanical copy of PR #121 mouse_click wrap pattern
+ * (`tests/unit/expansion-mouse-click-wrapper.test.ts`), the raw shape (3a)
+ * family for fixed-coordinate drag.
+ *
+ * Trunk contract conformance:
+ *   - L5 wrapper のみで mechanical コピー成立 (engine-perception layer 改変ゼロ)
+ *   - lease 不在 commit variant (`leaseValidator` 省略、coordinate-driven drag)
+ *   - run_macro 経路と server.tool 経路で同 instance 共有
+ *     (PR #112 shared registration handler pattern)
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  makeCommitWrapper,
+  defaultL1Emitter,
+  buildCausedBy,
+  buildBasedOn,
+  _resetHistoryBuffersForTest,
+  _resetToolCallSeqForTest,
+  type CommitL1Emitter,
+  type ViewSnapshot,
+} from "../../src/tools/_envelope.js";
+
+function resetAll(): void {
+  _resetHistoryBuffersForTest();
+  _resetToolCallSeqForTest();
+}
+
+function makeViewSnapshot(): ViewSnapshot {
+  return {
+    focus: { hwnd: null, elementName: "test-element" },
+    dirtyRectsByMonitor: new Map([[0, 1]]),
+    latestEventId: 100n,
+    queryWallclockMs: Date.now(),
+  };
+}
+
+// ── E1: mouse_drag wrap → L1 ToolCallStarted/Completed event 記録 ────────────
+
+describe("expansion swimlane 1 (mouse_drag): wrap → L1 events recorded (lease 不在 variant)", () => {
+  it("makeCommitWrapper flow 通過、ToolCallStarted/Completed 両 event push、lease_token undefined", async () => {
+    resetAll();
+    const events: Array<{ kind: "started" | "completed"; tool: string; leaseToken?: unknown }> = [];
+    const fakeEmitter: CommitL1Emitter = {
+      pushStarted: ({ tool, sessionId, toolCallId, leaseToken }) => {
+        events.push({ kind: "started", tool, leaseToken });
+        defaultL1Emitter.pushStarted({
+          tool,
+          argsJson: "{}",
+          sessionId,
+          toolCallId,
+          leaseToken,
+        });
+      },
+      pushCompleted: ({ tool, elapsedMs, ok, errorCode, sessionId, toolCallId }) => {
+        events.push({ kind: "completed", tool });
+        defaultL1Emitter.pushCompleted({
+          tool,
+          elapsedMs,
+          ok,
+          errorCode,
+          sessionId,
+          toolCallId,
+        });
+      },
+    };
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"action":"drag","from":{"x":50,"y":50},"to":{"x":200,"y":200}}' }],
+    });
+    // Lease 不在 commit variant: leaseValidator omitted (mouse_drag is
+    // coordinate-driven without a lease 4-tuple, sub-plan §3.1 line 153
+    // expansion 30 分 template、PR #121 mouse_click pattern mechanical copy)
+    const wrapped = makeCommitWrapper(handler, "mouse_drag", {
+      l1Emitter: fakeEmitter,
+    });
+    const result = await wrapped({
+      startX: 50,
+      startY: 50,
+      endX: 200,
+      endY: 200,
+    } as Record<string, unknown>);
+    // Started + Completed 両 event push されている
+    expect(events).toHaveLength(2);
+    expect(events[0].kind).toBe("started");
+    expect(events[0].tool).toBe("mouse_drag");
+    // lease 不在 variant のため lease_token undefined
+    expect(events[0].leaseToken).toBeUndefined();
+    expect(events[1].kind).toBe("completed");
+    expect(events[1].tool).toBe("mouse_drag");
+    expect(result.content).toBeDefined();
+  });
+});
+
+// ── E2: include 未指定時 raw shape return (既存 raw client 互換) ─────────────
+
+describe("expansion swimlane 1 (mouse_drag): include 未指定時 raw shape return", () => {
+  it("default 経路 → envelope shape を hoist して raw client 互換", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"action":"drag"}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "mouse_drag", {});
+    const result = await wrapped({
+      startX: 50,
+      startY: 50,
+      endX: 200,
+      endY: 200,
+    } as Record<string, unknown>);
+    const text = (result.content[0] as { text: string }).text;
+    const parsed = JSON.parse(text);
+    // _version 不在 = raw shape (compat hoist で envelope flatten)
+    expect(parsed._version).toBeUndefined();
+    expect(parsed.ok).toBe(true);
+    expect(parsed.action).toBe("drag");
+  });
+});
+
+// ── E3: include=causal 経路 → caused_by.your_last_action = "mouse_drag(...)" ─
+
+describe("expansion swimlane 1 (mouse_drag): include=causal で caused_by.your_last_action に mouse_drag 記録", () => {
+  it("mouse_drag wrap → history buffer に entry → buildCausedBy で your_last_action = mouse_drag(...)", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "mouse_drag", {
+      getSessionId: () => "sessMD",
+    });
+    await wrapped({
+      startX: 50,
+      startY: 50,
+      endX: 200,
+      endY: 200,
+    } as Record<string, unknown>);
+    // history buffer に entry が記録されているか確認
+    const causedBy = buildCausedBy("sessMD", makeViewSnapshot());
+    expect(causedBy).toBeDefined();
+    expect(causedBy?.your_last_action).toContain("mouse_drag");
+    expect(causedBy?.tool_call_id).toMatch(/^sessMD:\d+$/);
+    // based_on も並列で動作確認
+    const basedOn = buildBasedOn("sessMD", makeViewSnapshot());
+    expect(basedOn).toBeDefined();
+    // events は string[] (u64 decimal) で JSON-safe
+    if (basedOn?.events && basedOn.events.length > 0) {
+      expect(typeof basedOn.events[0]).toBe("string");
+    }
+  });
+});
+
+// ── E4: trunk completion contract: L5 wrapper のみで mechanical copy 成立 ────
+
+describe("expansion swimlane 1 (mouse_drag): trunk completion contract — mechanical copy", () => {
+  it("S5 contract が mouse_drag wrap でそのまま機能 (lease validator omit のみで lease 不在 variant)", async () => {
+    resetAll();
+    const handler = vi.fn(async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    }));
+    const wrapped = makeCommitWrapper(handler, "mouse_drag", {
+      // sub-plan §3.1: getSessionId / argsSummary / clock も default 利用
+      // = mechanical コピー最小、leaseValidator のみ omit
+    });
+    const result = await wrapped({
+      startX: 50,
+      startY: 50,
+      endX: 200,
+      endY: 200,
+    } as Record<string, unknown>);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(result.content).toBeDefined();
+    // L1 emitter は default で動作 (production では nativeL1 push、test では history buffer のみ)
+  });
+});


### PR DESCRIPTION
## Summary

`mouse_drag` を `makeCommitWrapper` で wrap (lease-less commit variant)。PR #121 mouse_click 同型 pattern (sub-plan §3 30 分タイムアタック template、raw shape 3a family)。

## scope

- `src/tools/mouse.ts`: module-scope `mouseDragRegistrationHandler` + `mouseDragRegistrationSchema = withEnvelopeIncludeSchema(mouseDragSchema)` export、`server.tool` の 3rd arg を `mouseDragRegistrationSchema` に切替、handler を `mouseDragRegistrationHandler` に切替。`withRichNarration` 内側 (windowTitleKey: \"windowTitle\"、本 PR 前から既に wrap 済) → `makeCommitWrapper` 外側で envelope wrap を追加。
- `src/tools/macro.ts`: `TOOL_REGISTRY.mouse_drag.schema` を `z.object(mouseDragRegistrationSchema)` に切替 + handler を shared instance に切替 (PR #112 shared registration handler pattern、strip risk 防止)。
- `tests/unit/expansion-mouse-drag-wrapper.test.ts`: 4 contract tests (E1: L1 ToolCallStarted/Completed events、E2: include 未指定時 raw shape return、E3: include=causal で `your_last_action = \"mouse_drag(...)\"`、E4: trunk completion contract mechanical copy) — PR #121 mouse_click wrapper test pattern mechanical copy。
- `src/stub-tool-catalog.ts`: `npm run check:stub-catalog` で再生成された差分 (`include` field 追加分)。

## trunk contract conformance check

- engine-perception layer 改変ゼロ (\`npm run check:expansion-disjoint\` OK + expansion-pr-guard.yml)
- run_macro 経路同 instance 共有 (PR #112 pattern)
- handler internal logic + Zod schema + 戻り値 shape 不変 (ADR-010 §1.5)

## Test plan

- [x] \`npm run build\` (tsc) green
- [x] \`npm run check:stub-catalog\` (再生成 diff を本 PR に commit)
- [x] \`npm run check:expansion-disjoint\` OK (trunk lock paths 4 untouched)
- [x] \`npx vitest run tests/unit/expansion-mouse-drag-wrapper.test.ts\` 4/4 pass
- [ ] CI Linux で trunk lock layer 改変ゼロ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)