### PR TITLE
feat(expansion): run_macro commit wrapper (L5 envelope) — final tool

### DIFF
--- a/src/stub-tool-catalog.ts
+++ b/src/stub-tool-catalog.ts
@@ -1254,6 +1254,13 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
           "description": "Stop execution on the first error (default true). Set false to collect all results.",
           "type": "boolean",
           "default": true
+        },
+        "include": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
         }
       },
       "additionalProperties": false

--- a/src/tools/macro.ts
+++ b/src/tools/macro.ts
@@ -4,6 +4,7 @@ import { buildDesc } from "./_types.js";
 import type { ToolHandler, ToolResult } from "./_types.js";
 import { checkFailsafe } from "../utils/failsafe.js";
 import { assertKeyComboSafe } from "../utils/key-safety.js";
+import { makeCommitWrapper, withEnvelopeIncludeSchema } from "./_envelope.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Phase 4: TOOL_REGISTRY mirrors the v1.0.0 public surface — privatized tools
@@ -487,6 +488,31 @@ export const runMacroHandler = async ({
 // Registration
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * Walking skeleton expansion phase swimlane 1 (L5 commit tool wrapper):
+ * `run_macro` is wrapped via `makeCommitWrapper` (lease-less commit variant)。
+ * Macro orchestration 自体を一つの commit event として L1 に記録 (各 step は
+ * 個別の wrapped tool が L1 event を発行するため、run_macro level の event
+ * は orchestration-level の boundary marker としてのみ機能)。
+ *
+ * windowTitleKey 省略 (run_macro は steps[].params.windowTitle を見ないため
+ * orchestration level では window target なし)。
+ *
+ * Module-scope export — run_macro 自体は `TOOL_REGISTRY` から除外
+ * (recursion 防止、macro.ts 内 line 「run_macro is intentionally excluded →
+ * prevents recursion」参照) のため、shared instance 共有は不要。
+ */
+export const runMacroRegistrationSchema = withEnvelopeIncludeSchema(runMacroSchema);
+
+export const runMacroRegistrationHandler = makeCommitWrapper(
+  runMacroHandler as (args: Record<string, unknown>) => Promise<ToolResult>,
+  "run_macro",
+  {
+    // leaseValidator omitted = lease-less commit variant
+    // getSessionId / argsSummary / clock も default 利用 = mechanical コピー最小
+  },
+);
+
 export function registerMacroTools(server: McpServer): void {
   server.tool(
     "run_macro",
@@ -500,7 +526,7 @@ export function registerMacroTools(server: McpServer): void {
         "[{tool:'browser_navigate',params:{url:'https://example.com'}},{tool:'wait_until',params:{condition:'element_matches',target:{by:'text',pattern:'Example Domain'}}}]",
       ],
     }),
-    runMacroSchema,
-    runMacroHandler
+    runMacroRegistrationSchema,
+    runMacroRegistrationHandler as typeof runMacroHandler
   );
 }

--- a/src/tools/macro.ts
+++ b/src/tools/macro.ts
@@ -491,9 +491,17 @@ export const runMacroHandler = async ({
 /**
  * Walking skeleton expansion phase swimlane 1 (L5 commit tool wrapper):
  * `run_macro` is wrapped via `makeCommitWrapper` (lease-less commit variant)。
- * Macro orchestration 自体を一つの commit event として L1 に記録 (各 step は
- * 個別の wrapped tool が L1 event を発行するため、run_macro level の event
- * は orchestration-level の boundary marker としてのみ機能)。
+ * Macro orchestration 自体を一つの commit event として L1 に記録 — 結果として
+ * N step macro 1 回で **N+1 個** の L1 event が発行される (outer = run_macro
+ * orchestration boundary marker、inner = 各 step の wrapped handler が発行)。
+ * outer event は「run_macro が呼ばれて完了した」事実 + summary を保持し、
+ * step 単位の詳細は inner event 群に委ねる重畳構造。
+ *
+ * Caveat: causal envelope の `your_last_action` は最新 1 件のみ参照する
+ * (history ring capacity = `_envelope.ts:HISTORY_BUFFER_CAPACITY`)。Step 数が
+ * capacity を超えると outer run_macro event が ring から evict され、後続
+ * `desktop_state(include=causal)` は最終 step を `your_last_action` として
+ * 返す (orchestration boundary としての run_macro 識別は失われる)。
  *
  * windowTitleKey 省略 (run_macro は steps[].params.windowTitle を見ないため
  * orchestration level では window target なし)。

--- a/tests/unit/expansion-run-macro-wrapper.test.ts
+++ b/tests/unit/expansion-run-macro-wrapper.test.ts
@@ -1,0 +1,120 @@
+/**
+ * expansion-run-macro-wrapper.test.ts — swimlane 1 (L5 commit wrapper)
+ * contract test for run_macro orchestration tool.
+ * Note: run_macro は TOOL_REGISTRY から除外 (recursion 防止) のため、
+ * macro path test なし。L1 event 発火は orchestration boundary marker。
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  makeCommitWrapper,
+  defaultL1Emitter,
+  buildCausedBy,
+  buildBasedOn,
+  _resetHistoryBuffersForTest,
+  _resetToolCallSeqForTest,
+  type CommitL1Emitter,
+  type ViewSnapshot,
+} from "../../src/tools/_envelope.js";
+
+function resetAll(): void {
+  _resetHistoryBuffersForTest();
+  _resetToolCallSeqForTest();
+}
+
+function makeViewSnapshot(): ViewSnapshot {
+  return {
+    focus: { hwnd: null, elementName: "test-element" },
+    dirtyRectsByMonitor: new Map([[0, 1]]),
+    latestEventId: 100n,
+    queryWallclockMs: Date.now(),
+  };
+}
+
+describe("expansion swimlane 1 (run_macro): wrap → L1 events recorded (lease 不在 variant)", () => {
+  it("makeCommitWrapper flow 通過、両 event push、lease_token undefined", async () => {
+    resetAll();
+    const events: Array<{ kind: "started" | "completed"; tool: string; leaseToken?: unknown }> = [];
+    const fakeEmitter: CommitL1Emitter = {
+      pushStarted: ({ tool, sessionId, toolCallId, leaseToken }) => {
+        events.push({ kind: "started", tool, leaseToken });
+        defaultL1Emitter.pushStarted({ tool, argsJson: "{}", sessionId, toolCallId, leaseToken });
+      },
+      pushCompleted: ({ tool, elapsedMs, ok, errorCode, sessionId, toolCallId }) => {
+        events.push({ kind: "completed", tool });
+        defaultL1Emitter.pushCompleted({ tool, elapsedMs, ok, errorCode, sessionId, toolCallId });
+      },
+    };
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"steps_total":2,"steps_completed":2,"results":[]}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "run_macro", { l1Emitter: fakeEmitter });
+    const result = await wrapped({
+      steps: [{ tool: "sleep", params: { ms: 100 } }],
+      stop_on_error: true,
+    } as Record<string, unknown>);
+    expect(events).toHaveLength(2);
+    expect(events[0].tool).toBe("run_macro");
+    expect(events[0].leaseToken).toBeUndefined();
+    expect(events[1].kind).toBe("completed");
+    expect(result.content).toBeDefined();
+  });
+});
+
+describe("expansion swimlane 1 (run_macro): include 未指定時 raw shape return", () => {
+  it("default 経路 → envelope shape を hoist して raw client 互換", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"steps_total":1,"steps_completed":1}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "run_macro", {});
+    const result = await wrapped({
+      steps: [{ tool: "sleep", params: { ms: 100 } }],
+      stop_on_error: true,
+    } as Record<string, unknown>);
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed._version).toBeUndefined();
+    expect(parsed.steps_total).toBe(1);
+  });
+});
+
+describe("expansion swimlane 1 (run_macro): include=causal で caused_by.your_last_action に run_macro 記録", () => {
+  it("run_macro wrap → history buffer に entry → buildCausedBy で your_last_action = run_macro(...)", async () => {
+    resetAll();
+    const handler = async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    });
+    const wrapped = makeCommitWrapper(handler, "run_macro", {
+      getSessionId: () => "sessRM",
+    });
+    await wrapped({
+      steps: [{ tool: "sleep", params: { ms: 100 } }],
+      stop_on_error: true,
+    } as Record<string, unknown>);
+    const causedBy = buildCausedBy("sessRM", makeViewSnapshot());
+    expect(causedBy).toBeDefined();
+    expect(causedBy?.your_last_action).toContain("run_macro");
+    expect(causedBy?.tool_call_id).toMatch(/^sessRM:\d+$/);
+    const basedOn = buildBasedOn("sessRM", makeViewSnapshot());
+    expect(basedOn).toBeDefined();
+    if (basedOn?.events && basedOn.events.length > 0) {
+      expect(typeof basedOn.events[0]).toBe("string");
+    }
+  });
+});
+
+describe("expansion swimlane 1 (run_macro): trunk completion contract — mechanical copy", () => {
+  it("S5 contract が run_macro wrap でそのまま機能 (orchestration commit pipeline)", async () => {
+    resetAll();
+    const handler = vi.fn(async () => ({
+      content: [{ type: "text", text: '{"ok":true}' }],
+    }));
+    const wrapped = makeCommitWrapper(handler, "run_macro", {});
+    const result = await wrapped({
+      steps: [{ tool: "sleep", params: { ms: 50 } }],
+      stop_on_error: true,
+    } as Record<string, unknown>);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(result.content).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

`run_macro` を `makeCommitWrapper` で wrap (lease-less commit variant、orchestration boundary marker)。**これで expansion swimlane 1+2 全 20 tool wrap 完了**。

## scope

- \`src/tools/macro.ts\`: module-scope \`runMacroRegistrationHandler\` + \`runMacroRegistrationSchema\` export、\`server.tool\` の 3rd arg を切替。run_macro 自体は \`TOOL_REGISTRY\` から除外 (recursion 防止) のため shared instance 共有不要。
- \`tests/unit/expansion-run-macro-wrapper.test.ts\`: 4 contract tests (E1-E4)。
- \`src/stub-tool-catalog.ts\`: 再生成差分 (\`include\` field 追加)。

## design note

各 step は個別の wrapped tool が L1 event を発行するため、run_macro level の event は orchestration-level の boundary marker としてのみ機能。windowTitleKey 省略 (orchestration level では window target なし)。

## Test plan

- [x] \`npm run build\` (tsc) green
- [x] \`npm run check:stub-catalog\`
- [x] \`npm run check:expansion-disjoint\` OK
- [x] \`npx vitest run tests/unit/expansion-run-macro-wrapper.test.ts\` 4/4 pass
- [ ] CI Linux で trunk lock layer 改変ゼロ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)