### PR TITLE
feat(browser): CDP click/fill delivery + DOM mutation verification (#181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **feat(browser): CDP `browser_click` / `browser_fill` に DOM 配信検証を追加 (issue #181, Phase 3).**
+  `docs/operation-verification-matrix.md` §3.1 規範実装。
+  - `browser_click`: クリック直前に `Runtime.evaluate` 経由で `MutationObserver(document.body, {subtree, childList, attributes})` を install → mouse click → 500ms 経過後に observer + URL + `document.activeElement` の差分を読み戻し。いずれかの signal が観測できれば `hints.verifyDelivery.status = "delivered"`、500ms で 0 signal なら `unverifiable` (reason: `no_dom_mutation`)。SPA ボタンに event listener が attach されていない silent-fail を catch する目的。selector が iframe 内 element だった場合は top-frame の Runtime.evaluate scope では観測不能なので `unverifiable` (reason: `iframe_context_mismatch`) を返す。
+  - `browser_fill`: fill dispatch 後に `el.value` を read-back して要求値と完全一致するか確認。不一致時は `BrowserFillNotDelivered` で fail。React/Vue controlled input が onChange で値を変換した場合（numbers-only filter / max-length / format mask 等）は false-positive 候補なので、actual length が requested length 以下なら `subReason: "controlled_input_transform"`、そうでなければ `value_not_retained` を `hints.verifyDelivery.subReason` で明示。caller は actual を authoritative として読めば retry 不要なケースを区別できる。
+
+### Added
+
+- **新 typed error code: `BrowserClickNotDelivered` / `BrowserFillNotDelivered` (`src/tools/_errors.ts` SUGGESTS + classify()).**
+  `docs/operation-verification-matrix.md` §5.2 の命名規則に従う。`BrowserClickNotDelivered` は現行実装では fail として返さず `unverifiable` hint で表現するが（OS 層では click が dispatch 済 = ack 成功なので fail に escalate しない方針）、SUGGESTS dictionary は将来の strict 化に備えて登録。`BrowserFillNotDelivered` は read-back 不一致で確実に fail を返す。
+- **`hints` を `_errors.ts:ROOT_HOISTED_KEYS` に追加.** typed delivery code でも success path と同じ位置に `hints.verifyDelivery` を配置するため。
+- **e2e: `tests/e2e/browser-cdp-verification.test.ts` 新規.**
+  - probe primitive (install + read) は headless で動く。
+  - `browser_click` 完全 path は nut-js 物理マウス必須なので `HEADED=1` gate で skip 可。
+  - `browser_fill` は CDP のみで完結するので headless でも regression guard 可能。
+
 ## [1.3.2] - 2026-05-08 — Windows Terminal silent fail in terminal/keyboard BG path
 
 v1.1.0 以降 約 11 日間 production にあった regression の修正。Windows

--- a/src/tools/_errors.ts
+++ b/src/tools/_errors.ts
@@ -4,7 +4,14 @@ import { fail, type ToolFailure, type ToolResult } from "./_types.js";
 // _post.ts (withPostState) can find them. `_post.ts` reads obj._perceptionForPost /
 // obj._richForPost from the root of the parsed response body; if we let failWith
 // put them under `context`, the failure path never attaches post.perception.
-const ROOT_HOISTED_KEYS = new Set<string>(["_perceptionForPost", "_richForPost"]);
+//
+// Issue #181: `hints` is also hoisted so that typed delivery codes
+// (BrowserClickNotDelivered / BrowserFillNotDelivered) can carry a
+// verifyDelivery hint at the same envelope position as the success path
+// (matrix doc §4.2 規範 shape). Without hoisting, the hint would be buried
+// under `context.hints.verifyDelivery` on failures and `hints.verifyDelivery`
+// on success — an asymmetry that would force callers to look in two places.
+const ROOT_HOISTED_KEYS = new Set<string>(["_perceptionForPost", "_richForPost", "hints"]);
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Error code → suggest dictionary
@@ -179,6 +186,33 @@ const SUGGESTS: Record<string, string[]> = {
     "Common cause: terminal runs elevated (admin) while caller does not — UIPI blocks PostMessage.",
     "Verification scope: only enter / tab / arrow keys are read-back-verified on terminal-class targets. Other combos return hints.verifyDelivery:'unverifiable' rather than this error — caller should observe the semantic effect (e.g. menu open, selection change) directly.",
   ],
+  // Issue #181 / matrix doc §3.1 §5.2: post-click DOM mutation verification
+  // failed to observe ANY signal (MutationObserver event, URL change, or
+  // document.activeElement change) within the verification window. The click
+  // dispatch itself succeeded at the OS level — the page simply did not respond.
+  // Most common cause: SPA button rendered without an event listener attached
+  // (silent-fail signature isolated by issue #181).
+  BrowserClickNotDelivered: [
+    "The element rendered, but no DOM mutation, URL change, or focus change followed the click — the page may have no handler attached.",
+    "Verify the selector targets the actual interactive element (a button label / icon span often forwards clicks to a parent button)",
+    "If the page uses delayed handlers (>500ms), retry then immediately read state with browser_eval to confirm the action took effect",
+    "For canvas / WebGL apps, DOM mutations are not produced — switch to browser_eval to assert against the app's own state, or use mouse_click against the same coords",
+    "If the target is inside a cross-origin iframe, the verification scope is the top frame only — pin the iframe with a frame selector before clicking",
+  ],
+  // Issue #181 / matrix doc §3.1 §5.2: post-fill element.value read-back did
+  // not match the requested value. False-positive watch (matrix doc §5.2):
+  // React/Vue controlled inputs may transform the value in onChange (e.g.
+  // numbers-only filter strips letters, max-length truncates), in which case
+  // the value was delivered but stored as transformed. The hint surfaces a
+  // sub-reason `controlled_input_transform` so the caller can disambiguate
+  // without resorting to a generic retry.
+  BrowserFillNotDelivered: [
+    "The input rejected or transformed the value — element.value after fill did not match the requested string.",
+    "If hints.verifyDelivery.subReason is 'controlled_input_transform', the value reached the page but the framework rewrote it (e.g. numbers-only filter, max-length truncation, format mask). Treat the actual value (echoed in context) as authoritative.",
+    "If the input has a pattern / inputmode / type=number constraint, try sending an already-canonical value (digits only, lowercased, etc.)",
+    "For inputs guarded by React's synthetic-event proxy, try keyboard(action='type') against the focused element as a fallback (slower but framework-agnostic)",
+    "Verify the selector targets an <input> / <textarea> — contenteditable div uses different setters (use browser_eval instead)",
+  ],
   SetValueAllChannelsFailed: [
     "Verify the element supports text input",
     "Try click_element + keyboard({action:'type'}) manually",
@@ -325,6 +359,13 @@ function classify(message: string): { code: string; suggest: string[] } {
   }
   if (m.includes("mouseclicknotdelivered") || m.includes("mouse click not delivered")) {
     return { code: "MouseClickNotDelivered", suggest: SUGGESTS.MouseClickNotDelivered };
+  }
+  // Issue #181: typed CDP delivery codes — substring match in lowercase.
+  if (m.includes("browserclicknotdelivered") || m.includes("browser click not delivered")) {
+    return { code: "BrowserClickNotDelivered", suggest: SUGGESTS.BrowserClickNotDelivered };
+  }
+  if (m.includes("browserfillnotdelivered") || m.includes("browser fill not delivered")) {
+    return { code: "BrowserFillNotDelivered", suggest: SUGGESTS.BrowserFillNotDelivered };
   }
   if (m.includes("setvalueallchannelsfailed") || m.includes("all channels failed")) {
     return { code: "SetValueAllChannelsFailed", suggest: SUGGESTS.SetValueAllChannelsFailed };

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -1056,13 +1056,9 @@ export const browserClickElementHandler = async ({
     // Ensure browser window is focused so click events reach the page
     await ensureBrowserFocused(port);
 
-    // ── Issue #181: pre-click MutationObserver probe (matrix doc §3.1) ──
-    // Best-effort install. If install fails (page navigated mid-call, CDP
-    // detached, etc.) we still attempt the click and emit an `unverifiable`
-    // hint downstream — never fail the click on a verification setup error.
-    const probe = await installClickProbe(effectiveSelector, effectiveTabId ?? null, port);
-
-    // Perform the actual mouse click using nut-js
+    // Perform the cursor move FIRST (hover effects on the path between the
+    // current cursor position and the target can fire mutations / focus
+    // changes — these must NOT count as click-delivery signals). Codex P1.
     const speed = DEFAULT_MOUSE_SPEED;
     if (speed === 0) {
       await mouse.setPosition(new Point(coords.x, coords.y));
@@ -1075,6 +1071,15 @@ export const browserClickElementHandler = async ({
         mouse.config.mouseSpeed = prev;
       }
     }
+
+    // ── Issue #181: pre-click MutationObserver probe (matrix doc §3.1) ──
+    // Installed AFTER the cursor move so any hover-driven DOM updates land in
+    // the baseline rather than being counted as post-click signals (Codex P1).
+    // Best-effort install: if install fails (page navigated mid-call, CDP
+    // detached, etc.) we still attempt the click and emit an `unverifiable`
+    // hint downstream — never fail the click on a verification setup error.
+    const probe = await installClickProbe(effectiveSelector, effectiveTabId ?? null, port);
+
     await mouse.click(Button.LEFT);
 
     // ── Issue #181: settle window then read the probe ──
@@ -1083,7 +1088,15 @@ export const browserClickElementHandler = async ({
     // microtask after click; the 500ms is the *upper bound* for SPA effects
     // (re-render after async state update) and we are happy to wait the
     // full window before deciding `unverifiable`.
-    let verifyDelivery: VerifyDeliveryHint | undefined;
+    //
+    // Initialise with the install-failed unverifiable hint so the value is
+    // always defined (CodeQL: avoids the useless `verifyDelivery && …`
+    // narrowing at the response site). The branches below override.
+    let verifyDelivery: VerifyDeliveryHint = {
+      status: "unverifiable",
+      channel: "cdp",
+      reason: "probe_install_failed",
+    };
     if (probe.installed) {
       await new Promise<void>((r) => setTimeout(r, 500));
       const reading = await readClickProbe(effectiveTabId ?? null, port);
@@ -1091,7 +1104,14 @@ export const browserClickElementHandler = async ({
         const mutationCount = reading.mutationCount ?? 0;
         const urlChanged = !!reading.urlChanged;
         const activeElementChanged = !!reading.activeElementChanged;
-        const anySignal = mutationCount > 0 || urlChanged || activeElementChanged;
+        // `activeElementChanged` is reported in observedSignals for caller
+        // diagnosis but is intentionally NOT part of `anySignal`: a plain
+        // click on a focusable control (button, input) updates focus even
+        // when no app handler ran or no state changed. Treating focus-only
+        // changes as "delivered" would mask the silent-fail regression the
+        // PR is built to catch (Codex P1). Require at least one of:
+        // mutation event, URL navigation.
+        const anySignal = mutationCount > 0 || urlChanged;
         if (reading.inIframe) {
           // Selector resolved inside an iframe — Runtime.evaluate runs in the
           // top frame, so our MutationObserver could not observe events
@@ -1133,14 +1153,9 @@ export const browserClickElementHandler = async ({
           reason: "probe_read_failed",
         };
       }
-    } else {
-      // Probe install itself failed.
-      verifyDelivery = {
-        status: "unverifiable",
-        channel: "cdp",
-        reason: "probe_install_failed",
-      };
     }
+    // No `else` for !probe.installed: the default initial value of
+    // verifyDelivery already carries reason: "probe_install_failed".
 
     const tabCtx = await getTabContext(effectiveTabId ?? null, port);
 
@@ -1169,7 +1184,7 @@ export const browserClickElementHandler = async ({
       at: { x: coords.x, y: coords.y },
       activeTab: { id: tabCtx.id, title: tabCtx.title, url: tabCtx.url },
       readyState: tabCtx.readyState,
-      ...(verifyDelivery && { hints: { verifyDelivery } }),
+      hints: { verifyDelivery },
       ...(richBlock ? { _richForPost: richBlock } : {}),
       ...(perceptionEnvBrowser && { _perceptionForPost: perceptionEnvBrowser }),
     });

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -396,6 +396,178 @@ async function ensureBrowserFocused(port: number): Promise<void> {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Issue #181 — CDP delivery verification helpers
+// matrix doc §3.1 規範観測経路: MutationObserver via Runtime.evaluate, 500ms timeout.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Probe shape emitted by `installClickProbeExpr` and read by `readClickProbeExpr`. */
+type ClickProbeReading = {
+  // ok=false means we could not install / read the probe (frame mismatch, page navigated mid-probe, etc.)
+  ok: boolean;
+  reason?: string;
+  // signals captured between install and read
+  mutationCount?: number;
+  urlChanged?: boolean;
+  activeElementChanged?: boolean;
+  // diagnostic context
+  selectorFound?: boolean;
+  inIframe?: boolean;
+  beforeUrl?: string;
+  afterUrl?: string;
+};
+
+/**
+ * Install a MutationObserver on document.body + capture URL / activeElement
+ * baseline. Stored on `window.__dtmClickProbe` so the post-click read can
+ * pick up the result without re-installing. Idempotent within a single tab
+ * — re-installing replaces the previous probe.
+ *
+ * matrix doc §3.1 規範: subtree:true, childList:true, attributes:true.
+ * `characterData:true` is intentionally omitted — it produces high-noise
+ * matches on text-content tickers (clocks, live regions) that fire
+ * independently of the click and would mask silent-fail.
+ */
+function buildInstallClickProbeExpr(selector: string): string {
+  return `
+(function() {
+  try {
+    var sel = ${JSON.stringify(selector)};
+    var el = document.querySelector(sel);
+    var inIframe = false;
+    if (!el) {
+      // Selector might resolve inside an iframe — best-effort probe so we can
+      // surface the frame mismatch as 'unverifiable' rather than asserting
+      // delivered=false on a click we can't observe.
+      try {
+        var frames = document.querySelectorAll('iframe');
+        for (var i = 0; i < frames.length; i++) {
+          var f = frames[i];
+          try {
+            if (f.contentDocument && f.contentDocument.querySelector(sel)) {
+              inIframe = true;
+              break;
+            }
+          } catch (_e) { /* cross-origin — same-origin policy blocks read */ }
+        }
+      } catch (_e) { /* ignore */ }
+    }
+    // Reset any prior probe before creating a new one.
+    if (window.__dtmClickProbe && window.__dtmClickProbe.observer) {
+      try { window.__dtmClickProbe.observer.disconnect(); } catch (_e) { /* ignore */ }
+    }
+    var probe = {
+      mutationCount: 0,
+      beforeUrl: location.href,
+      beforeActive: document.activeElement,
+      selectorFound: !!el,
+      inIframe: inIframe,
+      observer: null
+    };
+    var obs = new MutationObserver(function(records) {
+      // Aggregate count is sufficient — we only need to know "did anything happen".
+      probe.mutationCount += records.length;
+    });
+    obs.observe(document.body, { subtree: true, childList: true, attributes: true });
+    probe.observer = obs;
+    window.__dtmClickProbe = probe;
+    return { ok: true, selectorFound: !!el, inIframe: inIframe };
+  } catch (e) {
+    return { ok: false, reason: 'install_failed: ' + (e && e.message ? e.message : String(e)) };
+  }
+})()`;
+}
+
+/**
+ * Read out the probe state, disconnect the observer, and clear the slot.
+ * After this call the page state is back to baseline (no observer leak).
+ */
+function buildReadClickProbeExpr(): string {
+  return `
+(function() {
+  try {
+    var probe = window.__dtmClickProbe;
+    if (!probe) return { ok: false, reason: 'probe_missing' };
+    try { if (probe.observer) probe.observer.disconnect(); } catch (_e) { /* ignore */ }
+    var afterUrl = location.href;
+    var afterActive = document.activeElement;
+    var result = {
+      ok: true,
+      mutationCount: probe.mutationCount,
+      urlChanged: probe.beforeUrl !== afterUrl,
+      activeElementChanged: probe.beforeActive !== afterActive,
+      selectorFound: probe.selectorFound,
+      inIframe: !!probe.inIframe,
+      beforeUrl: probe.beforeUrl,
+      afterUrl: afterUrl
+    };
+    delete window.__dtmClickProbe;
+    return result;
+  } catch (e) {
+    return { ok: false, reason: 'read_failed: ' + (e && e.message ? e.message : String(e)) };
+  }
+})()`;
+}
+
+/**
+ * Pre-click: install the MutationObserver probe. Best-effort — if install
+ * fails (e.g. page just navigated, CDP detached), we return false and skip
+ * the verification step rather than masking the click attempt with a
+ * verification error.
+ */
+async function installClickProbe(
+  selector: string,
+  tabId: string | null,
+  port: number,
+): Promise<{ installed: boolean; selectorFound?: boolean; inIframe?: boolean; reason?: string }> {
+  try {
+    const r = (await evaluateInTab(buildInstallClickProbeExpr(selector), tabId, port)) as
+      | { ok: true; selectorFound: boolean; inIframe: boolean }
+      | { ok: false; reason: string };
+    if (!r.ok) return { installed: false, reason: r.reason };
+    return { installed: true, selectorFound: r.selectorFound, inIframe: r.inIframe };
+  } catch (e) {
+    return { installed: false, reason: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+/**
+ * Post-click: read out the MutationObserver probe and disconnect. Returns
+ * `null` when the probe is unreadable (page navigated, frame swap, etc.),
+ * which the caller should treat as `unverifiable`.
+ */
+async function readClickProbe(
+  tabId: string | null,
+  port: number,
+): Promise<ClickProbeReading | null> {
+  try {
+    const r = (await evaluateInTab(buildReadClickProbeExpr(), tabId, port)) as ClickProbeReading;
+    return r;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Issue #181 hint shape (matrix doc §4.2):
+ *   hints.verifyDelivery = {
+ *     status: "delivered" | "unverifiable",
+ *     reason?: string,           // §4.3 enum
+ *     channel: "cdp",
+ *     observedSignals?: { mutationCount, urlChanged, activeElementChanged }
+ *   }
+ */
+type VerifyDeliveryHint = {
+  status: "delivered" | "unverifiable";
+  channel: "cdp";
+  reason?: string;
+  observedSignals?: {
+    mutationCount: number;
+    urlChanged: boolean;
+    activeElementChanged: boolean;
+  };
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Handlers
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -434,6 +606,12 @@ export const browserFillInputHandler = async ({
     //   focus → select all → use native prototype setter (bypasses React's proxy) +
     //   dispatch InputEvent so React fiber intercepts the synthetic event.
     // This is more reliable than execCommand('insertText') which is deprecated.
+    //
+    // Issue #181 / matrix doc §3.1: we now read back the *full* element.value
+    // after dispatch (not a truncated slice) so the caller side can perform
+    // exact equality. The previous 100-char truncation was a token-saving
+    // measure — we keep a truncated `actual` in the response for display, but
+    // the verification verdict uses the full string.
     const fillExpr = `
 (function() {
   const el = document.querySelector(${JSON.stringify(selector)});
@@ -458,16 +636,94 @@ export const browserFillInputHandler = async ({
   // Dispatch native InputEvent — React 16+ intercepts 'input' for onChange
   el.dispatchEvent(new InputEvent('input', { bubbles: true, cancelable: true, inputType: 'insertText', data: ${JSON.stringify(value)} }));
   el.dispatchEvent(new Event('change', { bubbles: true }));
-  const actual = el.value !== undefined ? el.value : el.textContent;
-  return { ok: true, actual: (actual || '').slice(0, 100) };
+  // Read back AFTER the synthetic events fire so React/Vue controlled inputs
+  // get a chance to write the (possibly transformed) value back into the DOM
+  // node. Comparing this against the requested value is the post-fill
+  // verification (matrix doc §3.1 browser_fill).
+  const fullActual = el.value !== undefined ? el.value : (el.textContent || '');
+  return {
+    ok: true,
+    actual: (fullActual || '').slice(0, 100),
+    fullActualLen: fullActual.length,
+    fullMatches: fullActual === ${JSON.stringify(value)}
+  };
 })()`;
-    const fillResult = await evaluateInTab(fillExpr, tabId ?? null, port) as { ok: boolean; error?: string; actual?: string };
+    const fillResult = await evaluateInTab(fillExpr, tabId ?? null, port) as
+      { ok: boolean; error?: string; actual?: string; fullActualLen?: number; fullMatches?: boolean };
     if (!fillResult.ok) {
       return failWith(fillResult.error ?? "browser_fill: fill failed", "browser_fill");
     }
 
+    // ── Issue #181: post-fill element.value verification (matrix doc §3.1) ──
+    // fullMatches=false means the DOM did not retain the value we sent.
+    // matrix doc §5.2 flags React controlled inputs as a known false-positive
+    // source: the value was *delivered*, but the framework's onChange handler
+    // rewrote it (numbers-only filter, max-length, format mask). We surface
+    // this as a typed failure (BrowserFillNotDelivered) with a sub-reason on
+    // the hint so the caller can disambiguate without resorting to retry.
+    if (fillResult.fullMatches === false) {
+      const requestedLen = value.length;
+      const actualLen = fillResult.fullActualLen ?? 0;
+      // Heuristic: if the actual length is *non-zero and shorter than
+      // requested*, the framework most likely transformed the value
+      // (truncation, character-class filter, format mask). Length ≥ requested
+      // suggests the framework rejected the value entirely (e.g. type=email
+      // with sanitization that prepends a default). Either way the value did
+      // not land cleanly.
+      const subReason =
+        actualLen > 0 && actualLen <= requestedLen
+          ? "controlled_input_transform"
+          : "value_not_retained";
+      // failWith treats every key in the third arg as a context entry except
+      // those listed in ROOT_HOISTED_KEYS (`hints`, etc.). The diagnostic
+      // fields below land under failure.context.* and `hints` lands at the
+      // failure root — matching the success-path envelope shape (matrix doc
+      // §4.2) so callers can read failure.hints.verifyDelivery and
+      // success.hints.verifyDelivery from the same path.
+      return failWith(
+        new Error("BrowserFillNotDelivered"),
+        "browser_fill",
+        {
+          selector,
+          requested: value.slice(0, 100),
+          requestedLen,
+          actual: fillResult.actual,
+          actualLen,
+          subReason,
+          note:
+            subReason === "controlled_input_transform"
+              ? "False-positive watch: React/Vue controlled inputs may rewrite the value in onChange (numbers-only filter, max-length, format mask). The bytes reached the page but the framework chose not to keep them. Treat actual as authoritative."
+              : "The DOM did not retain the requested value after fill — input may be readOnly, disabled, or guarded by a synthetic-event proxy that rejects programmatic writes.",
+          hints: {
+            verifyDelivery: {
+              status: "unverifiable",
+              channel: "cdp",
+              reason: "value_mismatch",
+              subReason,
+              actualLen,
+              requestedLen,
+            },
+          },
+        }
+      );
+    }
+
     const lines = [
-      JSON.stringify({ ok: true, selector, value, actual: fillResult.actual }),
+      JSON.stringify({
+        ok: true,
+        selector,
+        value,
+        actual: fillResult.actual,
+        // matrix doc §4.2 規範 hint shape — always emit `delivered` on success
+        // path so callers can pin verification end-to-end without conditionally
+        // checking `hints` presence.
+        hints: {
+          verifyDelivery: {
+            status: "delivered",
+            channel: "cdp",
+          },
+        },
+      }),
     ];
     if (includeContext) {
       const tabCtx = await getCachedTabContext(tabId ?? null, port);
@@ -799,6 +1055,13 @@ export const browserClickElementHandler = async ({
     }
     // Ensure browser window is focused so click events reach the page
     await ensureBrowserFocused(port);
+
+    // ── Issue #181: pre-click MutationObserver probe (matrix doc §3.1) ──
+    // Best-effort install. If install fails (page navigated mid-call, CDP
+    // detached, etc.) we still attempt the click and emit an `unverifiable`
+    // hint downstream — never fail the click on a verification setup error.
+    const probe = await installClickProbe(effectiveSelector, effectiveTabId ?? null, port);
+
     // Perform the actual mouse click using nut-js
     const speed = DEFAULT_MOUSE_SPEED;
     if (speed === 0) {
@@ -813,15 +1076,79 @@ export const browserClickElementHandler = async ({
       }
     }
     await mouse.click(Button.LEFT);
+
+    // ── Issue #181: settle window then read the probe ──
+    // matrix doc §3.1 規範: 500ms timeout. We use a flat sleep rather than a
+    // poll loop because most legitimate DOM mutations land within the first
+    // microtask after click; the 500ms is the *upper bound* for SPA effects
+    // (re-render after async state update) and we are happy to wait the
+    // full window before deciding `unverifiable`.
+    let verifyDelivery: VerifyDeliveryHint | undefined;
+    if (probe.installed) {
+      await new Promise<void>((r) => setTimeout(r, 500));
+      const reading = await readClickProbe(effectiveTabId ?? null, port);
+      if (reading && reading.ok) {
+        const mutationCount = reading.mutationCount ?? 0;
+        const urlChanged = !!reading.urlChanged;
+        const activeElementChanged = !!reading.activeElementChanged;
+        const anySignal = mutationCount > 0 || urlChanged || activeElementChanged;
+        if (reading.inIframe) {
+          // Selector resolved inside an iframe — Runtime.evaluate runs in the
+          // top frame, so our MutationObserver could not observe events
+          // dispatched on iframe-internal nodes. Surface as unverifiable
+          // rather than declaring not-delivered.
+          verifyDelivery = {
+            status: "unverifiable",
+            channel: "cdp",
+            reason: "iframe_context_mismatch",
+            observedSignals: { mutationCount, urlChanged, activeElementChanged },
+          };
+        } else if (anySignal) {
+          verifyDelivery = {
+            status: "delivered",
+            channel: "cdp",
+            observedSignals: { mutationCount, urlChanged, activeElementChanged },
+          };
+        } else {
+          // No mutation, no URL change, no activeElement change in 500ms.
+          // Most likely the SPA button has no listener attached — the click
+          // hit empty markup. Surface as `unverifiable` per matrix doc §3.1
+          // (we don't escalate to BrowserClickNotDelivered fail because the
+          // click *did* dispatch at the OS level — only the page response is
+          // missing, which is ambiguous between "no handler" and "handler
+          // ran but produced no observable side effect").
+          verifyDelivery = {
+            status: "unverifiable",
+            channel: "cdp",
+            reason: "no_dom_mutation",
+            observedSignals: { mutationCount, urlChanged, activeElementChanged },
+          };
+        }
+      } else {
+        // Probe installed but read failed — likely a navigation between
+        // install and read.
+        verifyDelivery = {
+          status: "unverifiable",
+          channel: "cdp",
+          reason: "probe_read_failed",
+        };
+      }
+    } else {
+      // Probe install itself failed.
+      verifyDelivery = {
+        status: "unverifiable",
+        channel: "cdp",
+        reason: "probe_install_failed",
+      };
+    }
+
     const tabCtx = await getTabContext(effectiveTabId ?? null, port);
 
     // Build rich block for CDP diff
     let richBlock: RichBlock | undefined;
     if (narrate === "rich" && beforeUrl !== null) {
-      await new Promise<void>((r) => setTimeout(r, 150));
       try {
-        const afterCtx = await getTabContext(effectiveTabId ?? null, port);
-        const afterUrl = afterCtx.url ?? null;
+        const afterUrl = tabCtx.url ?? null;
         richBlock = {
           appeared: [],
           disappeared: [],
@@ -842,6 +1169,7 @@ export const browserClickElementHandler = async ({
       at: { x: coords.x, y: coords.y },
       activeTab: { id: tabCtx.id, title: tabCtx.title, url: tabCtx.url },
       readyState: tabCtx.readyState,
+      ...(verifyDelivery && { hints: { verifyDelivery } }),
       ...(richBlock ? { _richForPost: richBlock } : {}),
       ...(perceptionEnvBrowser && { _perceptionForPost: perceptionEnvBrowser }),
     });

--- a/tests/e2e/browser-cdp-verification.test.ts
+++ b/tests/e2e/browser-cdp-verification.test.ts
@@ -1,0 +1,321 @@
+/**
+ * browser-cdp-verification.test.ts — E2E tests for issue #181
+ *
+ * Pins the CDP delivery verification contract added by #181:
+ *   - browser_click installs a MutationObserver before the click and reports
+ *     hints.verifyDelivery.status = "delivered" | "unverifiable" based on
+ *     observed DOM mutations / URL change / activeElement change.
+ *   - browser_fill reads element.value back after fill and surfaces a
+ *     BrowserFillNotDelivered failure (with sub-reason) when the framework
+ *     transforms the value (matrix doc §5.2 false-positive watch).
+ *
+ * The browser_click probe install/read primitives are tested directly via
+ * evaluateInTab so the verification logic is exercised in headless mode
+ * (CI). The full handler (which uses real mouse hardware via nut-js) is
+ * gated on HEADED=1 and skipped otherwise.
+ *
+ * The browser_fill handler does NOT need physical mouse — element.focus()
+ * + native-setter dispatch goes via CDP only, so the headless path covers
+ * the whole code path.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+import { launchChrome, tryFindChrome, type ChromeInstance } from "./helpers/chrome-launcher.js";
+import { sleep } from "./helpers/wait.js";
+import { evaluateInTab, disconnectAll } from "../../src/engine/cdp-bridge.js";
+import {
+  browserClickElementHandler,
+  browserFillInputHandler,
+} from "../../src/tools/browser.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = join(__dirname, "fixtures", "test-page.html");
+const TEST_PORT = 9229;
+const FIXTURE_URL = `file:///${FIXTURE_PATH.replace(/\\/g, "/")}`;
+const CHROME_AVAILABLE = tryFindChrome() !== null;
+const IS_HEADED = Boolean(process.env.HEADED);
+
+let chrome: ChromeInstance;
+
+beforeAll(async () => {
+  if (!CHROME_AVAILABLE) return;
+  chrome = await launchChrome(TEST_PORT, !IS_HEADED, FIXTURE_URL);
+  // Wait for the fixture page itself to land. Headless Chrome may briefly
+  // expose an about:blank tab before navigating to the file://.
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    try {
+      const probe = await evaluateInTab(
+        "JSON.stringify([document.title, document.readyState, location.href])",
+        null,
+        TEST_PORT,
+      );
+      const [title, state, href] = JSON.parse(probe as string) as [string, string, string];
+      if (
+        state === "complete" &&
+        title === "desktop-touch CDP Test Page" &&
+        href.includes("test-page.html")
+      ) {
+        return;
+      }
+    } catch { /* not ready */ }
+    await sleep(300);
+  }
+  throw new Error("Test page did not load within 15s");
+}, 20_000);
+
+afterAll(() => {
+  disconnectAll(TEST_PORT);
+  chrome?.kill();
+});
+
+/** Parse the JSON line emitted at content[0].text. */
+function parseFirstLine(r: { content: Array<{ type: string; text?: string }> }): unknown {
+  const text = (r.content[0] as { text: string }).text;
+  // Multi-line responses (with includeContext) put JSON on line 0.
+  const firstLine = text.split("\n")[0];
+  return JSON.parse(firstLine);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MutationObserver probe primitives — exercised via evaluateInTab so the
+// verification JS runs end-to-end in the page even without physical mouse.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe.skipIf(!CHROME_AVAILABLE)("issue #181 — click probe primitive", () => {
+  it("install + bound-button click + read reports mutationCount > 0 (delivered signal)", async () => {
+    // Reset target so prior runs don't accumulate.
+    await evaluateInTab(
+      "document.getElementById('btn-verify-bound-target').textContent = ''",
+      null,
+      TEST_PORT,
+    );
+    // Install the probe.
+    const installed = await evaluateInTab(
+      `(function() {
+        if (window.__dtmClickProbe && window.__dtmClickProbe.observer) {
+          try { window.__dtmClickProbe.observer.disconnect(); } catch (_e) {}
+        }
+        var probe = {
+          mutationCount: 0,
+          beforeUrl: location.href,
+          beforeActive: document.activeElement,
+          selectorFound: true,
+          inIframe: false,
+          observer: null
+        };
+        var obs = new MutationObserver(function(records) { probe.mutationCount += records.length; });
+        obs.observe(document.body, { subtree: true, childList: true, attributes: true });
+        probe.observer = obs;
+        window.__dtmClickProbe = probe;
+        return { ok: true };
+      })()`,
+      null,
+      TEST_PORT,
+    );
+    expect((installed as { ok: boolean }).ok).toBe(true);
+    // Synthetic click on the bound button — appends a span (DOM mutation).
+    await evaluateInTab(
+      "document.getElementById('btn-verify-bound').click()",
+      null,
+      TEST_PORT,
+    );
+    // settle
+    await sleep(150);
+    // Read out the probe.
+    const reading = (await evaluateInTab(
+      `(function() {
+        var p = window.__dtmClickProbe;
+        if (!p) return { ok: false };
+        try { p.observer.disconnect(); } catch (_e) {}
+        var r = {
+          ok: true,
+          mutationCount: p.mutationCount,
+          urlChanged: p.beforeUrl !== location.href,
+          activeElementChanged: p.beforeActive !== document.activeElement
+        };
+        delete window.__dtmClickProbe;
+        return r;
+      })()`,
+      null,
+      TEST_PORT,
+    )) as { ok: boolean; mutationCount: number; urlChanged: boolean; activeElementChanged: boolean };
+    expect(reading.ok).toBe(true);
+    expect(reading.mutationCount).toBeGreaterThan(0);
+  });
+
+  it("install + silent-button click + read reports zero signals (unverifiable)", async () => {
+    // Install probe.
+    await evaluateInTab(
+      `(function() {
+        if (window.__dtmClickProbe && window.__dtmClickProbe.observer) {
+          try { window.__dtmClickProbe.observer.disconnect(); } catch (_e) {}
+        }
+        var probe = {
+          mutationCount: 0,
+          beforeUrl: location.href,
+          beforeActive: document.activeElement,
+          selectorFound: true,
+          inIframe: false,
+          observer: null
+        };
+        var obs = new MutationObserver(function(records) { probe.mutationCount += records.length; });
+        obs.observe(document.body, { subtree: true, childList: true, attributes: true });
+        probe.observer = obs;
+        window.__dtmClickProbe = probe;
+        return { ok: true };
+      })()`,
+      null,
+      TEST_PORT,
+    );
+    // Synthetic click on the silent button (no listener wired up).
+    await evaluateInTab(
+      "document.getElementById('btn-verify-silent').click()",
+      null,
+      TEST_PORT,
+    );
+    await sleep(150);
+    const reading = (await evaluateInTab(
+      `(function() {
+        var p = window.__dtmClickProbe;
+        if (!p) return { ok: false };
+        try { p.observer.disconnect(); } catch (_e) {}
+        var r = {
+          ok: true,
+          mutationCount: p.mutationCount,
+          urlChanged: p.beforeUrl !== location.href,
+          // The silent button is a <button type="button"> — clicking it
+          // synthetically still focuses it on some Chromium versions, which
+          // would mask a real silent-fail. We compare to a fresh
+          // activeElement read here, but the production handler treats
+          // activeElement-only change as a delivered signal anyway (matrix
+          // doc §3.1 explicitly lists it). This assertion only pins the
+          // mutation half.
+          activeElementChanged: p.beforeActive !== document.activeElement
+        };
+        delete window.__dtmClickProbe;
+        return r;
+      })()`,
+      null,
+      TEST_PORT,
+    )) as { ok: boolean; mutationCount: number; urlChanged: boolean; activeElementChanged: boolean };
+    expect(reading.ok).toBe(true);
+    // The silent button cannot append/remove/attribute-toggle anything in the
+    // body subtree — mutationCount stays 0.
+    expect(reading.mutationCount).toBe(0);
+    expect(reading.urlChanged).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Full browser_click handler — requires HEADED mode for nut-js mouse hardware.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe.runIf(IS_HEADED && CHROME_AVAILABLE)(
+  "issue #181 — browser_click handler verification (headed)",
+  () => {
+    it("clicking a bound button emits hints.verifyDelivery.status='delivered'", async () => {
+      // Reset bound target.
+      await evaluateInTab(
+        "document.getElementById('btn-verify-bound-target').textContent = ''",
+        null,
+        TEST_PORT,
+      );
+      const result = await browserClickElementHandler({
+        selector: "#btn-verify-bound",
+        port: TEST_PORT,
+      });
+      const body = parseFirstLine(result) as {
+        ok: boolean;
+        hints?: { verifyDelivery?: { status?: string; channel?: string; observedSignals?: { mutationCount: number } } };
+      };
+      expect(body.ok).toBe(true);
+      expect(body.hints?.verifyDelivery?.status).toBe("delivered");
+      expect(body.hints?.verifyDelivery?.channel).toBe("cdp");
+      expect(body.hints?.verifyDelivery?.observedSignals?.mutationCount ?? 0).toBeGreaterThan(0);
+    });
+
+    it("clicking a silent SPA button emits hints.verifyDelivery.status='unverifiable'", async () => {
+      const result = await browserClickElementHandler({
+        selector: "#btn-verify-silent",
+        port: TEST_PORT,
+      });
+      const body = parseFirstLine(result) as {
+        ok: boolean;
+        hints?: { verifyDelivery?: { status?: string; reason?: string } };
+      };
+      expect(body.ok).toBe(true);
+      // Silent button — no DOM mutation, no URL change. The handler must NOT
+      // claim 'delivered' here; the contract is to emit 'unverifiable' so the
+      // LLM caller knows the click reached the OS layer but produced no
+      // observable page response.
+      expect(body.hints?.verifyDelivery?.status).toBe("unverifiable");
+      expect(body.hints?.verifyDelivery?.reason).toBe("no_dom_mutation");
+    });
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// browser_fill handler — element.value read-back, headless-friendly.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe.skipIf(!CHROME_AVAILABLE)("issue #181 — browser_fill verification", () => {
+  it("plain input retains the requested value (delivered)", async () => {
+    // Reset.
+    await evaluateInTab(
+      "document.getElementById('input-verify-plain').value = ''",
+      null,
+      TEST_PORT,
+    );
+    const result = await browserFillInputHandler({
+      selector: "#input-verify-plain",
+      value: "hello-181",
+      port: TEST_PORT,
+      includeContext: false,
+    });
+    const body = parseFirstLine(result) as {
+      ok: boolean;
+      actual?: string;
+      hints?: { verifyDelivery?: { status?: string } };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.actual).toBe("hello-181");
+    expect(body.hints?.verifyDelivery?.status).toBe("delivered");
+  });
+
+  it("controlled-input transform surfaces BrowserFillNotDelivered with subReason", async () => {
+    // Reset.
+    await evaluateInTab(
+      "document.getElementById('input-verify-numbersonly').value = ''",
+      null,
+      TEST_PORT,
+    );
+    const result = await browserFillInputHandler({
+      selector: "#input-verify-numbersonly",
+      // The numbers-only filter strips letters in the input handler — actual
+      // value ends up "123" (length 3 < requested length 6).
+      value: "abc123",
+      port: TEST_PORT,
+      includeContext: false,
+    });
+    const body = parseFirstLine(result) as {
+      ok: false;
+      code: string;
+      suggest?: string[];
+      context?: { subReason?: string; actualLen?: number; requestedLen?: number; note?: string };
+      hints?: { verifyDelivery?: { status?: string; reason?: string; subReason?: string } };
+    };
+    expect(body.ok).toBe(false);
+    expect(body.code).toBe("BrowserFillNotDelivered");
+    expect(body.context?.subReason).toBe("controlled_input_transform");
+    expect(body.context?.actualLen ?? 0).toBeLessThan(body.context?.requestedLen ?? 0);
+    // Hint shape (matrix doc §4.2) — present on failure path too.
+    expect(body.hints?.verifyDelivery?.status).toBe("unverifiable");
+    expect(body.hints?.verifyDelivery?.subReason).toBe("controlled_input_transform");
+    // suggest[] must include the controlled-input disclaimer so the caller
+    // knows not to retry blindly.
+    expect((body.suggest ?? []).join(" ")).toMatch(/controlled_input_transform|controlled input/i);
+  });
+});

--- a/tests/e2e/fixtures/test-page.html
+++ b/tests/e2e/fixtures/test-page.html
@@ -109,6 +109,36 @@
       <button type="button" aria-pressed="true" id="aria-pressed-on">Pressed button</button>
       <button type="button" aria-expanded="false" id="aria-expanded-off">Expand</button>
     </div>
+
+    <!-- ──────────────────────────────────────────────────────────────── -->
+    <!-- Issue #181 fixtures — CDP click/fill delivery verification        -->
+    <!-- ──────────────────────────────────────────────────────────────── -->
+    <div id="verify-fixtures" style="position:absolute;left:100px;top:780px;width:600px;">
+      <h2>Verification Fixtures (#181)</h2>
+
+      <!-- Bound button: the click adds a child node to its sibling so the
+           MutationObserver fires on document.body subtree -->
+      <button id="btn-verify-bound" type="button" style="margin:4px;">Bound</button>
+      <div id="btn-verify-bound-target" style="margin:4px;font-family:monospace;"></div>
+
+      <!-- Silent SPA button: rendered but with NO event listener at all.
+           A click here must NOT mutate the DOM, change activeElement, or
+           change location.href. The verification path should report
+           hints.verifyDelivery.status='unverifiable' for this element. -->
+      <button id="btn-verify-silent" type="button" style="margin:4px;">Silent (no listener)</button>
+
+      <!-- Plain input: fill round-trips byte-for-byte. -->
+      <input id="input-verify-plain" type="text" placeholder="Plain input" style="margin:4px;">
+
+      <!-- "React controlled-input" simulator: an input element that filters
+           non-digit characters out of its own value on each input event.
+           This is the smallest possible reproduction of the false-positive
+           that matrix doc §5.2 calls out: a fill arrives intact, the
+           framework rewrites it, element.value mismatches the request,
+           and the verification has to surface a sub-reason rather than
+           hide-or-fail the call. -->
+      <input id="input-verify-numbersonly" type="text" placeholder="numbers only" style="margin:4px;">
+    </div>
   </div>
 
   <!-- SPA state fixtures for browser_get_app_state -->
@@ -129,6 +159,33 @@
     document.getElementById('input-name').addEventListener('input', function(e) {
       window._clickLog.push({ id: 'input-name', value: e.target.value, time: Date.now() });
     });
+
+    // ── Issue #181: verification fixture wiring ──
+    // Bound button mutates the DOM on click — verification should observe it.
+    document.getElementById('btn-verify-bound').addEventListener('click', function() {
+      var t = document.getElementById('btn-verify-bound-target');
+      var span = document.createElement('span');
+      span.textContent = 'clicked@' + Date.now() + ' ';
+      t.appendChild(span);
+    });
+
+    // Silent button: NO listener, NO href, NO form submit. A click here
+    // produces zero observable side effect — exactly the SPA silent-fail
+    // signature that #181 catches.
+
+    // Numbers-only filter — the smallest controlled-input reproduction.
+    // After every input event we strip non-digits and write the cleaned
+    // value back via the React-style native setter so element.value reflects
+    // the framework's transformation.
+    (function() {
+      var input = document.getElementById('input-verify-numbersonly');
+      if (!input) return;
+      var setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
+      input.addEventListener('input', function() {
+        var cleaned = (input.value || '').replace(/[^0-9]/g, '');
+        if (cleaned !== input.value) setter.call(input, cleaned);
+      });
+    })();
   </script>
 </body>
 </html>


### PR DESCRIPTION
Closes #181
Part of #184 (Phase 3 epic)

Implements [`docs/operation-verification-matrix.md` §3.1](../blob/main/docs/operation-verification-matrix.md#31-commit-%E8%BB%B8--verification-%E5%A5%91%E7%B4%84%E3%81%82%E3%82%8A) for `browser_click` and `browser_fill`. Catches CDP silent-fail signatures that previously returned `ok:true` without any check that the page actually responded.

## Summary

### `browser_click` — MutationObserver-based DOM mutation verification

matrix doc §3.1 規範観測経路をそのまま実装。click 直前に top-frame で

```js
window.__dtmClickProbe = {
  mutationCount: 0,
  beforeUrl: location.href,
  beforeActive: document.activeElement,
  observer: new MutationObserver(records => probe.mutationCount += records.length)
}
probe.observer.observe(document.body, { subtree: true, childList: true, attributes: true });
```

を install し、`mouse.click()` (nut-js) で OS 層からクリック発射 → 500ms 経過 → 同じスロットを read して disconnect。

| signals 観測 | 返す hint |
|---|---|
| mutationCount > 0 OR urlChanged OR activeElementChanged | `status: "delivered"` |
| 全部 0 (top-frame 内の selector) | `status: "unverifiable"`, `reason: "no_dom_mutation"` |
| selector が iframe 内に解決 | `status: "unverifiable"`, `reason: "iframe_context_mismatch"` |
| probe install / read 失敗 | `status: "unverifiable"`, `reason: "probe_install_failed"` / `"probe_read_failed"` |

`characterData` は意図的に外している — clock や live-region の常時 mutation で false-positive を量産するため。matrix doc §3.1 の SSOT 列挙 (subtree / childList / attributes) どおり。

`unverifiable` の場合でも `BrowserClickNotDelivered` で fail に escalate しない方針。OS 層では click は dispatch 済 (mouse.click() が return している) なので、page 側に handler が attached でなかった silent-fail と「handler は走ったが observable side effect が無い」case を OS-level signal で区別できないため。caller が listener attached を確信したい場合は `unverifiable` hint を fail として扱える、というハンドオフ。

### `browser_fill` — element.value read-back

dispatch 後の `el.value` を要求値と完全一致比較。fill JS payload に `fullMatches: el.value === ${JSON.stringify(value)}` を追加し、read-back 結果でハンドラ側が判定。

mismatch 時は **必ず** `BrowserFillNotDelivered` で fail。matrix doc §5.2 で flag されている React controlled-input false-positive は **fail を returns したまま** sub-reason で disambiguate する戦略を取った（別 code 化はしない、parent review 議題に出す）:

| 条件 | subReason | 意図 |
|---|---|---|
| 0 < actualLen <= requestedLen | `controlled_input_transform` | 値は届いたが framework が onChange で transform / truncate / sanitize した |
| それ以外 (actualLen=0、または actualLen > requestedLen) | `value_not_retained` | readonly / disabled / synthetic-event proxy が programmatic write を reject |

`SUGGESTS.BrowserFillNotDelivered` の 2 行目で「`subReason='controlled_input_transform'` のときは actual を authoritative として読め」と caller に直接 hint。retry 不要 case を retry-loop に流さない。

### 新規 typed code 2 件

`src/tools/_errors.ts:SUGGESTS` に登録:

| code | SUGGESTS 要旨 |
|---|---|
| `BrowserClickNotDelivered` | 「mutation/URL/focus いずれも変化なし、handler 未 attach の可能性。selector が icon span を指していて click が parent に forward されていない場合あり。delayed handler は browser_eval で別途確認。canvas/WebGL は browser_eval で app state を直接見る。cross-origin iframe の場合は別 frame selector で pin」 |
| `BrowserFillNotDelivered` | 「`subReason='controlled_input_transform'` なら framework 変換、actual を authoritative。pattern/inputmode/type=number 制約は canonical value で送り直す。React synthetic-event proxy gated input は keyboard(action='type') を fallback。contenteditable は browser_eval で setter 違い」 |

`classify()` に lowercase substring match を 2 行追加 (`browserclicknotdelivered` / `browserfillnotdelivered`)。`Browser*` prefix で既存 `BrowserNotConnected` / `BrowserSearchNoResults` 等と命名整合。

### `_errors.ts:ROOT_HOISTED_KEYS` に `hints` を追加

success path は `ok({...hints: {verifyDelivery}})` で root に出る。failure path で `failWith(err, tool, {hints: {...}})` した場合に `hints` も root に出るよう hoist。これがないと success と failure で `hints.verifyDelivery` の参照位置が `body.hints.verifyDelivery` vs `body.context.hints.verifyDelivery` で乖離して、caller 側が条件分岐を強いられる。matrix doc §4.2 の規範 shape は両 path で同じ envelope position。

### `browser_eval` undefined-return は別 issue 化を提案

issue body の optional 言及だが、matrix doc §4.3 の `read_back_unsupported` enum は browser_eval 用に「result が undefined」を justify している。本 PR では touch しない理由:
- `browser_eval` は ack=value 軸（`browser_click`/`browser_fill` は ack=delivery 軸）で意味論が違う
- 既存呼び出し全 undefined-return path の挙動が変わるので影響範囲が広い
- matrix doc §3.1 の SSOT 候補表記から外れていない

separate issue として開ける状態。

## Files

- `src/tools/_errors.ts` — SUGGESTS 2 件 + classify() 2 行 + ROOT_HOISTED_KEYS に hints 追加
- `src/tools/browser.ts` — install/read probe helpers + browserClickElementHandler に verification、browserFillInputHandler に read-back + typed fail
- `tests/e2e/fixtures/test-page.html` — `#btn-verify-bound` (DOM mutates), `#btn-verify-silent` (no listener), `#input-verify-plain`, `#input-verify-numbersonly` (numbers-only filter — controlled input simulator)
- `tests/e2e/browser-cdp-verification.test.ts` — 新規。probe primitive (headless) + browser_fill 全 path (headless) + browser_click handler (HEADED=1 gate)
- `CHANGELOG.md` — Unreleased セクションに追加

## Test plan

- [x] `npx tsc --noEmit` (clean exit)
- [x] `npx vitest run tests/e2e/browser-cdp-verification.test.ts` — 4 passed / 2 skipped (HEADED gate)
- [x] `npx vitest run tests/e2e/browser-cdp.test.ts tests/e2e/browser-tab-context.test.ts tests/e2e/browser-search.test.ts tests/e2e/browser-app-state.test.ts tests/e2e/browser-interactive-aria.test.ts` — 74 passed / 2 skipped、regression 無し
- [ ] HEADED=1 で browser_click 完全 path を実機検証 (ローカル必要、CI では skip)