### PR TITLE
feat(expansion): browser_locate query wrapper (L5 envelope)

### DIFF
--- a/src/stub-tool-catalog.ts
+++ b/src/stub-tool-catalog.ts
@@ -348,6 +348,13 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
           "type": "boolean",
           "default": true,
           "description": "When true, append activeTab and readyState context to the response."
+        },
+        "include": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
         }
       },
       "additionalProperties": false,

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -2229,6 +2229,19 @@ export const browserOverviewRegistrationHandler = makeQueryWrapper(
   "browser_overview",
 );
 
+/**
+ * Walking skeleton expansion phase swimlane 2 (L5 query tool wrapper):
+ * `browser_locate` is wrapped via `makeQueryWrapper`. PR #122 screenshot /
+ * PR #140 browser_overview 同型 pattern (read-only DOM lookup、coordinate
+ * extraction、L1 events 不発、causedByProjector 省略 fast path)。
+ */
+export const browserLocateRegistrationSchema = withEnvelopeIncludeSchema(browserFindElementSchema);
+
+export const browserLocateRegistrationHandler = makeQueryWrapper(
+  browserFindElementHandler as (args: Record<string, unknown>) => Promise<ToolResult>,
+  "browser_locate",
+);
+
 export function registerBrowserTools(server: McpServer): void {
   // Wire wait_until(element_matches) — resolve top result for callers that just need selector + text.
   setBrowserSearchHook(async ({ port, tabId, by, pattern, scope }) => {
@@ -2274,8 +2287,8 @@ export function registerBrowserTools(server: McpServer): void {
   server.tool(
     "browser_locate",
     "Find a DOM element by CSS selector and return its physical screen coordinates — compatible directly with mouse_click. Prefer browser_click to find+click in one step. Prefer browser_overview to discover selectors. Caveats: Coordinates are captured at call time; if the page reflows before mouse_click, coords may be stale.",
-    browserFindElementSchema,
-    browserFindElementHandler
+    browserLocateRegistrationSchema,
+    browserLocateRegistrationHandler as typeof browserFindElementHandler
   );
 
   server.tool(

--- a/src/tools/macro.ts
+++ b/src/tools/macro.ts
@@ -86,7 +86,9 @@ import {
   browserGetInteractiveHandler,
   browserOverviewRegistrationSchema,
   browserOverviewRegistrationHandler,
-  browserFindElementHandler, browserFindElementSchema,
+  browserFindElementHandler,
+  browserLocateRegistrationSchema,
+  browserLocateRegistrationHandler,
   browserClickElementHandler,
   browserClickRegistrationSchema,
   browserClickRegistrationHandler,
@@ -236,7 +238,7 @@ const TOOL_REGISTRY: Record<string, ToolEntry> = {
   // server.tool 経路と同 instance を共有 (PR #112 shared registration handler
   // pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
   browser_overview:     { schema: z.object(browserOverviewRegistrationSchema), handler: browserOverviewRegistrationHandler as typeof browserGetInteractiveHandler },
-  browser_locate:       { schema: z.object(browserFindElementSchema),  handler: browserFindElementHandler },
+  browser_locate:       { schema: z.object(browserLocateRegistrationSchema), handler: browserLocateRegistrationHandler as typeof browserFindElementHandler },
   // Walking skeleton expansion swimlane 1 (L5 commit wrapper): use the
   // module-scope wrapped handler from browser.ts so run_macro 経路は
   // server.tool 経路と同 instance を共有 (PR #112 shared registration handler

--- a/tests/unit/expansion-browser-locate-wrapper.test.ts
+++ b/tests/unit/expansion-browser-locate-wrapper.test.ts
@@ -1,0 +1,87 @@
+/**
+ * expansion-browser-locate-wrapper.test.ts — swimlane 2 (L5 query wrapper)
+ * contract test. Mechanical copy of PR #140 browser_overview pattern.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  makeQueryWrapper,
+  _resetHistoryBuffersForTest,
+  _resetToolCallSeqForTest,
+} from "../../src/tools/_envelope.js";
+
+function resetAll(): void {
+  _resetHistoryBuffersForTest();
+  _resetToolCallSeqForTest();
+}
+
+describe("expansion swimlane 2 (browser_locate): query wrapper raw shape default", () => {
+  it("default 経路 → envelope shape を hoist", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"x":100,"y":200}' }],
+    });
+    const wrapped = makeQueryWrapper(handler, "browser_locate");
+    const result = await wrapped({
+      selector: "#btn",
+      port: 9222,
+    } as Record<string, unknown>);
+    const text = (result.content[0] as { text: string }).text;
+    const parsed = JSON.parse(text);
+    expect(parsed._version).toBeUndefined();
+    expect(parsed.ok).toBe(true);
+    expect(parsed.x).toBe(100);
+  });
+});
+
+describe("expansion swimlane 2 (browser_locate): include=envelope returns envelope shape", () => {
+  it("include=[envelope] → 4 fields", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    });
+    const wrapped = makeQueryWrapper(handler, "browser_locate");
+    const result = await wrapped({
+      selector: "#btn",
+      port: 9222,
+      include: ["envelope"],
+    } as Record<string, unknown>);
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed._version).toBe("1.0");
+    expect(parsed.data).toBeDefined();
+    expect(parsed.as_of).toBeDefined();
+    expect(parsed.confidence).toBeDefined();
+  });
+});
+
+describe("expansion swimlane 2 (browser_locate): query wrapper does NOT emit L1 events", () => {
+  it("query-axis = read-only", async () => {
+    resetAll();
+    let invoked = false;
+    const handler = async () => {
+      invoked = true;
+      return { content: [{ type: "text", text: '{"ok":true}' }] };
+    };
+    const wrapped = makeQueryWrapper(handler, "browser_locate");
+    await wrapped({ selector: "#btn", port: 9222 } as Record<string, unknown>);
+    expect(invoked).toBe(true);
+  });
+});
+
+describe("expansion swimlane 2 (browser_locate): trunk completion contract — mechanical copy", () => {
+  it("S4 fast path で envelope shape only (caused_by 不在)", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    });
+    const wrapped = makeQueryWrapper(handler, "browser_locate");
+    const result = await wrapped({
+      selector: "#btn",
+      port: 9222,
+      include: ["envelope"],
+    } as Record<string, unknown>);
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed._version).toBe("1.0");
+    expect(parsed.caused_by).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

`browser_locate` を `makeQueryWrapper` で wrap (S4 query-axis wrapper)。PR #140 browser_overview 同型 pattern。

## scope

- \`src/tools/browser.ts\`: module-scope \`browserLocateRegistrationHandler\` + \`browserLocateRegistrationSchema\` export。
- \`src/tools/macro.ts\`: \`TOOL_REGISTRY.browser_locate\` を shared instance に切替。
- \`tests/unit/expansion-browser-locate-wrapper.test.ts\`: 4 contract tests。
- \`src/stub-tool-catalog.ts\`: 再生成差分 (\`include\` field 追加)。

## Test plan

- [x] \`npm run build\` (tsc) green
- [x] \`npm run check:stub-catalog\`
- [x] \`npm run check:expansion-disjoint\` OK
- [x] \`npx vitest run tests/unit/expansion-browser-locate-wrapper.test.ts\` 4/4 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)