### PR TITLE
feat(expansion): browser_navigate commit wrapper (L5 envelope)

### DIFF
--- a/src/stub-tool-catalog.ts
+++ b/src/stub-tool-catalog.ts
@@ -359,6 +359,13 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
         "lensId": {
           "description": "Optional perception lens ID. Guards (target.identityStable) are evaluated before navigating, and a perception envelope is attached to post.perception on success.",
           "type": "string"
+        },
+        "include": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
         }
       },
       "additionalProperties": false,

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -23,9 +23,8 @@ import { getCdpPort } from "../utils/desktop-config.js";
 import { fail } from "./_types.js";
 import { setBrowserSearchHook } from "./wait-until.js";
 import { withPostState } from "./_post.js";
-import { withRichNarration } from "./_narration.js";
+import { narrateParam, withRichNarration } from "./_narration.js";
 import { makeCommitWrapper, withEnvelopeIncludeSchema } from "./_envelope.js";
-import { narrateParam } from "./_narration.js";
 import type { RichBlock } from "../engine/uia-diff.js";
 import { evaluatePreToolGuards, buildEnvelopeFor } from "../engine/perception/registry.js";
 import { runActionGuard, isAutoGuardEnabled, validateAndPrepareFix, consumeFix } from "./_action-guard.js";
@@ -2093,6 +2092,28 @@ export const browserOpenRegistrationHandler = makeCommitWrapper(
   },
 );
 
+/**
+ * Walking skeleton expansion phase swimlane 1 (L5 commit tool wrapper):
+ * `browser_navigate` is wrapped via `makeCommitWrapper` (lease-less commit
+ * variant). Replaces the pre-expansion `withPostState("browser_navigate", ...)`
+ * direct wrap. PR #134 browser_open 同型 pattern (raw shape 3a family、
+ * windowTitleKey 省略 — browser targets a CDP tab not a Win32 window).
+ */
+export const browserNavigateRegistrationSchema = withEnvelopeIncludeSchema(browserNavigateSchema);
+
+export const browserNavigateRegistrationHandler = makeCommitWrapper(
+  withRichNarration(
+    "browser_navigate",
+    browserNavigateHandler as (args: Record<string, unknown>) => Promise<ToolResult>,
+    {},
+  ) as (args: Record<string, unknown>) => Promise<ToolResult>,
+  "browser_navigate",
+  {
+    // leaseValidator omitted = lease-less commit variant
+    // getSessionId / argsSummary / clock も default 利用 = mechanical コピー最小
+  },
+);
+
 export function registerBrowserTools(server: McpServer): void {
   // Wire wait_until(element_matches) — resolve top result for callers that just need selector + text.
   setBrowserSearchHook(async ({ port, tabId, by, pattern, scope }) => {
@@ -2180,8 +2201,8 @@ export function registerBrowserTools(server: McpServer): void {
   server.tool(
     "browser_navigate",
     "Navigate a browser tab to a URL via CDP Page.navigate — more reliable than clicking the address bar. Pass tabId+port so the server auto-guards (verifies tab readyState) and returns post.perception.status. lensId is optional for advanced pinned-tab workflows. Caveats: Does not block until page load completes — follow with wait_until(element_matches) or repeated browser_eval polling for slow pages.",
-    browserNavigateSchema,
-    withPostState("browser_navigate", browserNavigateHandler)
+    browserNavigateRegistrationSchema,
+    browserNavigateRegistrationHandler as typeof browserNavigateHandler
   );
 
   server.tool(

--- a/src/tools/macro.ts
+++ b/src/tools/macro.ts
@@ -84,7 +84,9 @@ import {
   browserGetInteractiveHandler, browserGetInteractiveSchema,
   browserFindElementHandler, browserFindElementSchema,
   browserClickElementHandler, browserClickElementSchema,
-  browserNavigateHandler, browserNavigateSchema,
+  browserNavigateHandler,
+  browserNavigateRegistrationSchema,
+  browserNavigateRegistrationHandler,
   browserFillInputHandler, browserFillInputSchema,
   browserGetFormHandler, browserGetFormSchema,
 } from "./browser.js";
@@ -218,7 +220,11 @@ const TOOL_REGISTRY: Record<string, ToolEntry> = {
   browser_overview:     { schema: z.object(browserGetInteractiveSchema), handler: browserGetInteractiveHandler },
   browser_locate:       { schema: z.object(browserFindElementSchema),  handler: browserFindElementHandler },
   browser_click:        { schema: z.object(browserClickElementSchema), handler: browserClickElementHandler },
-  browser_navigate:     { schema: z.object(browserNavigateSchema),     handler: browserNavigateHandler },
+  // Walking skeleton expansion swimlane 1 (L5 commit wrapper): use the
+  // module-scope wrapped handler from browser.ts so run_macro 経路は
+  // server.tool 経路と同 instance を共有 (PR #112 shared registration handler
+  // pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
+  browser_navigate:     { schema: z.object(browserNavigateRegistrationSchema), handler: browserNavigateRegistrationHandler as typeof browserNavigateHandler },
   browser_fill:         { schema: z.object(browserFillInputSchema),    handler: browserFillInputHandler },
   browser_form:         { schema: z.object(browserGetFormSchema),      handler: browserGetFormHandler },
   // Workspace / wait / notification

--- a/tests/unit/expansion-browser-navigate-wrapper.test.ts
+++ b/tests/unit/expansion-browser-navigate-wrapper.test.ts
@@ -1,0 +1,156 @@
+/**
+ * expansion-browser-navigate-wrapper.test.ts — walking skeleton expansion
+ * phase swimlane 1 (L5 commit tool wrapper) contract test.
+ *
+ * Pins the bit-equal contract for `browser_navigate` wrap via
+ * `makeCommitWrapper` per `docs/walking-skeleton-expansion-plan.md` §3
+ * (30 分タイムアタック template) — mechanical copy of PR #134 browser_open
+ * (raw shape 3a OS-level commit、windowTitleKey 省略).
+ *
+ * Trunk contract conformance:
+ *   - L5 wrapper のみで mechanical コピー成立 (engine-perception layer 改変ゼロ)
+ *   - lease 不在 commit variant (`leaseValidator` 省略、tabId-driven nav)
+ *   - run_macro 経路と server.tool 経路で同 instance 共有
+ *     (PR #112 shared registration handler pattern)
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  makeCommitWrapper,
+  defaultL1Emitter,
+  buildCausedBy,
+  buildBasedOn,
+  _resetHistoryBuffersForTest,
+  _resetToolCallSeqForTest,
+  type CommitL1Emitter,
+  type ViewSnapshot,
+} from "../../src/tools/_envelope.js";
+
+function resetAll(): void {
+  _resetHistoryBuffersForTest();
+  _resetToolCallSeqForTest();
+}
+
+function makeViewSnapshot(): ViewSnapshot {
+  return {
+    focus: { hwnd: null, elementName: "test-element" },
+    dirtyRectsByMonitor: new Map([[0, 1]]),
+    latestEventId: 100n,
+    queryWallclockMs: Date.now(),
+  };
+}
+
+// ── E1: browser_navigate wrap → L1 ToolCallStarted/Completed event 記録 ─────
+
+describe("expansion swimlane 1 (browser_navigate): wrap → L1 events recorded (lease 不在 variant)", () => {
+  it("makeCommitWrapper flow 通過、ToolCallStarted/Completed 両 event push、lease_token undefined", async () => {
+    resetAll();
+    const events: Array<{ kind: "started" | "completed"; tool: string; leaseToken?: unknown }> = [];
+    const fakeEmitter: CommitL1Emitter = {
+      pushStarted: ({ tool, sessionId, toolCallId, leaseToken }) => {
+        events.push({ kind: "started", tool, leaseToken });
+        defaultL1Emitter.pushStarted({
+          tool,
+          argsJson: "{}",
+          sessionId,
+          toolCallId,
+          leaseToken,
+        });
+      },
+      pushCompleted: ({ tool, elapsedMs, ok, errorCode, sessionId, toolCallId }) => {
+        events.push({ kind: "completed", tool });
+        defaultL1Emitter.pushCompleted({
+          tool,
+          elapsedMs,
+          ok,
+          errorCode,
+          sessionId,
+          toolCallId,
+        });
+      },
+    };
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"url":"https://example.com"}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "browser_navigate", {
+      l1Emitter: fakeEmitter,
+    });
+    const result = await wrapped({
+      url: "https://example.com",
+      port: 9222,
+    } as Record<string, unknown>);
+    expect(events).toHaveLength(2);
+    expect(events[0].kind).toBe("started");
+    expect(events[0].tool).toBe("browser_navigate");
+    expect(events[0].leaseToken).toBeUndefined();
+    expect(events[1].kind).toBe("completed");
+    expect(events[1].tool).toBe("browser_navigate");
+    expect(result.content).toBeDefined();
+  });
+});
+
+// ── E2: include 未指定時 raw shape return ────────────────────────────────────
+
+describe("expansion swimlane 1 (browser_navigate): include 未指定時 raw shape return", () => {
+  it("default 経路 → envelope shape を hoist して raw client 互換", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"url":"https://example.com"}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "browser_navigate", {});
+    const result = await wrapped({
+      url: "https://example.com",
+      port: 9222,
+    } as Record<string, unknown>);
+    const text = (result.content[0] as { text: string }).text;
+    const parsed = JSON.parse(text);
+    expect(parsed._version).toBeUndefined();
+    expect(parsed.ok).toBe(true);
+    expect(parsed.url).toBe("https://example.com");
+  });
+});
+
+// ── E3: include=causal 経路 → caused_by.your_last_action = "browser_navigate(...)" ─
+
+describe("expansion swimlane 1 (browser_navigate): include=causal で caused_by.your_last_action に browser_navigate 記録", () => {
+  it("browser_navigate wrap → history buffer に entry → buildCausedBy で your_last_action = browser_navigate(...)", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "browser_navigate", {
+      getSessionId: () => "sessBN",
+    });
+    await wrapped({
+      url: "https://example.com",
+      port: 9222,
+    } as Record<string, unknown>);
+    const causedBy = buildCausedBy("sessBN", makeViewSnapshot());
+    expect(causedBy).toBeDefined();
+    expect(causedBy?.your_last_action).toContain("browser_navigate");
+    expect(causedBy?.tool_call_id).toMatch(/^sessBN:\d+$/);
+    const basedOn = buildBasedOn("sessBN", makeViewSnapshot());
+    expect(basedOn).toBeDefined();
+    if (basedOn?.events && basedOn.events.length > 0) {
+      expect(typeof basedOn.events[0]).toBe("string");
+    }
+  });
+});
+
+// ── E4: trunk completion contract ────────────────────────────────────────────
+
+describe("expansion swimlane 1 (browser_navigate): trunk completion contract — mechanical copy", () => {
+  it("S5 contract が browser_navigate wrap でそのまま機能 (lease validator omit のみで lease 不在 variant)", async () => {
+    resetAll();
+    const handler = vi.fn(async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    }));
+    const wrapped = makeCommitWrapper(handler, "browser_navigate", {});
+    const result = await wrapped({
+      url: "https://example.com",
+      port: 9222,
+    } as Record<string, unknown>);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(result.content).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

`browser_navigate` を `makeCommitWrapper` で wrap (lease-less commit variant)。PR #134 browser_open 同型 pattern (raw shape 3a family、windowTitleKey 省略)。pre-expansion \`withPostState\` 直接 wrap を \`makeCommitWrapper(withRichNarration(...))\` に置換。

## scope

- \`src/tools/browser.ts\`: module-scope \`browserNavigateRegistrationHandler\` + \`browserNavigateRegistrationSchema = withEnvelopeIncludeSchema(browserNavigateSchema)\` export、\`server.tool\` の 3rd arg を切替、handler を切替。
- \`src/tools/macro.ts\`: \`TOOL_REGISTRY.browser_navigate\` を shared instance に切替 (PR #112 pattern)。
- \`tests/unit/expansion-browser-navigate-wrapper.test.ts\`: 4 contract tests (E1-E4)。
- \`src/stub-tool-catalog.ts\`: 再生成差分 (\`include\` field 追加)。

## trunk contract conformance

- engine-perception layer 改変ゼロ (\`npm run check:expansion-disjoint\` OK)
- run_macro 経路同 instance 共有 (PR #112 pattern)
- handler internal logic + Zod schema + 戻り値 shape 不変 (ADR-010 §1.5)

## Test plan

- [x] \`npm run build\` (tsc) green
- [x] \`npm run check:stub-catalog\`
- [x] \`npm run check:expansion-disjoint\` OK
- [x] \`npx vitest run tests/unit/expansion-browser-navigate-wrapper.test.ts\` 4/4 pass
- [ ] CI Linux で trunk lock layer 改変ゼロ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)