### PR TITLE
feat(expansion): server_status query wrapper (L5 envelope)

### DIFF
--- a/src/stub-tool-catalog.ts
+++ b/src/stub-tool-catalog.ts
@@ -1759,7 +1759,15 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
     "description": "Return MCP server status: version / native engine availability / Auto Perception state / v2 activation. uia: 'native' = Rust UIA addon (fast, ~2 ms focus / ~100 ms tree); 'powershell' = PS fallback (~366 ms focus). imageDiff: 'native' = Rust SSE2 SIMD (0.26 ms @ 1080p); 'typescript' = TS fallback (~3.8 ms). Diagnostic metadata — do not surface these values to the user unless they ask about performance or troubleshooting. Call once per session if you need to know which path is active; the result is stable for the lifetime of the server process.",
     "inputSchema": {
       "type": "object",
-      "properties": {},
+      "properties": {
+        "include": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
+        }
+      },
       "additionalProperties": false
     }
   },

--- a/src/tools/server-status.ts
+++ b/src/tools/server-status.ts
@@ -3,6 +3,13 @@ import { ok } from "./_types.js";
 import type { ToolResult } from "./_types.js";
 import { failWith } from "./_errors.js";
 import { getEngineStatus } from "../engine/status.js";
+import { makeQueryWrapper, withEnvelopeIncludeSchema } from "./_envelope.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Schema
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const serverStatusSchema = {};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Handler
@@ -21,11 +28,26 @@ export const serverStatusHandler = async (): Promise<ToolResult> => {
 // Registration
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * Walking skeleton expansion phase swimlane 2 (L5 query tool wrapper):
+ * `server_status` is wrapped via `makeQueryWrapper`. PR #122 screenshot 同型
+ * pattern (read-only diagnostic snapshot、L1 events 不発、causedByProjector
+ * 省略 fast path)。server_status は `run_macro` から呼び出されない (macro.ts
+ * 内 comment 「not callable from macros — diagnostic」のため TOOL_REGISTRY
+ * 改修不要)。
+ */
+export const serverStatusRegistrationSchema = withEnvelopeIncludeSchema(serverStatusSchema);
+
+export const serverStatusRegistrationHandler = makeQueryWrapper(
+  (serverStatusHandler as unknown as (args: Record<string, unknown>) => Promise<ToolResult>),
+  "server_status",
+);
+
 export function registerServerStatusTool(server: McpServer): void {
   server.tool(
     "server_status",
     "Return MCP server status: version / native engine availability / Auto Perception state / v2 activation. uia: 'native' = Rust UIA addon (fast, ~2 ms focus / ~100 ms tree); 'powershell' = PS fallback (~366 ms focus). imageDiff: 'native' = Rust SSE2 SIMD (0.26 ms @ 1080p); 'typescript' = TS fallback (~3.8 ms). Diagnostic metadata — do not surface these values to the user unless they ask about performance or troubleshooting. Call once per session if you need to know which path is active; the result is stable for the lifetime of the server process.",
-    {},
-    serverStatusHandler
+    serverStatusRegistrationSchema,
+    serverStatusRegistrationHandler as typeof serverStatusHandler
   );
 }

--- a/tests/unit/expansion-server-status-wrapper.test.ts
+++ b/tests/unit/expansion-server-status-wrapper.test.ts
@@ -1,0 +1,81 @@
+/**
+ * expansion-server-status-wrapper.test.ts — swimlane 2 (L5 query wrapper)
+ * contract test. Mechanical copy of PR #122 / #140-#144 query pattern.
+ * Note: server_status is not in TOOL_REGISTRY (diagnostic only、not callable
+ * from run_macro)、so no macro path test.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  makeQueryWrapper,
+  _resetHistoryBuffersForTest,
+  _resetToolCallSeqForTest,
+} from "../../src/tools/_envelope.js";
+
+function resetAll(): void {
+  _resetHistoryBuffersForTest();
+  _resetToolCallSeqForTest();
+}
+
+describe("expansion swimlane 2 (server_status): query wrapper raw shape default", () => {
+  it("default 経路 → envelope shape を hoist", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"engine":{"version":"1.1.3"}}' }],
+    });
+    const wrapped = makeQueryWrapper(handler, "server_status");
+    const result = await wrapped({} as Record<string, unknown>);
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed._version).toBeUndefined();
+    expect(parsed.ok).toBe(true);
+    expect(parsed.engine).toBeDefined();
+  });
+});
+
+describe("expansion swimlane 2 (server_status): include=envelope returns envelope shape", () => {
+  it("include=[envelope] → 4 fields", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true,"engine":{"version":"1.1.3"}}' }],
+    });
+    const wrapped = makeQueryWrapper(handler, "server_status");
+    const result = await wrapped({
+      include: ["envelope"],
+    } as Record<string, unknown>);
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed._version).toBe("1.0");
+    expect(parsed.data).toBeDefined();
+    expect(parsed.as_of).toBeDefined();
+    expect(parsed.confidence).toBeDefined();
+  });
+});
+
+describe("expansion swimlane 2 (server_status): query wrapper does NOT emit L1 events", () => {
+  it("query-axis = read-only", async () => {
+    resetAll();
+    let invoked = false;
+    const handler = async () => {
+      invoked = true;
+      return { content: [{ type: "text", text: '{"ok":true}' }] };
+    };
+    const wrapped = makeQueryWrapper(handler, "server_status");
+    await wrapped({} as Record<string, unknown>);
+    expect(invoked).toBe(true);
+  });
+});
+
+describe("expansion swimlane 2 (server_status): trunk completion contract — mechanical copy", () => {
+  it("S4 fast path で envelope shape only", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    });
+    const wrapped = makeQueryWrapper(handler, "server_status");
+    const result = await wrapped({
+      include: ["envelope"],
+    } as Record<string, unknown>);
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed._version).toBe("1.0");
+    expect(parsed.caused_by).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

`server_status` を `makeQueryWrapper` で wrap (S4 query-axis、最後の query)。PR #122 screenshot 同型 pattern。`run_macro` から呼び出されない (diagnostic only、macro.ts 内 comment 参照) ため `TOOL_REGISTRY` 改修不要。

## scope
- src/tools/server-status.ts: module-scope `serverStatusRegistration*` export、server.tool 切替
- tests/unit/expansion-server-status-wrapper.test.ts: 4 contract tests
- src/stub-tool-catalog.ts: \`include\` field 追加

## Test plan
- [x] build green / stub-catalog / expansion-disjoint OK / 4 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)