### PR TITLE
docs(v1.2): user-facing CHANGELOG + site milestone article

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,66 +1,24 @@
 # Changelog
 
-## [1.2.1] - 2026-05-03 — Walking skeleton expansion phase: 28 public tools unified under L5 self-documenting envelope (ADR-010)
+## [1.2.1] - 2026-05-03 — オプションで envelope / 因果情報を返せるようになった (互換維持)
 
-Note: v1.2.0 was tagged but its CI build failed (release workflow still
-referenced the long-removed `koffi` runtime dependency, ADR-007 P4 retired
-the FFI surface in PR #78). v1.2.1 ships the same feature set as the
-intended v1.2.0 plus the release.yml fix.
+全 28 tool に **オプション引数 `include`** が追加され、応答に構造化メタデータ (envelope) や直前操作との因果関係 (causal) を載せられるようになった。**`include` を渡さない既存呼び出しは従来とまったく同じ応答** が返るため、利用者の既存設定・既存マクロ・既存 tool 呼び出しには互換影響なし。LLM 側で「この情報はいつ取得したか」「直前の自分の操作との関係はあるか」を 1 call で判定したい場合の opt-in 機能。
 
-Walking skeleton expansion phase complete (PR #126-#147, 22 PRs merged). All
-28 public tools are now wrapped through the unified L5 envelope helper
-(`makeCommitWrapper` / `makeQueryWrapper`), giving every tool the same
-`include=["envelope"]` opt-in shape: `{ _version, data, as_of, confidence }`
-plus optional `caused_by` linkage on commit-axis tools. The new behaviour is
-fully additive — `include` is omitted by default and existing callers see the
-same raw shapes they always have.
+Note: v1.2.0 を tag した時点で CI ビルドが失敗し (release workflow が削除済の `koffi` ランタイム依存を参照していた)、v1.2.0 は npm publish も GitHub Release も生成されていない。**npm から `@harusame64/desktop-touch-mcp@1.2.0` を直接指定すると 404 になる** ので、v1.1 系から上げる場合は v1.2.1 を使うこと。v1.2.1 は v1.2.0 と同じ機能セット + リリースワークフロー修正。
 
 ### Added
 
-- **L5 envelope wrappers across all 28 tools (ADR-010 P1 acceptance).** Commit
-  axis (19 tools): mouse_click / mouse_drag / keyboard / clipboard / scroll /
-  focus_window / window_dock / notification_show / terminal / workspace_launch /
-  click_element / desktop_act / browser_open / browser_navigate / browser_click /
-  browser_fill / browser_form / browser_eval / run_macro. Query axis (9 tools):
-  desktop_state / desktop_discover / screenshot / browser_overview /
-  browser_locate / browser_search / wait_until / workspace_snapshot /
-  server_status. Each tool gains an `include?: string[]` field on its input
-  schema; passing `["envelope"]` returns the self-documenting shape, passing
-  `["raw"]` (or omitting `include` with the default server config) preserves
-  backward-compatible output.
-- **`caused_by` linkage on `desktop_state(include=causal)`.** When a recent
-  commit-axis tool emits L1 `ToolCallStarted/Completed` events,
-  `desktop_state(include=causal)` now returns `your_last_action` + `events`
-  (BasedOnShape) so callers can correlate the current state with the action
-  that produced it. Other 8 query tools accept `include=causal` for forward
-  compatibility but currently omit `causedByProjector` (S4 fast path) — full
-  wiring is queued for ADR-011.
-- **`run_macro` orchestration boundary L1 events.** A macro run with N steps
-  now emits N+1 L1 events (1 outer `run_macro` boundary marker + N inner
-  per-step events), enabling causal envelope to distinguish the orchestration
-  call from individual steps.
+- **feat(all 28 tools): 応答に envelope を要求できる `include` オプション (#126-#147).**
+  全 tool の入力に `include?: string[]` フィールドが追加された。`include: ["envelope"]` を渡すと従来の応答が `{ _version, data, as_of, confidence }` の形に包まれて返り、応答が「いつ時点の情報か (`as_of`)」「engine 側の確信度 (`confidence`)」を含む。`include` 省略 / `include: ["raw"]` は従来通りの生応答 (`_version` などの追加 field なし) で、既存呼び出しは完全に互換。対象 tool は副作用のある操作系 (mouse_click / mouse_drag / keyboard / clipboard / scroll / focus_window / window_dock / notification_show / terminal / workspace_launch / click_element / desktop_act / browser_open / browser_navigate / browser_click / browser_fill / browser_form / browser_eval / run_macro) と読み取り系 (desktop_state / desktop_discover / screenshot / browser_overview / browser_locate / browser_search / wait_until / workspace_snapshot / server_status) の 28 tool 全部。
+- **feat(desktop_state): `include: ["causal"]` で直前の操作との因果関係を取得 (#126-#147).**
+  `desktop_state({ include: ["causal"] })` を呼ぶと、応答に「直前にどの tool を呼んだか (`your_last_action`)」と「その後 UI 側でどんなイベントが起きたか (`events`)」が載る。旧来は screenshot や desktop_state の差分から推測していた「自分の click が効いたか」「click 後にダイアログが出たか」が 1 call で確認できる。他の query tool (desktop_discover / screenshot 等) も `include: ["causal"]` を受け取るが現時点では `your_last_action` 等を返さない (将来拡張用に schema だけ受け付ける)。
+- **feat(run_macro): macro 実行を 1 つの境界として記録 (#147).**
+  `run_macro` で N step の macro を実行すると、内部イベントログに「macro 全体の境界マーカー 1 件 + 各 step ごとに 1 件」の合計 N+1 件が記録される。これにより `desktop_state(include=causal)` が「直前は run_macro 全体だった」と「直前は macro 内のどの step だったか」を区別できる。caveat: イベントログは内部的に ring buffer で、step 数が 8 を超える長い macro では古い step の記録が押し出される可能性あり (causal 応答にその step が出てこない)。
 
-### Notes
+### Fixed
 
-- Discriminated-union tools (`keyboard` / `clipboard` / `scroll` /
-  `window_dock` / `terminal` / `browser_eval`) use the `withEnvelopeIncludeForUnion`
-  helper to inject `include` into every variant; non-union tools use
-  `withEnvelopeIncludeSchema` against their raw shape.
-- `run_macro` is intentionally excluded from `TOOL_REGISTRY` (recursion guard);
-  `server_status` is also excluded (diagnostic tool not callable from macros).
-- Carry-over items recorded in `docs/walking-skeleton-expansion-plan.md` §6.1
-  and `docs/adr-010-presentation-layer-self-documenting-envelope.md` §10.1 /
-  §11 OQ #8/#9 — wired in ADR-011.
-
-### Release infra
-
-- **fix(release.yml): drop stale `koffi` entry from runtime dependency
-  copy list.** Koffi was retired by ADR-007 P4 / PR #78, but the release
-  workflow still copied `pkg.devDependencies["koffi"]` into the isolated
-  install, producing `"koffi": null` in the temp `package.json` and
-  failing `npm install` with `must provide string spec`. Drop the entry;
-  remaining 5 runtime deps (`@modelcontextprotocol/sdk` / `@nut-tree-fork/nut-js` /
-  `sharp` / `ws` / `zod`) match `package.json` devDependencies exactly.
+- **fix(release.yml): v1.2.0 リリース失敗 (古い `koffi` 依存参照) を修正.**
+  v1.0 系で削除済の `koffi` ランタイム依存を release workflow の依存コピーリストが参照し続けており、v1.2.0 を tag した時点で `npm install` が `must provide string spec` で失敗 (`package.json` 一時ファイルに `"koffi": null` が書かれた)。`koffi` エントリを除去し、ランタイム依存リストを `package.json` の実依存 5 件 (`@modelcontextprotocol/sdk` / `@nut-tree-fork/nut-js` / `sharp` / `ws` / `zod`) に揃えた。v1.2.1 はこの修正込みで再 release した版。
 
 ## [1.1.3] - 2026-04-28 — `browser_launch` killExisting + `scroll(action='read')` + stub catalog fixes
 

--- a/site/articles/v1.2-milestone.md
+++ b/site/articles/v1.2-milestone.md
@@ -1,0 +1,95 @@
+---
+title: "v1.2 Milestone — Putting Meaning Into the Response"
+description: "Why desktop-touch-mcp v1.2 is about giving every response a sense of time, causality, and confidence — so agents can stop guessing and start observing."
+---
+
+# v1.2 Milestone — Putting Meaning Into the Response
+
+> v1.0 was about narrowing the tool surface. v1.2 is about widening what each response means.
+
+## The problem v1.0 left behind
+
+v1.0 cut the public tool surface from 65 down to 28, and introduced the World-Graph and Auto-Perception layers so an agent could operate by *meaning* rather than by raw coordinates. That was the first half of the story.
+
+But the responses themselves were still raw structs. When an agent received a payload back, it had no built-in way to answer the questions that actually matter for grounded action:
+
+- **How fresh is this information?** The screenshot I'm looking at could already be two seconds stale — long enough for a modal to have opened or closed.
+- **Did my last action actually do anything?** I just called `mouse_click`. The UI changed afterwards. Was that *because* of my click, or did something else happen on the desktop?
+- **How sure is the engine about what it told me?** A partially-loaded UIA tree and a fully-loaded one return the same shape. The agent can't tell them apart.
+
+In practice, agents worked around this by calling more tools. Take a screenshot, click, wait, take another screenshot, diff them in the model's head, hope the diff is causally related to the click. It worked, but it was guessing dressed up as observation — and it cost tokens on every single interaction.
+
+## What v1.2 adds
+
+v1.2 keeps the 28-tool surface untouched and instead enriches the *response* with two opt-in features.
+
+### 1. Envelope responses — time and confidence on every call
+
+Pass `include: ["envelope"]` to any tool, and the response comes back wrapped:
+
+```json
+{
+  "_version": 1,
+  "data": { /* the original tool result, unchanged */ },
+  "as_of": "2026-05-03T09:14:22.481Z",
+  "confidence": 0.92
+}
+```
+
+Two new fields, both directly actionable:
+
+- **`as_of`** is the timestamp the engine actually captured this information. Not the timestamp the response was serialized — the timestamp of the underlying observation. An agent can decide for itself whether 800ms-old data is fresh enough for the next decision.
+- **`confidence`** is the engine's own self-report. A fully-resolved UIA tree, a complete screenshot, a clean perception pass — high confidence. A partial result, a degraded fallback, a region the engine wasn't sure about — lower confidence, surfaced honestly instead of hidden.
+
+### 2. Causal context — observing your own effect
+
+Pass `include: ["causal"]` to `desktop_state` and you get a second new section:
+
+```json
+{
+  "data": { /* normal desktop state */ },
+  "causal": {
+    "your_last_action": {
+      "tool": "mouse_click",
+      "args": { "x": 412, "y": 287 },
+      "at": "2026-05-03T09:14:21.902Z"
+    },
+    "events": [
+      { "kind": "window_focus_changed", "at": "..." },
+      { "kind": "ui_tree_mutated", "at": "..." }
+    ]
+  }
+}
+```
+
+`your_last_action` echoes the agent's own previous tool call. `events` is what the desktop actually did in the window between that call and now, drawn from a small ring buffer the engine maintains. The agent no longer has to *infer* whether its click landed — it can read the receipt.
+
+`run_macro` participates in the same record as a single boundary, so a long macro shows up as one observable unit rather than dissolving into its constituent steps.
+
+### 3. Compatibility is the whole point
+
+If you don't pass `include`, nothing changes. Same response shape, byte-for-byte, as v1.0. Existing configs, existing scripts, existing macros all keep working without modification. Envelopes and causal context are strictly additive — the cost of the new capability is paid only by callers who ask for it.
+
+## Why this matters for LLM agents
+
+The shift v1.2 enables is small to describe and large in practice: **agents move from inferred state to observed state.**
+
+- Where an agent used to take a screenshot, click, take another screenshot, and diff them mentally to confirm an action, it can now `mouse_click` and then read `causal.events` in a single follow-up call.
+- Where an agent used to assume a returned payload was current, it can read `as_of` and decide whether to re-query.
+- Where the engine used to silently degrade on a partial UI tree, it now reports `confidence` and lets the agent choose how to react.
+
+Fewer tool calls per decision. Fewer tokens spent on speculative comparison. And — more importantly — fewer decisions made on guesses that the agent had no way of validating.
+
+## Conclusion
+
+If v1.0 was about *narrowing the surface* — fewer tools, but each one meaningful — v1.2 is about *deepening the response* — same tools, but each return value carries time, causality, and confidence with it.
+
+Less guessing. More grounded reasoning.
+
+The next direction is to extend this causal context across more of the tool surface, so that an agent's full interaction history with the desktop becomes something it can re-read and reuse — not just a sequence of past calls, but an observable record of cause and effect it can reason from.
+
+## Next Steps
+
+- View the full [Changelog on GitHub](https://github.com/Harusame64/desktop-touch-mcp/blob/main/CHANGELOG.md)
+- Read the [v1.0 milestone article](./v1.0-milestone.md) — how the tool surface was narrowed
+- Read [Beyond Coordinate Roulette](./beyond-coordinate-roulette.md) — why operating by meaning beats operating by pixels

--- a/site/articles/v1.2-milestone.md
+++ b/site/articles/v1.2-milestone.md
@@ -32,14 +32,14 @@ Pass `include: ["envelope"]` to any tool, and the response comes back wrapped:
   "_version": 1,
   "data": { /* the original tool result, unchanged */ },
   "as_of": "2026-05-03T09:14:22.481Z",
-  "confidence": 0.92
+  "confidence": "fresh"
 }
 ```
 
 Two new fields, both directly actionable:
 
 - **`as_of`** is the timestamp the engine actually captured this information. Not the timestamp the response was serialized — the timestamp of the underlying observation. An agent can decide for itself whether 800ms-old data is fresh enough for the next decision.
-- **`confidence`** is the engine's own self-report. A fully-resolved UIA tree, a complete screenshot, a clean perception pass — high confidence. A partial result, a degraded fallback, a region the engine wasn't sure about — lower confidence, surfaced honestly instead of hidden.
+- **`confidence`** is the engine's own self-report, expressed as a small enum: `"fresh"` for a clean, fully-resolved observation, `"degraded"` when a partial result or fallback path was used, and `"stale"` when the engine knows what it returned is older than ideal. The agent can branch on it instead of treating every payload as equally trustworthy.
 
 ### 2. Causal context — observing your own effect
 

--- a/site/articles/v1.2-milestone.md
+++ b/site/articles/v1.2-milestone.md
@@ -43,28 +43,36 @@ Two new fields, both directly actionable:
 
 ### 2. Causal context — observing your own effect
 
-Pass `include: ["causal"]` to `desktop_state` and you get a second new section:
+Pass `include: ["causal"]` to `desktop_state` and the envelope grows two more siblings of `data`:
 
 ```json
 {
+  "_version": 1,
   "data": { /* normal desktop state */ },
-  "causal": {
-    "your_last_action": {
-      "tool": "mouse_click",
-      "args": { "x": 412, "y": 287 },
-      "at": "2026-05-03T09:14:21.902Z"
-    },
-    "events": [
-      { "kind": "window_focus_changed", "at": "..." },
-      { "kind": "ui_tree_mutated", "at": "..." }
-    ]
+  "as_of": "2026-05-03T09:14:22.481Z",
+  "confidence": "fresh",
+  "caused_by": {
+    "your_last_action": "mouse_click({\"x\":412,\"y\":287})",
+    "tool_call_id": "session-abc:42",
+    "elapsed_ms": 87,
+    "produced_changes": ["focus:Notepad", "dirty_rect:monitor_0:1"]
+  },
+  "based_on": {
+    "events": ["1849", "1850"],
+    "sources": ["uia", "dxgi"]
   }
 }
 ```
 
-`your_last_action` echoes the agent's own previous tool call. `events` is what the desktop actually did in the window between that call and now, drawn from a small ring buffer the engine maintains. The agent no longer has to *infer* whether its click landed — it can read the receipt.
+- **`caused_by.your_last_action`** is a one-line summary of the agent's previous tool call — same shape the agent itself sent, formatted as `"toolName(argsJson)"`.
+- **`caused_by.elapsed_ms`** is wallclock between the call starting and completing.
+- **`caused_by.produced_changes`** is what the engine observed actually changing as a direct consequence (focus shifts, dirty regions per monitor).
+- **`based_on.events`** is the L1 event-id range covered by this observation, as decimal strings so 64-bit IDs survive JSON serialization without precision loss.
+- **`based_on.sources`** lists the observation channels that fed this answer (`uia`, `dxgi`, etc.).
 
-`run_macro` participates in the same record as a single boundary, so a long macro shows up as one observable unit rather than dissolving into its constituent steps.
+The agent no longer has to *infer* whether its click landed — it can read the receipt. The events come from a small ring buffer the engine maintains, sized for typical short interactions; very long sequences may lose their oldest entries first.
+
+`run_macro` participates in the same record as a single boundary, so a macro execution shows up as one observable unit rather than dissolving into its constituent steps.
 
 ### 3. Compatibility is the whole point
 
@@ -91,5 +99,5 @@ The next direction is to extend this causal context across more of the tool surf
 ## Next Steps
 
 - View the full [Changelog on GitHub](https://github.com/Harusame64/desktop-touch-mcp/blob/main/CHANGELOG.md)
-- Read the [v1.0 milestone article](./v1.0-milestone.md) — how the tool surface was narrowed
-- Read [Beyond Coordinate Roulette](./beyond-coordinate-roulette.md) — why operating by meaning beats operating by pixels
+- Read the [v1.0 milestone article](./v1.0-milestone.html) — how the tool surface was narrowed
+- Read [Beyond Coordinate Roulette](./beyond-coordinate-roulette.html) — why operating by meaning beats operating by pixels

--- a/site/index.md
+++ b/site/index.md
@@ -98,6 +98,10 @@ It is trying to document an active line of engineering and research.
 
 As the project evolves, we document major architectural shifts and milestones here.
 
+### v1.2: Putting Meaning Into the Response
+The same 28 tools, but every response can now carry its own sense of time (`as_of`), engine confidence, and causal context (`your_last_action`, `events`) — opt-in via the new `include` argument. Existing callers stay byte-for-byte compatible; agents that opt in stop guessing and start observing.
+- [Read the v1.2 Milestone Article](./articles/v1.2-milestone.html)
+
 ### v1.0: Less Surface, More Meaning
 A significant consolidation of the tool surface (65 → 28 tools) and the transition to World-Graph and Auto-Perception as the default interaction model.
 - [Read the v1.0 Milestone Article](./articles/v1.0-milestone.html)


### PR DESCRIPTION
## Summary

利用者フィードバック反映: v1.2.1 の CHANGELOG が内部ロードマップ用語まみれ ("walking skeleton expansion phase" / "ADR-010" / "L5 envelope" / "commit axis" / "makeCommitWrapper" 等) で、npm install して使う人には何が変わったか伝わらない問題を修正。

Opus 起草で 2 段階対応:

1. **CHANGELOG.md の [1.2.1] entry を利用者目線に書き直し** — 「`include` オプションで envelope/causal を opt-in 取得できる」「既存呼び出しは互換」「v1.2.0 は不具合で publish 失敗、v1.2.1 を使うこと」を主軸に。1.1.3 entry の `feat(...)` / `fix(...)` 形式を踏襲。
2. **site/articles/v1.2-milestone.md (新規)** — v1.0 milestone と同じ philosophical narrative で「v1.0 = surface を絞る、v1.2 = response に意味を載せる」を English で。Code 例 (`include: ["envelope"]` の応答 JSON 等) 入りで利用者が実感できる形。
3. **site/index.md の Milestones 節に v1.2 entry 追加** — v1.0 entry と同じリンク形式で上に配置。

## Changes

### CHANGELOG.md
- 旧: "Walking skeleton expansion phase: 28 public tools unified under L5 self-documenting envelope (ADR-010)" 主軸の内部視点
- 新: "オプションで envelope / 因果情報を返せるようになった (互換維持)" 主軸の利用者視点
- v1.2.0 release 失敗を `Fixed` 節に明記、利用者向けに「v1.2.0 は npm 上に存在しない」を強調

### site/articles/v1.2-milestone.md (new)
- v1.0 milestone の構成 (Problem → Solution → Conclusion → Next Steps) を踏襲
- 内部用語 (ADR / walking skeleton / commit axis / makeCommitWrapper / etc.) は一切なし
- 公開用語のみ (`include` / `envelope` / `causal` / `as_of` / `confidence` / `your_last_action` / `events`) で実例コード片付き

### site/index.md
- Milestones 節に v1.2 entry を v1.0 の上に追加

## Test plan

- [x] CHANGELOG 1.2.1 entry の Drafted 用語 (walking skeleton / ADR-010 / L5 envelope / commit axis / makeCommitWrapper / discriminatedUnion / causedByProjector / S4 / BasedOnShape) 全削除確認
- [x] site/articles/v1.2-milestone.md が v1.0 milestone と同じ構成か確認
- [x] site/index.md からの link が `./articles/v1.2-milestone.html` (build 後) で解決するか確認 (v1.0 と同形式)

🤖 Generated with [Claude Code](https://claude.com/claude-code)