### PR TITLE
feat(expansion): browser_form commit wrapper (L5 envelope)

### DIFF
--- a/src/stub-tool-catalog.ts
+++ b/src/stub-tool-catalog.ts
@@ -287,6 +287,13 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
           "type": "boolean",
           "default": true,
           "description": "When true, append activeTab and readyState context to the response."
+        },
+        "include": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
         }
       },
       "additionalProperties": false,

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -2159,6 +2159,31 @@ export const browserFillRegistrationHandler = makeCommitWrapper(
   },
 );
 
+/**
+ * Walking skeleton expansion phase swimlane 1 (L5 commit tool wrapper):
+ * `browser_form` is wrapped via `makeCommitWrapper` (lease-less commit
+ * variant). Per `docs/walking-skeleton-expansion-plan.md` §2.1 line 38、
+ * browser_form は swimlane 1 (commit) に分類される (form inspection は
+ * read-only だが、L1 ToolCall event 記録 + envelope hoist の対象として
+ * commit pipeline に乗せる方針)。PR #134 browser_open / PR #135 browser_navigate
+ * / PR #136 browser_click / PR #137 browser_fill 同型 pattern (raw shape 3a
+ * family、windowTitleKey 省略 — browser targets a CDP tab not a Win32 window)。
+ */
+export const browserFormRegistrationSchema = withEnvelopeIncludeSchema(browserGetFormSchema);
+
+export const browserFormRegistrationHandler = makeCommitWrapper(
+  withRichNarration(
+    "browser_form",
+    browserGetFormHandler as (args: Record<string, unknown>) => Promise<ToolResult>,
+    {},
+  ) as (args: Record<string, unknown>) => Promise<ToolResult>,
+  "browser_form",
+  {
+    // leaseValidator omitted = lease-less commit variant
+    // getSessionId / argsSummary / clock も default 利用 = mechanical コピー最小
+  },
+);
+
 export function registerBrowserTools(server: McpServer): void {
   // Wire wait_until(element_matches) — resolve top result for callers that just need selector + text.
   setBrowserSearchHook(async ({ port, tabId, by, pattern, scope }) => {
@@ -2260,7 +2285,7 @@ export function registerBrowserTools(server: McpServer): void {
   server.tool(
     "browser_form",
     "Inspect all form fields (input, select, textarea, button) within a CSS-selector-specified container and return their name, type, id, current value, hint text, disabled/readOnly state, and associated label text (resolved via for[id], ancestor LABEL, aria-labelledby, aria-label in that order). Use this before browser_fill to discover exact field selectors and avoid accidentally targeting the wrong input (e.g. a global search bar). Caveats: Requires browser_open (CDP active). Hidden inputs (type=hidden) are excluded by default — set includeHidden:true if needed. Value text is truncated at 200 chars.",
-    browserGetFormSchema,
-    browserGetFormHandler
+    browserFormRegistrationSchema,
+    browserFormRegistrationHandler as typeof browserGetFormHandler
   );
 }

--- a/src/tools/macro.ts
+++ b/src/tools/macro.ts
@@ -92,7 +92,9 @@ import {
   browserFillInputHandler,
   browserFillRegistrationSchema,
   browserFillRegistrationHandler,
-  browserGetFormHandler, browserGetFormSchema,
+  browserGetFormHandler,
+  browserFormRegistrationSchema,
+  browserFormRegistrationHandler,
 } from "./browser.js";
 // Notification (server_status not callable from macros — diagnostic)
 import {
@@ -234,7 +236,11 @@ const TOOL_REGISTRY: Record<string, ToolEntry> = {
   // server.tool 経路と同 instance を共有 (PR #112 shared registration handler
   // pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
   browser_fill:         { schema: z.object(browserFillRegistrationSchema), handler: browserFillRegistrationHandler as typeof browserFillInputHandler },
-  browser_form:         { schema: z.object(browserGetFormSchema),      handler: browserGetFormHandler },
+  // Walking skeleton expansion swimlane 1 (L5 commit wrapper): use the
+  // module-scope wrapped handler from browser.ts so run_macro 経路は
+  // server.tool 経路と同 instance を共有 (PR #112 shared registration handler
+  // pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
+  browser_form:         { schema: z.object(browserFormRegistrationSchema), handler: browserFormRegistrationHandler as typeof browserGetFormHandler },
   // Workspace / wait / notification
   workspace_snapshot:   { schema: z.object(workspaceSnapshotSchema),   handler: workspaceSnapshotHandler },
   // Walking skeleton expansion swimlane 1 (L5 commit wrapper): use the

--- a/tests/unit/expansion-browser-form-wrapper.test.ts
+++ b/tests/unit/expansion-browser-form-wrapper.test.ts
@@ -1,0 +1,122 @@
+/**
+ * expansion-browser-form-wrapper.test.ts — walking skeleton expansion phase
+ * swimlane 1 (L5 commit tool wrapper) contract test.
+ * Mechanical copy of PR #134 browser_open / PR #135 browser_navigate /
+ * PR #136 browser_click pattern.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  makeCommitWrapper,
+  defaultL1Emitter,
+  buildCausedBy,
+  buildBasedOn,
+  _resetHistoryBuffersForTest,
+  _resetToolCallSeqForTest,
+  type CommitL1Emitter,
+  type ViewSnapshot,
+} from "../../src/tools/_envelope.js";
+
+function resetAll(): void {
+  _resetHistoryBuffersForTest();
+  _resetToolCallSeqForTest();
+}
+
+function makeViewSnapshot(): ViewSnapshot {
+  return {
+    focus: { hwnd: null, elementName: "test-element" },
+    dirtyRectsByMonitor: new Map([[0, 1]]),
+    latestEventId: 100n,
+    queryWallclockMs: Date.now(),
+  };
+}
+
+describe("expansion swimlane 1 (browser_form): wrap → L1 events recorded", () => {
+  it("makeCommitWrapper flow 通過、両 event push、lease_token undefined", async () => {
+    resetAll();
+    const events: Array<{ kind: "started" | "completed"; tool: string; leaseToken?: unknown }> = [];
+    const fakeEmitter: CommitL1Emitter = {
+      pushStarted: ({ tool, sessionId, toolCallId, leaseToken }) => {
+        events.push({ kind: "started", tool, leaseToken });
+        defaultL1Emitter.pushStarted({ tool, argsJson: "{}", sessionId, toolCallId, leaseToken });
+      },
+      pushCompleted: ({ tool, elapsedMs, ok, errorCode, sessionId, toolCallId }) => {
+        events.push({ kind: "completed", tool });
+        defaultL1Emitter.pushCompleted({ tool, elapsedMs, ok, errorCode, sessionId, toolCallId });
+      },
+    };
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"fields":[]}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "browser_form", { l1Emitter: fakeEmitter });
+    const result = await wrapped({
+      selector: "form",
+      port: 9222,
+    } as Record<string, unknown>);
+    expect(events).toHaveLength(2);
+    expect(events[0].tool).toBe("browser_form");
+    expect(events[0].leaseToken).toBeUndefined();
+    expect(events[1].kind).toBe("completed");
+    expect(result.content).toBeDefined();
+  });
+});
+
+describe("expansion swimlane 1 (browser_form): include 未指定時 raw shape return", () => {
+  it("default 経路 → envelope shape を hoist して raw client 互換", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"fields":[]}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "browser_form", {});
+    const result = await wrapped({
+      selector: "form",
+      port: 9222,
+    } as Record<string, unknown>);
+    const text = (result.content[0] as { text: string }).text;
+    const parsed = JSON.parse(text);
+    expect(parsed._version).toBeUndefined();
+    expect(parsed.ok).toBe(true);
+    expect(Array.isArray(parsed.fields)).toBe(true);
+  });
+});
+
+describe("expansion swimlane 1 (browser_form): include=causal で caused_by.your_last_action に browser_form 記録", () => {
+  it("browser_form wrap → history buffer に entry → buildCausedBy で your_last_action = browser_form(...)", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "browser_form", {
+      getSessionId: () => "sessBM",
+    });
+    await wrapped({
+      selector: "form",
+      port: 9222,
+    } as Record<string, unknown>);
+    const causedBy = buildCausedBy("sessBM", makeViewSnapshot());
+    expect(causedBy).toBeDefined();
+    expect(causedBy?.your_last_action).toContain("browser_form");
+    expect(causedBy?.tool_call_id).toMatch(/^sessBM:\d+$/);
+    const basedOn = buildBasedOn("sessBM", makeViewSnapshot());
+    expect(basedOn).toBeDefined();
+    if (basedOn?.events && basedOn.events.length > 0) {
+      expect(typeof basedOn.events[0]).toBe("string");
+    }
+  });
+});
+
+describe("expansion swimlane 1 (browser_form): trunk completion contract — mechanical copy", () => {
+  it("S5 contract が browser_form wrap でそのまま機能", async () => {
+    resetAll();
+    const handler = vi.fn(async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    }));
+    const wrapped = makeCommitWrapper(handler, "browser_form", {});
+    const result = await wrapped({
+      selector: "form",
+      port: 9222,
+    } as Record<string, unknown>);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(result.content).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

`browser_form` を `makeCommitWrapper` で wrap (lease-less commit variant)。expansion-plan §2.1 line 38 で swimlane 1 (commit) 分類のため、form inspection の read-only にも commit pipeline (L1 event 記録 + envelope) を適用。PR #134 browser_open / PR #135 browser_navigate / PR #136 browser_click 同型 pattern (raw shape 3a family)。

## scope

- \`src/tools/browser.ts\`: module-scope \`browserFormRegistrationHandler\` + \`browserFormRegistrationSchema\` export、\`server.tool\` の 3rd arg を切替。
- \`src/tools/macro.ts\`: \`TOOL_REGISTRY.browser_form\` を shared instance に切替 (PR #112 pattern)。
- \`tests/unit/expansion-browser-form-wrapper.test.ts\`: 4 contract tests (E1-E4)。
- \`src/stub-tool-catalog.ts\`: 再生成差分 (\`include\` field 追加)。

## Test plan

- [x] \`npm run build\` (tsc) green
- [x] \`npm run check:stub-catalog\`
- [x] \`npm run check:expansion-disjoint\` OK
- [x] \`npx vitest run tests/unit/expansion-browser-form-wrapper.test.ts\` 4/4 pass
- [ ] CI Linux で trunk lock layer 改変ゼロ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)