### PR TITLE
fix(deps): override ip-address to 10.1.1 (Dependabot #9)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5202,9 +5202,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.1.tgz",
+      "integrity": "sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "overrides": {
+    "ip-address": "10.1.1"
+  },
   "napi": {
     "name": "desktop-touch-engine",
     "triples": {


### PR DESCRIPTION
## Summary
- Closes Dependabot alert #9 (GHSA-v2v4-37r5-5v8g / CVE-2026-42338, ip-address ≤10.1.0 XSS in `Address6` HTML-emitting methods).
- `express-rate-limit@8.3.2` (transitive via `@modelcontextprotocol/sdk`) **pins `ip-address` to exactly `10.1.0`**, so `npm update ip-address` is a no-op. Added an `overrides` entry in `package.json` to force `10.1.1` (the patched release).
- `npm audit` moderate count: 10 → 7 (ip-address occurrences resolved).

## Impact assessment
- ip-address is a **dev-only transitive** dep.
- This repo does not call `ip-address` / `Address6` directly (`grep src/` → 0 hits).
- The advisory itself notes that across all 425 dependent npm packages, `group()` / `link()` / `spanAll()` are unused; `express-rate-limit` only uses parse/compare APIs, not HTML emitters.
- No browser/HTML rendering surface in this server; XSS is not exploitable here. Bumping is purely to clear the alert.

## Test plan
- [x] `npm install` — override applied (`npm ls ip-address` shows `10.1.1 overridden`).
- [x] `npm run build` — clean.
- [x] `npm run test:unit` — 151 files / 2431 tests pass, 5 skipped.
- [x] e2e tests skipped locally (heavy, unrelated to dep change); CI will run them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)