### PR TITLE
feat(expansion): browser_eval commit/dual wrapper (L5 envelope)

### DIFF
--- a/src/stub-tool-catalog.ts
+++ b/src/stub-tool-catalog.ts
@@ -115,6 +115,13 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
               "type": "boolean",
               "default": true,
               "description": "When true, append activeTab and readyState context to the response."
+            },
+            "include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
             }
           },
           "additionalProperties": false,
@@ -155,6 +162,13 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
               "type": "boolean",
               "default": true,
               "description": "When true, append activeTab and readyState context to the response."
+            },
+            "include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
             }
           },
           "additionalProperties": false,
@@ -194,6 +208,13 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
               "type": "boolean",
               "default": true,
               "description": "When true, append activeTab and readyState context to the response."
+            },
+            "include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
             }
           },
           "additionalProperties": false,

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -24,7 +24,7 @@ import { fail } from "./_types.js";
 import { setBrowserSearchHook } from "./wait-until.js";
 import { withPostState } from "./_post.js";
 import { narrateParam, withRichNarration } from "./_narration.js";
-import { makeCommitWrapper, withEnvelopeIncludeSchema } from "./_envelope.js";
+import { makeCommitWrapper, withEnvelopeIncludeSchema, withEnvelopeIncludeForUnion } from "./_envelope.js";
 import type { RichBlock } from "../engine/uia-diff.js";
 import { evaluatePreToolGuards, buildEnvelopeFor } from "../engine/perception/registry.js";
 import { runActionGuard, isAutoGuardEnabled, validateAndPrepareFix, consumeFix } from "./_action-guard.js";
@@ -2184,6 +2184,32 @@ export const browserFormRegistrationHandler = makeCommitWrapper(
   },
 );
 
+/**
+ * Walking skeleton expansion phase swimlane 1 (L5 commit tool wrapper):
+ * `browser_eval` is wrapped via `makeCommitWrapper` (lease-less commit
+ * variant、discriminatedUnion 3b family — actions: js / dom / appState)。
+ * 'js' / 'dom' は side-effecting でない読み取り、'appState' は SPA 状態
+ * extraction で commit pipeline 適用 (form inspection 同様 read-only でも
+ * L1 event 記録目的)。expansion plan §2.1 line 38 で commit (dual) 分類。
+ * PR #126 clipboard / PR #127 scroll / PR #131 window_dock / PR #132
+ * terminal の discriminatedUnion 3b family 同型 (windowTitleKey 省略 —
+ * browser CDP tab; pre-expansion `withPostState` 直 wrap を置換)。
+ */
+export const browserEvalRegistrationSchema = withEnvelopeIncludeForUnion(browserEvalSchema);
+
+export const browserEvalRegistrationHandler = makeCommitWrapper(
+  withRichNarration(
+    "browser_eval",
+    browserEvalHandler as (args: Record<string, unknown>) => Promise<ToolResult>,
+    {},
+  ) as (args: Record<string, unknown>) => Promise<ToolResult>,
+  "browser_eval",
+  {
+    // leaseValidator omitted = lease-less commit variant
+    // getSessionId / argsSummary / clock も default 利用 = mechanical コピー最小
+  },
+);
+
 export function registerBrowserTools(server: McpServer): void {
   // Wire wait_until(element_matches) — resolve top result for callers that just need selector + text.
   setBrowserSearchHook(async ({ port, tabId, by, pattern, scope }) => {
@@ -2263,9 +2289,9 @@ export function registerBrowserTools(server: McpServer): void {
           "browser_eval({action:'appState'}) → default SPA state probes",
         ],
       }),
-      inputSchema: browserEvalSchema,
+      inputSchema: browserEvalRegistrationSchema,
     },
-    withPostState("browser_eval", browserEvalHandler as (args: Record<string, unknown>) => Promise<ToolResult>)
+    browserEvalRegistrationHandler as (args: Record<string, unknown>) => Promise<ToolResult>
   );
 
   server.tool(

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -22,7 +22,6 @@ import { resolveWellKnownPath, spawnDetached, killProcessesByName } from "../uti
 import { getCdpPort } from "../utils/desktop-config.js";
 import { fail } from "./_types.js";
 import { setBrowserSearchHook } from "./wait-until.js";
-import { withPostState } from "./_post.js";
 import { narrateParam, withRichNarration } from "./_narration.js";
 import { makeCommitWrapper, withEnvelopeIncludeSchema, withEnvelopeIncludeForUnion } from "./_envelope.js";
 import type { RichBlock } from "../engine/uia-diff.js";

--- a/src/tools/macro.ts
+++ b/src/tools/macro.ts
@@ -79,7 +79,9 @@ import {
   browserOpenHandler,
   browserOpenRegistrationSchema,
   browserOpenRegistrationHandler,
-  browserEvalHandler, browserEvalSchema,
+  browserEvalHandler,
+  browserEvalRegistrationSchema,
+  browserEvalRegistrationHandler,
   browserSearchHandler, browserSearchSchema,
   browserGetInteractiveHandler, browserGetInteractiveSchema,
   browserFindElementHandler, browserFindElementSchema,
@@ -221,7 +223,11 @@ const TOOL_REGISTRY: Record<string, ToolEntry> = {
   // server.tool 経路と同 instance を共有 (PR #112 shared registration handler
   // pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
   browser_open:         { schema: z.object(browserOpenRegistrationSchema), handler: browserOpenRegistrationHandler as typeof browserOpenHandler },
-  browser_eval:         { schema: browserEvalSchema,                   handler: browserEvalHandler },
+  // Walking skeleton expansion swimlane 1 (L5 commit wrapper、discriminatedUnion):
+  // use the module-scope wrapped handler from browser.ts so run_macro 経路は
+  // server.registerTool 経路と同 instance を共有 (PR #112 shared registration
+  // handler pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
+  browser_eval:         { schema: browserEvalRegistrationSchema,         handler: browserEvalRegistrationHandler as typeof browserEvalHandler },
   browser_search:       { schema: z.object(browserSearchSchema),       handler: browserSearchHandler },
   browser_overview:     { schema: z.object(browserGetInteractiveSchema), handler: browserGetInteractiveHandler },
   browser_locate:       { schema: z.object(browserFindElementSchema),  handler: browserFindElementHandler },

--- a/tests/unit/expansion-browser-eval-wrapper.test.ts
+++ b/tests/unit/expansion-browser-eval-wrapper.test.ts
@@ -1,0 +1,125 @@
+/**
+ * expansion-browser-eval-wrapper.test.ts — walking skeleton expansion phase
+ * swimlane 1 (L5 commit tool wrapper) contract test.
+ * Mechanical copy of PR #131 window_dock / PR #132 terminal pattern
+ * (discriminatedUnion 3b family、3 actions: js / dom / appState).
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  makeCommitWrapper,
+  defaultL1Emitter,
+  buildCausedBy,
+  buildBasedOn,
+  _resetHistoryBuffersForTest,
+  _resetToolCallSeqForTest,
+  type CommitL1Emitter,
+  type ViewSnapshot,
+} from "../../src/tools/_envelope.js";
+
+function resetAll(): void {
+  _resetHistoryBuffersForTest();
+  _resetToolCallSeqForTest();
+}
+
+function makeViewSnapshot(): ViewSnapshot {
+  return {
+    focus: { hwnd: null, elementName: "test-element" },
+    dirtyRectsByMonitor: new Map([[0, 1]]),
+    latestEventId: 100n,
+    queryWallclockMs: Date.now(),
+  };
+}
+
+describe("expansion swimlane 1 (browser_eval): wrap → L1 events recorded", () => {
+  it("makeCommitWrapper flow 通過、両 event push、lease_token undefined", async () => {
+    resetAll();
+    const events: Array<{ kind: "started" | "completed"; tool: string; leaseToken?: unknown }> = [];
+    const fakeEmitter: CommitL1Emitter = {
+      pushStarted: ({ tool, sessionId, toolCallId, leaseToken }) => {
+        events.push({ kind: "started", tool, leaseToken });
+        defaultL1Emitter.pushStarted({ tool, argsJson: "{}", sessionId, toolCallId, leaseToken });
+      },
+      pushCompleted: ({ tool, elapsedMs, ok, errorCode, sessionId, toolCallId }) => {
+        events.push({ kind: "completed", tool });
+        defaultL1Emitter.pushCompleted({ tool, elapsedMs, ok, errorCode, sessionId, toolCallId });
+      },
+    };
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"result":"page title"}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "browser_eval", { l1Emitter: fakeEmitter });
+    const result = await wrapped({
+      action: "js",
+      expression: "document.title",
+      port: 9222,
+    } as Record<string, unknown>);
+    expect(events).toHaveLength(2);
+    expect(events[0].tool).toBe("browser_eval");
+    expect(events[0].leaseToken).toBeUndefined();
+    expect(events[1].kind).toBe("completed");
+    expect(result.content).toBeDefined();
+  });
+});
+
+describe("expansion swimlane 1 (browser_eval): include 未指定時 raw shape return", () => {
+  it("default 経路 → envelope shape を hoist して raw client 互換", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"result":"page title"}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "browser_eval", {});
+    const result = await wrapped({
+      action: "js",
+      expression: "document.title",
+      port: 9222,
+    } as Record<string, unknown>);
+    const text = (result.content[0] as { text: string }).text;
+    const parsed = JSON.parse(text);
+    expect(parsed._version).toBeUndefined();
+    expect(parsed.ok).toBe(true);
+    expect(parsed.result).toBe("page title");
+  });
+});
+
+describe("expansion swimlane 1 (browser_eval): include=causal で caused_by.your_last_action に browser_eval 記録", () => {
+  it("browser_eval wrap → history buffer に entry → buildCausedBy で your_last_action = browser_eval(...)", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "browser_eval", {
+      getSessionId: () => "sessBE",
+    });
+    await wrapped({
+      action: "appState",
+      port: 9222,
+    } as Record<string, unknown>);
+    const causedBy = buildCausedBy("sessBE", makeViewSnapshot());
+    expect(causedBy).toBeDefined();
+    expect(causedBy?.your_last_action).toContain("browser_eval");
+    expect(causedBy?.tool_call_id).toMatch(/^sessBE:\d+$/);
+    const basedOn = buildBasedOn("sessBE", makeViewSnapshot());
+    expect(basedOn).toBeDefined();
+    if (basedOn?.events && basedOn.events.length > 0) {
+      expect(typeof basedOn.events[0]).toBe("string");
+    }
+  });
+});
+
+describe("expansion swimlane 1 (browser_eval): trunk completion contract — mechanical copy", () => {
+  it("S5 contract が browser_eval wrap でそのまま機能", async () => {
+    resetAll();
+    const handler = vi.fn(async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    }));
+    const wrapped = makeCommitWrapper(handler, "browser_eval", {});
+    const result = await wrapped({
+      action: "dom",
+      selector: "#main",
+      port: 9222,
+    } as Record<string, unknown>);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(result.content).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

`browser_eval` を `makeCommitWrapper` で wrap (lease-less commit variant、discriminatedUnion 3b family — 3 actions: js / dom / appState)。expansion plan §2.1 line 38 で commit (dual) 分類。windowTitleKey 省略 (browser CDP tab)。pre-expansion \`withPostState\` 直 wrap を置換。

## scope

- \`src/tools/browser.ts\`: module-scope \`browserEvalRegistrationHandler\` + \`browserEvalRegistrationSchema = withEnvelopeIncludeForUnion(browserEvalSchema)\` export、\`server.registerTool\` の inputSchema を切替、handler を切替。
- \`src/tools/macro.ts\`: \`TOOL_REGISTRY.browser_eval\` を shared instance に切替 (discriminatedUnion 系のため z.object() ラップ不要)。
- \`tests/unit/expansion-browser-eval-wrapper.test.ts\`: 4 contract tests (E1-E4)。
- \`src/stub-tool-catalog.ts\`: 再生成差分 (3 variants × \`include\` field 追加: js / dom / appState)。

## Test plan

- [x] \`npm run build\` (tsc) green
- [x] \`npm run check:stub-catalog\`
- [x] \`npm run check:expansion-disjoint\` OK
- [x] \`npx vitest run tests/unit/expansion-browser-eval-wrapper.test.ts\` 4/4 pass
- [ ] CI Linux で trunk lock layer 改変ゼロ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)