### PR TITLE
feat(expansion): wait_until query wrapper (L5 envelope)

### DIFF
--- a/src/stub-tool-catalog.ts
+++ b/src/stub-tool-catalog.ts
@@ -1896,6 +1896,13 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
           "default": 200,
           "minimum": 50,
           "maximum": 5000
+        },
+        "include": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
         }
       },
       "additionalProperties": false,

--- a/src/tools/macro.ts
+++ b/src/tools/macro.ts
@@ -62,7 +62,11 @@ import {
   scrollRegistrationHandler,
 } from "./scroll.js";
 // Wait until
-import { waitUntilHandler, waitUntilSchema } from "./wait-until.js";
+import {
+  waitUntilHandler,
+  waitUntilRegistrationSchema,
+  waitUntilRegistrationHandler,
+} from "./wait-until.js";
 // Desktop state
 import {
   desktopStateRegistrationHandler,
@@ -264,7 +268,11 @@ const TOOL_REGISTRY: Record<string, ToolEntry> = {
   // server.tool 経路と同 instance を共有 (PR #112 shared registration handler
   // pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
   workspace_launch:     { schema: z.object(workspaceLaunchRegistrationSchema), handler: workspaceLaunchRegistrationHandler as typeof workspaceLaunchHandler },
-  wait_until:           { schema: z.object(waitUntilSchema),           handler: waitUntilHandler },
+  // Walking skeleton expansion swimlane 2 (L5 query wrapper): use the
+  // module-scope wrapped handler from wait-until.ts so run_macro 経路は
+  // server.tool 経路と同 instance を共有 (PR #112 shared registration handler
+  // pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
+  wait_until:           { schema: z.object(waitUntilRegistrationSchema), handler: waitUntilRegistrationHandler as typeof waitUntilHandler },
   // Walking skeleton expansion swimlane 1 (L5 commit wrapper): use the
   // module-scope wrapped handler from notification.ts so run_macro 経路は
   // server.tool 経路と同 instance を共有 (PR #112 shared registration handler

--- a/src/tools/wait-until.ts
+++ b/src/tools/wait-until.ts
@@ -5,6 +5,7 @@ import type { ToolResult } from "./_types.js";
 import { failWith } from "./_errors.js";
 import { coercedBoolean, coercedJsonObject } from "./_coerce.js";
 import { pollUntil } from "../engine/poll.js";
+import { makeQueryWrapper, withEnvelopeIncludeSchema } from "./_envelope.js";
 import {
   enumWindowsInZOrder,
   getWindowProcessId,
@@ -383,6 +384,19 @@ export const waitUntilHandler = async ({ condition, target, timeoutMs, intervalM
 // Registration
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * Walking skeleton expansion phase swimlane 2 (L5 query tool wrapper):
+ * `wait_until` is wrapped via `makeQueryWrapper`. PR #122 screenshot 同型
+ * pattern (read-only condition polling、L1 events 不発、causedByProjector
+ * 省略 fast path)。
+ */
+export const waitUntilRegistrationSchema = withEnvelopeIncludeSchema(waitUntilSchema);
+
+export const waitUntilRegistrationHandler = makeQueryWrapper(
+  waitUntilHandler as (args: Record<string, unknown>) => Promise<ToolResult>,
+  "wait_until",
+);
+
 export function registerWaitUntilTool(server: McpServer): void {
   server.tool(
     "wait_until",
@@ -399,7 +413,7 @@ export function registerWaitUntilTool(server: McpServer): void {
         "wait_until({condition:'url_matches', target:{pattern:'^https://app\\\\.example\\\\.com/orders/[0-9]+$', regex:true}})",
       ],
     }),
-    waitUntilSchema,
-    waitUntilHandler
+    waitUntilRegistrationSchema,
+    waitUntilRegistrationHandler as typeof waitUntilHandler
   );
 }

--- a/tests/unit/expansion-wait-until-wrapper.test.ts
+++ b/tests/unit/expansion-wait-until-wrapper.test.ts
@@ -1,0 +1,93 @@
+/**
+ * expansion-wait-until-wrapper.test.ts — swimlane 2 (L5 query wrapper)
+ * contract test. Mechanical copy of PR #140 / #141 / #142 query pattern.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  makeQueryWrapper,
+  _resetHistoryBuffersForTest,
+  _resetToolCallSeqForTest,
+} from "../../src/tools/_envelope.js";
+
+function resetAll(): void {
+  _resetHistoryBuffersForTest();
+  _resetToolCallSeqForTest();
+}
+
+describe("expansion swimlane 2 (wait_until): query wrapper raw shape default", () => {
+  it("default 経路 → envelope shape を hoist", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"elapsedMs":1234}' }],
+    });
+    const wrapped = makeQueryWrapper(handler, "wait_until");
+    const result = await wrapped({
+      condition: "window_appears",
+      target: { windowTitle: "Save As" },
+      timeoutMs: 5000,
+    } as Record<string, unknown>);
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed._version).toBeUndefined();
+    expect(parsed.ok).toBe(true);
+    expect(parsed.elapsedMs).toBe(1234);
+  });
+});
+
+describe("expansion swimlane 2 (wait_until): include=envelope returns envelope shape", () => {
+  it("include=[envelope] → 4 fields", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    });
+    const wrapped = makeQueryWrapper(handler, "wait_until");
+    const result = await wrapped({
+      condition: "window_appears",
+      target: { windowTitle: "x" },
+      timeoutMs: 5000,
+      include: ["envelope"],
+    } as Record<string, unknown>);
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed._version).toBe("1.0");
+    expect(parsed.data).toBeDefined();
+    expect(parsed.as_of).toBeDefined();
+    expect(parsed.confidence).toBeDefined();
+  });
+});
+
+describe("expansion swimlane 2 (wait_until): query wrapper does NOT emit L1 events", () => {
+  it("query-axis = read-only", async () => {
+    resetAll();
+    let invoked = false;
+    const handler = async () => {
+      invoked = true;
+      return { content: [{ type: "text", text: '{"ok":true}' }] };
+    };
+    const wrapped = makeQueryWrapper(handler, "wait_until");
+    await wrapped({
+      condition: "window_appears",
+      target: { windowTitle: "x" },
+      timeoutMs: 5000,
+    } as Record<string, unknown>);
+    expect(invoked).toBe(true);
+  });
+});
+
+describe("expansion swimlane 2 (wait_until): trunk completion contract — mechanical copy", () => {
+  it("S4 fast path で envelope shape only", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    });
+    const wrapped = makeQueryWrapper(handler, "wait_until");
+    const result = await wrapped({
+      condition: "ready_state",
+      target: { windowTitle: "x" },
+      timeoutMs: 5000,
+      include: ["envelope"],
+    } as Record<string, unknown>);
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed._version).toBe("1.0");
+    expect(parsed.caused_by).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

`wait_until` を `makeQueryWrapper` で wrap (S4 query-axis)。PR #122 screenshot 同型 pattern。

## scope
- src/tools/wait-until.ts: module-scope `waitUntilRegistration*` export、server.tool 切替
- src/tools/macro.ts: TOOL_REGISTRY shared instance
- tests/unit/expansion-wait-until-wrapper.test.ts: 4 contract tests
- src/stub-tool-catalog.ts: \`include\` field 追加

## Test plan
- [x] build green / stub-catalog / expansion-disjoint OK / 4 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)