### PR TITLE
fix(ci): lint errors on main HEAD 183ecec (PR #159 follow-up)

### DIFF
--- a/benches/a2_http_multisession_isolation.mjs
+++ b/benches/a2_http_multisession_isolation.mjs
@@ -187,8 +187,10 @@ try {
   const b = await newClient(port, "B");
 
   // Each client commits its own notification, then queries causal.
-  const ca = await commitNotification(a.client, "A");
-  const cb = await commitNotification(b.client, "B");
+  // commit return value is ignored — only the post-commit causal projection
+  // (queried via desktop_state include=["causal"]) is the bench observable.
+  await commitNotification(a.client, "A");
+  await commitNotification(b.client, "B");
   await sleep(50); // pushHistoryCompleted settle
   const qa = await queryDesktopStateWithCausal(a.client);
   const qb = await queryDesktopStateWithCausal(b.client);

--- a/src/tools/_envelope.ts
+++ b/src/tools/_envelope.ts
@@ -391,7 +391,6 @@ export function withEnvelopeIncludeForUnion(union: any): any {
     .array(z.string())
     .optional()
     .describe(ENVELOPE_INCLUDE_FIELD_DESCRIPTION);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const newOptions = (union.options as readonly z.ZodObject<z.ZodRawShape>[]).map(
     (opt) => opt.extend({ include: includeField }),
   );


### PR DESCRIPTION
## Summary

main HEAD \`183ecec\` (PR #159 merge 後) の CI lint job で 2 errors + 1 warning が発火し CI 全体が fail。本 hotfix で全件解消。

## scope

CLAUDE.md §3.3 Step 0 の **trivial PR** に該当 (lint fix の 2 file × 4 line)、Opus 単独 review で merge。

### benches/a2_http_multisession_isolation.mjs:190-191 (error × 2)

\`'ca' / 'cb' is assigned a value but never used\` — commit return value は bench observable ではない (post-commit causal projection を query で観測する設計)。変数 capture 削除、\`await commitNotification(...)\` 直接呼出に変更 + コメントで意図明記。

### src/tools/_envelope.ts:394 (warning)

\`Unused eslint-disable directive\` — line 395 の cast は \`as readonly z.ZodObject<z.ZodRawShape>[]\` で \`any\` 不在、directive 不要。削除。line 398-399 の directive は \`as any\` を伴うため維持。

## acceptance

- [x] \`npm run build\` (tsc) clean
- [x] \`npm run lint\` clean (errors 0、warnings 0)
- [x] bench 再実行 PASS (1.2s elapsed、stateless production gap 挙動 pin 維持)

## trunk contract conformance

- engine-perception layer 改変ゼロ
- L1 napi binding shape 不変
- handler internal logic + Zod schema + 戻り値 shape 不変
- 28 public tool 数不変
- production runtime 挙動不変 (lint cosmetic + bench script 内部の cosmetic、機能変更なし)

## Test plan

- [x] build + lint clean
- [x] bench 再実行 PASS
- [ ] CI が green
- [ ] Opus 単独 merge (trivial fix、§3.3 Step 0 trivial PR 例外)

🤖 Generated with [Claude Code](https://claude.com/claude-code)