### PR TITLE
feat(expansion): window_dock commit wrapper (L5 envelope)

### DIFF
--- a/src/stub-tool-catalog.ts
+++ b/src/stub-tool-catalog.ts
@@ -1806,6 +1806,13 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
               "type": "integer",
               "minimum": 0,
               "maximum": 60000
+            },
+            "include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
             }
           },
           "additionalProperties": false,
@@ -1823,6 +1830,13 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
             "title": {
               "description": "Partial window title (case-insensitive)",
               "type": "string"
+            },
+            "include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
             }
           },
           "additionalProperties": false,
@@ -1877,6 +1891,13 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
               "type": "integer",
               "default": 8,
               "minimum": 0
+            },
+            "include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
             }
           },
           "additionalProperties": false,

--- a/src/tools/macro.ts
+++ b/src/tools/macro.ts
@@ -31,7 +31,11 @@ import {
   getWindowsHandler, getWindowsSchema,
 } from "./window.js";
 // Window dock dispatcher (Phase 2)
-import { windowDockHandler, windowDockSchema } from "./window-dock.js";
+import {
+  windowDockHandler,
+  windowDockRegistrationSchema,
+  windowDockRegistrationHandler,
+} from "./window-dock.js";
 // UI elements (click_element always public after Phase 4; the next two are
 // V1 fallbacks only reachable when DESKTOP_TOUCH_DISABLE_FUKUWARAI_V2=1).
 import {
@@ -160,7 +164,11 @@ const TOOL_REGISTRY: Record<string, ToolEntry> = {
   // pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
   clipboard:            { schema: clipboardRegistrationSchema,         handler: clipboardRegistrationHandler as typeof clipboardHandler },
   // Action — window/scroll/terminal dispatchers (Phase 2)
-  window_dock:          { schema: windowDockSchema,                    handler: windowDockHandler },
+  // Walking skeleton expansion swimlane 1 (L5 commit wrapper): use the
+  // module-scope wrapped handler from window-dock.ts so run_macro 経路は
+  // server.registerTool 経路と同 instance を共有 (PR #112 shared registration
+  // handler pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
+  window_dock:          { schema: windowDockRegistrationSchema,         handler: windowDockRegistrationHandler as typeof windowDockHandler },
   // Walking skeleton expansion swimlane 1 (L5 commit wrapper): use the
   // module-scope wrapped handler from scroll.ts so run_macro 経路は
   // server.registerTool 経路と同 instance を共有 (PR #112 shared registration

--- a/src/tools/window-dock.ts
+++ b/src/tools/window-dock.ts
@@ -4,6 +4,8 @@ import { buildDesc } from "./_types.js";
 import type { ToolResult } from "./_types.js";
 import { pinWindowHandler, unpinWindowHandler } from "./pin.js";
 import { dockWindowHandler } from "./dock.js";
+import { withRichNarration } from "./_narration.js";
+import { makeCommitWrapper, withEnvelopeIncludeForUnion } from "./_envelope.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Dispatcher schema (discriminated union)
@@ -61,6 +63,40 @@ export const windowDockHandler = async (args: WindowDockArgs): Promise<ToolResul
 // Registration
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * Walking skeleton expansion phase swimlane 1 (L5 commit tool wrapper):
+ * `window_dock` is wrapped via `makeCommitWrapper` (lease-less commit
+ * variant — `leaseValidator` omitted; window_dock dispatches to pin/unpin/dock
+ * actions without a lease 4-tuple, mirroring PR #123 keyboard / PR #126
+ * clipboard discriminatedUnion (3b) family pattern).
+ *
+ * `withRichNarration` (inner, windowTitleKey: "title" — all 3 variants share
+ * the `title` field) → `makeCommitWrapper` (outer):
+ *   - withRichNarration enriches the handler's ToolResult with post.* state
+ *     (rich-narrate UIA-diff path is unreachable since `narrate` isn't in
+ *     the schema — falls through to withPostState only)
+ *   - makeCommitWrapper handles L1 ToolCallStarted/Completed push +
+ *     envelope assembly + compat hoist + tool_call_id seq
+ *
+ * Module-scope export so `run_macro` (`TOOL_REGISTRY.window_dock` in
+ * `macro.ts`) shares the same wrapped instance (PR #112 shared
+ * registration handler pattern, strip risk prevention).
+ */
+export const windowDockRegistrationSchema = withEnvelopeIncludeForUnion(windowDockSchema);
+
+export const windowDockRegistrationHandler = makeCommitWrapper(
+  withRichNarration(
+    "window_dock",
+    windowDockHandler as (args: Record<string, unknown>) => Promise<ToolResult>,
+    { windowTitleKey: "title" },
+  ) as (args: Record<string, unknown>) => Promise<ToolResult>,
+  "window_dock",
+  {
+    // leaseValidator omitted = lease-less commit variant
+    // getSessionId / argsSummary / clock も default 利用 = mechanical コピー最小
+  },
+);
+
 export function registerWindowDockTools(server: McpServer): void {
   server.registerTool(
     "window_dock",
@@ -76,8 +112,8 @@ export function registerWindowDockTools(server: McpServer): void {
           "window_dock({action:'unpin', title:'Settings'})",
         ],
       }),
-      inputSchema: windowDockSchema,
+      inputSchema: windowDockRegistrationSchema,
     },
-    windowDockHandler
+    windowDockRegistrationHandler as typeof windowDockHandler
   );
 }

--- a/tests/unit/expansion-window-dock-wrapper.test.ts
+++ b/tests/unit/expansion-window-dock-wrapper.test.ts
@@ -1,0 +1,159 @@
+/**
+ * expansion-window-dock-wrapper.test.ts — walking skeleton expansion phase
+ * swimlane 1 (L5 commit tool wrapper) contract test.
+ *
+ * Pins the bit-equal contract for `window_dock` wrap via `makeCommitWrapper`
+ * per `docs/walking-skeleton-expansion-plan.md` §3 (30 分タイムアタック
+ * template) — mechanical copy of PR #126 clipboard / PR #127 scroll wrap
+ * pattern, the discriminatedUnion (3b) family for pin/unpin/dock dispatch.
+ *
+ * Trunk contract conformance:
+ *   - L5 wrapper のみで mechanical コピー成立 (engine-perception layer 改変ゼロ)
+ *   - lease 不在 commit variant (`leaseValidator` 省略、title-driven dock)
+ *   - run_macro 経路と server.registerTool 経路で同 instance 共有
+ *     (PR #112 shared registration handler pattern)
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  makeCommitWrapper,
+  defaultL1Emitter,
+  buildCausedBy,
+  buildBasedOn,
+  _resetHistoryBuffersForTest,
+  _resetToolCallSeqForTest,
+  type CommitL1Emitter,
+  type ViewSnapshot,
+} from "../../src/tools/_envelope.js";
+
+function resetAll(): void {
+  _resetHistoryBuffersForTest();
+  _resetToolCallSeqForTest();
+}
+
+function makeViewSnapshot(): ViewSnapshot {
+  return {
+    focus: { hwnd: null, elementName: "test-element" },
+    dirtyRectsByMonitor: new Map([[0, 1]]),
+    latestEventId: 100n,
+    queryWallclockMs: Date.now(),
+  };
+}
+
+// ── E1: window_dock wrap → L1 ToolCallStarted/Completed event 記録 ───────────
+
+describe("expansion swimlane 1 (window_dock): wrap → L1 events recorded (lease 不在 variant)", () => {
+  it("makeCommitWrapper flow 通過、ToolCallStarted/Completed 両 event push、lease_token undefined", async () => {
+    resetAll();
+    const events: Array<{ kind: "started" | "completed"; tool: string; leaseToken?: unknown }> = [];
+    const fakeEmitter: CommitL1Emitter = {
+      pushStarted: ({ tool, sessionId, toolCallId, leaseToken }) => {
+        events.push({ kind: "started", tool, leaseToken });
+        defaultL1Emitter.pushStarted({
+          tool,
+          argsJson: "{}",
+          sessionId,
+          toolCallId,
+          leaseToken,
+        });
+      },
+      pushCompleted: ({ tool, elapsedMs, ok, errorCode, sessionId, toolCallId }) => {
+        events.push({ kind: "completed", tool });
+        defaultL1Emitter.pushCompleted({
+          tool,
+          elapsedMs,
+          ok,
+          errorCode,
+          sessionId,
+          toolCallId,
+        });
+      },
+    };
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"action":"pin","title":"Notepad"}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "window_dock", {
+      l1Emitter: fakeEmitter,
+    });
+    const result = await wrapped({
+      action: "pin",
+      title: "Notepad",
+    } as Record<string, unknown>);
+    expect(events).toHaveLength(2);
+    expect(events[0].kind).toBe("started");
+    expect(events[0].tool).toBe("window_dock");
+    expect(events[0].leaseToken).toBeUndefined();
+    expect(events[1].kind).toBe("completed");
+    expect(events[1].tool).toBe("window_dock");
+    expect(result.content).toBeDefined();
+  });
+});
+
+// ── E2: include 未指定時 raw shape return (既存 raw client 互換) ─────────────
+
+describe("expansion swimlane 1 (window_dock): include 未指定時 raw shape return", () => {
+  it("default 経路 → envelope shape を hoist して raw client 互換", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"action":"pin","title":"Notepad"}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "window_dock", {});
+    const result = await wrapped({
+      action: "pin",
+      title: "Notepad",
+    } as Record<string, unknown>);
+    const text = (result.content[0] as { text: string }).text;
+    const parsed = JSON.parse(text);
+    expect(parsed._version).toBeUndefined();
+    expect(parsed.ok).toBe(true);
+    expect(parsed.action).toBe("pin");
+  });
+});
+
+// ── E3: include=causal 経路 → caused_by.your_last_action = "window_dock(...)" ─
+
+describe("expansion swimlane 1 (window_dock): include=causal で caused_by.your_last_action に window_dock 記録", () => {
+  it("window_dock wrap → history buffer に entry → buildCausedBy で your_last_action = window_dock(...)", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "window_dock", {
+      getSessionId: () => "sessWD",
+    });
+    await wrapped({
+      action: "dock",
+      title: "Notepad",
+      corner: "bottom-right",
+      width: 480,
+      height: 360,
+    } as Record<string, unknown>);
+    const causedBy = buildCausedBy("sessWD", makeViewSnapshot());
+    expect(causedBy).toBeDefined();
+    expect(causedBy?.your_last_action).toContain("window_dock");
+    expect(causedBy?.tool_call_id).toMatch(/^sessWD:\d+$/);
+    const basedOn = buildBasedOn("sessWD", makeViewSnapshot());
+    expect(basedOn).toBeDefined();
+    if (basedOn?.events && basedOn.events.length > 0) {
+      expect(typeof basedOn.events[0]).toBe("string");
+    }
+  });
+});
+
+// ── E4: trunk completion contract: L5 wrapper のみで mechanical copy 成立 ────
+
+describe("expansion swimlane 1 (window_dock): trunk completion contract — mechanical copy", () => {
+  it("S5 contract が window_dock wrap でそのまま機能 (lease validator omit のみで lease 不在 variant)", async () => {
+    resetAll();
+    const handler = vi.fn(async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    }));
+    const wrapped = makeCommitWrapper(handler, "window_dock", {});
+    const result = await wrapped({
+      action: "unpin",
+      title: "Notepad",
+    } as Record<string, unknown>);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(result.content).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

`window_dock` を `makeCommitWrapper` で wrap (lease-less commit variant)。PR #123 keyboard / PR #126 clipboard / PR #127 scroll 同型 pattern (sub-plan §3 30 分タイムアタック template、discriminatedUnion 3b family、windowTitleKey: \"title\")。

## scope

- `src/tools/window-dock.ts`: module-scope `windowDockRegistrationHandler` + `windowDockRegistrationSchema = withEnvelopeIncludeForUnion(windowDockSchema)` export、`server.registerTool` の `inputSchema` を切替、handler を切替。`withRichNarration` 内側 (windowTitleKey: \"title\" — pin / unpin / dock 全 variant 共通) → `makeCommitWrapper` 外側。
- `src/tools/macro.ts`: `TOOL_REGISTRY.window_dock` を shared instance に切替 (PR #112 pattern、discriminatedUnion 系のため z.object() ラップ不要)。
- `tests/unit/expansion-window-dock-wrapper.test.ts`: 4 contract tests (E1-E4)。
- `src/stub-tool-catalog.ts`: 再生成差分 (3 variants × \`include\` field 追加: pin / unpin / dock)。

## trunk contract conformance check

- engine-perception layer 改変ゼロ (\`npm run check:expansion-disjoint\` OK)
- run_macro 経路同 instance 共有 (PR #112 pattern)
- handler internal logic + Zod schema + 戻り値 shape 不変 (ADR-010 §1.5)

## Test plan

- [x] \`npm run build\` (tsc) green
- [x] \`npm run check:stub-catalog\` (再生成 diff を本 PR に commit)
- [x] \`npm run check:expansion-disjoint\` OK
- [x] \`npx vitest run tests/unit/expansion-window-dock-wrapper.test.ts\` 4/4 pass
- [ ] CI Linux で trunk lock layer 改変ゼロ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)