### PR TITLE
feat(expansion): workspace_snapshot query wrapper (L5 envelope)

### DIFF
--- a/src/stub-tool-catalog.ts
+++ b/src/stub-tool-catalog.ts
@@ -2088,6 +2088,13 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
           "description": "Whether to include UI element summaries for each window",
           "type": "boolean",
           "default": true
+        },
+        "include": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
         }
       },
       "additionalProperties": false

--- a/src/tools/macro.ts
+++ b/src/tools/macro.ts
@@ -50,7 +50,9 @@ import {
 } from "./ui-elements.js";
 // Workspace
 import {
-  workspaceSnapshotHandler, workspaceSnapshotSchema,
+  workspaceSnapshotHandler,
+  workspaceSnapshotRegistrationSchema,
+  workspaceSnapshotRegistrationHandler,
   workspaceLaunchHandler,
   workspaceLaunchRegistrationSchema,
   workspaceLaunchRegistrationHandler,
@@ -262,7 +264,11 @@ const TOOL_REGISTRY: Record<string, ToolEntry> = {
   // pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
   browser_form:         { schema: z.object(browserFormRegistrationSchema), handler: browserFormRegistrationHandler as typeof browserGetFormHandler },
   // Workspace / wait / notification
-  workspace_snapshot:   { schema: z.object(workspaceSnapshotSchema),   handler: workspaceSnapshotHandler },
+  // Walking skeleton expansion swimlane 2 (L5 query wrapper): use the
+  // module-scope wrapped handler from workspace.ts so run_macro 経路は
+  // server.tool 経路と同 instance を共有 (PR #112 shared registration handler
+  // pattern, strip risk 防止)。`include` per-call envelope opt-in も自動波及。
+  workspace_snapshot:   { schema: z.object(workspaceSnapshotRegistrationSchema), handler: workspaceSnapshotRegistrationHandler as typeof workspaceSnapshotHandler },
   // Walking skeleton expansion swimlane 1 (L5 commit wrapper): use the
   // module-scope wrapped handler from workspace.ts so run_macro 経路は
   // server.tool 経路と同 instance を共有 (PR #112 shared registration handler

--- a/src/tools/workspace.ts
+++ b/src/tools/workspace.ts
@@ -13,7 +13,7 @@ import type { ToolResult } from "./_types.js";
 import { failWith } from "./_errors.js";
 import { pollUntil } from "../engine/poll.js";
 import { withRichNarration } from "./_narration.js";
-import { makeCommitWrapper, withEnvelopeIncludeSchema } from "./_envelope.js";
+import { makeCommitWrapper, makeQueryWrapper, withEnvelopeIncludeSchema } from "./_envelope.js";
 
 /** Chromium-based browser windows — UIA traversal is prohibitively slow on these */
 export const CHROMIUM_TITLE_RE = /- (?:Google Chrome|Microsoft Edge|Brave|Opera|Vivaldi|Arc|Chromium)$/;
@@ -290,6 +290,19 @@ export const workspaceLaunchRegistrationHandler = makeCommitWrapper(
   },
 );
 
+/**
+ * Walking skeleton expansion phase swimlane 2 (L5 query tool wrapper):
+ * `workspace_snapshot` is wrapped via `makeQueryWrapper`. PR #122 screenshot
+ * 同型 pattern (read-only orientation snapshot、L1 events 不発、
+ * causedByProjector 省略 fast path)。
+ */
+export const workspaceSnapshotRegistrationSchema = withEnvelopeIncludeSchema(workspaceSnapshotSchema);
+
+export const workspaceSnapshotRegistrationHandler = makeQueryWrapper(
+  workspaceSnapshotHandler as (args: Record<string, unknown>) => Promise<ToolResult>,
+  "workspace_snapshot",
+);
+
 export function registerWorkspaceTools(server: McpServer): void {
   server.tool(
     "workspace_snapshot",
@@ -299,8 +312,8 @@ export function registerWorkspaceTools(server: McpServer): void {
       prefer: "Use at session start or after major workspace changes. Use screenshot(detail='meta') for cheap re-orientation within a session. Use screenshot(detail='text', windowTitle=X) for a single-window update.",
       caveats: "Thumbnails are scaled, not 1:1 — use screenshot(dotByDot=true, windowTitle=X) for pixel-accurate coords on a specific window after snapshot.",
     }),
-    workspaceSnapshotSchema,
-    workspaceSnapshotHandler
+    workspaceSnapshotRegistrationSchema,
+    workspaceSnapshotRegistrationHandler as typeof workspaceSnapshotHandler
   );
 
   server.tool(

--- a/tests/unit/expansion-workspace-snapshot-wrapper.test.ts
+++ b/tests/unit/expansion-workspace-snapshot-wrapper.test.ts
@@ -1,0 +1,88 @@
+/**
+ * expansion-workspace-snapshot-wrapper.test.ts — swimlane 2 (L5 query wrapper)
+ * contract test. Mechanical copy of PR #140-#143 query wrapper pattern.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  makeQueryWrapper,
+  _resetHistoryBuffersForTest,
+  _resetToolCallSeqForTest,
+} from "../../src/tools/_envelope.js";
+
+function resetAll(): void {
+  _resetHistoryBuffersForTest();
+  _resetToolCallSeqForTest();
+}
+
+describe("expansion swimlane 2 (workspace_snapshot): query wrapper raw shape default", () => {
+  it("default 経路 → envelope shape を hoist", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"windowCount":3,"windows":[]}' }],
+    });
+    const wrapped = makeQueryWrapper(handler, "workspace_snapshot");
+    const result = await wrapped({
+      thumbnailMaxDimension: 400,
+      includeUiSummary: true,
+    } as Record<string, unknown>);
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed._version).toBeUndefined();
+    expect(parsed.windowCount).toBe(3);
+  });
+});
+
+describe("expansion swimlane 2 (workspace_snapshot): include=envelope returns envelope shape", () => {
+  it("include=[envelope] → 4 fields", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"windowCount":0}' }],
+    });
+    const wrapped = makeQueryWrapper(handler, "workspace_snapshot");
+    const result = await wrapped({
+      thumbnailMaxDimension: 400,
+      includeUiSummary: true,
+      include: ["envelope"],
+    } as Record<string, unknown>);
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed._version).toBe("1.0");
+    expect(parsed.data).toBeDefined();
+    expect(parsed.as_of).toBeDefined();
+    expect(parsed.confidence).toBeDefined();
+  });
+});
+
+describe("expansion swimlane 2 (workspace_snapshot): query wrapper does NOT emit L1 events", () => {
+  it("query-axis = read-only", async () => {
+    resetAll();
+    let invoked = false;
+    const handler = async () => {
+      invoked = true;
+      return { content: [{ type: "text", text: '{"ok":true}' }] };
+    };
+    const wrapped = makeQueryWrapper(handler, "workspace_snapshot");
+    await wrapped({
+      thumbnailMaxDimension: 400,
+      includeUiSummary: true,
+    } as Record<string, unknown>);
+    expect(invoked).toBe(true);
+  });
+});
+
+describe("expansion swimlane 2 (workspace_snapshot): trunk completion contract — mechanical copy", () => {
+  it("S4 fast path で envelope shape only", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    });
+    const wrapped = makeQueryWrapper(handler, "workspace_snapshot");
+    const result = await wrapped({
+      thumbnailMaxDimension: 400,
+      includeUiSummary: false,
+      include: ["envelope"],
+    } as Record<string, unknown>);
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed._version).toBe("1.0");
+    expect(parsed.caused_by).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

`workspace_snapshot` を `makeQueryWrapper` で wrap (S4 query-axis)。PR #122 screenshot 同型 pattern。

## scope
- src/tools/workspace.ts: module-scope `workspaceSnapshotRegistration*` export、server.tool 切替
- src/tools/macro.ts: TOOL_REGISTRY shared instance
- tests/unit/expansion-workspace-snapshot-wrapper.test.ts: 4 contract tests
- src/stub-tool-catalog.ts: \`include\` field 追加

## Test plan
- [x] build green / stub-catalog / expansion-disjoint OK / 4 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)