### PR TITLE
feat(expansion): terminal commit wrapper (L5 envelope)

### DIFF
--- a/src/stub-tool-catalog.ts
+++ b/src/stub-tool-catalog.ts
@@ -1697,6 +1697,13 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
           "properties": {
             "action": {
               "const": "read"
+            },
+            "include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
             }
           },
           "additionalProperties": false,
@@ -1709,6 +1716,13 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
           "properties": {
             "action": {
               "const": "send"
+            },
+            "include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
             }
           },
           "additionalProperties": false,
@@ -1749,6 +1763,13 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
             "readOptions": {
               "description": "Extra options forwarded to terminal read (lines, source, ocrLanguage, etc.)",
               "type": "object"
+            },
+            "include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
             }
           },
           "additionalProperties": false,

--- a/src/tools/macro.ts
+++ b/src/tools/macro.ts
@@ -64,7 +64,11 @@ import {
   desktopStateRegistrationSchema,
 } from "./desktop-state.js";
 // Terminal dispatcher (Phase 2)
-import { terminalDispatchHandler, terminalSchema } from "./terminal.js";
+import {
+  terminalDispatchHandler,
+  terminalRegistrationSchema,
+  terminalRegistrationHandler,
+} from "./terminal.js";
 // Browser tools (Phase 3)
 import {
   browserOpenHandler, browserOpenSchema,
@@ -191,7 +195,11 @@ const TOOL_REGISTRY: Record<string, ToolEntry> = {
   // server.registerTool 経路と同 instance を共有 (PR #112 shared registration
   // handler pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
   scroll:               { schema: scrollRegistrationSchema,             handler: scrollRegistrationHandler as typeof scrollDispatchHandler },
-  terminal:             { schema: terminalSchema,                      handler: terminalDispatchHandler },
+  // Walking skeleton expansion swimlane 1 (L5 commit wrapper): use the
+  // module-scope wrapped handler from terminal.ts so run_macro 経路は
+  // server.registerTool 経路と同 instance を共有 (PR #112 shared registration
+  // handler pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
+  terminal:             { schema: terminalRegistrationSchema,           handler: terminalRegistrationHandler as typeof terminalDispatchHandler },
   // Action — browser (Phase 3)
   browser_open:         { schema: z.object(browserOpenSchema),         handler: browserOpenHandler },
   browser_eval:         { schema: browserEvalSchema,                   handler: browserEvalHandler },

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -33,6 +33,8 @@ import { keyboard } from "../engine/nutjs.js";
 import { parseKeys } from "../utils/key-map.js";
 import { typeViaClipboard } from "./keyboard.js";
 import { setTerminalReadHook } from "./wait-until.js";
+import { withRichNarration } from "./_narration.js";
+import { makeCommitWrapper, withEnvelopeIncludeForUnion } from "./_envelope.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Schemas
@@ -953,6 +955,40 @@ async function readForHook(windowTitle: string): Promise<{ text: string; marker:
 
 export { TERMINAL_PROCESS_RE };
 
+/**
+ * Walking skeleton expansion phase swimlane 1 (L5 commit tool wrapper):
+ * `terminal` is wrapped via `makeCommitWrapper` (lease-less commit variant —
+ * `leaseValidator` omitted; terminal dispatches to read/send/run actions
+ * without a lease 4-tuple, mirroring PR #123 keyboard / PR #126 clipboard /
+ * PR #127 scroll / PR #131 window_dock discriminatedUnion (3b) family pattern).
+ *
+ * `withRichNarration` (inner, windowTitleKey: "windowTitle" — all 3 variants
+ * share the `windowTitle` field) → `makeCommitWrapper` (outer):
+ *   - withRichNarration enriches the handler's ToolResult with post.* state
+ *     (rich-narrate UIA-diff path is unreachable since `narrate` isn't in
+ *     the schema — falls through to withPostState only)
+ *   - makeCommitWrapper handles L1 ToolCallStarted/Completed push +
+ *     envelope assembly + compat hoist + tool_call_id seq
+ *
+ * Module-scope export so `run_macro` (`TOOL_REGISTRY.terminal` in
+ * `macro.ts`) shares the same wrapped instance (PR #112 shared
+ * registration handler pattern, strip risk prevention).
+ */
+export const terminalRegistrationSchema = withEnvelopeIncludeForUnion(terminalSchema);
+
+export const terminalRegistrationHandler = makeCommitWrapper(
+  withRichNarration(
+    "terminal",
+    terminalDispatchHandler as (args: Record<string, unknown>) => Promise<ToolResult>,
+    { windowTitleKey: "windowTitle" },
+  ) as (args: Record<string, unknown>) => Promise<ToolResult>,
+  "terminal",
+  {
+    // leaseValidator omitted = lease-less commit variant
+    // getSessionId / argsSummary / clock も default 利用 = mechanical コピー最小
+  },
+);
+
 export function registerTerminalTools(server: McpServer): void {
   setTerminalReadHook(readForHook);
 
@@ -971,8 +1007,8 @@ export function registerTerminalTools(server: McpServer): void {
           "terminal({action:'send', windowTitle:'PowerShell', input:'echo hello'}) → sends text + Enter",
         ],
       }),
-      inputSchema: terminalSchema,
+      inputSchema: terminalRegistrationSchema,
     },
-    terminalDispatchHandler as (args: Record<string, unknown>) => Promise<ToolResult>
+    terminalRegistrationHandler as (args: Record<string, unknown>) => Promise<ToolResult>
   );
 }

--- a/tests/unit/expansion-terminal-wrapper.test.ts
+++ b/tests/unit/expansion-terminal-wrapper.test.ts
@@ -1,0 +1,157 @@
+/**
+ * expansion-terminal-wrapper.test.ts — walking skeleton expansion phase
+ * swimlane 1 (L5 commit tool wrapper) contract test.
+ *
+ * Pins the bit-equal contract for `terminal` wrap via `makeCommitWrapper`
+ * per `docs/walking-skeleton-expansion-plan.md` §3 (30 分タイムアタック
+ * template) — mechanical copy of PR #131 window_dock / PR #127 scroll /
+ * PR #126 clipboard / PR #123 keyboard discriminatedUnion (3b) family.
+ *
+ * Trunk contract conformance:
+ *   - L5 wrapper のみで mechanical コピー成立 (engine-perception layer 改変ゼロ)
+ *   - lease 不在 commit variant (`leaseValidator` 省略、windowTitle-driven dispatch)
+ *   - run_macro 経路と server.registerTool 経路で同 instance 共有
+ *     (PR #112 shared registration handler pattern)
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  makeCommitWrapper,
+  defaultL1Emitter,
+  buildCausedBy,
+  buildBasedOn,
+  _resetHistoryBuffersForTest,
+  _resetToolCallSeqForTest,
+  type CommitL1Emitter,
+  type ViewSnapshot,
+} from "../../src/tools/_envelope.js";
+
+function resetAll(): void {
+  _resetHistoryBuffersForTest();
+  _resetToolCallSeqForTest();
+}
+
+function makeViewSnapshot(): ViewSnapshot {
+  return {
+    focus: { hwnd: null, elementName: "test-element" },
+    dirtyRectsByMonitor: new Map([[0, 1]]),
+    latestEventId: 100n,
+    queryWallclockMs: Date.now(),
+  };
+}
+
+// ── E1: terminal wrap → L1 ToolCallStarted/Completed event 記録 ──────────────
+
+describe("expansion swimlane 1 (terminal): wrap → L1 events recorded (lease 不在 variant)", () => {
+  it("makeCommitWrapper flow 通過、ToolCallStarted/Completed 両 event push、lease_token undefined", async () => {
+    resetAll();
+    const events: Array<{ kind: "started" | "completed"; tool: string; leaseToken?: unknown }> = [];
+    const fakeEmitter: CommitL1Emitter = {
+      pushStarted: ({ tool, sessionId, toolCallId, leaseToken }) => {
+        events.push({ kind: "started", tool, leaseToken });
+        defaultL1Emitter.pushStarted({
+          tool,
+          argsJson: "{}",
+          sessionId,
+          toolCallId,
+          leaseToken,
+        });
+      },
+      pushCompleted: ({ tool, elapsedMs, ok, errorCode, sessionId, toolCallId }) => {
+        events.push({ kind: "completed", tool });
+        defaultL1Emitter.pushCompleted({
+          tool,
+          elapsedMs,
+          ok,
+          errorCode,
+          sessionId,
+          toolCallId,
+        });
+      },
+    };
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"text":"$ ls\\nfile1\\nfile2"}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "terminal", {
+      l1Emitter: fakeEmitter,
+    });
+    const result = await wrapped({
+      action: "read",
+      windowTitle: "PowerShell",
+    } as Record<string, unknown>);
+    expect(events).toHaveLength(2);
+    expect(events[0].kind).toBe("started");
+    expect(events[0].tool).toBe("terminal");
+    expect(events[0].leaseToken).toBeUndefined();
+    expect(events[1].kind).toBe("completed");
+    expect(events[1].tool).toBe("terminal");
+    expect(result.content).toBeDefined();
+  });
+});
+
+// ── E2: include 未指定時 raw shape return (既存 raw client 互換) ─────────────
+
+describe("expansion swimlane 1 (terminal): include 未指定時 raw shape return", () => {
+  it("default 経路 → envelope shape を hoist して raw client 互換", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"text":"hello"}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "terminal", {});
+    const result = await wrapped({
+      action: "read",
+      windowTitle: "PowerShell",
+    } as Record<string, unknown>);
+    const text = (result.content[0] as { text: string }).text;
+    const parsed = JSON.parse(text);
+    expect(parsed._version).toBeUndefined();
+    expect(parsed.ok).toBe(true);
+    expect(parsed.text).toBe("hello");
+  });
+});
+
+// ── E3: include=causal 経路 → caused_by.your_last_action = "terminal(...)" ───
+
+describe("expansion swimlane 1 (terminal): include=causal で caused_by.your_last_action に terminal 記録", () => {
+  it("terminal wrap → history buffer に entry → buildCausedBy で your_last_action = terminal(...)", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "terminal", {
+      getSessionId: () => "sessTM",
+    });
+    await wrapped({
+      action: "send",
+      windowTitle: "PowerShell",
+      input: "ls",
+    } as Record<string, unknown>);
+    const causedBy = buildCausedBy("sessTM", makeViewSnapshot());
+    expect(causedBy).toBeDefined();
+    expect(causedBy?.your_last_action).toContain("terminal");
+    expect(causedBy?.tool_call_id).toMatch(/^sessTM:\d+$/);
+    const basedOn = buildBasedOn("sessTM", makeViewSnapshot());
+    expect(basedOn).toBeDefined();
+    if (basedOn?.events && basedOn.events.length > 0) {
+      expect(typeof basedOn.events[0]).toBe("string");
+    }
+  });
+});
+
+// ── E4: trunk completion contract: L5 wrapper のみで mechanical copy 成立 ────
+
+describe("expansion swimlane 1 (terminal): trunk completion contract — mechanical copy", () => {
+  it("S5 contract が terminal wrap でそのまま機能 (lease validator omit のみで lease 不在 variant)", async () => {
+    resetAll();
+    const handler = vi.fn(async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    }));
+    const wrapped = makeCommitWrapper(handler, "terminal", {});
+    const result = await wrapped({
+      action: "read",
+      windowTitle: "PowerShell",
+    } as Record<string, unknown>);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(result.content).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

`terminal` を `makeCommitWrapper` で wrap (lease-less commit variant)。PR #123 keyboard / PR #126 clipboard / PR #127 scroll / PR #131 window_dock 同型 pattern (sub-plan §3 30 分タイムアタック template、discriminatedUnion 3b family、windowTitleKey: \"windowTitle\"、3 variants: read / send / run)。

## scope

- \`src/tools/terminal.ts\`: module-scope \`terminalRegistrationHandler\` + \`terminalRegistrationSchema = withEnvelopeIncludeForUnion(terminalSchema)\` export、\`server.registerTool\` の \`inputSchema\` を切替、handler を切替。\`withRichNarration\` 内側 (windowTitleKey: \"windowTitle\" — read / send / run 全 variant 共通) → \`makeCommitWrapper\` 外側。
- \`src/tools/macro.ts\`: \`TOOL_REGISTRY.terminal\` を shared instance に切替 (PR #112 pattern、discriminatedUnion 系のため z.object() ラップ不要)。
- \`tests/unit/expansion-terminal-wrapper.test.ts\`: 4 contract tests (E1-E4)。
- \`src/stub-tool-catalog.ts\`: 再生成差分 (3 variants × \`include\` field 追加: read / send / run)。

## trunk contract conformance

- engine-perception layer 改変ゼロ (\`npm run check:expansion-disjoint\` OK)
- run_macro 経路同 instance 共有 (PR #112 pattern)
- handler internal logic + Zod schema + 戻り値 shape 不変 (ADR-010 §1.5)

## Test plan

- [x] \`npm run build\` (tsc) green
- [x] \`npm run check:stub-catalog\` (再生成 diff を本 PR に commit)
- [x] \`npm run check:expansion-disjoint\` OK
- [x] \`npx vitest run tests/unit/expansion-terminal-wrapper.test.ts\` 4/4 pass
- [ ] CI Linux で trunk lock layer 改変ゼロ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)