### PR TITLE
feat(expansion): browser_fill commit wrapper (L5 envelope)

### DIFF
--- a/src/stub-tool-catalog.ts
+++ b/src/stub-tool-catalog.ts
@@ -234,6 +234,13 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
           "type": "boolean",
           "default": true,
           "description": "When true, append activeTab and readyState context to the response."
+        },
+        "include": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
         }
       },
       "additionalProperties": false,

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -2135,6 +2135,30 @@ export const browserClickRegistrationHandler = makeCommitWrapper(
   },
 );
 
+/**
+ * Walking skeleton expansion phase swimlane 1 (L5 commit tool wrapper):
+ * `browser_fill` is wrapped via `makeCommitWrapper` (lease-less commit
+ * variant). PR #134 browser_open / PR #135 browser_navigate / PR #136
+ * browser_click 同型 pattern (raw shape 3a family、windowTitleKey 省略 —
+ * browser targets a CDP tab not a Win32 window). pre-expansion では bare
+ * `browserFillInputHandler` 直接渡しだったため post.* block も追加される
+ * behavior 変化あり (additive、互換維持)。
+ */
+export const browserFillRegistrationSchema = withEnvelopeIncludeSchema(browserFillInputSchema);
+
+export const browserFillRegistrationHandler = makeCommitWrapper(
+  withRichNarration(
+    "browser_fill",
+    browserFillInputHandler as (args: Record<string, unknown>) => Promise<ToolResult>,
+    {},
+  ) as (args: Record<string, unknown>) => Promise<ToolResult>,
+  "browser_fill",
+  {
+    // leaseValidator omitted = lease-less commit variant
+    // getSessionId / argsSummary / clock も default 利用 = mechanical コピー最小
+  },
+);
+
 export function registerBrowserTools(server: McpServer): void {
   // Wire wait_until(element_matches) — resolve top result for callers that just need selector + text.
   setBrowserSearchHook(async ({ port, tabId, by, pattern, scope }) => {
@@ -2229,8 +2253,8 @@ export function registerBrowserTools(server: McpServer): void {
   server.tool(
     "browser_fill",
     "Fill a form input with a value via CDP — works on React/Vue/Svelte controlled inputs that reject browser_eval value assignment. Use browser_overview or browser_locate first to obtain a stable selector. Use this over browser_eval when setting a controlled input's value via JS does not update the framework state. Caveats: Requires browser_open (CDP active). Does not work on contenteditable rich-text editors — use keyboard(action='type') for those. actual in response shows what the element's value property reads after fill; verify it matches the intended value.",
-    browserFillInputSchema,
-    browserFillInputHandler
+    browserFillRegistrationSchema,
+    browserFillRegistrationHandler as typeof browserFillInputHandler
   );
 
   server.tool(

--- a/src/tools/macro.ts
+++ b/src/tools/macro.ts
@@ -89,7 +89,9 @@ import {
   browserNavigateHandler,
   browserNavigateRegistrationSchema,
   browserNavigateRegistrationHandler,
-  browserFillInputHandler, browserFillInputSchema,
+  browserFillInputHandler,
+  browserFillRegistrationSchema,
+  browserFillRegistrationHandler,
   browserGetFormHandler, browserGetFormSchema,
 } from "./browser.js";
 // Notification (server_status not callable from macros — diagnostic)
@@ -227,7 +229,11 @@ const TOOL_REGISTRY: Record<string, ToolEntry> = {
   // pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
   browser_click:        { schema: z.object(browserClickRegistrationSchema), handler: browserClickRegistrationHandler as typeof browserClickElementHandler },
   browser_navigate:     { schema: z.object(browserNavigateRegistrationSchema), handler: browserNavigateRegistrationHandler as typeof browserNavigateHandler },
-  browser_fill:         { schema: z.object(browserFillInputSchema),    handler: browserFillInputHandler },
+  // Walking skeleton expansion swimlane 1 (L5 commit wrapper): use the
+  // module-scope wrapped handler from browser.ts so run_macro 経路は
+  // server.tool 経路と同 instance を共有 (PR #112 shared registration handler
+  // pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
+  browser_fill:         { schema: z.object(browserFillRegistrationSchema), handler: browserFillRegistrationHandler as typeof browserFillInputHandler },
   browser_form:         { schema: z.object(browserGetFormSchema),      handler: browserGetFormHandler },
   // Workspace / wait / notification
   workspace_snapshot:   { schema: z.object(workspaceSnapshotSchema),   handler: workspaceSnapshotHandler },

--- a/tests/unit/expansion-browser-fill-wrapper.test.ts
+++ b/tests/unit/expansion-browser-fill-wrapper.test.ts
@@ -1,0 +1,125 @@
+/**
+ * expansion-browser-fill-wrapper.test.ts — walking skeleton expansion phase
+ * swimlane 1 (L5 commit tool wrapper) contract test.
+ * Mechanical copy of PR #135 browser_navigate / PR #134 browser_open pattern.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  makeCommitWrapper,
+  defaultL1Emitter,
+  buildCausedBy,
+  buildBasedOn,
+  _resetHistoryBuffersForTest,
+  _resetToolCallSeqForTest,
+  type CommitL1Emitter,
+  type ViewSnapshot,
+} from "../../src/tools/_envelope.js";
+
+function resetAll(): void {
+  _resetHistoryBuffersForTest();
+  _resetToolCallSeqForTest();
+}
+
+function makeViewSnapshot(): ViewSnapshot {
+  return {
+    focus: { hwnd: null, elementName: "test-element" },
+    dirtyRectsByMonitor: new Map([[0, 1]]),
+    latestEventId: 100n,
+    queryWallclockMs: Date.now(),
+  };
+}
+
+describe("expansion swimlane 1 (browser_fill): wrap → L1 events recorded", () => {
+  it("makeCommitWrapper flow 通過、両 event push、lease_token undefined", async () => {
+    resetAll();
+    const events: Array<{ kind: "started" | "completed"; tool: string; leaseToken?: unknown }> = [];
+    const fakeEmitter: CommitL1Emitter = {
+      pushStarted: ({ tool, sessionId, toolCallId, leaseToken }) => {
+        events.push({ kind: "started", tool, leaseToken });
+        defaultL1Emitter.pushStarted({ tool, argsJson: "{}", sessionId, toolCallId, leaseToken });
+      },
+      pushCompleted: ({ tool, elapsedMs, ok, errorCode, sessionId, toolCallId }) => {
+        events.push({ kind: "completed", tool });
+        defaultL1Emitter.pushCompleted({ tool, elapsedMs, ok, errorCode, sessionId, toolCallId });
+      },
+    };
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"selector":"#input","actual":"hello"}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "browser_fill", { l1Emitter: fakeEmitter });
+    const result = await wrapped({
+      selector: "#input",
+      value: "hello",
+      port: 9222,
+    } as Record<string, unknown>);
+    expect(events).toHaveLength(2);
+    expect(events[0].tool).toBe("browser_fill");
+    expect(events[0].leaseToken).toBeUndefined();
+    expect(events[1].kind).toBe("completed");
+    expect(result.content).toBeDefined();
+  });
+});
+
+describe("expansion swimlane 1 (browser_fill): include 未指定時 raw shape return", () => {
+  it("default 経路 → envelope shape を hoist して raw client 互換", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"actual":"hello"}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "browser_fill", {});
+    const result = await wrapped({
+      selector: "#input",
+      value: "hello",
+      port: 9222,
+    } as Record<string, unknown>);
+    const text = (result.content[0] as { text: string }).text;
+    const parsed = JSON.parse(text);
+    expect(parsed._version).toBeUndefined();
+    expect(parsed.ok).toBe(true);
+    expect(parsed.actual).toBe("hello");
+  });
+});
+
+describe("expansion swimlane 1 (browser_fill): include=causal で caused_by.your_last_action に browser_fill 記録", () => {
+  it("browser_fill wrap → history buffer に entry → buildCausedBy で your_last_action = browser_fill(...)", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "browser_fill", {
+      getSessionId: () => "sessBF",
+    });
+    await wrapped({
+      selector: "#input",
+      value: "x",
+      port: 9222,
+    } as Record<string, unknown>);
+    const causedBy = buildCausedBy("sessBF", makeViewSnapshot());
+    expect(causedBy).toBeDefined();
+    expect(causedBy?.your_last_action).toContain("browser_fill");
+    expect(causedBy?.tool_call_id).toMatch(/^sessBF:\d+$/);
+    const basedOn = buildBasedOn("sessBF", makeViewSnapshot());
+    expect(basedOn).toBeDefined();
+    if (basedOn?.events && basedOn.events.length > 0) {
+      expect(typeof basedOn.events[0]).toBe("string");
+    }
+  });
+});
+
+describe("expansion swimlane 1 (browser_fill): trunk completion contract — mechanical copy", () => {
+  it("S5 contract が browser_fill wrap でそのまま機能", async () => {
+    resetAll();
+    const handler = vi.fn(async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    }));
+    const wrapped = makeCommitWrapper(handler, "browser_fill", {});
+    const result = await wrapped({
+      selector: "#input",
+      value: "x",
+      port: 9222,
+    } as Record<string, unknown>);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(result.content).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

`browser_fill` を `makeCommitWrapper` で wrap (lease-less commit variant)。PR #134 browser_open / PR #135 browser_navigate / PR #136 browser_click 同型 pattern (raw shape 3a)。pre-expansion で bare handler 直渡しだったため withPostState 経由で post.* block 追加の behavior 変化あり (additive、互換維持)。

## scope

- \`src/tools/browser.ts\`: module-scope \`browserFillRegistrationHandler\` + \`browserFillRegistrationSchema\` export、\`server.tool\` の 3rd arg を切替。
- \`src/tools/macro.ts\`: \`TOOL_REGISTRY.browser_fill\` を shared instance に切替 (PR #112 pattern)。
- \`tests/unit/expansion-browser-fill-wrapper.test.ts\`: 4 contract tests (E1-E4)。
- \`src/stub-tool-catalog.ts\`: 再生成差分 (\`include\` field 追加)。

## Test plan

- [x] \`npm run build\` (tsc) green
- [x] \`npm run check:stub-catalog\`
- [x] \`npm run check:expansion-disjoint\` OK
- [x] \`npx vitest run tests/unit/expansion-browser-fill-wrapper.test.ts\` 4/4 pass
- [ ] CI Linux で trunk lock layer 改変ゼロ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)