### PR TITLE
feat(expansion): workspace_launch commit wrapper (L5 envelope)

### DIFF
--- a/src/stub-tool-catalog.ts
+++ b/src/stub-tool-catalog.ts
@@ -1953,6 +1953,13 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
           "default": 2000,
           "minimum": 0,
           "maximum": 30000
+        },
+        "include": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
         }
       },
       "additionalProperties": false,

--- a/src/tools/macro.ts
+++ b/src/tools/macro.ts
@@ -49,7 +49,12 @@ import {
   setElementValueHandler, setElementValueSchema,
 } from "./ui-elements.js";
 // Workspace
-import { workspaceSnapshotHandler, workspaceSnapshotSchema, workspaceLaunchHandler, workspaceLaunchSchema } from "./workspace.js";
+import {
+  workspaceSnapshotHandler, workspaceSnapshotSchema,
+  workspaceLaunchHandler,
+  workspaceLaunchRegistrationSchema,
+  workspaceLaunchRegistrationHandler,
+} from "./workspace.js";
 // Scroll dispatcher (Phase 2)
 import {
   scrollDispatchHandler,
@@ -204,7 +209,11 @@ const TOOL_REGISTRY: Record<string, ToolEntry> = {
   browser_form:         { schema: z.object(browserGetFormSchema),      handler: browserGetFormHandler },
   // Workspace / wait / notification
   workspace_snapshot:   { schema: z.object(workspaceSnapshotSchema),   handler: workspaceSnapshotHandler },
-  workspace_launch:     { schema: z.object(workspaceLaunchSchema),     handler: workspaceLaunchHandler },
+  // Walking skeleton expansion swimlane 1 (L5 commit wrapper): use the
+  // module-scope wrapped handler from workspace.ts so run_macro 経路は
+  // server.tool 経路と同 instance を共有 (PR #112 shared registration handler
+  // pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
+  workspace_launch:     { schema: z.object(workspaceLaunchRegistrationSchema), handler: workspaceLaunchRegistrationHandler as typeof workspaceLaunchHandler },
   wait_until:           { schema: z.object(waitUntilSchema),           handler: waitUntilHandler },
   // Walking skeleton expansion swimlane 1 (L5 commit wrapper): use the
   // module-scope wrapped handler from notification.ts so run_macro 経路は

--- a/src/tools/workspace.ts
+++ b/src/tools/workspace.ts
@@ -12,6 +12,8 @@ import { ok, buildDesc } from "./_types.js";
 import type { ToolResult } from "./_types.js";
 import { failWith } from "./_errors.js";
 import { pollUntil } from "../engine/poll.js";
+import { withRichNarration } from "./_narration.js";
+import { makeCommitWrapper, withEnvelopeIncludeSchema } from "./_envelope.js";
 
 /** Chromium-based browser windows — UIA traversal is prohibitively slow on these */
 export const CHROMIUM_TITLE_RE = /- (?:Google Chrome|Microsoft Edge|Brave|Opera|Vivaldi|Arc|Chromium)$/;
@@ -257,6 +259,37 @@ export const workspaceLaunchHandler = async ({
 // Registration
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * Walking skeleton expansion phase swimlane 1 (L5 commit tool wrapper):
+ * `workspace_launch` is wrapped via `makeCommitWrapper` (lease-less commit
+ * variant — `leaseValidator` omitted; spawns a process without a lease
+ * 4-tuple, mirroring PR #126 clipboard / PR #130 notification_show pattern
+ * for OS-level commits).
+ *
+ * `windowTitleKey` is omitted because workspace_launch has no pre-existing
+ * window-scoped target (the new window appears after the spawn).
+ * `withRichNarration` falls through to `withPostState` only since `narrate`
+ * isn't in the schema.
+ *
+ * Module-scope export so `run_macro` (`TOOL_REGISTRY.workspace_launch` in
+ * `macro.ts`) shares the same wrapped instance (PR #112 shared
+ * registration handler pattern, strip risk prevention).
+ */
+export const workspaceLaunchRegistrationSchema = withEnvelopeIncludeSchema(workspaceLaunchSchema);
+
+export const workspaceLaunchRegistrationHandler = makeCommitWrapper(
+  withRichNarration(
+    "workspace_launch",
+    workspaceLaunchHandler as (args: Record<string, unknown>) => Promise<ToolResult>,
+    {},
+  ) as (args: Record<string, unknown>) => Promise<ToolResult>,
+  "workspace_launch",
+  {
+    // leaseValidator omitted = lease-less commit variant
+    // getSessionId / argsSummary / clock も default 利用 = mechanical コピー最小
+  },
+);
+
 export function registerWorkspaceTools(server: McpServer): void {
   server.tool(
     "workspace_snapshot",
@@ -282,7 +315,7 @@ export function registerWorkspaceTools(server: McpServer): void {
         "workspace_launch({command:'calc.exe', timeoutMs:15000})",
       ],
     }),
-    workspaceLaunchSchema,
-    workspaceLaunchHandler
+    workspaceLaunchRegistrationSchema,
+    workspaceLaunchRegistrationHandler as typeof workspaceLaunchHandler
   );
 }

--- a/tests/unit/expansion-workspace-launch-wrapper.test.ts
+++ b/tests/unit/expansion-workspace-launch-wrapper.test.ts
@@ -1,0 +1,160 @@
+/**
+ * expansion-workspace-launch-wrapper.test.ts — walking skeleton expansion
+ * phase swimlane 1 (L5 commit tool wrapper) contract test.
+ *
+ * Pins the bit-equal contract for `workspace_launch` wrap via
+ * `makeCommitWrapper` per `docs/walking-skeleton-expansion-plan.md` §3
+ * (30 分タイムアタック template) — mechanical copy of PR #130 notification_show
+ * (raw shape 3a OS-level commit、windowTitleKey 省略).
+ *
+ * Trunk contract conformance:
+ *   - L5 wrapper のみで mechanical コピー成立 (engine-perception layer 改変ゼロ)
+ *   - lease 不在 commit variant (`leaseValidator` 省略、process spawn)
+ *   - run_macro 経路と server.tool 経路で同 instance 共有
+ *     (PR #112 shared registration handler pattern)
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  makeCommitWrapper,
+  defaultL1Emitter,
+  buildCausedBy,
+  buildBasedOn,
+  _resetHistoryBuffersForTest,
+  _resetToolCallSeqForTest,
+  type CommitL1Emitter,
+  type ViewSnapshot,
+} from "../../src/tools/_envelope.js";
+
+function resetAll(): void {
+  _resetHistoryBuffersForTest();
+  _resetToolCallSeqForTest();
+}
+
+function makeViewSnapshot(): ViewSnapshot {
+  return {
+    focus: { hwnd: null, elementName: "test-element" },
+    dirtyRectsByMonitor: new Map([[0, 1]]),
+    latestEventId: 100n,
+    queryWallclockMs: Date.now(),
+  };
+}
+
+// ── E1: workspace_launch wrap → L1 ToolCallStarted/Completed event 記録 ─────
+
+describe("expansion swimlane 1 (workspace_launch): wrap → L1 events recorded (lease 不在 variant)", () => {
+  it("makeCommitWrapper flow 通過、ToolCallStarted/Completed 両 event push、lease_token undefined", async () => {
+    resetAll();
+    const events: Array<{ kind: "started" | "completed"; tool: string; leaseToken?: unknown }> = [];
+    const fakeEmitter: CommitL1Emitter = {
+      pushStarted: ({ tool, sessionId, toolCallId, leaseToken }) => {
+        events.push({ kind: "started", tool, leaseToken });
+        defaultL1Emitter.pushStarted({
+          tool,
+          argsJson: "{}",
+          sessionId,
+          toolCallId,
+          leaseToken,
+        });
+      },
+      pushCompleted: ({ tool, elapsedMs, ok, errorCode, sessionId, toolCallId }) => {
+        events.push({ kind: "completed", tool });
+        defaultL1Emitter.pushCompleted({
+          tool,
+          elapsedMs,
+          ok,
+          errorCode,
+          sessionId,
+          toolCallId,
+        });
+      },
+    };
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"launched":"notepad.exe"}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "workspace_launch", {
+      l1Emitter: fakeEmitter,
+    });
+    const result = await wrapped({
+      command: "notepad.exe",
+      args: [],
+      waitMs: 2000,
+    } as Record<string, unknown>);
+    expect(events).toHaveLength(2);
+    expect(events[0].kind).toBe("started");
+    expect(events[0].tool).toBe("workspace_launch");
+    expect(events[0].leaseToken).toBeUndefined();
+    expect(events[1].kind).toBe("completed");
+    expect(events[1].tool).toBe("workspace_launch");
+    expect(result.content).toBeDefined();
+  });
+});
+
+// ── E2: include 未指定時 raw shape return (既存 raw client 互換) ─────────────
+
+describe("expansion swimlane 1 (workspace_launch): include 未指定時 raw shape return", () => {
+  it("default 経路 → envelope shape を hoist して raw client 互換", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"launched":"notepad.exe"}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "workspace_launch", {});
+    const result = await wrapped({
+      command: "notepad.exe",
+      args: [],
+      waitMs: 2000,
+    } as Record<string, unknown>);
+    const text = (result.content[0] as { text: string }).text;
+    const parsed = JSON.parse(text);
+    expect(parsed._version).toBeUndefined();
+    expect(parsed.ok).toBe(true);
+    expect(parsed.launched).toBe("notepad.exe");
+  });
+});
+
+// ── E3: include=causal 経路 → caused_by.your_last_action = "workspace_launch(...)" ─
+
+describe("expansion swimlane 1 (workspace_launch): include=causal で caused_by.your_last_action に workspace_launch 記録", () => {
+  it("workspace_launch wrap → history buffer に entry → buildCausedBy で your_last_action = workspace_launch(...)", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "workspace_launch", {
+      getSessionId: () => "sessWL",
+    });
+    await wrapped({
+      command: "notepad.exe",
+      args: [],
+      waitMs: 2000,
+    } as Record<string, unknown>);
+    const causedBy = buildCausedBy("sessWL", makeViewSnapshot());
+    expect(causedBy).toBeDefined();
+    expect(causedBy?.your_last_action).toContain("workspace_launch");
+    expect(causedBy?.tool_call_id).toMatch(/^sessWL:\d+$/);
+    const basedOn = buildBasedOn("sessWL", makeViewSnapshot());
+    expect(basedOn).toBeDefined();
+    if (basedOn?.events && basedOn.events.length > 0) {
+      expect(typeof basedOn.events[0]).toBe("string");
+    }
+  });
+});
+
+// ── E4: trunk completion contract: L5 wrapper のみで mechanical copy 成立 ────
+
+describe("expansion swimlane 1 (workspace_launch): trunk completion contract — mechanical copy", () => {
+  it("S5 contract が workspace_launch wrap でそのまま機能 (lease validator omit のみで lease 不在 variant)", async () => {
+    resetAll();
+    const handler = vi.fn(async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    }));
+    const wrapped = makeCommitWrapper(handler, "workspace_launch", {});
+    const result = await wrapped({
+      command: "calc.exe",
+      args: [],
+      waitMs: 2000,
+    } as Record<string, unknown>);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(result.content).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

`workspace_launch` を `makeCommitWrapper` で wrap (lease-less commit variant、OS-level process spawn)。PR #130 notification_show 同型 pattern (sub-plan §3 30 分タイムアタック template、raw shape 3a family、windowTitleKey 省略 — pre-existing window 不在)。

## scope

- `src/tools/workspace.ts`: module-scope `workspaceLaunchRegistrationHandler` + `workspaceLaunchRegistrationSchema = withEnvelopeIncludeSchema(workspaceLaunchSchema)` export、`server.tool` の 3rd arg を切替、handler を切替。`withRichNarration` 内側 (windowTitleKey 省略 — process spawn は new window 出現前のため pre-target なし) → `makeCommitWrapper` 外側。
- `src/tools/macro.ts`: `TOOL_REGISTRY.workspace_launch` を shared instance に切替 (PR #112 pattern)。
- `tests/unit/expansion-workspace-launch-wrapper.test.ts`: 4 contract tests (E1-E4)。
- `src/stub-tool-catalog.ts`: 再生成差分 (\`include\` field 追加)。

## trunk contract conformance

- engine-perception layer 改変ゼロ (\`npm run check:expansion-disjoint\` OK)
- run_macro 経路同 instance 共有 (PR #112 pattern)
- handler internal logic + Zod schema + 戻り値 shape 不変 (ADR-010 §1.5)

## Test plan

- [x] \`npm run build\` (tsc) green
- [x] \`npm run check:stub-catalog\` (再生成 diff を本 PR に commit)
- [x] \`npm run check:expansion-disjoint\` OK
- [x] \`npx vitest run tests/unit/expansion-workspace-launch-wrapper.test.ts\` 4/4 pass
- [ ] CI Linux で trunk lock layer 改変ゼロ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)