### PR TITLE
feat(keyboard): BG path delivery verification (#177)

### DIFF
--- a/src/tools/_errors.ts
+++ b/src/tools/_errors.ts
@@ -165,6 +165,20 @@ const SUGGESTS: Record<string, string[]> = {
     "If a modifier key (Shift / Ctrl) must be held during the drag, send it via keyboard({action:'press'}) before the drag and release after — modifier state is not preserved across the SendInput sequence",
     "If the drop target is a dragdrop API consumer (Explorer, IDE file tabs), pixel SendInput cannot signal DROPEFFECT — use desktop_act(lease, action='drag') if the target is UIA-discoverable",
   ],
+  // Issue #177: keyboard({action:'press', method:'background'}) WM_KEYDOWN/UP
+  // delivery verification (terminal-class targets only). Distinct from
+  // BackgroundInputNotDelivered because the channel is WM_KEYDOWN/UP (key combo)
+  // not WM_CHAR (text), and the verification scope is narrower (only enter /
+  // tab / arrow keys produce a buffer mutation that UIA TextPattern read-back
+  // can detect — other combos return hints.verifyDelivery: 'unverifiable'
+  // instead of failing). Suggest copy is keyboard-press specific so classify()
+  // is 1:1 with SUGGESTS dictionary (PR #174 Codex round 2 P1-1 SSOT pattern).
+  BackgroundKeyNotDelivered: [
+    "Retry with method:'foreground' — post-send UIA read-back did not observe the expected buffer mutation (cursor advance / new line / tab insertion).",
+    "Common cause: Windows Terminal (WinUI/XAML host) silently drops WM_KEYDOWN; use foreground SendInput which dispatches via the system input queue.",
+    "Common cause: terminal runs elevated (admin) while caller does not — UIPI blocks PostMessage.",
+    "Verification scope: only enter / tab / arrow keys are read-back-verified on terminal-class targets. Other combos return hints.verifyDelivery:'unverifiable' rather than this error — caller should observe the semantic effect (e.g. menu open, selection change) directly.",
+  ],
   SetValueAllChannelsFailed: [
     "Verify the element supports text input",
     "Try click_element + keyboard({action:'type'}) manually",
@@ -299,6 +313,9 @@ function classify(message: string): { code: string; suggest: string[] } {
   }
   if (m.includes("clipboardwritenotdelivered") || m.includes("clipboard write not delivered")) {
     return { code: "ClipboardWriteNotDelivered", suggest: SUGGESTS.ClipboardWriteNotDelivered };
+  }
+  if (m.includes("backgroundkeynotdelivered") || m.includes("background key not delivered")) {
+    return { code: "BackgroundKeyNotDelivered", suggest: SUGGESTS.BackgroundKeyNotDelivered };
   }
   // Issue #178: keep mouse_drag check BEFORE mouse_click — "mouseclicknotdelivered"
   // would otherwise substring-match a longer string like "mousedragnotdelivered" (it

--- a/src/tools/keyboard.ts
+++ b/src/tools/keyboard.ts
@@ -728,7 +728,14 @@ export const keyboardTypeHandler = async ({
               const postCleaned = stripAnsi(postRaw);
               const sliced = applyKeyboardSinceMarker(postCleaned, baselineMarker!);
               if (sliced.matched) {
-                const exact = sliced.text.includes(checkText);
+                // sliced.text is already normalised (normalizeForMarker strips
+                // trailing whitespace per line + trailing newlines), so
+                // checkText must be normalised the same way before exact
+                // matching — otherwise inputs ending in spaces (e.g. "cd ")
+                // would false-fail because the post-buffer had the trailing
+                // space stripped during marker normalisation. Codex P1.
+                const checkTextNormalized = normalizeForMarker(checkText);
+                const exact = sliced.text.includes(checkTextNormalized);
                 const tail = checkText.replace(/\s+/g, "").slice(-8);
                 const slicedNoWs = sliced.text.replace(/\s+/g, "");
                 const tailMatch = tail.length >= 4 && slicedNoWs.includes(tail);
@@ -1119,8 +1126,20 @@ export const keyboardPressHandler = async ({
               const diffNoWs = sliced.text.replace(/\s+/g, "");
               if (trimmed === "enter") {
                 verifiedDelivery = sliced.text.includes("\n") || diffNoWs.length > 0;
-              } else {
+              } else if (trimmed === "tab") {
+                // Tab inserts whitespace (or completion text) at the cursor;
+                // any non-empty diff in the slice = delivered.
                 verifiedDelivery = sliced.text.length > 0;
+              } else {
+                // Arrow keys (left/right/up/down): cursor moves but UIA
+                // TextPattern frequently does NOT expose cursor-position
+                // changes in the diff slice. An empty diff is therefore
+                // undetermined, NOT a failure: report `unverifiable` so a
+                // legitimate arrow press is not classified as
+                // BackgroundKeyNotDelivered (Codex P1). Non-empty diff (e.g.
+                // a host that does repaint cursor row into the buffer) is
+                // still accepted as `delivered`.
+                verifiedDelivery = sliced.text.length > 0 ? true : "unverifiable";
               }
             }
             if (verifiedDelivery === "unverifiable") {

--- a/src/tools/keyboard.ts
+++ b/src/tools/keyboard.ts
@@ -98,11 +98,21 @@ export async function typeViaClipboard(text: string, pasteCombo: "ctrl+v" | "ctr
 //     target-specific observation channels we can't generalise
 // See docs/operation-verification-matrix.md §3.1 (keyboard rows) and §4.
 
-/** Normalise text the same way terminal.ts marker logic does. */
+/**
+ * Normalise text the same way terminal.ts marker logic does.
+ *
+ * Removed the per-line `[ \t]+$/gm` strip after Codex P1 v2: stripping
+ * trailing whitespace from every line in the read-back snapshot caused
+ * legitimate inputs that end in spaces (`"cd "`, indentation tokens) to
+ * silently lose those spaces in the diff and false-fail exact matching as
+ * BackgroundInputNotDelivered. Trailing-newline collapse and CRLF→LF
+ * normalisation are kept because the input side already strips
+ * `[\r\n]+$` and we don't want to compare a shell prompt's terminator
+ * against an input boundary.
+ */
 function normalizeForMarker(text: string): string {
   return text
     .replace(/\r\n/g, "\n")
-    .replace(/[ \t]+$/gm, "")
     .replace(/\n+$/, "");
 }
 
@@ -728,14 +738,10 @@ export const keyboardTypeHandler = async ({
               const postCleaned = stripAnsi(postRaw);
               const sliced = applyKeyboardSinceMarker(postCleaned, baselineMarker!);
               if (sliced.matched) {
-                // sliced.text is already normalised (normalizeForMarker strips
-                // trailing whitespace per line + trailing newlines), so
-                // checkText must be normalised the same way before exact
-                // matching — otherwise inputs ending in spaces (e.g. "cd ")
-                // would false-fail because the post-buffer had the trailing
-                // space stripped during marker normalisation. Codex P1.
-                const checkTextNormalized = normalizeForMarker(checkText);
-                const exact = sliced.text.includes(checkTextNormalized);
+                // normalizeForMarker no longer strips trailing whitespace
+                // per line (Codex P1), so sliced.text preserves the input's
+                // trailing spaces — compare raw checkText directly.
+                const exact = sliced.text.includes(checkText);
                 const tail = checkText.replace(/\s+/g, "").slice(-8);
                 const slicedNoWs = sliced.text.replace(/\s+/g, "");
                 const tailMatch = tail.length >= 4 && slicedNoWs.includes(tail);

--- a/src/tools/keyboard.ts
+++ b/src/tools/keyboard.ts
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { createHash } from "node:crypto";
 import { buildDesc } from "./_types.js";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
@@ -15,6 +16,8 @@ import {
   isBgAutoEnabled,
   TERMINAL_WINDOW_CLASSES,
 } from "../engine/bg-input.js";
+import { getTextViaTextPattern } from "../engine/uia-bridge.js";
+import { stripAnsi } from "../engine/ansi.js";
 import { ok } from "./_types.js";
 import type { ToolResult } from "./_types.js";
 import { failWith } from "./_errors.js";
@@ -78,6 +81,125 @@ export async function typeViaClipboard(text: string, pasteCombo: "ctrl+v" | "ctr
       // Restore is best-effort — don't fail the overall operation
     }
   }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #177 — BG path post-send delivery verification helpers
+// ─────────────────────────────────────────────────────────────────────────────
+// Mirrors `src/tools/terminal.ts` (PR #174 v1.3.2 規範): pre-send UIA
+// TextPattern baseline → WM_CHAR / WM_KEYDOWN send → 150ms settle → post-send
+// read-back. Embedded-newline gate (conhost prompt interleaving) and
+// SHA-256 marker boundary are kept identical. The only divergence from
+// terminal.ts is keyboard.ts targets a wider class of windows (not just
+// terminals), so the verification gate adds:
+//   - TextPattern unavailability → "unverifiable" (status hint), not fail
+//   - press(non-arrow / non-enter / non-tab) → "unverifiable" by design,
+//     because semantic effects (selection change, menu open) need
+//     target-specific observation channels we can't generalise
+// See docs/operation-verification-matrix.md §3.1 (keyboard rows) and §4.
+
+/** Normalise text the same way terminal.ts marker logic does. */
+function normalizeForMarker(text: string): string {
+  return text
+    .replace(/\r\n/g, "\n")
+    .replace(/[ \t]+$/gm, "")
+    .replace(/\n+$/, "");
+}
+
+/** SHA-256 (hex, 16 chars) of the last 256 normalised chars. */
+function makeKeyboardBaselineMarker(text: string): string {
+  const norm = normalizeForMarker(text);
+  const slice = norm.slice(-256);
+  return createHash("sha256").update(slice).digest("hex").slice(0, 16);
+}
+
+/**
+ * Slice `text` after a previously-recorded marker. Returns matched:false when
+ * the baseline boundary cannot be relocated (caller treats that as
+ * "verification undetermined", not "delivery failed").
+ */
+function applyKeyboardSinceMarker(
+  text: string,
+  marker: string,
+): { text: string; matched: boolean } {
+  const norm = normalizeForMarker(text);
+  const WINDOW = 256;
+  const tailFromNormEnd = (normEnd: number): string =>
+    norm.slice(normEnd).replace(/^\n/, "");
+
+  if (norm.length >= WINDOW) {
+    const maxScan = Math.min(norm.length, WINDOW + 32_000);
+    for (let end = norm.length; end >= norm.length - maxScan && end >= WINDOW; end--) {
+      const slice = norm.slice(end - WINDOW, end);
+      if (createHash("sha256").update(slice).digest("hex").slice(0, 16) === marker) {
+        return { text: tailFromNormEnd(end), matched: true };
+      }
+    }
+    return { text, matched: false };
+  }
+
+  for (let end = norm.length; end >= 0; end--) {
+    if (createHash("sha256").update(norm.slice(0, end)).digest("hex").slice(0, 16) === marker) {
+      return { text: tailFromNormEnd(end), matched: true };
+    }
+  }
+  return { text, matched: false };
+}
+
+/**
+ * Issue #177: shape for `hints.verifyDelivery` per matrix doc §4.2.
+ *
+ * - `delivered`: Strict / Indirect verification passed.
+ * - `unverifiable`: no observation channel available — caller should not
+ *   assume delivery from `ok:true` alone. `reason` is a typed enum from
+ *   matrix doc §4.3.
+ *
+ * `focus_only` is reserved for the FG path (mouse_click / keyboard FG) and
+ * is not used here — BG is HWND-targeted, focus is irrelevant.
+ */
+type VerifyDeliveryStatus = "delivered" | "unverifiable";
+interface VerifyDeliveryHint {
+  status: VerifyDeliveryStatus;
+  /**
+   * Typed reason from matrix doc §4.3. Intentionally typed loose (string)
+   * because the enum is documented in the matrix doc, not in code — adding
+   * new reasons is a doc-only PR (matrix §4.3 last paragraph).
+   */
+  reason?: string;
+  /** Send channel (matrix doc §4.2). */
+  channel?: "wm_char" | "wm_keydown";
+  /** Suggested next path the caller can try. */
+  fallback?: string;
+}
+
+/**
+ * Keys that produce a buffer mutation visible to UIA TextPattern read-back
+ * on terminal-class targets:
+ *   - enter / "\r": appends a new line → cursor advance + new prompt.
+ *   - tab: inserts whitespace at cursor → trailing-content diff visible
+ *     when the prompt does not consume it as completion.
+ *   - arrows: move cursor → may alter the rendered cursor row in the
+ *     TextPattern snapshot (best-effort; some hosts repaint without diff).
+ *
+ * The check is intentionally narrow — broader combos (ctrl+c interrupting a
+ * running command, ctrl+l clearing the screen) DO mutate the buffer but the
+ * *direction* of the change differs per target, so a generic "post.length >
+ * pre.length" check would false-positive on ctrl+l (clears) and false-negative
+ * on ctrl+c at a clean prompt.
+ */
+function isReadBackVerifiableCombo(keys: string): boolean {
+  const trimmed = keys.toLowerCase().trim();
+  // No modifiers (the read-back signal is only reliable for plain navigation /
+  // line-commit keys; modified combos take semantic actions we can't generalise).
+  if (trimmed.includes("+")) return false;
+  return (
+    trimmed === "enter" ||
+    trimmed === "tab" ||
+    trimmed === "left" ||
+    trimmed === "right" ||
+    trimmed === "up" ||
+    trimmed === "down"
+  );
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -518,6 +640,44 @@ export const keyboardTypeHandler = async ({
           if (use_clipboard && !forceKeystrokes) {
             bgWarnings.push("BackgroundClipboardDowngraded");
           }
+
+          // Issue #177 — post-send delivery verification (matrix doc §3.1
+          // "keyboard (action:type BG)": Strict). Mirrors terminal.ts:299-496:
+          //   Phase 1: pre-send TextPattern baseline + SHA-256 marker.
+          //   Phase 2: side-effect injection (postCharsToHwnd).
+          //   Phase 3: 150ms settle.
+          //   Phase 4: post-send TextPattern read-back, exact substring +
+          //            tail-N (>=4 non-whitespace chars) fallback.
+          //   Phase 5: judge → BackgroundInputNotDelivered (shared with
+          //            terminal — same WM_CHAR channel, same silent-drop
+          //            symptom, matrix doc §3.1 row "code shared").
+          //
+          // Verification gate (matches terminal.ts verificationNeeded scope):
+          //   - method:'background' explicit → always verify (covers WT and
+          //     other auto-rejected handles the caller forced through).
+          //   - DTM_BG_AUTO=1 + non-terminal class → verify (env override can
+          //     route input to unknown apps).
+          //   - terminal-class auto-route → skip (well-tested conhost case,
+          //     150ms read-back wouldn't catch anything).
+          const targetClass = (() => {
+            try { return getWindowClassName(target.hwnd); } catch { return ""; }
+          })();
+          const isTerminalTarget = !!targetClass && TERMINAL_WINDOW_CLASSES.has(targetClass);
+          const verificationNeeded =
+            inputMethod === "background" || (isBgAutoEnabled() && !isTerminalTarget);
+
+          // Skip the baseline read for unverifiable inputs to save the
+          // ~PowerShell-UIA round-trip cost (no TextPattern call when we
+          // already know we can't compare).
+          const checkText = effectiveText.replace(/[\r\n]+$/, "");
+          const hasEmbeddedNewline = /[\r\n]/.test(checkText);
+          const baselineRaw =
+            verificationNeeded && checkText.length > 0 && !hasEmbeddedNewline
+              ? await getTextViaTextPattern(target.title)
+              : null;
+          const baselineMarker =
+            baselineRaw !== null ? makeKeyboardBaselineMarker(stripAnsi(baselineRaw)) : null;
+
           if (replaceAll) postKeyComboToHwnd(target.hwnd, "ctrl+a");
           const result = postCharsToHwnd(target.hwnd, effectiveText);
           if (!result.full) {
@@ -535,17 +695,110 @@ export const keyboardTypeHandler = async ({
                 ...(bgPerception && { _perceptionForPost: bgPerception }),
               }
             );
-          } else {
-            return ok({
-              ok: true,
-              typed: result.sent,
-              method: "background",
-              channel: "wm_char",
-              foregroundChanged: false,
-              ...(bgWarnings.length > 0 && { hints: { warnings: bgWarnings } }),
-              ...(bgPerception && { _perceptionForPost: bgPerception }),
-            });
           }
+
+          // ── Issue #177: post-send UIA read-back delivery verification ──
+          //
+          // PostMessage(WM_CHAR) returns true when the message is queued, even
+          // if the target never consumes it. Without this check, ok:true would
+          // silently lie about delivery on Windows Terminal (XAML pipeline
+          // swallow) and other WinUI hosts. See terminal.ts:406-460 for the
+          // canonical comment thread that motivated this design.
+          //
+          // The check is gated by `verificationNeeded` above; here we
+          // additionally skip when:
+          //   - baseline could not be read (no TextPattern provider) → produce
+          //     a `verifyDelivery: unverifiable` hint instead of failing,
+          //   - input has no echo-able content (only trailing newlines), or
+          //   - input contains embedded newlines. conhost commits each line at
+          //     the CR and inserts a fresh prompt before the next line, so the
+          //     buffer interleaves prompts between input lines and a plain
+          //     substring includes() would false-fail.
+          let verifiedDelivery: boolean | "unverifiable" = "unverifiable";
+          let verifyReason: string | undefined;
+          const verifiable =
+            verificationNeeded &&
+            baselineMarker !== null &&
+            checkText.length > 0 &&
+            !hasEmbeddedNewline;
+          if (verifiable) {
+            await new Promise<void>((r) => setTimeout(r, 150));
+            const postRaw = await getTextViaTextPattern(target.title);
+            if (postRaw !== null) {
+              const postCleaned = stripAnsi(postRaw);
+              const sliced = applyKeyboardSinceMarker(postCleaned, baselineMarker!);
+              if (sliced.matched) {
+                const exact = sliced.text.includes(checkText);
+                const tail = checkText.replace(/\s+/g, "").slice(-8);
+                const slicedNoWs = sliced.text.replace(/\s+/g, "");
+                const tailMatch = tail.length >= 4 && slicedNoWs.includes(tail);
+                verifiedDelivery = exact || tailMatch;
+              }
+              // Marker miss (matched:false): undetermined — keep "unverifiable"
+              // and fall through to ok with verifyDelivery hint.
+              if (verifiedDelivery === "unverifiable") {
+                verifyReason = "read_back_unsupported";
+              }
+            } else {
+              verifyReason = "read_back_unsupported";
+            }
+          } else if (verificationNeeded) {
+            // verifiable=false reasons (matrix §4.3 enum): TextPattern
+            // baseline missing → read_back_unsupported; embedded newline →
+            // embedded_newline. Empty checkText falls through silently.
+            if (baselineMarker === null && checkText.length > 0) {
+              verifyReason = "read_back_unsupported";
+            } else if (hasEmbeddedNewline) {
+              verifyReason = "embedded_newline";
+            }
+          }
+
+          if (verifiedDelivery === false) {
+            // suggest[] is provided by classify() via SUGGESTS.BackgroundInputNotDelivered
+            // — keep this call site free of duplicated copy so the dictionary stays SSOT.
+            return failWith(
+              new Error("BackgroundInputNotDelivered"),
+              "keyboard:type",
+              {
+                context: {
+                  hint: "post-send UIA read-back did not contain the input substring",
+                  targetClass,
+                },
+                ...(bgPerception && { _perceptionForPost: bgPerception }),
+              }
+            );
+          }
+
+          // Build hints.verifyDelivery (matrix doc §4.2). Always include the
+          // hint when verification was attempted so callers can tell apart
+          // "delivered (passed Strict check)" from "ok:true (no observation
+          // path)" — the latter is the silent-success category we're hardening
+          // against in issue #173.
+          const verifyDelivery: VerifyDeliveryHint | null = verificationNeeded
+            ? verifiedDelivery === true
+              ? { status: "delivered", channel: "wm_char" }
+              : {
+                  status: "unverifiable",
+                  ...(verifyReason && { reason: verifyReason }),
+                  channel: "wm_char",
+                  fallback: "method:'foreground'",
+                }
+            : null;
+
+          return ok({
+            ok: true,
+            typed: result.sent,
+            method: "background",
+            channel: "wm_char",
+            foregroundChanged: false,
+            ...((bgWarnings.length > 0 || verifyDelivery) && {
+              hints: {
+                ...(bgWarnings.length > 0 && { warnings: bgWarnings }),
+                ...(verifyDelivery && { verifyDelivery }),
+              },
+            }),
+            ...(bgPerception && { _perceptionForPost: bgPerception }),
+          });
         } else if (effectiveMethod === "background") {
           return failWith(
             new Error("BackgroundInputUnsupported"),
@@ -788,37 +1041,139 @@ export const keyboardPressHandler = async ({
         if (!bgGuard.ok) return bgGuard.errorResult;
         const bgPerception = bgGuard.perceptionEnv;
 
+          // Issue #177 — post-send delivery verification (matrix doc §3.1
+          // "keyboard (action:press BG)": Indirect). Most key combos take
+          // semantic actions (selection change, menu open, app shortcut) that
+          // need target-specific observation channels, so the default outcome
+          // is `verifyDelivery: { status: "unverifiable" }` to be honest about
+          // not having checked.
+          //
+          // **Exception**: enter / tab / arrow on terminal-class targets
+          // produce a buffer mutation that UIA TextPattern read-back can
+          // detect (cursor advance, new line). See `isReadBackVerifiableCombo`
+          // for the explicit allow-list and matrix doc §3.1 row "press BG"
+          // for the rationale.
+          const targetClass = (() => {
+            try { return getWindowClassName(target.hwnd); } catch { return ""; }
+          })();
+          const isTerminalTarget = !!targetClass && TERMINAL_WINDOW_CLASSES.has(targetClass);
+          const verificationNeeded =
+            inputMethod === "background" || (isBgAutoEnabled() && !isTerminalTarget);
+          const readBackVerifiable =
+            verificationNeeded && isTerminalTarget && isReadBackVerifiableCombo(keys);
+
         const isEnter = keys.toLowerCase() === "enter";
+
+        // Pre-send baseline (only when read-back will be attempted).
+        const baselineRaw = readBackVerifiable
+          ? await getTextViaTextPattern(target.title)
+          : null;
+        const baselineMarker =
+          baselineRaw !== null ? makeKeyboardBaselineMarker(stripAnsi(baselineRaw)) : null;
+
         const ok2 = isEnter
           ? postEnterToHwnd(target.hwnd)
           : postKeyComboToHwnd(target.hwnd, keys);
-        if (ok2) {
-          return ok({
-            ok: true,
-            pressed: keys,
-            method: "background",
-            channel: "wm_char",
-            foregroundChanged: false,
-            ...(bgPerception && { _perceptionForPost: bgPerception }),
-          });
+        if (!ok2) {
+          // postKeyComboToHwnd may fail after partially sending a combo (e.g.,
+          // modifier WM_KEYDOWN succeeded but the next message failed), leaving
+          // modifier state inconsistent in the target. Falling through to the
+          // foreground path would replay the combo and double-input or leave
+          // dangling modifiers — fail regardless of method (PR #64 Codex P1).
+          return failWith(
+            new Error("BackgroundInputIncomplete"),
+            "keyboard:press",
+            {
+              suggest: [
+                "Key press failed in background mode - retry with method:'foreground'",
+                "If terminal runs elevated (admin) and caller does not, foreground delivery may be required (UIPI blocks WM_CHAR)",
+              ],
+              context: { keys },
+              ...(bgPerception && { _perceptionForPost: bgPerception }),
+            }
+          );
         }
-        // postKeyComboToHwnd may fail after partially sending a combo (e.g.,
-        // modifier WM_KEYDOWN succeeded but the next message failed), leaving
-        // modifier state inconsistent in the target. Falling through to the
-        // foreground path would replay the combo and double-input or leave
-        // dangling modifiers — fail regardless of method (PR #64 Codex P1).
-        return failWith(
-          new Error("BackgroundInputIncomplete"),
-          "keyboard:press",
-          {
-            suggest: [
-              "Key press failed in background mode - retry with method:'foreground'",
-              "If terminal runs elevated (admin) and caller does not, foreground delivery may be required (UIPI blocks WM_CHAR)",
-            ],
-            context: { keys },
-            ...(bgPerception && { _perceptionForPost: bgPerception }),
+
+        // ── Post-send read-back (terminal-class enter/tab/arrow only) ──
+        let verifiedDelivery: boolean | "unverifiable" = "unverifiable";
+        let verifyReason: string | undefined;
+        if (readBackVerifiable && baselineMarker !== null) {
+          await new Promise<void>((r) => setTimeout(r, 150));
+          const postRaw = await getTextViaTextPattern(target.title);
+          if (postRaw !== null) {
+            const postCleaned = stripAnsi(postRaw);
+            const sliced = applyKeyboardSinceMarker(postCleaned, baselineMarker);
+            // Detection rule per key:
+            //   - enter: a new line appeared in the diff (the prompt printed
+            //     after the line commit), so sliced.text contains '\n' OR
+            //     non-empty new content.
+            //   - tab: cursor moved → diff is non-empty (whitespace insertion
+            //     OR completion suggestion rendered into the buffer).
+            //   - arrows: cursor row may shift; we accept any non-whitespace
+            //     diff as evidence of repaint. False-negatives are possible
+            //     when the host repaints in place — that's why this is gated
+            //     to terminal-class targets where the prompt + cursor model
+            //     is well-defined.
+            if (sliced.matched) {
+              const trimmed = keys.toLowerCase().trim();
+              const diffNoWs = sliced.text.replace(/\s+/g, "");
+              if (trimmed === "enter") {
+                verifiedDelivery = sliced.text.includes("\n") || diffNoWs.length > 0;
+              } else {
+                verifiedDelivery = sliced.text.length > 0;
+              }
+            }
+            if (verifiedDelivery === "unverifiable") {
+              verifyReason = "read_back_unsupported";
+            }
+          } else {
+            verifyReason = "read_back_unsupported";
           }
-        );
+        } else if (verificationNeeded) {
+          // Most combos: no observation channel → unverifiable by design.
+          // matrix doc §3.1 explicitly lists this as the regular outcome.
+          verifyReason = "read_back_unsupported";
+        }
+
+        if (verifiedDelivery === false) {
+          return failWith(
+            new Error("BackgroundKeyNotDelivered"),
+            "keyboard:press",
+            {
+              context: {
+                hint: "post-send UIA read-back did not observe the expected buffer mutation",
+                keys,
+                targetClass,
+              },
+              ...(bgPerception && { _perceptionForPost: bgPerception }),
+            }
+          );
+        }
+
+        // Channel for hints (matrix §4.2): enter uses postEnterToHwnd which
+        // sends WM_CHAR '\r' (terminals normalise it as a line commit), all
+        // other combos use postKeyComboToHwnd / WM_KEYDOWN+WM_KEYUP.
+        const pressChannel: "wm_char" | "wm_keydown" = isEnter ? "wm_char" : "wm_keydown";
+        const verifyDelivery: VerifyDeliveryHint | null = verificationNeeded
+          ? verifiedDelivery === true
+            ? { status: "delivered", channel: pressChannel }
+            : {
+                status: "unverifiable",
+                ...(verifyReason && { reason: verifyReason }),
+                channel: pressChannel,
+                fallback: "method:'foreground'",
+              }
+          : null;
+
+        return ok({
+          ok: true,
+          pressed: keys,
+          method: "background",
+          channel: "wm_char",
+          foregroundChanged: false,
+          ...(verifyDelivery && { hints: { verifyDelivery } }),
+          ...(bgPerception && { _perceptionForPost: bgPerception }),
+        });
       } else if (effectiveMethod === "background") {
         return failWith(
           new Error("BackgroundInputUnsupported"),

--- a/tests/e2e/keyboard-bg-verification.test.ts
+++ b/tests/e2e/keyboard-bg-verification.test.ts
@@ -1,0 +1,204 @@
+/**
+ * keyboard-bg-verification.test.ts — E2E for issue #177:
+ * keyboard({action:'type'/'press', method:'background'}) post-send delivery
+ * verification (matrix doc §3.1 keyboard rows).
+ *
+ * Coverage:
+ *  1. type BG to Windows Terminal (WT) → BackgroundInputNotDelivered
+ *     (`DTM_E2E_WT=1` opt-in; same channel/code as terminal({action:'send'})
+ *     because WM_CHAR + WT XAML pipeline silently drops the message).
+ *  2. type BG to conhost-hosted PowerShell → ok:true with
+ *     hints.verifyDelivery: { status: "delivered", channel: "wm_char" }
+ *     (regression guard for the well-tested path).
+ *  3. type BG to Notepad → ok:true, regression guard for non-terminal.
+ *     Verification is skipped when method:'auto' on a non-terminal class
+ *     (no DTM_BG_AUTO=1), so the test forces method:'background' and
+ *     accepts either status:"delivered" (TextPattern read-back succeeded)
+ *     or status:"unverifiable" (TextPattern unavailable on the Edit child) —
+ *     the contract is "no silent ok:true without a hint".
+ *  4. press BG (non-arrow combo) on conhost → ok:true with
+ *     hints.verifyDelivery: { status: "unverifiable", channel: "wm_keydown" }
+ *     pinning the matrix doc §4.2 unverifiable shape (matrix doc §3.1
+ *     "press BG" Indirect by-design degradation).
+ *  5. press BG (enter) on conhost → ok:true with verifyDelivery:delivered
+ *     (read-back-verifiable combo per allow-list).
+ *
+ * Skip policy: WT scenario is opt-in via `DTM_E2E_WT=1` — WT-launcher cleanup
+ * has been hardened to single-PID kill (no /T) but the env-var gate prevents
+ * accidental WT-tree damage for casual `npm test` runs (memory:
+ * feedback_e2e_wt_host_taskkill_risk.md). conhost / Notepad cases run always.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { keyboardTypeHandler, keyboardPressHandler } from "../../src/tools/keyboard.js";
+import { launchPowerShell, type PsInstance } from "./helpers/powershell-launcher.js";
+import { launchNotepad, type NpInstance } from "./helpers/notepad-launcher.js";
+import { parsePayload } from "./helpers/wait.js";
+
+const WT_E2E_ENABLED = process.env["DTM_E2E_WT"] === "1";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// type BG verification
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("keyboard({action:'type', method:'background'}) — issue #177 verification", () => {
+  // 1. Windows Terminal — opt-in; surfaces BackgroundInputNotDelivered.
+  if (WT_E2E_ENABLED) {
+    describe("[Windows Terminal] type BG", () => {
+      let ps: PsInstance;
+      beforeAll(async () => {
+        ps = await launchPowerShell({ host: "wt", banner: "ready-bg-type-wt" });
+      }, 15_000);
+      afterAll(() => { ps?.kill(); });
+
+      it("returns BackgroundInputNotDelivered (post-send UIA read-back catches WT silent drop)", async () => {
+        const tag = `bg-type-wt-${Date.now().toString(36)}`;
+        const r = parsePayload(await keyboardTypeHandler({
+          text: tag,
+          method: "background",
+          use_clipboard: false,
+          replaceAll: false,
+          forceKeystrokes: false,
+          windowTitle: ps.title,
+          trackFocus: false,
+          settleMs: 0,
+        }));
+        expect(r.ok, JSON.stringify(r)).toBe(false);
+        expect(r.code).toBe("BackgroundInputNotDelivered");
+        expect(Array.isArray(r.suggest)).toBe(true);
+        expect(r.suggest.some((s: string) => /foreground/i.test(s))).toBe(true);
+      }, 10_000);
+    });
+  }
+
+  // 2. conhost — BG path is well-tested, must succeed with delivered hint.
+  describe("[conhost] type BG", () => {
+    let ps: PsInstance;
+    beforeAll(async () => {
+      ps = await launchPowerShell({ host: "conhost", banner: "ready-bg-type-conhost" });
+    }, 15_000);
+    afterAll(() => { ps?.kill(); });
+
+    it("succeeds with hints.verifyDelivery: delivered/wm_char on conhost", async () => {
+      const tag = `bg-type-conhost-${Date.now().toString(36)}`;
+      const r = parsePayload(await keyboardTypeHandler({
+        text: tag,
+        method: "background",
+        use_clipboard: false,
+        replaceAll: false,
+        forceKeystrokes: false,
+        windowTitle: ps.title,
+        trackFocus: false,
+        settleMs: 0,
+      }));
+      expect(r.ok, JSON.stringify(r)).toBe(true);
+      expect(r.method).toBe("background");
+      expect(r.channel).toBe("wm_char");
+      // Verification ran (method:'background' explicit → verificationNeeded=true)
+      // and conhost echoes WM_CHAR into the buffer → status:'delivered'.
+      expect(r.hints?.verifyDelivery).toBeDefined();
+      expect(r.hints.verifyDelivery.channel).toBe("wm_char");
+      // We accept either "delivered" (TextPattern read-back found the tag) or
+      // "unverifiable" (UIA TextPattern not available on this conhost build —
+      // env-dependent). Bare ok:true without verifyDelivery is the regression.
+      expect(["delivered", "unverifiable"]).toContain(r.hints.verifyDelivery.status);
+    }, 10_000);
+  });
+
+  // 3. Notepad — non-terminal regression guard. Verification is opt-in
+  //    (method:'background' explicit) so the path runs; result depends on
+  //    whether TextPattern is available on the Edit child.
+  describe("[Notepad] type BG", () => {
+    let np: NpInstance;
+    beforeAll(async () => {
+      np = await launchNotepad();
+    }, 25_000);
+    afterAll(() => { np?.kill(); });
+
+    it("succeeds and never returns ok:true without a verifyDelivery hint", async () => {
+      const tag = `bg-type-np-${Date.now().toString(36)}`;
+      const r = parsePayload(await keyboardTypeHandler({
+        text: tag,
+        method: "background",
+        use_clipboard: false,
+        replaceAll: false,
+        forceKeystrokes: false,
+        windowTitle: np.title,
+        trackFocus: false,
+        settleMs: 0,
+      }));
+      // Notepad accepts WM_CHAR — should never fail with NotDelivered. (If
+      // canInjectViaPostMessage rejects Notepad on a future Win11 patch, the
+      // test will surface that as a clear failure rather than a silent skip.)
+      expect(r.ok, JSON.stringify(r)).toBe(true);
+      expect(r.method).toBe("background");
+      // Core invariant of issue #177: when verification is requested
+      // (method:'background' explicit), the response MUST carry
+      // hints.verifyDelivery — otherwise we're back to the silent-success
+      // regression that motivated this PR.
+      expect(r.hints?.verifyDelivery).toBeDefined();
+      expect(["delivered", "unverifiable"]).toContain(r.hints.verifyDelivery.status);
+      expect(r.hints.verifyDelivery.channel).toBe("wm_char");
+      if (r.hints.verifyDelivery.status === "unverifiable") {
+        // matrix §4.2 fallback hint must be present so the caller knows the
+        // next path to try.
+        expect(r.hints.verifyDelivery.fallback).toMatch(/foreground/);
+      }
+    }, 15_000);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// press BG verification — pin the unverifiable hint shape
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("keyboard({action:'press', method:'background'}) — issue #177 verification", () => {
+  describe("[conhost] press BG", () => {
+    let ps: PsInstance;
+    beforeAll(async () => {
+      ps = await launchPowerShell({ host: "conhost", banner: "ready-bg-press-conhost" });
+    }, 15_000);
+    afterAll(() => { ps?.kill(); });
+
+    // 4. Non-arrow combo — pin the unverifiable hint shape (matrix §4.2).
+    it("non-arrow combo (ctrl+a) returns hints.verifyDelivery:unverifiable with channel/fallback", async () => {
+      const r = parsePayload(await keyboardPressHandler({
+        keys: "ctrl+a",
+        method: "background",
+        windowTitle: ps.title,
+        trackFocus: false,
+        settleMs: 0,
+      }));
+      expect(r.ok, JSON.stringify(r)).toBe(true);
+      expect(r.method).toBe("background");
+      expect(r.hints?.verifyDelivery).toBeDefined();
+      expect(r.hints.verifyDelivery.status).toBe("unverifiable");
+      expect(r.hints.verifyDelivery.channel).toBe("wm_keydown");
+      expect(r.hints.verifyDelivery.fallback).toMatch(/foreground/);
+      // matrix §4.3 reason enum — read_back_unsupported is the regular
+      // "no observation channel" reason.
+      expect(r.hints.verifyDelivery.reason).toBe("read_back_unsupported");
+    }, 10_000);
+
+    // 5. enter on terminal-class — read-back-verifiable per allow-list.
+    it("enter on conhost succeeds with verifyDelivery:delivered (read-back catches new line)", async () => {
+      const r = parsePayload(await keyboardPressHandler({
+        keys: "enter",
+        method: "background",
+        windowTitle: ps.title,
+        trackFocus: false,
+        settleMs: 0,
+      }));
+      expect(r.ok, JSON.stringify(r)).toBe(true);
+      expect(r.hints?.verifyDelivery).toBeDefined();
+      // We accept "delivered" (read-back saw the new line) or "unverifiable"
+      // (TextPattern not available on this build) — bare ok:true is the
+      // regression. enter is dispatched as WM_CHAR '\r' (postEnterToHwnd),
+      // so channel reflects that on the unverifiable branch; on the
+      // delivered branch the press handler classifies the channel as
+      // wm_keydown by default. Don't pin the channel on this case to keep
+      // the assertion focused on the matrix-doc invariant.
+      expect(["delivered", "unverifiable"]).toContain(r.hints.verifyDelivery.status);
+    }, 10_000);
+  });
+});


### PR DESCRIPTION
## Summary

Add post-send UIA TextPattern read-back to `keyboard({action:'type'/'press', method:'background'})` so silent WM_CHAR / WM_KEYDOWN drops surface as typed errors instead of bare `ok:true`. Same regression class as issue #173 (Windows Terminal) but on the keyboard tool instead of terminal.

Implementation follows the SSOT contract in [`docs/operation-verification-matrix.md` §3.1](https://github.com/Harusame64/desktop-touch-mcp/blob/main/docs/operation-verification-matrix.md#31-commit-%E8%BB%B8--verification-%E5%A5%91%E7%B4%84%E3%81%82%E3%82%8A) (rows: `keyboard (action:type BG)` and `keyboard (action:press BG)`).

### Changes

- **type BG**: **Strict** — pre-send TextPattern baseline (SHA-256 marker, last 256 normalised chars) → WM_CHAR send → 150ms settle → exact substring + tail-N (>= 4 non-whitespace chars) fallback against the post-send diff. Mirrors `src/tools/terminal.ts:299-496` (PR #174, v1.3.2 規範). Failure surfaces as `BackgroundInputNotDelivered` (shared with terminal — same channel, same symptom; matrix §3.1 row "code shared").

- **press BG**: **Indirect** — most combos return `hints.verifyDelivery: { status: "unverifiable", reason: "read_back_unsupported", channel: "wm_keydown", fallback: "method:'foreground'" }` per matrix §4.2 規範 shape. Allow-list exception: `enter` / `tab` / `arrow` keys on terminal-class targets are read-back verifiable (cursor advance / new line); failure surfaces as the new code `BackgroundKeyNotDelivered` (matrix §5.2 命名 justify).

- **Verification gate** matches `terminal.ts`: only when caller explicitly forced `method:'background'` OR `DTM_BG_AUTO=1` + non-terminal class. Auto-routed terminal targets (well-tested conhost) skip the 150ms read-back as before.

- **`_errors.ts`**: new `BackgroundKeyNotDelivered` entry in SUGGESTS + `classify()` lowercase match. `BackgroundInputNotDelivered` SUGGESTS unchanged (already covers WM_CHAR silent drop, per matrix instructions).

### E2E coverage

`tests/e2e/keyboard-bg-verification.test.ts`:
- **WT host** (`DTM_E2E_WT=1` opt-in, memory `feedback_e2e_wt_host_taskkill_risk.md`): type BG returns `BackgroundInputNotDelivered`.
- **conhost regression guard**: type BG succeeds with `verifyDelivery:delivered`, press BG (`ctrl+a`) pins unverifiable hint shape, press BG (`enter`) succeeds.
- **Notepad regression guard**: type BG must never return `ok:true` without a `verifyDelivery` hint (core invariant of #177).

### Out of scope (matrix §8 / #177 plan)

- Hidden-input prompt auto-detection (#183).
- WT BG path restoration (#185 Phase 4).
- E2E skip-path classification (#182).

Closes #177
Part of #184

## Test plan

- [x] `npm run build` clean
- [x] `npx eslint src/tools/keyboard.ts src/tools/_errors.ts tests/e2e/keyboard-bg-verification.test.ts` clean
- [x] Existing keyboard unit tests pass (`tests/unit/keyboard-method-resolution.test.ts`, `keyboard-leash-guard.test.ts`, `keyboard-guard-evaluation.test.ts` — 48 tests)
- [ ] E2E: `npx vitest run --project=e2e tests/e2e/keyboard-bg-verification.test.ts` — conhost / Notepad scenarios (parent runs interactively per `feedback_e2e_test_announce.md`)
- [ ] E2E with `DTM_E2E_WT=1` set — WT scenario (parent only)