### PR TITLE
fix(codeql #114/#115): dead initial value + unused import cleanup

### DIFF
--- a/benches/a2_http_multisession_isolation.mjs
+++ b/benches/a2_http_multisession_isolation.mjs
@@ -223,7 +223,8 @@ try {
   //     client B の操作を「自分がやった」と誤認知する runtime regression。
   //   - 旧 strict 不足 (`notification_show` substring のみ) は last-writer-wins
   //     の実害が pin できなかった問題 (Round 1 Codex P2 #4 反映)。
-  let analysis = "indeterminate";
+  // CodeQL #114 fix: 全分岐で unconditionally 代入されるので initial value は dead
+  let analysis;
   let pass = false;
   if (idA && idB) {
     const sidA = idA.split(":")[0];

--- a/tests/unit/session-context-a2.test.ts
+++ b/tests/unit/session-context-a2.test.ts
@@ -46,7 +46,6 @@ import {
   makeCommitWrapper,
   genericQueryCausedByProjector,
   buildCausedBy,
-  defaultL1Emitter,
   _resetHistoryBuffersForTest,
   _resetToolCallSeqForTest,
   _setDefaultQuerySingleSessionForTest,


### PR DESCRIPTION
## Summary

GitHub Code Scanning の main ブランチ alert を 2 件 fix (trivial cleanup):

- **#114 (warning, `js/useless-assignment-to-local`)**: `benches/a2_http_multisession_isolation.mjs:226` の `let analysis = "indeterminate";` は直後の if/else 全分岐で unconditionally 上書きされ、初期値は dead → 初期値削除 (declaration は再代入のため `let` のまま)
- **#115 (note, `js/unused-local-variable`)**: `tests/unit/session-context-a2.test.ts:49` の `defaultL1Emitter` import が genuine unused → import 削除

CLAUDE.md §3.3 Step 0 = trivial PR (cosmetic / 1 line)、user 確認済 (B-3 merge 後対応の依頼)。

## Test plan

- [x] `node --check benches/a2_http_multisession_isolation.mjs`: syntax OK
- [x] `npm run build` (tsc): clean
- [x] `npx vitest run tests/unit/session-context-a2.test.ts`: 31/31 pass
- [ ] CI all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)