### PR TITLE
feat(expansion): browser_overview query wrapper (L5 envelope)

### DIFF
--- a/src/stub-tool-catalog.ts
+++ b/src/stub-tool-catalog.ts
@@ -532,6 +532,13 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
           "type": "boolean",
           "default": true,
           "description": "When true, append activeTab and readyState context to the response."
+        },
+        "include": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
         }
       },
       "additionalProperties": false

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -23,7 +23,7 @@ import { getCdpPort } from "../utils/desktop-config.js";
 import { fail } from "./_types.js";
 import { setBrowserSearchHook } from "./wait-until.js";
 import { narrateParam, withRichNarration } from "./_narration.js";
-import { makeCommitWrapper, withEnvelopeIncludeSchema, withEnvelopeIncludeForUnion } from "./_envelope.js";
+import { makeCommitWrapper, makeQueryWrapper, withEnvelopeIncludeSchema, withEnvelopeIncludeForUnion } from "./_envelope.js";
 import type { RichBlock } from "../engine/uia-diff.js";
 import { evaluatePreToolGuards, buildEnvelopeFor } from "../engine/perception/registry.js";
 import { runActionGuard, isAutoGuardEnabled, validateAndPrepareFix, consumeFix } from "./_action-guard.js";
@@ -2209,6 +2209,26 @@ export const browserEvalRegistrationHandler = makeCommitWrapper(
   },
 );
 
+/**
+ * Walking skeleton expansion phase swimlane 2 (L5 query tool wrapper):
+ * `browser_overview` is wrapped via `makeQueryWrapper` (S4 query-axis wrapper).
+ * browser_overview は read-only (interactive elements list) のため query 軸が
+ * 正しい — L1 ToolCallStarted/Completed events は commit-axis 専用で本 PR では
+ * 発行しない。S5 caused_by linkage は本 PR で wire しない (causedByProjector
+ * 省略 → makeQueryWrapper の S4 fast path、PR #122 screenshot 同型)。
+ *
+ * `include=["envelope"]` per-call opt-in + env `DESKTOP_TOUCH_ENVELOPE=1`
+ * server default は機能、`include=["causal"]` は envelope shape を返すが
+ * `caused_by` projection なし (S4-default behaviour for tools not yet wired
+ * with causedByProjector)。
+ */
+export const browserOverviewRegistrationSchema = withEnvelopeIncludeSchema(browserGetInteractiveSchema);
+
+export const browserOverviewRegistrationHandler = makeQueryWrapper(
+  browserGetInteractiveHandler as (args: Record<string, unknown>) => Promise<ToolResult>,
+  "browser_overview",
+);
+
 export function registerBrowserTools(server: McpServer): void {
   // Wire wait_until(element_matches) — resolve top result for callers that just need selector + text.
   setBrowserSearchHook(async ({ port, tabId, by, pattern, scope }) => {
@@ -2236,8 +2256,8 @@ export function registerBrowserTools(server: McpServer): void {
   server.tool(
     "browser_overview",
     "List all interactive elements (links, buttons, inputs, ARIA controls) on the current page with CSS selectors, visible text or value for inputs, and viewport status — use before browser_click to discover stable selectors, and prefer this over screenshot when verifying button/toggle state after submission (no image tokens, structured output). scope limits to a CSS subsection (e.g. '.sidebar'). Returns state (checked/pressed/selected/expanded) for ARIA custom controls. Caveats: Selectors are CDP-generated snapshots — re-call after page navigates or re-renders. Input text reflects the empty-field hint text when defined (takes priority over typed value) — use browser_eval('document.querySelector(sel).value') to read actual typed content.",
-    browserGetInteractiveSchema,
-    browserGetInteractiveHandler
+    browserOverviewRegistrationSchema,
+    browserOverviewRegistrationHandler as typeof browserGetInteractiveHandler
   );
 
   server.tool(

--- a/src/tools/macro.ts
+++ b/src/tools/macro.ts
@@ -83,7 +83,9 @@ import {
   browserEvalRegistrationSchema,
   browserEvalRegistrationHandler,
   browserSearchHandler, browserSearchSchema,
-  browserGetInteractiveHandler, browserGetInteractiveSchema,
+  browserGetInteractiveHandler,
+  browserOverviewRegistrationSchema,
+  browserOverviewRegistrationHandler,
   browserFindElementHandler, browserFindElementSchema,
   browserClickElementHandler,
   browserClickRegistrationSchema,
@@ -229,7 +231,11 @@ const TOOL_REGISTRY: Record<string, ToolEntry> = {
   // handler pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
   browser_eval:         { schema: browserEvalRegistrationSchema,         handler: browserEvalRegistrationHandler as typeof browserEvalHandler },
   browser_search:       { schema: z.object(browserSearchSchema),       handler: browserSearchHandler },
-  browser_overview:     { schema: z.object(browserGetInteractiveSchema), handler: browserGetInteractiveHandler },
+  // Walking skeleton expansion swimlane 2 (L5 query wrapper): use the
+  // module-scope wrapped handler from browser.ts so run_macro 経路は
+  // server.tool 経路と同 instance を共有 (PR #112 shared registration handler
+  // pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
+  browser_overview:     { schema: z.object(browserOverviewRegistrationSchema), handler: browserOverviewRegistrationHandler as typeof browserGetInteractiveHandler },
   browser_locate:       { schema: z.object(browserFindElementSchema),  handler: browserFindElementHandler },
   // Walking skeleton expansion swimlane 1 (L5 commit wrapper): use the
   // module-scope wrapped handler from browser.ts so run_macro 経路は

--- a/tests/unit/expansion-browser-overview-wrapper.test.ts
+++ b/tests/unit/expansion-browser-overview-wrapper.test.ts
@@ -1,0 +1,91 @@
+/**
+ * expansion-browser-overview-wrapper.test.ts — walking skeleton expansion
+ * phase swimlane 2 (L5 query tool wrapper) contract test.
+ * Mechanical copy of PR #122 screenshot pattern (S4 query-axis wrapper).
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  makeQueryWrapper,
+  _resetHistoryBuffersForTest,
+  _resetToolCallSeqForTest,
+} from "../../src/tools/_envelope.js";
+
+function resetAll(): void {
+  _resetHistoryBuffersForTest();
+  _resetToolCallSeqForTest();
+}
+
+describe("expansion swimlane 2 (browser_overview): query wrapper raw shape default", () => {
+  it("default 経路 → envelope shape を hoist して raw client 互換", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"actionable":[{"selector":"#btn","name":"Submit"}]}' }],
+    });
+    const wrapped = makeQueryWrapper(handler, "browser_overview");
+    const result = await wrapped({
+      port: 9222,
+    } as Record<string, unknown>);
+    const text = (result.content[0] as { text: string }).text;
+    const parsed = JSON.parse(text);
+    expect(parsed._version).toBeUndefined();
+    expect(parsed.ok).toBe(true);
+    expect(Array.isArray(parsed.actionable)).toBe(true);
+  });
+});
+
+describe("expansion swimlane 2 (browser_overview): include=envelope returns envelope shape", () => {
+  it("include=[envelope] → _version + data + as_of + confidence 4 fields", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"actionable":[]}' }],
+    });
+    const wrapped = makeQueryWrapper(handler, "browser_overview");
+    const result = await wrapped({
+      port: 9222,
+      include: ["envelope"],
+    } as Record<string, unknown>);
+    const text = (result.content[0] as { text: string }).text;
+    const parsed = JSON.parse(text);
+    expect(parsed._version).toBe("1.0");
+    expect(parsed.data).toBeDefined();
+    expect(parsed.as_of).toBeDefined();
+    expect(parsed.confidence).toBeDefined();
+  });
+});
+
+describe("expansion swimlane 2 (browser_overview): query wrapper does NOT emit L1 events", () => {
+  it("query-axis = read-only、L1 ToolCallStarted/Completed events 不発", async () => {
+    resetAll();
+    let pushedAny = false;
+    const handler = async () => {
+      pushedAny = true;
+      return { content: [{ type: "text", text: '{"ok":true}' }] };
+    };
+    const wrapped = makeQueryWrapper(handler, "browser_overview");
+    await wrapped({
+      port: 9222,
+    } as Record<string, unknown>);
+    expect(pushedAny).toBe(true);
+    // makeQueryWrapper does NOT call CommitL1Emitter — only commit wrappers do
+  });
+});
+
+describe("expansion swimlane 2 (browser_overview): trunk completion contract — mechanical copy", () => {
+  it("S4 fast path (causedByProjector 省略) で envelope shape return only", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    });
+    const wrapped = makeQueryWrapper(handler, "browser_overview");
+    const result = await wrapped({
+      port: 9222,
+      include: ["envelope"],
+    } as Record<string, unknown>);
+    const text = (result.content[0] as { text: string }).text;
+    const parsed = JSON.parse(text);
+    // S4 fast path: caused_by が含まれず、_version + data + as_of + confidence のみ
+    expect(parsed._version).toBe("1.0");
+    expect(parsed.caused_by).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

`browser_overview` を `makeQueryWrapper` で wrap (S4 query-axis wrapper)。PR #122 screenshot 同型 pattern (read-only observation、L1 events 不発、S5 caused_by linkage は未 wire = causedByProjector 省略 fast path)。

## scope

- \`src/tools/browser.ts\`: module-scope \`browserOverviewRegistrationHandler\` + \`browserOverviewRegistrationSchema = withEnvelopeIncludeSchema(browserGetInteractiveSchema)\` export、\`server.tool\` の 3rd arg を切替。
- \`src/tools/macro.ts\`: \`TOOL_REGISTRY.browser_overview\` を shared instance に切替。
- \`tests/unit/expansion-browser-overview-wrapper.test.ts\`: 4 contract tests。
- \`src/stub-tool-catalog.ts\`: 再生成差分 (\`include\` field 追加)。

## Test plan

- [x] \`npm run build\` (tsc) green
- [x] \`npm run check:stub-catalog\`
- [x] \`npm run check:expansion-disjoint\` OK
- [x] \`npx vitest run tests/unit/expansion-browser-overview-wrapper.test.ts\` 4/4 pass
- [ ] CI Linux で trunk lock layer 改変ゼロ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)