### PR TITLE
feat(expansion): notification_show commit wrapper (L5 envelope)

### DIFF
--- a/src/stub-tool-catalog.ts
+++ b/src/stub-tool-catalog.ts
@@ -1131,6 +1131,13 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
           "description": "Notification body text",
           "type": "string",
           "maxLength": 500
+        },
+        "include": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
         }
       },
       "additionalProperties": false,

--- a/src/tools/macro.ts
+++ b/src/tools/macro.ts
@@ -69,7 +69,11 @@ import {
   browserGetFormHandler, browserGetFormSchema,
 } from "./browser.js";
 // Notification (server_status not callable from macros — diagnostic)
-import { notificationShowHandler, notificationShowSchema } from "./notification.js";
+import {
+  notificationShowHandler,
+  notificationShowRegistrationSchema,
+  notificationShowRegistrationHandler,
+} from "./notification.js";
 // v2 World-Graph dispatchers (Phase 4 / Codex PR #41 P1): the public surface
 // for discovery and lease-based action; macros need access to use the
 // action='setValue' / 'click' / 'type' flow advertised in the schema.
@@ -181,7 +185,11 @@ const TOOL_REGISTRY: Record<string, ToolEntry> = {
   workspace_snapshot:   { schema: z.object(workspaceSnapshotSchema),   handler: workspaceSnapshotHandler },
   workspace_launch:     { schema: z.object(workspaceLaunchSchema),     handler: workspaceLaunchHandler },
   wait_until:           { schema: z.object(waitUntilSchema),           handler: waitUntilHandler },
-  notification_show:    { schema: z.object(notificationShowSchema),    handler: notificationShowHandler },
+  // Walking skeleton expansion swimlane 1 (L5 commit wrapper): use the
+  // module-scope wrapped handler from notification.ts so run_macro 経路は
+  // server.tool 経路と同 instance を共有 (PR #112 shared registration handler
+  // pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
+  notification_show:    { schema: z.object(notificationShowRegistrationSchema), handler: notificationShowRegistrationHandler as typeof notificationShowHandler },
   // v2 World-Graph (default-on; kill switch DESKTOP_TOUCH_DISABLE_FUKUWARAI_V2=1).
   // Both handlers re-check the kill switch on every call so run_macro cannot
   // bypass the operator's opt-out. (Codex PR #41 round 3 P1.)

--- a/src/tools/notification.ts
+++ b/src/tools/notification.ts
@@ -4,6 +4,8 @@ import { execFile } from "node:child_process";
 import { ok } from "./_types.js";
 import type { ToolResult } from "./_types.js";
 import { failWith } from "./_errors.js";
+import { withRichNarration } from "./_narration.js";
+import { makeCommitWrapper, withEnvelopeIncludeSchema } from "./_envelope.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Schemas
@@ -74,11 +76,41 @@ export const notificationShowHandler = async ({
 // Registration
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * Walking skeleton expansion phase swimlane 1 (L5 commit tool wrapper):
+ * `notification_show` is wrapped via `makeCommitWrapper` (lease-less commit
+ * variant — `leaseValidator` omitted; OS-level balloon tip without a lease
+ * 4-tuple, mirroring PR #126 clipboard pattern for OS-level tools).
+ *
+ * `windowTitleKey` is omitted because notification_show has no window-scoped
+ * target (system tray balloon is OS-level regardless of foreground window).
+ * `withRichNarration` falls through to `withPostState` only since `narrate`
+ * isn't in the schema.
+ *
+ * Module-scope export so `run_macro` (`TOOL_REGISTRY.notification_show` in
+ * `macro.ts`) shares the same wrapped instance (PR #112 shared
+ * registration handler pattern, strip risk prevention).
+ */
+export const notificationShowRegistrationSchema = withEnvelopeIncludeSchema(notificationShowSchema);
+
+export const notificationShowRegistrationHandler = makeCommitWrapper(
+  withRichNarration(
+    "notification_show",
+    notificationShowHandler as (args: Record<string, unknown>) => Promise<ToolResult>,
+    {},
+  ) as (args: Record<string, unknown>) => Promise<ToolResult>,
+  "notification_show",
+  {
+    // leaseValidator omitted = lease-less commit variant
+    // getSessionId / argsSummary / clock も default 利用 = mechanical コピー最小
+  },
+);
+
 export function registerNotificationTools(server: McpServer): void {
   server.tool(
     "notification_show",
     "Show a Windows system tray balloon notification to alert the user. Use at the end of a long-running task so the user knows it finished without watching the screen. Caveats: Focus Assist (Do Not Disturb) mode suppresses balloon tips; the tool still returns ok:true in that case. Uses System.Windows.Forms — no external modules needed.",
-    notificationShowSchema,
-    notificationShowHandler
+    notificationShowRegistrationSchema,
+    notificationShowRegistrationHandler as typeof notificationShowHandler
   );
 }

--- a/tests/unit/expansion-notification-show-wrapper.test.ts
+++ b/tests/unit/expansion-notification-show-wrapper.test.ts
@@ -1,0 +1,156 @@
+/**
+ * expansion-notification-show-wrapper.test.ts — walking skeleton expansion
+ * phase swimlane 1 (L5 commit tool wrapper) contract test.
+ *
+ * Pins the bit-equal contract for `notification_show` wrap via
+ * `makeCommitWrapper` per `docs/walking-skeleton-expansion-plan.md` §3
+ * (30 分タイムアタック template) — mechanical copy of PR #126 clipboard
+ * pattern (OS-level commit without windowTitleKey).
+ *
+ * Trunk contract conformance:
+ *   - L5 wrapper のみで mechanical コピー成立 (engine-perception layer 改変ゼロ)
+ *   - lease 不在 commit variant (`leaseValidator` 省略、OS-level balloon)
+ *   - run_macro 経路と server.tool 経路で同 instance 共有
+ *     (PR #112 shared registration handler pattern)
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  makeCommitWrapper,
+  defaultL1Emitter,
+  buildCausedBy,
+  buildBasedOn,
+  _resetHistoryBuffersForTest,
+  _resetToolCallSeqForTest,
+  type CommitL1Emitter,
+  type ViewSnapshot,
+} from "../../src/tools/_envelope.js";
+
+function resetAll(): void {
+  _resetHistoryBuffersForTest();
+  _resetToolCallSeqForTest();
+}
+
+function makeViewSnapshot(): ViewSnapshot {
+  return {
+    focus: { hwnd: null, elementName: "test-element" },
+    dirtyRectsByMonitor: new Map([[0, 1]]),
+    latestEventId: 100n,
+    queryWallclockMs: Date.now(),
+  };
+}
+
+// ── E1: notification_show wrap → L1 ToolCallStarted/Completed event 記録 ────
+
+describe("expansion swimlane 1 (notification_show): wrap → L1 events recorded (lease 不在 variant)", () => {
+  it("makeCommitWrapper flow 通過、ToolCallStarted/Completed 両 event push、lease_token undefined", async () => {
+    resetAll();
+    const events: Array<{ kind: "started" | "completed"; tool: string; leaseToken?: unknown }> = [];
+    const fakeEmitter: CommitL1Emitter = {
+      pushStarted: ({ tool, sessionId, toolCallId, leaseToken }) => {
+        events.push({ kind: "started", tool, leaseToken });
+        defaultL1Emitter.pushStarted({
+          tool,
+          argsJson: "{}",
+          sessionId,
+          toolCallId,
+          leaseToken,
+        });
+      },
+      pushCompleted: ({ tool, elapsedMs, ok, errorCode, sessionId, toolCallId }) => {
+        events.push({ kind: "completed", tool });
+        defaultL1Emitter.pushCompleted({
+          tool,
+          elapsedMs,
+          ok,
+          errorCode,
+          sessionId,
+          toolCallId,
+        });
+      },
+    };
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"title":"Done","body":"Task finished"}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "notification_show", {
+      l1Emitter: fakeEmitter,
+    });
+    const result = await wrapped({
+      title: "Done",
+      body: "Task finished",
+    } as Record<string, unknown>);
+    expect(events).toHaveLength(2);
+    expect(events[0].kind).toBe("started");
+    expect(events[0].tool).toBe("notification_show");
+    expect(events[0].leaseToken).toBeUndefined();
+    expect(events[1].kind).toBe("completed");
+    expect(events[1].tool).toBe("notification_show");
+    expect(result.content).toBeDefined();
+  });
+});
+
+// ── E2: include 未指定時 raw shape return (既存 raw client 互換) ─────────────
+
+describe("expansion swimlane 1 (notification_show): include 未指定時 raw shape return", () => {
+  it("default 経路 → envelope shape を hoist して raw client 互換", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"title":"Done","body":"x"}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "notification_show", {});
+    const result = await wrapped({
+      title: "Done",
+      body: "x",
+    } as Record<string, unknown>);
+    const text = (result.content[0] as { text: string }).text;
+    const parsed = JSON.parse(text);
+    expect(parsed._version).toBeUndefined();
+    expect(parsed.ok).toBe(true);
+    expect(parsed.title).toBe("Done");
+  });
+});
+
+// ── E3: include=causal 経路 → caused_by.your_last_action = "notification_show(...)" ─
+
+describe("expansion swimlane 1 (notification_show): include=causal で caused_by.your_last_action に notification_show 記録", () => {
+  it("notification_show wrap → history buffer に entry → buildCausedBy で your_last_action = notification_show(...)", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "notification_show", {
+      getSessionId: () => "sessNS",
+    });
+    await wrapped({
+      title: "Done",
+      body: "x",
+    } as Record<string, unknown>);
+    const causedBy = buildCausedBy("sessNS", makeViewSnapshot());
+    expect(causedBy).toBeDefined();
+    expect(causedBy?.your_last_action).toContain("notification_show");
+    expect(causedBy?.tool_call_id).toMatch(/^sessNS:\d+$/);
+    const basedOn = buildBasedOn("sessNS", makeViewSnapshot());
+    expect(basedOn).toBeDefined();
+    if (basedOn?.events && basedOn.events.length > 0) {
+      expect(typeof basedOn.events[0]).toBe("string");
+    }
+  });
+});
+
+// ── E4: trunk completion contract: L5 wrapper のみで mechanical copy 成立 ────
+
+describe("expansion swimlane 1 (notification_show): trunk completion contract — mechanical copy", () => {
+  it("S5 contract が notification_show wrap でそのまま機能 (lease validator omit のみで lease 不在 variant)", async () => {
+    resetAll();
+    const handler = vi.fn(async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    }));
+    const wrapped = makeCommitWrapper(handler, "notification_show", {});
+    const result = await wrapped({
+      title: "T",
+      body: "B",
+    } as Record<string, unknown>);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(result.content).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

`notification_show` を `makeCommitWrapper` で wrap (lease-less commit variant、OS-level)。PR #126 clipboard 同型 pattern (sub-plan §3 30 分タイムアタック template、raw shape 3a family、windowTitleKey 省略 — OS-level balloon)。

## scope

- `src/tools/notification.ts`: module-scope `notificationShowRegistrationHandler` + `notificationShowRegistrationSchema = withEnvelopeIncludeSchema(notificationShowSchema)` export、`server.tool` の 3rd arg を `notificationShowRegistrationSchema` に切替、handler を `notificationShowRegistrationHandler` に切替。`withRichNarration` 内側 (windowTitleKey 省略 — system tray balloon は OS-level、no window-scoped target、PR #126 clipboard と同型) → `makeCommitWrapper` 外側。
- `src/tools/macro.ts`: `TOOL_REGISTRY.notification_show` を shared instance に切替 (PR #112 shared registration handler pattern、strip risk 防止)。
- `tests/unit/expansion-notification-show-wrapper.test.ts`: 4 contract tests (E1: L1 events、E2: include 未指定 raw shape、E3: include=causal で your_last_action=\"notification_show(...)\"、E4: trunk completion contract mechanical copy) — PR #126 clipboard wrapper test pattern コピー。
- `src/stub-tool-catalog.ts`: \`npm run check:stub-catalog\` で再生成された差分。

## trunk contract conformance

- engine-perception layer 改変ゼロ (\`npm run check:expansion-disjoint\` OK)
- run_macro 経路同 instance 共有 (PR #112 pattern)
- handler internal logic + Zod schema + 戻り値 shape 不変 (ADR-010 §1.5)

## Test plan

- [x] \`npm run build\` (tsc) green
- [x] \`npm run check:stub-catalog\` (再生成 diff を本 PR に commit)
- [x] \`npm run check:expansion-disjoint\` OK
- [x] \`npx vitest run tests/unit/expansion-notification-show-wrapper.test.ts\` 4/4 pass
- [ ] CI Linux で trunk lock layer 改変ゼロ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)