### PR TITLE
feat(expansion): browser_click commit wrapper (L5 envelope)

### DIFF
--- a/src/stub-tool-catalog.ts
+++ b/src/stub-tool-catalog.ts
@@ -60,6 +60,13 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
         "fixId": {
           "description": "Approve a pending suggestedFix (one-shot, 15s TTL).",
           "type": "string"
+        },
+        "include": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
         }
       },
       "additionalProperties": false,

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -2114,6 +2114,27 @@ export const browserNavigateRegistrationHandler = makeCommitWrapper(
   },
 );
 
+/**
+ * Walking skeleton expansion phase swimlane 1 (L5 commit tool wrapper):
+ * `browser_click` is wrapped via `makeCommitWrapper` (lease-less commit
+ * variant). Replaces the pre-expansion `withPostState("browser_click", ...)`
+ * direct wrap. PR #134 browser_open / PR #135 browser_navigate 同型 pattern.
+ */
+export const browserClickRegistrationSchema = withEnvelopeIncludeSchema(browserClickElementSchema);
+
+export const browserClickRegistrationHandler = makeCommitWrapper(
+  withRichNarration(
+    "browser_click",
+    browserClickElementHandler as (args: Record<string, unknown>) => Promise<ToolResult>,
+    {},
+  ) as (args: Record<string, unknown>) => Promise<ToolResult>,
+  "browser_click",
+  {
+    // leaseValidator omitted = lease-less commit variant
+    // getSessionId / argsSummary / clock も default 利用 = mechanical コピー最小
+  },
+);
+
 export function registerBrowserTools(server: McpServer): void {
   // Wire wait_until(element_matches) — resolve top result for callers that just need selector + text.
   setBrowserSearchHook(async ({ port, tabId, by, pattern, scope }) => {
@@ -2166,8 +2187,8 @@ export function registerBrowserTools(server: McpServer): void {
   server.tool(
     "browser_click",
     "Find a DOM element by CSS selector and click it (combines browser_locate + mouse_click in one step). Prefer over mouse_click for Chrome — selector-based clicking is stable across repaints. Pass tabId+port so the server auto-guards (verifies tab readyState and identity) and returns post.perception.status. lensId is optional for advanced pinned-tab workflows. Caveats: Fails if the element is outside the visible viewport — scroll it into view with browser_eval(\"document.querySelector('sel').scrollIntoView()\") first.",
-    browserClickElementSchema,
-    withPostState("browser_click", browserClickElementHandler)
+    browserClickRegistrationSchema,
+    browserClickRegistrationHandler as typeof browserClickElementHandler
   );
 
   server.registerTool(

--- a/src/tools/macro.ts
+++ b/src/tools/macro.ts
@@ -83,7 +83,9 @@ import {
   browserSearchHandler, browserSearchSchema,
   browserGetInteractiveHandler, browserGetInteractiveSchema,
   browserFindElementHandler, browserFindElementSchema,
-  browserClickElementHandler, browserClickElementSchema,
+  browserClickElementHandler,
+  browserClickRegistrationSchema,
+  browserClickRegistrationHandler,
   browserNavigateHandler,
   browserNavigateRegistrationSchema,
   browserNavigateRegistrationHandler,
@@ -219,11 +221,11 @@ const TOOL_REGISTRY: Record<string, ToolEntry> = {
   browser_search:       { schema: z.object(browserSearchSchema),       handler: browserSearchHandler },
   browser_overview:     { schema: z.object(browserGetInteractiveSchema), handler: browserGetInteractiveHandler },
   browser_locate:       { schema: z.object(browserFindElementSchema),  handler: browserFindElementHandler },
-  browser_click:        { schema: z.object(browserClickElementSchema), handler: browserClickElementHandler },
   // Walking skeleton expansion swimlane 1 (L5 commit wrapper): use the
   // module-scope wrapped handler from browser.ts so run_macro 経路は
   // server.tool 経路と同 instance を共有 (PR #112 shared registration handler
   // pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
+  browser_click:        { schema: z.object(browserClickRegistrationSchema), handler: browserClickRegistrationHandler as typeof browserClickElementHandler },
   browser_navigate:     { schema: z.object(browserNavigateRegistrationSchema), handler: browserNavigateRegistrationHandler as typeof browserNavigateHandler },
   browser_fill:         { schema: z.object(browserFillInputSchema),    handler: browserFillInputHandler },
   browser_form:         { schema: z.object(browserGetFormSchema),      handler: browserGetFormHandler },

--- a/tests/unit/expansion-browser-click-wrapper.test.ts
+++ b/tests/unit/expansion-browser-click-wrapper.test.ts
@@ -1,0 +1,123 @@
+/**
+ * expansion-browser-click-wrapper.test.ts — walking skeleton expansion phase
+ * swimlane 1 (L5 commit tool wrapper) contract test.
+ *
+ * Pins the bit-equal contract for `browser_click` wrap via `makeCommitWrapper`
+ * — mechanical copy of PR #134 browser_open / PR #135 browser_navigate.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  makeCommitWrapper,
+  defaultL1Emitter,
+  buildCausedBy,
+  buildBasedOn,
+  _resetHistoryBuffersForTest,
+  _resetToolCallSeqForTest,
+  type CommitL1Emitter,
+  type ViewSnapshot,
+} from "../../src/tools/_envelope.js";
+
+function resetAll(): void {
+  _resetHistoryBuffersForTest();
+  _resetToolCallSeqForTest();
+}
+
+function makeViewSnapshot(): ViewSnapshot {
+  return {
+    focus: { hwnd: null, elementName: "test-element" },
+    dirtyRectsByMonitor: new Map([[0, 1]]),
+    latestEventId: 100n,
+    queryWallclockMs: Date.now(),
+  };
+}
+
+describe("expansion swimlane 1 (browser_click): wrap → L1 events recorded (lease 不在 variant)", () => {
+  it("makeCommitWrapper flow 通過、ToolCallStarted/Completed 両 event push、lease_token undefined", async () => {
+    resetAll();
+    const events: Array<{ kind: "started" | "completed"; tool: string; leaseToken?: unknown }> = [];
+    const fakeEmitter: CommitL1Emitter = {
+      pushStarted: ({ tool, sessionId, toolCallId, leaseToken }) => {
+        events.push({ kind: "started", tool, leaseToken });
+        defaultL1Emitter.pushStarted({ tool, argsJson: "{}", sessionId, toolCallId, leaseToken });
+      },
+      pushCompleted: ({ tool, elapsedMs, ok, errorCode, sessionId, toolCallId }) => {
+        events.push({ kind: "completed", tool });
+        defaultL1Emitter.pushCompleted({ tool, elapsedMs, ok, errorCode, sessionId, toolCallId });
+      },
+    };
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"clicked":"#button"}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "browser_click", { l1Emitter: fakeEmitter });
+    const result = await wrapped({
+      selector: "#button",
+      port: 9222,
+    } as Record<string, unknown>);
+    expect(events).toHaveLength(2);
+    expect(events[0].tool).toBe("browser_click");
+    expect(events[0].leaseToken).toBeUndefined();
+    expect(events[1].kind).toBe("completed");
+    expect(result.content).toBeDefined();
+  });
+});
+
+describe("expansion swimlane 1 (browser_click): include 未指定時 raw shape return", () => {
+  it("default 経路 → envelope shape を hoist して raw client 互換", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"clicked":"#button"}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "browser_click", {});
+    const result = await wrapped({
+      selector: "#button",
+      port: 9222,
+    } as Record<string, unknown>);
+    const text = (result.content[0] as { text: string }).text;
+    const parsed = JSON.parse(text);
+    expect(parsed._version).toBeUndefined();
+    expect(parsed.ok).toBe(true);
+    expect(parsed.clicked).toBe("#button");
+  });
+});
+
+describe("expansion swimlane 1 (browser_click): include=causal で caused_by.your_last_action に browser_click 記録", () => {
+  it("browser_click wrap → history buffer に entry → buildCausedBy で your_last_action = browser_click(...)", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "browser_click", {
+      getSessionId: () => "sessBC",
+    });
+    await wrapped({
+      selector: "#button",
+      port: 9222,
+    } as Record<string, unknown>);
+    const causedBy = buildCausedBy("sessBC", makeViewSnapshot());
+    expect(causedBy).toBeDefined();
+    expect(causedBy?.your_last_action).toContain("browser_click");
+    expect(causedBy?.tool_call_id).toMatch(/^sessBC:\d+$/);
+    const basedOn = buildBasedOn("sessBC", makeViewSnapshot());
+    expect(basedOn).toBeDefined();
+    if (basedOn?.events && basedOn.events.length > 0) {
+      expect(typeof basedOn.events[0]).toBe("string");
+    }
+  });
+});
+
+describe("expansion swimlane 1 (browser_click): trunk completion contract — mechanical copy", () => {
+  it("S5 contract が browser_click wrap でそのまま機能 (lease validator omit のみで lease 不在 variant)", async () => {
+    resetAll();
+    const handler = vi.fn(async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    }));
+    const wrapped = makeCommitWrapper(handler, "browser_click", {});
+    const result = await wrapped({
+      selector: "#button",
+      port: 9222,
+    } as Record<string, unknown>);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(result.content).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

`browser_click` を `makeCommitWrapper` で wrap (lease-less commit variant)。PR #134 browser_open / PR #135 browser_navigate 同型 pattern (raw shape 3a family)。pre-expansion \`withPostState\` 直接 wrap を \`makeCommitWrapper(withRichNarration(...))\` に置換。

## scope

- \`src/tools/browser.ts\`: module-scope \`browserClickRegistrationHandler\` + \`browserClickRegistrationSchema = withEnvelopeIncludeSchema(browserClickElementSchema)\` export、\`server.tool\` の 3rd arg を切替、handler を切替。
- \`src/tools/macro.ts\`: \`TOOL_REGISTRY.browser_click\` を shared instance に切替 (PR #112 pattern)。
- \`tests/unit/expansion-browser-click-wrapper.test.ts\`: 4 contract tests (E1-E4)。
- \`src/stub-tool-catalog.ts\`: 再生成差分 (\`include\` field 追加)。

## Test plan

- [x] \`npm run build\` (tsc) green
- [x] \`npm run check:stub-catalog\`
- [x] \`npm run check:expansion-disjoint\` OK
- [x] \`npx vitest run tests/unit/expansion-browser-click-wrapper.test.ts\` 4/4 pass
- [ ] CI Linux で trunk lock layer 改変ゼロ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)