### PR TITLE
feat(expansion): browser_search query wrapper (L5 envelope)

### DIFF
--- a/src/stub-tool-catalog.ts
+++ b/src/stub-tool-catalog.ts
@@ -615,6 +615,13 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
           "maximum": 65535,
           "default": 9222,
           "description": "Chrome/Edge CDP remote debugging port."
+        },
+        "include": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
         }
       },
       "additionalProperties": false,

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -2242,6 +2242,19 @@ export const browserLocateRegistrationHandler = makeQueryWrapper(
   "browser_locate",
 );
 
+/**
+ * Walking skeleton expansion phase swimlane 2 (L5 query tool wrapper):
+ * `browser_search` is wrapped via `makeQueryWrapper`. PR #122 screenshot /
+ * PR #140 browser_overview / PR #141 browser_locate 同型 pattern (read-only
+ * grep-like element lookup、L1 events 不発、causedByProjector 省略 fast path)。
+ */
+export const browserSearchRegistrationSchema = withEnvelopeIncludeSchema(browserSearchSchema);
+
+export const browserSearchRegistrationHandler = makeQueryWrapper(
+  browserSearchHandler as (args: Record<string, unknown>) => Promise<ToolResult>,
+  "browser_search",
+);
+
 export function registerBrowserTools(server: McpServer): void {
   // Wire wait_until(element_matches) — resolve top result for callers that just need selector + text.
   setBrowserSearchHook(async ({ port, tabId, by, pattern, scope }) => {
@@ -2262,8 +2275,8 @@ export function registerBrowserTools(server: McpServer): void {
   server.tool(
     "browser_search",
     "Grep-like element search across the current page. by: 'text' (literal substring), 'regex', 'role', 'ariaLabel', 'selector' (CSS). Returns results[] sorted by confidence descending — pass results[0].selector to browser_click. Pagination via offset/maxResults. Caveats: Use browser_overview for broad discovery; use browser_search when you know specific text or role to target.",
-    browserSearchSchema,
-    browserSearchHandler
+    browserSearchRegistrationSchema,
+    browserSearchRegistrationHandler as typeof browserSearchHandler
   );
 
   server.tool(

--- a/src/tools/macro.ts
+++ b/src/tools/macro.ts
@@ -82,7 +82,9 @@ import {
   browserEvalHandler,
   browserEvalRegistrationSchema,
   browserEvalRegistrationHandler,
-  browserSearchHandler, browserSearchSchema,
+  browserSearchHandler,
+  browserSearchRegistrationSchema,
+  browserSearchRegistrationHandler,
   browserGetInteractiveHandler,
   browserOverviewRegistrationSchema,
   browserOverviewRegistrationHandler,
@@ -232,11 +234,11 @@ const TOOL_REGISTRY: Record<string, ToolEntry> = {
   // server.registerTool 経路と同 instance を共有 (PR #112 shared registration
   // handler pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
   browser_eval:         { schema: browserEvalRegistrationSchema,         handler: browserEvalRegistrationHandler as typeof browserEvalHandler },
-  browser_search:       { schema: z.object(browserSearchSchema),       handler: browserSearchHandler },
   // Walking skeleton expansion swimlane 2 (L5 query wrapper): use the
   // module-scope wrapped handler from browser.ts so run_macro 経路は
   // server.tool 経路と同 instance を共有 (PR #112 shared registration handler
   // pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
+  browser_search:       { schema: z.object(browserSearchRegistrationSchema), handler: browserSearchRegistrationHandler as typeof browserSearchHandler },
   browser_overview:     { schema: z.object(browserOverviewRegistrationSchema), handler: browserOverviewRegistrationHandler as typeof browserGetInteractiveHandler },
   browser_locate:       { schema: z.object(browserLocateRegistrationSchema), handler: browserLocateRegistrationHandler as typeof browserFindElementHandler },
   // Walking skeleton expansion swimlane 1 (L5 commit wrapper): use the

--- a/tests/unit/expansion-browser-search-wrapper.test.ts
+++ b/tests/unit/expansion-browser-search-wrapper.test.ts
@@ -1,0 +1,89 @@
+/**
+ * expansion-browser-search-wrapper.test.ts — swimlane 2 (L5 query wrapper)
+ * contract test. Mechanical copy of PR #140 / #141 query wrapper pattern.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  makeQueryWrapper,
+  _resetHistoryBuffersForTest,
+  _resetToolCallSeqForTest,
+} from "../../src/tools/_envelope.js";
+
+function resetAll(): void {
+  _resetHistoryBuffersForTest();
+  _resetToolCallSeqForTest();
+}
+
+describe("expansion swimlane 2 (browser_search): query wrapper raw shape default", () => {
+  it("default 経路 → envelope shape を hoist", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"results":[]}' }],
+    });
+    const wrapped = makeQueryWrapper(handler, "browser_search");
+    const result = await wrapped({
+      by: "text",
+      pattern: "Submit",
+      port: 9222,
+    } as Record<string, unknown>);
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed._version).toBeUndefined();
+    expect(parsed.ok).toBe(true);
+    expect(Array.isArray(parsed.results)).toBe(true);
+  });
+});
+
+describe("expansion swimlane 2 (browser_search): include=envelope returns envelope shape", () => {
+  it("include=[envelope] → 4 fields", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    });
+    const wrapped = makeQueryWrapper(handler, "browser_search");
+    const result = await wrapped({
+      by: "text",
+      pattern: "Submit",
+      port: 9222,
+      include: ["envelope"],
+    } as Record<string, unknown>);
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed._version).toBe("1.0");
+    expect(parsed.data).toBeDefined();
+    expect(parsed.as_of).toBeDefined();
+    expect(parsed.confidence).toBeDefined();
+  });
+});
+
+describe("expansion swimlane 2 (browser_search): query wrapper does NOT emit L1 events", () => {
+  it("query-axis = read-only", async () => {
+    resetAll();
+    let invoked = false;
+    const handler = async () => {
+      invoked = true;
+      return { content: [{ type: "text", text: '{"ok":true}' }] };
+    };
+    const wrapped = makeQueryWrapper(handler, "browser_search");
+    await wrapped({ by: "text", pattern: "x", port: 9222 } as Record<string, unknown>);
+    expect(invoked).toBe(true);
+  });
+});
+
+describe("expansion swimlane 2 (browser_search): trunk completion contract — mechanical copy", () => {
+  it("S4 fast path で envelope shape only", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    });
+    const wrapped = makeQueryWrapper(handler, "browser_search");
+    const result = await wrapped({
+      by: "regex",
+      pattern: "^test",
+      port: 9222,
+      include: ["envelope"],
+    } as Record<string, unknown>);
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed._version).toBe("1.0");
+    expect(parsed.caused_by).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

`browser_search` を `makeQueryWrapper` で wrap (S4 query-axis)。PR #140/#141 同型 pattern。

## scope
- src/tools/browser.ts: module-scope `browserSearchRegistration*` export、server.tool 切替
- src/tools/macro.ts: TOOL_REGISTRY shared instance
- tests/unit/expansion-browser-search-wrapper.test.ts: 4 contract tests
- src/stub-tool-catalog.ts: \`include\` field 追加

## Test plan
- [x] build green / stub-catalog / expansion-disjoint OK / 4 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)