### PR TITLE
feat(expansion): browser_open commit wrapper (L5 envelope)

### DIFF
--- a/src/stub-tool-catalog.ts
+++ b/src/stub-tool-catalog.ts
@@ -418,6 +418,13 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
               "default": false
             }
           }
+        },
+        "include": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
         }
       },
       "additionalProperties": false

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -23,6 +23,8 @@ import { getCdpPort } from "../utils/desktop-config.js";
 import { fail } from "./_types.js";
 import { setBrowserSearchHook } from "./wait-until.js";
 import { withPostState } from "./_post.js";
+import { withRichNarration } from "./_narration.js";
+import { makeCommitWrapper, withEnvelopeIncludeSchema } from "./_envelope.js";
 import { narrateParam } from "./_narration.js";
 import type { RichBlock } from "../engine/uia-diff.js";
 import { evaluatePreToolGuards, buildEnvelopeFor } from "../engine/perception/registry.js";
@@ -2060,6 +2062,37 @@ export const browserEvalHandler = async (args: BrowserEvalArgs): Promise<ToolRes
 // Registration
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * Walking skeleton expansion phase swimlane 1 (L5 commit tool wrapper):
+ * `browser_open` is wrapped via `makeCommitWrapper` (lease-less commit
+ * variant — `leaseValidator` omitted; CDP connect / optional browser spawn
+ * without a lease 4-tuple, mirroring PR #130 notification_show / PR #133
+ * workspace_launch pattern for OS-level commits).
+ *
+ * `windowTitleKey` is omitted because browser_open has no pre-existing
+ * window-scoped target (the browser may not yet exist when launch:{} is
+ * passed). `withRichNarration` falls through to `withPostState` only since
+ * `narrate` isn't in the schema.
+ *
+ * Module-scope export so `run_macro` (`TOOL_REGISTRY.browser_open` in
+ * `macro.ts`) shares the same wrapped instance (PR #112 shared
+ * registration handler pattern, strip risk prevention).
+ */
+export const browserOpenRegistrationSchema = withEnvelopeIncludeSchema(browserOpenSchema);
+
+export const browserOpenRegistrationHandler = makeCommitWrapper(
+  withRichNarration(
+    "browser_open",
+    browserOpenHandler as (args: Record<string, unknown>) => Promise<ToolResult>,
+    {},
+  ) as (args: Record<string, unknown>) => Promise<ToolResult>,
+  "browser_open",
+  {
+    // leaseValidator omitted = lease-less commit variant
+    // getSessionId / argsSummary / clock も default 利用 = mechanical コピー最小
+  },
+);
+
 export function registerBrowserTools(server: McpServer): void {
   // Wire wait_until(element_matches) — resolve top result for callers that just need selector + text.
   setBrowserSearchHook(async ({ port, tabId, by, pattern, scope }) => {
@@ -2098,8 +2131,8 @@ export function registerBrowserTools(server: McpServer): void {
     "Returns tabs[] with id, url, title, active — pass tabId to browser_* tools to target a specific tab. " +
     "Caveats: CDP connection is per-process; if Chrome restarts, call browser_open again to get fresh tab IDs. " +
     "A Chrome session started without --remote-debugging-port cannot be taken over — close it first or use a separate userDataDir.",
-    browserOpenSchema,
-    browserOpenHandler
+    browserOpenRegistrationSchema,
+    browserOpenRegistrationHandler as typeof browserOpenHandler
   );
 
   server.tool(

--- a/src/tools/macro.ts
+++ b/src/tools/macro.ts
@@ -76,7 +76,9 @@ import {
 } from "./terminal.js";
 // Browser tools (Phase 3)
 import {
-  browserOpenHandler, browserOpenSchema,
+  browserOpenHandler,
+  browserOpenRegistrationSchema,
+  browserOpenRegistrationHandler,
   browserEvalHandler, browserEvalSchema,
   browserSearchHandler, browserSearchSchema,
   browserGetInteractiveHandler, browserGetInteractiveSchema,
@@ -206,7 +208,11 @@ const TOOL_REGISTRY: Record<string, ToolEntry> = {
   // handler pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
   terminal:             { schema: terminalRegistrationSchema,           handler: terminalRegistrationHandler as typeof terminalDispatchHandler },
   // Action — browser (Phase 3)
-  browser_open:         { schema: z.object(browserOpenSchema),         handler: browserOpenHandler },
+  // Walking skeleton expansion swimlane 1 (L5 commit wrapper): use the
+  // module-scope wrapped handler from browser.ts so run_macro 経路は
+  // server.tool 経路と同 instance を共有 (PR #112 shared registration handler
+  // pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
+  browser_open:         { schema: z.object(browserOpenRegistrationSchema), handler: browserOpenRegistrationHandler as typeof browserOpenHandler },
   browser_eval:         { schema: browserEvalSchema,                   handler: browserEvalHandler },
   browser_search:       { schema: z.object(browserSearchSchema),       handler: browserSearchHandler },
   browser_overview:     { schema: z.object(browserGetInteractiveSchema), handler: browserGetInteractiveHandler },

--- a/tests/unit/expansion-browser-open-wrapper.test.ts
+++ b/tests/unit/expansion-browser-open-wrapper.test.ts
@@ -1,0 +1,152 @@
+/**
+ * expansion-browser-open-wrapper.test.ts — walking skeleton expansion phase
+ * swimlane 1 (L5 commit tool wrapper) contract test.
+ *
+ * Pins the bit-equal contract for `browser_open` wrap via `makeCommitWrapper`
+ * per `docs/walking-skeleton-expansion-plan.md` §3 (30 分タイムアタック
+ * template) — mechanical copy of PR #130 notification_show / PR #133
+ * workspace_launch (raw shape 3a OS-level commit、windowTitleKey 省略).
+ *
+ * Trunk contract conformance:
+ *   - L5 wrapper のみで mechanical コピー成立 (engine-perception layer 改変ゼロ)
+ *   - lease 不在 commit variant (`leaseValidator` 省略、CDP connect)
+ *   - run_macro 経路と server.tool 経路で同 instance 共有
+ *     (PR #112 shared registration handler pattern)
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  makeCommitWrapper,
+  defaultL1Emitter,
+  buildCausedBy,
+  buildBasedOn,
+  _resetHistoryBuffersForTest,
+  _resetToolCallSeqForTest,
+  type CommitL1Emitter,
+  type ViewSnapshot,
+} from "../../src/tools/_envelope.js";
+
+function resetAll(): void {
+  _resetHistoryBuffersForTest();
+  _resetToolCallSeqForTest();
+}
+
+function makeViewSnapshot(): ViewSnapshot {
+  return {
+    focus: { hwnd: null, elementName: "test-element" },
+    dirtyRectsByMonitor: new Map([[0, 1]]),
+    latestEventId: 100n,
+    queryWallclockMs: Date.now(),
+  };
+}
+
+// ── E1: browser_open wrap → L1 ToolCallStarted/Completed event 記録 ─────────
+
+describe("expansion swimlane 1 (browser_open): wrap → L1 events recorded (lease 不在 variant)", () => {
+  it("makeCommitWrapper flow 通過、ToolCallStarted/Completed 両 event push、lease_token undefined", async () => {
+    resetAll();
+    const events: Array<{ kind: "started" | "completed"; tool: string; leaseToken?: unknown }> = [];
+    const fakeEmitter: CommitL1Emitter = {
+      pushStarted: ({ tool, sessionId, toolCallId, leaseToken }) => {
+        events.push({ kind: "started", tool, leaseToken });
+        defaultL1Emitter.pushStarted({
+          tool,
+          argsJson: "{}",
+          sessionId,
+          toolCallId,
+          leaseToken,
+        });
+      },
+      pushCompleted: ({ tool, elapsedMs, ok, errorCode, sessionId, toolCallId }) => {
+        events.push({ kind: "completed", tool });
+        defaultL1Emitter.pushCompleted({
+          tool,
+          elapsedMs,
+          ok,
+          errorCode,
+          sessionId,
+          toolCallId,
+        });
+      },
+    };
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"tabs":[{"id":"abc","url":"about:blank","title":"New Tab","active":true}]}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "browser_open", {
+      l1Emitter: fakeEmitter,
+    });
+    const result = await wrapped({
+      port: 9222,
+    } as Record<string, unknown>);
+    expect(events).toHaveLength(2);
+    expect(events[0].kind).toBe("started");
+    expect(events[0].tool).toBe("browser_open");
+    expect(events[0].leaseToken).toBeUndefined();
+    expect(events[1].kind).toBe("completed");
+    expect(events[1].tool).toBe("browser_open");
+    expect(result.content).toBeDefined();
+  });
+});
+
+// ── E2: include 未指定時 raw shape return (既存 raw client 互換) ─────────────
+
+describe("expansion swimlane 1 (browser_open): include 未指定時 raw shape return", () => {
+  it("default 経路 → envelope shape を hoist して raw client 互換", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"tabs":[]}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "browser_open", {});
+    const result = await wrapped({
+      port: 9222,
+    } as Record<string, unknown>);
+    const text = (result.content[0] as { text: string }).text;
+    const parsed = JSON.parse(text);
+    expect(parsed._version).toBeUndefined();
+    expect(parsed.ok).toBe(true);
+    expect(Array.isArray(parsed.tabs)).toBe(true);
+  });
+});
+
+// ── E3: include=causal 経路 → caused_by.your_last_action = "browser_open(...)" ─
+
+describe("expansion swimlane 1 (browser_open): include=causal で caused_by.your_last_action に browser_open 記録", () => {
+  it("browser_open wrap → history buffer に entry → buildCausedBy で your_last_action = browser_open(...)", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "browser_open", {
+      getSessionId: () => "sessBO",
+    });
+    await wrapped({
+      port: 9222,
+    } as Record<string, unknown>);
+    const causedBy = buildCausedBy("sessBO", makeViewSnapshot());
+    expect(causedBy).toBeDefined();
+    expect(causedBy?.your_last_action).toContain("browser_open");
+    expect(causedBy?.tool_call_id).toMatch(/^sessBO:\d+$/);
+    const basedOn = buildBasedOn("sessBO", makeViewSnapshot());
+    expect(basedOn).toBeDefined();
+    if (basedOn?.events && basedOn.events.length > 0) {
+      expect(typeof basedOn.events[0]).toBe("string");
+    }
+  });
+});
+
+// ── E4: trunk completion contract: L5 wrapper のみで mechanical copy 成立 ────
+
+describe("expansion swimlane 1 (browser_open): trunk completion contract — mechanical copy", () => {
+  it("S5 contract が browser_open wrap でそのまま機能 (lease validator omit のみで lease 不在 variant)", async () => {
+    resetAll();
+    const handler = vi.fn(async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    }));
+    const wrapped = makeCommitWrapper(handler, "browser_open", {});
+    const result = await wrapped({
+      port: 9222,
+    } as Record<string, unknown>);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(result.content).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

`browser_open` を `makeCommitWrapper` で wrap (lease-less commit variant、CDP connect / optional browser spawn)。PR #130 notification_show / PR #133 workspace_launch 同型 pattern (raw shape 3a family、windowTitleKey 省略 — pre-existing window 不在のため)。

## scope

- `src/tools/browser.ts`: module-scope `browserOpenRegistrationHandler` + `browserOpenRegistrationSchema = withEnvelopeIncludeSchema(browserOpenSchema)` export、`server.tool` の 3rd arg を切替、handler を切替。`withRichNarration` 内側 (windowTitleKey 省略 — browser may not yet exist when launch:{}) → `makeCommitWrapper` 外側。
- `src/tools/macro.ts`: `TOOL_REGISTRY.browser_open` を shared instance に切替 (PR #112 pattern)。
- `tests/unit/expansion-browser-open-wrapper.test.ts`: 4 contract tests (E1-E4)。
- `src/stub-tool-catalog.ts`: 再生成差分 (\`include\` field 追加)。

## trunk contract conformance

- engine-perception layer 改変ゼロ (\`npm run check:expansion-disjoint\` OK)
- run_macro 経路同 instance 共有 (PR #112 pattern)
- handler internal logic + Zod schema + 戻り値 shape 不変 (ADR-010 §1.5)

## Test plan

- [x] \`npm run build\` (tsc) green
- [x] \`npm run check:stub-catalog\`
- [x] \`npm run check:expansion-disjoint\` OK
- [x] \`npx vitest run tests/unit/expansion-browser-open-wrapper.test.ts\` 4/4 pass
- [ ] CI Linux で trunk lock layer 改変ゼロ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)