### PR TITLE
fix(envelope): resolve discriminator via _def for Zod v4 (v1.3.0 production fix, closes #171)

### DIFF
--- a/src/tools/_envelope.ts
+++ b/src/tools/_envelope.ts
@@ -473,6 +473,12 @@ export function withEnvelopeIncludeSchema<T extends Record<string, ZodTypeAny>>(
  * Runtime behaviour is bit-equal with `withEnvelopeIncludeSchema` per
  * variant: each `z.object` gains `include?: string[]`, the discriminator
  * is preserved, and the union still dispatches by the same field.
+ *
+ * Discriminator access: Zod v3 exposed `union.discriminator` on the public
+ * surface, but Zod v4 moved it under `_def.discriminator`. We read both so
+ * the helper survives the v3↔v4 transition (PR #153 bumped to zod 4.4.x —
+ * the v3 path returned `undefined`, breaking every variant's parse with
+ * "Invalid discriminated union option" until this fix landed).
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function withEnvelopeIncludeForUnion(union: any): any {
@@ -483,8 +489,15 @@ export function withEnvelopeIncludeForUnion(union: any): any {
   const newOptions = (union.options as readonly z.ZodObject<z.ZodRawShape>[]).map(
     (opt) => opt.extend({ include: includeField }),
   );
+  const discriminator = (union._def?.discriminator ?? union.discriminator) as string | undefined;
+  if (typeof discriminator !== "string" || discriminator.length === 0) {
+    throw new Error(
+      "withEnvelopeIncludeForUnion: failed to resolve discriminator field from input union " +
+        "(checked union._def.discriminator and union.discriminator). Zod major-version drift?",
+    );
+  }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return z.discriminatedUnion(union.discriminator as string, newOptions as any);
+  return z.discriminatedUnion(discriminator, newOptions as any);
 }
 
 /** Shared description for `include` field across raw-shape and discriminatedUnion injection. */

--- a/tests/unit/envelope-discriminated-union.test.ts
+++ b/tests/unit/envelope-discriminated-union.test.ts
@@ -1,0 +1,117 @@
+/**
+ * envelope-discriminated-union.test.ts
+ *
+ * Regression test for `withEnvelopeIncludeForUnion` discriminator access.
+ *
+ * Background: Zod v3 exposed `ZodDiscriminatedUnion.discriminator` on the
+ * public surface; Zod v4 moved it under `_def.discriminator`. PR #153
+ * bumped zod 4.3.6 → 4.4.x and the helper kept reading `union.discriminator`
+ * (now `undefined`), breaking every variant's parse with "Invalid
+ * discriminated union option at index 0" for keyboard / clipboard /
+ * window_dock / scroll / terminal / browser_eval. Shipped to v1.3.0.
+ *
+ * This suite parses each affected registration schema with a valid input
+ * shape (so the discriminator must resolve to a real string and dispatch
+ * correctly) and one wrong-discriminator input (must surface a typed
+ * Zod error rather than silently match the first variant).
+ */
+
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import {
+  withEnvelopeIncludeForUnion,
+} from "../../src/tools/_envelope.js";
+import { keyboardRegistrationSchema } from "../../src/tools/keyboard.js";
+import { clipboardRegistrationSchema } from "../../src/tools/clipboard.js";
+import { windowDockRegistrationSchema } from "../../src/tools/window-dock.js";
+import { scrollRegistrationSchema } from "../../src/tools/scroll.js";
+import { terminalRegistrationSchema } from "../../src/tools/terminal.js";
+import { browserEvalRegistrationSchema } from "../../src/tools/browser.js";
+
+interface DiscUnionCase {
+  name: string;
+  schema: z.ZodTypeAny;
+  validInput: Record<string, unknown>;
+  validInputAlt?: Record<string, unknown>;
+  invalidDiscriminatorInput: Record<string, unknown>;
+}
+
+const cases: DiscUnionCase[] = [
+  {
+    name: "keyboard",
+    schema: keyboardRegistrationSchema,
+    validInput: { action: "press", keys: "ctrl+n" },
+    validInputAlt: { action: "type", text: "hello" },
+    invalidDiscriminatorInput: { action: "bogus", text: "x" },
+  },
+  {
+    name: "clipboard",
+    schema: clipboardRegistrationSchema,
+    validInput: { action: "read" },
+    invalidDiscriminatorInput: { action: "no_such_action" },
+  },
+  {
+    name: "window_dock",
+    schema: windowDockRegistrationSchema,
+    validInput: { action: "pin", title: "Notepad" },
+    invalidDiscriminatorInput: { action: "no_such_action", title: "Notepad" },
+  },
+  {
+    name: "scroll",
+    schema: scrollRegistrationSchema,
+    validInput: { action: "raw", direction: "down" },
+    invalidDiscriminatorInput: { action: "no_such_action" },
+  },
+  {
+    name: "terminal",
+    schema: terminalRegistrationSchema,
+    validInput: { action: "read", windowTitle: "PowerShell" },
+    invalidDiscriminatorInput: { action: "no_such_action", windowTitle: "PowerShell" },
+  },
+  {
+    name: "browser_eval",
+    schema: browserEvalRegistrationSchema,
+    validInput: { action: "js", expression: "1+1" },
+    invalidDiscriminatorInput: { action: "no_such_action", expression: "1+1" },
+  },
+];
+
+describe("withEnvelopeIncludeForUnion: discriminator access survives Zod v3 → v4 transition (#regression after zod 4.3.6 → 4.4.3 bump)", () => {
+  for (const c of cases) {
+    it(`${c.name}: valid input parses (discriminator dispatches correctly)`, () => {
+      const result = c.schema.safeParse(c.validInput);
+      expect(result.success, `parse of ${JSON.stringify(c.validInput)} failed: ${
+        result.success ? "" : JSON.stringify(result.error.issues)
+      }`).toBe(true);
+    });
+
+    if (c.validInputAlt !== undefined) {
+      it(`${c.name}: alternate variant valid input also parses`, () => {
+        const result = c.schema.safeParse(c.validInputAlt);
+        expect(result.success).toBe(true);
+      });
+    }
+
+    it(`${c.name}: include opt-in survives the wrap (registration schema accepts include:["envelope"])`, () => {
+      const result = c.schema.safeParse({ ...c.validInput, include: ["envelope"] });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect((result.data as { include?: string[] }).include).toEqual(["envelope"]);
+      }
+    });
+
+    it(`${c.name}: invalid discriminator surfaces a Zod typed error (not a silent match)`, () => {
+      const result = c.schema.safeParse(c.invalidDiscriminatorInput);
+      expect(result.success).toBe(false);
+    });
+  }
+});
+
+describe("withEnvelopeIncludeForUnion: explicit guard for missing discriminator", () => {
+  it("throws a descriptive error when input is not a ZodDiscriminatedUnion", () => {
+    const fakeUnion = { options: [], _def: {} } as unknown as Parameters<typeof withEnvelopeIncludeForUnion>[0];
+    expect(() => withEnvelopeIncludeForUnion(fakeUnion)).toThrowError(
+      /failed to resolve discriminator field/i,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- v1.3.0 で `keyboard` / `clipboard` / `window_dock` / `scroll` / `terminal` / `browser_eval` の 6 tool が parse 時に "Invalid discriminated union option at index 0" で全失敗していた production bug を修正
- 原因: PR #153 (zod 4.3.6 → 4.4.x) で `ZodDiscriminatedUnion.discriminator` の public field 位置が `_def.discriminator` 配下へ移動。`withEnvelopeIncludeForUnion` (src/tools/_envelope.ts:487) が旧 path のまま `undefined` を `z.discriminatedUnion(...)` に渡し、結果として全 variant が dispatch 不能になっていた
- Fix: `_def.discriminator ?? union.discriminator` の二段アクセスで Zod v3 / v4 両対応。string 解決失敗時は明示的に throw（将来の major bump で同型 silent breakage を防ぐ）
- 回帰テスト `tests/unit/envelope-discriminated-union.test.ts` を新設。6 tool 全部の registration schema を parse して valid input + 別 variant + include opt-in 維持 + invalid discriminator → typed error を検査

## Verification
- `npx vitest run --project=unit tests/unit/envelope-discriminated-union.test.ts` → fix 適用前は 20/20 fail、適用後は 20/20 pass
- フル unit suite: 2670/2675 pass。残 1 件 `tests/unit/native-win32-panic-fuzz.test.ts > win32GetProcessIdentity stays consistent across 100 PIDs` は main の adfc4ab でも同様に失敗する pre-existing 環境依存 fail で本 PR と無関係（別 issue で扱うべき）
- ライブ検証: 修正前の MCP server (`C:\Git\desktop-touch-mcp\dist\index.js`) で `keyboard({action:'press', keys:'ctrl+n', windowTitle:'Outlook'})` が "Invalid discriminated union option at index 0" を返すことを確認

## Test plan
- [ ] CI: lint + type-check + unit
- [ ] Local: `/mcp` reconnect 後に `keyboard({action:'press',keys:'ctrl+n'})` で Outlook 新規メールが開くこと
- [ ] Local: `clipboard({action:'read'})` / `terminal({action:'read', windowTitle:'PowerShell'})` も復活すること
- [ ] Release: v1.3.1 として patch publish（v1.3.0 利用者全員影響、優先度高）

Closes #171.
