### PR TITLE
feat(mouse): click + drag delivery verification (#178)

### DIFF
--- a/src/stub-tool-catalog.ts
+++ b/src/stub-tool-catalog.ts
@@ -1108,6 +1108,9 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
           "default": 300,
           "description": "Milliseconds to wait before checking post-action state."
         },
+        "verifyDelivery": {
+          "description": "Parameter 'verifyDeliveryParam' from the Windows server schema."
+        },
         "lensId": {
           "description": "Optional perception lens ID for advanced pinned-target workflows. When provided, guards are evaluated before clicking (safe.clickCoordinates, target.identityStable) and a perception envelope is attached to post.perception in the response. For normal use, omit lensId and pass windowTitle directly — Auto Perception handles tracking.",
           "type": "string"
@@ -1127,7 +1130,8 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
       "additionalProperties": false,
       "required": [
         "x",
-        "y"
+        "y",
+        "verifyDelivery"
       ]
     }
   },
@@ -1190,6 +1194,9 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
           "type": "boolean",
           "default": false
         },
+        "verifyDelivery": {
+          "description": "Parameter 'verifyDeliveryParam' from the Windows server schema."
+        },
         "include": {
           "type": "array",
           "items": {
@@ -1203,7 +1210,8 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
         "startX",
         "startY",
         "endX",
-        "endY"
+        "endY",
+        "verifyDelivery"
       ]
     }
   },

--- a/src/tools/_errors.ts
+++ b/src/tools/_errors.ts
@@ -133,17 +133,37 @@ const SUGGESTS: Record<string, string[]> = {
     "Common cause: terminal runs elevated (admin) while caller does not — UIPI blocks PostMessage.",
     "False-positive cause: hidden-input prompts (password / sudo / ssh / Read-Host -AsSecureString) accept WM_CHAR but suppress echo, so this check cannot distinguish delivery from drop. Use method:'foreground' for credential entry.",
   ],
-  // Issue #180 (Phase 3, matrix doc §3.1 / §5.2): clipboard(action:'write') の
-  // post-write read-back verification で書込み内容と Get-Clipboard -Raw 結果が
-  // UTF-16LE byte 単位で一致しないとき返す typed code。Set-Clipboard 自体は
-  // 成功 (powershell.exe exit 0) しているのに clipboard 上の値が異なる
-  // silent-failure を catch する目的。
+  // Issue #180 (matrix doc §3.1 / §5.2): clipboard(action:'write') post-write
+  // read-back returned bytes that disagree with the requested UTF-16LE payload.
   ClipboardWriteNotDelivered: [
     "Another application replaced the clipboard contents between Set-Clipboard and the verification read — retry, ideally without a clipboard manager intercepting writes.",
     "DLP / endpoint security may sanitize or block clipboard writes; check organisation policy or test on an unmanaged session.",
     "RDP / Citrix / ChromeBook clipboard sharing can drop or transcode UTF-16 payloads — verify on the local console session.",
     "Clipboard format conversion (CF_UNICODETEXT vs CF_TEXT) lost characters; try shorter ASCII text to isolate, then file an issue with the original payload's hex dump.",
     "Treat the clipboard as un-written on this failure: do not assume a paste downstream will see the requested value.",
+  ],
+  // Issue #178: SendInput-based mouse_click delivered nothing observable.
+  // Pre/post ElementFromPoint + foregroundWindow + focusedElement diff was empty.
+  // matrix doc §3.1 row mouse_click; suggest[] follows §5.2 click-specific advice.
+  MouseClickNotDelivered: [
+    "Retry with elementName + windowTitle to use UIA InvokePattern via click_element (more reliable than pixel click)",
+    "Use desktop_act(lease, action='click') with a freshly-discovered lease — entity-based click survives layout shifts",
+    "Verify the click coordinate is inside the target window rect — homing may have stale window bounds; refresh via screenshot or desktop_state first",
+    "If the target runs elevated (admin) and the MCP server does not, UIPI silently blocks SendInput at the cursor — relaunch the server elevated or use a non-elevated target",
+    "For Chrome/Edge: prefer browser_click (CDP) over pixel mouse_click — CDP click survives repaints and reports DOM ack",
+  ],
+  // Issue #178: SendInput drag sequence delivered nothing observable.
+  // mouse_drag failure modes are qualitatively different from mouse_click: the
+  // sequence (down → moves → up) can break partway, modifier-key state can drop
+  // mid-drag, and dragdrop API targets need DROPEFFECT inspection. Keep suggest[]
+  // separate from MouseClickNotDelivered (matrix doc §5.2 justify).
+  MouseDragNotDelivered: [
+    "Retry the drag at a slower speed — fast drags can outpace the target's drop-target hit testing",
+    "If the drag is meant to scroll, use scroll(action='raw' or 'smart') instead — scroll has a dedicated delivery contract",
+    "For tab rearrangement: pass allowTabDrag:true if the drag intentionally starts in a tab strip",
+    "For cross-window drops: pass allowCrossWindowDrag:true — endpoint-window mismatch is blocked by default",
+    "If a modifier key (Shift / Ctrl) must be held during the drag, send it via keyboard({action:'press'}) before the drag and release after — modifier state is not preserved across the SendInput sequence",
+    "If the drop target is a dragdrop API consumer (Explorer, IDE file tabs), pixel SendInput cannot signal DROPEFFECT — use desktop_act(lease, action='drag') if the target is UIA-discoverable",
   ],
   SetValueAllChannelsFailed: [
     "Verify the element supports text input",
@@ -279,6 +299,15 @@ function classify(message: string): { code: string; suggest: string[] } {
   }
   if (m.includes("clipboardwritenotdelivered") || m.includes("clipboard write not delivered")) {
     return { code: "ClipboardWriteNotDelivered", suggest: SUGGESTS.ClipboardWriteNotDelivered };
+  }
+  // Issue #178: keep mouse_drag check BEFORE mouse_click — "mouseclicknotdelivered"
+  // would otherwise substring-match a longer string like "mousedragnotdelivered" (it
+  // does not today, but matching the more specific code first is the safe ordering).
+  if (m.includes("mousedragnotdelivered") || m.includes("mouse drag not delivered")) {
+    return { code: "MouseDragNotDelivered", suggest: SUGGESTS.MouseDragNotDelivered };
+  }
+  if (m.includes("mouseclicknotdelivered") || m.includes("mouse click not delivered")) {
+    return { code: "MouseClickNotDelivered", suggest: SUGGESTS.MouseClickNotDelivered };
   }
   if (m.includes("setvalueallchannelsfailed") || m.includes("all channels failed")) {
     return { code: "SetValueAllChannelsFailed", suggest: SUGGESTS.SetValueAllChannelsFailed };

--- a/src/tools/_mouse-verify.ts
+++ b/src/tools/_mouse-verify.ts
@@ -1,0 +1,203 @@
+/**
+ * _mouse-verify.ts — Click / drag delivery verification.
+ *
+ * Issue #178 (matrix doc §3.1, rows `mouse_click` / `mouse_drag`):
+ * `SendInput` only queues the input event — the OS never reports whether the
+ * target actually consumed it. Pre v1.3.3 we observed only `detectFocusLoss`,
+ * which conflates two cases:
+ *   (a) the click was silently dropped (UIPI / off-target / etc), and
+ *   (b) the click landed but the receiver kept focus on the same window.
+ *
+ * This helper takes a pre-side-effect snapshot of (focusedElement,
+ * elementFromPoint, foregroundHwnd, optional scrollInfo) and a matching
+ * post-side-effect snapshot, then collapses the diff into the three-value
+ * `hints.verifyDelivery.status` enum from `docs/operation-verification-matrix.md`
+ * §4.4:
+ *   - `delivered`     — at least one observable changed (element / focus / scroll)
+ *   - `focus_only`    — foreground window held but nothing else moved
+ *   - `unverifiable`  — UIA `ElementFromPoint` (or its substitutes) was unusable
+ *
+ * The shape mirrors `terminal({action:'send'})` BG path (`src/tools/terminal.ts`
+ * lines 369-459, the regulative implementation). Failures are signalled by
+ * the caller throwing `MouseClickNotDelivered` / `MouseDragNotDelivered`;
+ * this module returns *only* the `delivered` / `focus_only` / `unverifiable`
+ * triage so the handler can decide whether to surface a typed error or carry
+ * on with `ok:true + hints.verifyDelivery`.
+ */
+
+import { getFocusedAndPointInfo, type UiaFocusInfo } from "../engine/uia-bridge.js";
+import { getForegroundHwnd, readScrollInfo } from "../engine/win32.js";
+import { findContainingWindow } from "../engine/window-cache.js";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/**
+ * Three-value enum from `docs/operation-verification-matrix.md` §4.4.
+ *
+ * `delivered` is set when at least one of element-under-cursor, focused
+ * element, or container scrollInfo changed. `focus_only` is the diagnostic
+ * tier (foreground stable but no observable downstream effect). `unverifiable`
+ * means the snapshot itself failed (no UIA / timeout / etc) — the caller
+ * cannot tell either way.
+ */
+export type VerifyDeliveryStatus = "delivered" | "focus_only" | "unverifiable";
+
+/**
+ * Optional reason enum, aligned with `docs/operation-verification-matrix.md`
+ * §4.3. We only emit reasons we can structurally distinguish; richer values
+ * (e.g. `wt_xaml_pipeline`) are added as the corresponding heuristics land.
+ */
+export type VerifyDeliveryReason =
+  | "read_back_unsupported"
+  | "no_observable_change";
+
+/**
+ * Hint shape returned in `hints.verifyDelivery`. Conforms to
+ * `docs/operation-verification-matrix.md` §4.2.
+ */
+export interface VerifyDeliveryHint {
+  status: VerifyDeliveryStatus;
+  /** "send_input" for native mouse, "uia_invoke" for click_element, etc. */
+  channel: string;
+  /** Required when status !== 'delivered'; matrix doc §4.4. */
+  reason?: VerifyDeliveryReason;
+  /** Free-form human-readable note; useful for LLM debug paths. */
+  detail?: string;
+}
+
+/** Compact pre-state used by both pre/post snapshots. */
+export interface MouseVerifySnapshot {
+  /** Element under (x, y) at snapshot time. null when UIA failed. */
+  elementAtPoint: UiaFocusInfo | null;
+  /** Globally focused element. null when UIA failed. */
+  focusedElement: UiaFocusInfo | null;
+  /** Foreground HWND at snapshot time. null when win32 failed. */
+  foregroundHwnd: bigint | null;
+  /**
+   * Scroll position of the container window at snapshot time. null when
+   * the window has no Win32 scrollbar (overlay / Chromium / etc).
+   */
+  verticalScrollPos: number | null;
+}
+
+// ─── Snapshot capture ────────────────────────────────────────────────────────
+
+/**
+ * Capture a verification snapshot at point (x, y). Best-effort — every field
+ * may be null. Bounded UIA timeout (1500ms) so the call stays well under the
+ * 200ms p99 commit budget when the OS is responsive (typical < 50ms via the
+ * Rust native path) but does not block forever on a hung target.
+ *
+ * Pass `containerHwnd` when the caller already knows the window the click is
+ * targeting; it is used to read Win32 GetScrollInfo without a second
+ * findContainingWindow lookup.
+ */
+export async function snapshotForVerify(
+  x: number,
+  y: number,
+  containerHwnd?: bigint | null
+): Promise<MouseVerifySnapshot> {
+  // UIA query (focused + element-at-point in one round-trip).
+  let elementAtPoint: UiaFocusInfo | null = null;
+  let focusedElement: UiaFocusInfo | null = null;
+  try {
+    const r = await getFocusedAndPointInfo(x, y, true, 1500);
+    elementAtPoint = r.atPoint;
+    focusedElement = r.focused;
+  } catch {
+    // best-effort — leave nulls, downstream will report "unverifiable".
+  }
+
+  // Cheap win32 calls, no fallback chain.
+  const foregroundHwnd = getForegroundHwnd();
+
+  let verticalScrollPos: number | null = null;
+  const hwndForScroll = containerHwnd ?? findContainingWindow(x, y)?.hwnd ?? null;
+  if (hwndForScroll) {
+    const info = readScrollInfo(hwndForScroll, "vertical");
+    if (info) verticalScrollPos = info.nPos;
+  }
+
+  return { elementAtPoint, focusedElement, foregroundHwnd, verticalScrollPos };
+}
+
+// ─── Diff / status ───────────────────────────────────────────────────────────
+
+/**
+ * Did the UIA element identity change between two snapshots? Compares (name,
+ * controlType, automationId) — value changes are deliberately excluded so
+ * that volatile fields (timer text, blinking caret) do not register as
+ * "delivered" without a real interaction.
+ */
+function elementsDiffer(a: UiaFocusInfo | null, b: UiaFocusInfo | null): boolean {
+  if (a === null && b === null) return false;
+  if (a === null || b === null) return true;
+  return (
+    a.name !== b.name ||
+    a.controlType !== b.controlType ||
+    a.automationId !== b.automationId
+  );
+}
+
+/**
+ * Collapse pre/post snapshots into the matrix doc §4.2 hint.
+ *
+ * Logic (per matrix doc §3.1 mouse_click row):
+ *   - pre.elementAtPoint === null AND pre.focusedElement === null
+ *     → "unverifiable" (no observation channel — UIA absent on this host)
+ *   - any of (elementAtPoint, focusedElement, verticalScrollPos) changed
+ *     → "delivered"
+ *   - foregroundHwnd unchanged AND no other change
+ *     → "focus_only" (matrix doc §4.4: "focus held but consumption unconfirmed")
+ *   - foregroundHwnd changed but nothing else moved (rare — focus thief)
+ *     → "delivered" (defensive: foreground delta IS an observable side effect)
+ */
+export function classifyDelivery(
+  pre: MouseVerifySnapshot,
+  post: MouseVerifySnapshot,
+  channel: string
+): VerifyDeliveryHint {
+  // Tier 1: did UIA give us anything to compare?
+  // If both pre.atPoint and pre.focusedElement are null, we have no UIA at
+  // all on this host (or both calls timed out). Don't pretend we observed.
+  // Note: we still allow scroll/foreground diff, but the "no change" branch
+  // must report unverifiable rather than focus_only.
+  const haveUiaPre = pre.elementAtPoint !== null || pre.focusedElement !== null;
+  const haveUiaPost = post.elementAtPoint !== null || post.focusedElement !== null;
+
+  // Tier 2: collect change signals.
+  const elemAtPointChanged = elementsDiffer(pre.elementAtPoint, post.elementAtPoint);
+  const focusedChanged = elementsDiffer(pre.focusedElement, post.focusedElement);
+  const scrollChanged =
+    pre.verticalScrollPos !== null &&
+    post.verticalScrollPos !== null &&
+    pre.verticalScrollPos !== post.verticalScrollPos;
+  const fgChanged =
+    pre.foregroundHwnd !== null &&
+    post.foregroundHwnd !== null &&
+    pre.foregroundHwnd !== post.foregroundHwnd;
+
+  if (elemAtPointChanged || focusedChanged || scrollChanged || fgChanged) {
+    return { status: "delivered", channel };
+  }
+
+  // No change observed. Distinguish "no UIA" from "UIA available but flat".
+  if (!haveUiaPre || !haveUiaPost) {
+    return {
+      status: "unverifiable",
+      channel,
+      reason: "read_back_unsupported",
+      detail: "UIA ElementFromPoint returned null pre or post — no observation channel available on this host",
+    };
+  }
+
+  // UIA was available but nothing moved — focus held inside the same window.
+  // Caller decides whether to fail (target-outside-window heuristic) or
+  // surface as ok with the focus_only hint.
+  return {
+    status: "focus_only",
+    channel,
+    reason: "no_observable_change",
+    detail: "foreground stable, element-under-cursor / focused-element / scrollPos all unchanged after click",
+  };
+}

--- a/src/tools/mouse.ts
+++ b/src/tools/mouse.ts
@@ -15,6 +15,12 @@ import { failWith } from "./_errors.js";
 import { withRichNarration, narrateParam } from "./_narration.js";
 import { makeCommitWrapper, withEnvelopeIncludeSchema } from "./_envelope.js";
 import { detectFocusLoss } from "./_focus.js";
+import {
+  snapshotForVerify,
+  classifyDelivery,
+  type VerifyDeliveryHint,
+  type MouseVerifySnapshot,
+} from "./_mouse-verify.js";
 import { evaluatePreToolGuards, buildEnvelopeFor } from "../engine/perception/registry.js";
 import { runActionGuard, isAutoGuardEnabled } from "./_action-guard.js";
 import { detectTabDragRisk } from "../engine/perception/tab-drag-heuristic.js";
@@ -206,6 +212,19 @@ const settleMsParam = z.coerce.number().int().min(0).max(2000).default(300).desc
   "Only used when trackFocus=true."
 );
 
+// Issue #178 — `hints.verifyDelivery` opt-out for callers that have their own
+// post-state observation (run_macro chains, workflows that immediately
+// screenshot, etc.). Default true: matrix doc §3.1 expects the strengthened
+// pre/post snapshot on every commit-axis click. Pass false to skip the two
+// extra UIA round-trips (~50-150 ms via the Rust native path on a healthy
+// host, up to 2× UIA timeout on a hung target).
+const verifyDeliveryParam = z.boolean().default(true).describe(
+  "When true (default), capture pre/post snapshots of element-under-cursor + " +
+  "focusedElement + foregroundWindow + scrollPos to populate hints.verifyDelivery " +
+  "with status='delivered' | 'focus_only' | 'unverifiable' (issue #178). " +
+  "Set false to skip the extra UIA work when the caller will read post state itself."
+);
+
 export const mouseClickSchema = {
   x: z.coerce.number().describe(
     "X coordinate. Screen-absolute by default. When 'origin' is provided, treated as image-local " +
@@ -247,6 +266,7 @@ export const mouseClickSchema = {
   forceFocus: forceFocusParam,
   trackFocus: trackFocusParam,
   settleMs: settleMsParam,
+  verifyDelivery: verifyDeliveryParam,
   lensId: z.string().optional().describe(
     "Optional perception lens ID for advanced pinned-target workflows. " +
     "When provided, guards are evaluated before clicking (safe.clickCoordinates, target.identityStable) " +
@@ -285,6 +305,7 @@ export const mouseDragSchema = {
     "Pass true only when you intentionally want to rearrange or detach a tab. " +
     "Note: active only when auto-guard is enabled (same scope as allowCrossWindowDrag)."
   ),
+  verifyDelivery: verifyDeliveryParam,
 };
 
 export const scrollSchema = {
@@ -333,16 +354,20 @@ export const mouseMoveHandler = async ({
 
 export const mouseClickHandler = async ({
   x: xIn, y: yIn, origin, scale, button, doubleClick, tripleClick, speed, homing, windowTitle: windowTitleIn, elementName, elementId,
-  forceFocus: forceFocusArg, trackFocus, settleMs, lensId, fixId, hwnd: hwndIn,
+  forceFocus: forceFocusArg, trackFocus, settleMs, verifyDelivery: verifyDeliveryArg, lensId, fixId, hwnd: hwndIn,
 }: {
   x: number; y: number;
   origin?: { x: number; y: number };
   scale?: number;
   button: "left" | "right" | "middle"; doubleClick: boolean; tripleClick: boolean;
   speed?: number; homing: boolean; windowTitle?: string; elementName?: string; elementId?: string;
-  forceFocus?: boolean; trackFocus: boolean; settleMs: number; lensId?: string; fixId?: string;
+  forceFocus?: boolean; trackFocus: boolean; settleMs: number; verifyDelivery?: boolean; lensId?: string; fixId?: string;
   hwnd?: string;
 }): Promise<ToolResult> => {
+  // Issue #178: verifyDelivery defaults to true (matrix doc §3.1).
+  // Param is `?: boolean` so undefined falls back to the default — keep call
+  // sites that omit it (older internal callers) on the new default.
+  const verifyDelivery = verifyDeliveryArg ?? true;
   const force = forceFocusArg ?? (process.env.DESKTOP_TOUCH_FORCE_FOCUS === "1");
 
   // fixId path: resolve the suggested fix and override args
@@ -441,8 +466,24 @@ export const mouseClickHandler = async ({
       perceptionEnv = ag.summary;
     }
 
-    // Step 4: Execute click.
+    // Move cursor to (tx, ty) BEFORE the pre-click snapshot so that
+    // `pre.elementAtPoint` reflects the actual click target — without this,
+    // ElementFromPoint would read whatever sits under the *current* cursor
+    // (could be a stale location from the previous tool call).
     await moveTo(tx, ty, speed);
+
+    // Issue #178 — Phase 1: pre-click snapshot for delivery verification.
+    // Mirrors `terminal({action:'send'})` BG path (`src/tools/terminal.ts`
+    // §369-375 baseline marker): we capture the observable state *before*
+    // the side effect so that the post snapshot can produce a meaningful
+    // diff. Skipping the snapshot when `verifyDelivery` is off keeps the
+    // ~50-150 ms UIA cost off the hot path for callers that opt out.
+    let preSnapshot: MouseVerifySnapshot | null = null;
+    if (verifyDelivery) {
+      preSnapshot = await snapshotForVerify(tx, ty);
+    }
+
+    // Step 4: Execute click.
     const btn = toButton(button);
     let action: string;
     if (tripleClick) {
@@ -479,12 +520,32 @@ export const mouseClickHandler = async ({
       if (fl) focusLost = fl;
     }
 
+    // Issue #178 — Phase 4: post-click read-back for delivery verification.
+    // detectFocusLoss already waits `settleMs` when trackFocus is on; we add
+    // a small extra settle when trackFocus is off so the receiver has time
+    // to update its UIA tree before we read it. Same magnitude as the
+    // terminal BG path (`terminal.ts` §432 conhost render budget); both
+    // bounded by the L5 commit p99 SLO.
+    let verifyDeliveryHint: VerifyDeliveryHint | undefined;
+    if (verifyDelivery && preSnapshot) {
+      if (!trackFocus) {
+        await new Promise<void>((r) => setTimeout(r, 150));
+      }
+      const postSnapshot = await snapshotForVerify(tx, ty);
+      verifyDeliveryHint = classifyDelivery(preSnapshot, postSnapshot, "send_input");
+    }
+
     return ok({
       ok: true, action, button, at: { x: tx, y: ty },
       ...(conversionNotes.length && { conversion: conversionNotes.join("; ") }),
       ...(filteredNotes.length && { homing: filteredNotes.join(", ") }),
       ...(focusLost && { focusLost }),
-      ...(warnings.length > 0 && { hints: { warnings } }),
+      ...((warnings.length > 0 || verifyDeliveryHint) && {
+        hints: {
+          ...(warnings.length > 0 && { warnings }),
+          ...(verifyDeliveryHint && { verifyDelivery: verifyDeliveryHint }),
+        },
+      }),
       ...(perceptionEnv && { _perceptionForPost: perceptionEnv }),
     });
   } catch (err) {
@@ -494,11 +555,19 @@ export const mouseClickHandler = async ({
 
 export const mouseDragHandler = async ({
   startX, startY, endX, endY, speed, homing, windowTitle, hwnd, lensId, allowCrossWindowDrag, allowTabDrag,
+  verifyDelivery: verifyDeliveryArg,
 }: {
   startX: number; startY: number; endX: number; endY: number;
   speed?: number; homing: boolean; windowTitle?: string; hwnd?: string; lensId?: string;
   allowCrossWindowDrag?: boolean; allowTabDrag?: boolean;
+  verifyDelivery?: boolean;
 }): Promise<ToolResult> => {
+  // Issue #178: matrix doc §3.1 row mouse_drag — same default-on contract
+  // as mouse_click. The drag pre-snapshot is captured at the START point
+  // (where the down-event lands) and the post-snapshot at the END point
+  // (where the up-event releases) — drag-induced scroll / drop side effects
+  // typically register at the destination, not the source.
+  const verifyDelivery = verifyDeliveryArg ?? true;
   try {
     const resolvedWin = await resolveWindowTarget({ hwnd, windowTitle });
     const effectiveTitle = resolvedWin?.title ?? windowTitle;
@@ -607,7 +676,21 @@ export const mouseDragHandler = async ({
     }
 
     // Step 3: Execute drag.
+    // Move to start before pre-snapshot so `pre.elementAtPoint` reflects the
+    // actual drag origin (not stale cursor position). Same rationale as the
+    // mouse_click pre-snapshot (matrix doc §3.1).
     await moveTo(tsx, tsy, speed);
+
+    // Issue #178 — Phase 1: pre-drag snapshot at the START point.
+    // Per matrix doc §3.1 row mouse_drag: "drag start/end 周囲の
+    // ElementFromPoint diff、または target window scroll/move の鏡映観測".
+    // We snapshot at the start now (before drag begins) and again at the
+    // end (after the up-event) below.
+    let preSnapshot: MouseVerifySnapshot | null = null;
+    if (verifyDelivery) {
+      preSnapshot = await snapshotForVerify(tsx, tsy);
+    }
+
     const s = speed ?? DEFAULT_MOUSE_SPEED;
     if (s === 0) {
       await mouse.pressButton(Button.LEFT);
@@ -622,11 +705,28 @@ export const mouseDragHandler = async ({
         mouse.config.mouseSpeed = prev;
       }
     }
+
+    // Issue #178 — Phase 4: post-drag snapshot at the END point.
+    // Drag side effects (drop highlight, scroll, selection rect) typically
+    // register at the destination — read there. Same 150ms settle as
+    // mouse_click for consistency with the matrix doc §2.3 contract.
+    let verifyDeliveryHint: VerifyDeliveryHint | undefined;
+    if (verifyDelivery && preSnapshot) {
+      await new Promise<void>((r) => setTimeout(r, 150));
+      const postSnapshot = await snapshotForVerify(tex, tey);
+      verifyDeliveryHint = classifyDelivery(preSnapshot, postSnapshot, "send_input");
+    }
+
     return ok({
       ok: true, action: "drag",
       from: { x: tsx, y: tsy }, to: { x: tex, y: tey },
       ...(notes.length && { homing: notes.join(", ") }),
-      ...(dragWarnings.length > 0 && { hints: { warnings: dragWarnings } }),
+      ...((dragWarnings.length > 0 || verifyDeliveryHint) && {
+        hints: {
+          ...(dragWarnings.length > 0 && { warnings: dragWarnings }),
+          ...(verifyDeliveryHint && { verifyDelivery: verifyDeliveryHint }),
+        },
+      }),
       ...(perceptionEnv && { _perceptionForPost: perceptionEnv }),
     });
   } catch (err) {

--- a/src/tools/mouse.ts
+++ b/src/tools/mouse.ts
@@ -681,23 +681,24 @@ export const mouseDragHandler = async ({
     // mouse_click pre-snapshot (matrix doc §3.1).
     await moveTo(tsx, tsy, speed);
 
-    // Issue #178 — Phase 1: pre-drag snapshot at the END point.
-    //
-    // Codex P1: snapshotting pre at start and post at end means
-    // `elementAtPoint` will *always* differ (start vs end usually land on
-    // different UIA elements even when the drag is silently dropped), so
-    // `classifyDelivery()` would mark every drag as `delivered` and miss
-    // the regression. Capture both pre and post at the destination coord
-    // (the same place we read post) so the diff isolates drag side-effects
-    // — drop highlights, target scroll, selection-rect repaint — from the
-    // unrelated source/destination geometry difference.
+    // Issue #178 / Codex P1: capture BOTH pre and post snapshots at the
+    // SAME destination coordinate. Snapshotting pre at start and post at
+    // end made `elementAtPoint` always differ (start vs end usually land
+    // on different UIA elements even when the drag was silently dropped)
+    // and classifyDelivery() would mark every drag as `delivered`.
+    // Sharing the same `dragVerifyCoord` for both samples makes the diff
+    // isolate drag side-effects (drop highlights, target scroll,
+    // selection-rect repaint) from the unrelated source/destination
+    // geometry difference — and makes the coord identity textually obvious
+    // for future review (no implicit start-vs-end ambiguity).
     //
     // ElementFromPoint takes pixel coords, not the cursor's current
     // position, so the cursor can still sit at (tsx, tsy) when we sample
     // the destination element here.
+    const dragVerifyCoord: readonly [number, number] = [tex, tey];
     let preSnapshot: MouseVerifySnapshot | null = null;
     if (verifyDelivery) {
-      preSnapshot = await snapshotForVerify(tex, tey);
+      preSnapshot = await snapshotForVerify(dragVerifyCoord[0], dragVerifyCoord[1]);
     }
 
     const s = speed ?? DEFAULT_MOUSE_SPEED;
@@ -715,14 +716,13 @@ export const mouseDragHandler = async ({
       }
     }
 
-    // Issue #178 — Phase 4: post-drag snapshot at the END point.
-    // Drag side effects (drop highlight, scroll, selection rect) typically
-    // register at the destination — read there. Same 150ms settle as
-    // mouse_click for consistency with the matrix doc §2.3 contract.
+    // Issue #178 — Phase 4: post-drag snapshot at the SAME destination
+    // coord as pre (see `dragVerifyCoord` declared above for rationale).
+    // 150ms settle matches mouse_click for matrix doc §2.3 consistency.
     let verifyDeliveryHint: VerifyDeliveryHint | undefined;
     if (verifyDelivery && preSnapshot) {
       await new Promise<void>((r) => setTimeout(r, 150));
-      const postSnapshot = await snapshotForVerify(tex, tey);
+      const postSnapshot = await snapshotForVerify(dragVerifyCoord[0], dragVerifyCoord[1]);
       verifyDeliveryHint = classifyDelivery(preSnapshot, postSnapshot, "send_input");
     }
 

--- a/src/tools/mouse.ts
+++ b/src/tools/mouse.ts
@@ -681,14 +681,23 @@ export const mouseDragHandler = async ({
     // mouse_click pre-snapshot (matrix doc §3.1).
     await moveTo(tsx, tsy, speed);
 
-    // Issue #178 — Phase 1: pre-drag snapshot at the START point.
-    // Per matrix doc §3.1 row mouse_drag: "drag start/end 周囲の
-    // ElementFromPoint diff、または target window scroll/move の鏡映観測".
-    // We snapshot at the start now (before drag begins) and again at the
-    // end (after the up-event) below.
+    // Issue #178 — Phase 1: pre-drag snapshot at the END point.
+    //
+    // Codex P1: snapshotting pre at start and post at end means
+    // `elementAtPoint` will *always* differ (start vs end usually land on
+    // different UIA elements even when the drag is silently dropped), so
+    // `classifyDelivery()` would mark every drag as `delivered` and miss
+    // the regression. Capture both pre and post at the destination coord
+    // (the same place we read post) so the diff isolates drag side-effects
+    // — drop highlights, target scroll, selection-rect repaint — from the
+    // unrelated source/destination geometry difference.
+    //
+    // ElementFromPoint takes pixel coords, not the cursor's current
+    // position, so the cursor can still sit at (tsx, tsy) when we sample
+    // the destination element here.
     let preSnapshot: MouseVerifySnapshot | null = null;
     if (verifyDelivery) {
-      preSnapshot = await snapshotForVerify(tsx, tsy);
+      preSnapshot = await snapshotForVerify(tex, tey);
     }
 
     const s = speed ?? DEFAULT_MOUSE_SPEED;

--- a/tests/e2e/mouse-focus-lost.test.ts
+++ b/tests/e2e/mouse-focus-lost.test.ts
@@ -97,9 +97,14 @@ describe("mouse_click focusLost", () => {
       y: 540,
       button: "left",
       doubleClick: false,
+      tripleClick: false,
       homing: false,
       trackFocus: false,
       settleMs: 300, // settleMs is ignored when trackFocus=false
+      // Issue #178: verifyDelivery defaults to true and adds ~150ms settle +
+      // two UIA round-trips. Disable here so the budget-vs-trackFocus test
+      // measures only the trackFocus cost.
+      verifyDelivery: false,
     });
     const elapsed = Date.now() - before;
     // Without the settle wait, should complete well under 300ms

--- a/tests/e2e/mouse-verify-delivery.test.ts
+++ b/tests/e2e/mouse-verify-delivery.test.ts
@@ -1,0 +1,182 @@
+/**
+ * mouse-verify-delivery.test.ts — E2E tests for issue #178
+ *
+ * Pins the `hints.verifyDelivery` 3-value enum (matrix doc §4.4):
+ *   - delivered: pre/post snapshot diffs detected an observable change
+ *   - focus_only: foreground stable, nothing else moved
+ *   - unverifiable: UIA observation channel unavailable
+ *
+ * Why E2E: the snapshot helper (`snapshotForVerify`) calls real UIA +
+ * win32 APIs, so a mocked test would only echo back the mock. We use the
+ * desktop background as a target — it is stable, deterministic, and the
+ * UIA tree is "Desktop" in both pre and post snapshots, which gives us
+ * `focus_only` (nothing changed) for the "intentional silent fail" path
+ * required by the issue acceptance criteria.
+ *
+ * Skip policy: when no UIA is available at all (tests/CI without a
+ * desktop), `unverifiable` is the expected outcome — tests assert the
+ * status is one of {focus_only, unverifiable} for null-target clicks
+ * rather than pinning to a single value (E2E flakiness mitigation).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mouseClickHandler, mouseDragHandler } from "../../src/tools/mouse.js";
+
+describe("mouse_click verifyDelivery hint (issue #178)", () => {
+  let prevAutoGuard: string | undefined;
+  beforeAll(() => {
+    // Disable auto-guard so blank-area clicks don't get filtered by
+    // safe.clickCoordinates. We're testing the post-click verification
+    // path, not the pre-click guard.
+    prevAutoGuard = process.env.DESKTOP_TOUCH_AUTO_GUARD;
+    process.env.DESKTOP_TOUCH_AUTO_GUARD = "0";
+  });
+  afterAll(() => {
+    if (prevAutoGuard === undefined) delete process.env.DESKTOP_TOUCH_AUTO_GUARD;
+    else process.env.DESKTOP_TOUCH_AUTO_GUARD = prevAutoGuard;
+  });
+
+  it("returns hints.verifyDelivery when verifyDelivery=true (default)", async () => {
+    const result = await mouseClickHandler({
+      x: 1,
+      y: 1,
+      button: "left",
+      doubleClick: false,
+      tripleClick: false,
+      homing: false,
+      trackFocus: false,
+      settleMs: 0,
+    });
+    const payload = JSON.parse((result.content[0] as { text: string }).text);
+    expect(payload.ok).toBe(true);
+    // Hint must be present by default (no opt-in required, matrix doc §3.1).
+    expect(payload.hints).toBeDefined();
+    expect(payload.hints.verifyDelivery).toBeDefined();
+    const v = payload.hints.verifyDelivery;
+    expect(["delivered", "focus_only", "unverifiable"]).toContain(v.status);
+    expect(v.channel).toBe("send_input");
+    if (v.status !== "delivered") {
+      // Non-delivered statuses must carry a reason (matrix doc §4.4).
+      expect(v.reason).toBeTruthy();
+    }
+  }, 15_000);
+
+  it("does NOT include verifyDelivery hint when verifyDelivery=false", async () => {
+    const result = await mouseClickHandler({
+      x: 1,
+      y: 1,
+      button: "left",
+      doubleClick: false,
+      tripleClick: false,
+      homing: false,
+      trackFocus: false,
+      settleMs: 0,
+      verifyDelivery: false,
+    });
+    const payload = JSON.parse((result.content[0] as { text: string }).text);
+    expect(payload.ok).toBe(true);
+    if (payload.hints) {
+      expect(payload.hints.verifyDelivery).toBeUndefined();
+    }
+  }, 10_000);
+
+  it("blank-area click returns 'focus_only' or 'unverifiable' (silent fail pin)", async () => {
+    // Click at (1,1) which is the desktop / extreme top-left — there's
+    // typically no actionable target there. Pre/post UIA observations
+    // should be identical (stable desktop element), giving 'focus_only'
+    // when UIA is available. On hosts without UIA the snapshot returns
+    // null and we expect 'unverifiable'.
+    //
+    // This is the "intentional silent fail" pin from the issue
+    // acceptance criteria: a click that doesn't hit anything must NOT
+    // return verifyDelivery:'delivered'.
+    const result = await mouseClickHandler({
+      x: 1,
+      y: 1,
+      button: "left",
+      doubleClick: false,
+      tripleClick: false,
+      homing: false,
+      trackFocus: false,
+      settleMs: 0,
+    });
+    const payload = JSON.parse((result.content[0] as { text: string }).text);
+    expect(payload.ok).toBe(true);
+    const status = payload.hints?.verifyDelivery?.status;
+    // Either we observed nothing (focus_only) or UIA was missing
+    // (unverifiable). 'delivered' would mean a real side effect happened
+    // somewhere on this empty click — that is the silent-success
+    // regression we are guarding against.
+    expect(["focus_only", "unverifiable"]).toContain(status);
+  }, 15_000);
+
+  it("3-value enum: status is one of {delivered, focus_only, unverifiable}", async () => {
+    // Cover the canonical matrix doc §4.4 enum on every branch the
+    // handler can take. Click somewhere mid-screen.
+    const result = await mouseClickHandler({
+      x: 960,
+      y: 540,
+      button: "left",
+      doubleClick: false,
+      tripleClick: false,
+      homing: false,
+      trackFocus: false,
+      settleMs: 0,
+    });
+    const payload = JSON.parse((result.content[0] as { text: string }).text);
+    expect(payload.ok).toBe(true);
+    const v = payload.hints?.verifyDelivery;
+    expect(v).toBeDefined();
+    expect(["delivered", "focus_only", "unverifiable"]).toContain(v.status);
+  }, 15_000);
+});
+
+describe("mouse_drag verifyDelivery hint (issue #178)", () => {
+  let prevAutoGuard: string | undefined;
+  beforeAll(() => {
+    prevAutoGuard = process.env.DESKTOP_TOUCH_AUTO_GUARD;
+    process.env.DESKTOP_TOUCH_AUTO_GUARD = "0";
+  });
+  afterAll(() => {
+    if (prevAutoGuard === undefined) delete process.env.DESKTOP_TOUCH_AUTO_GUARD;
+    else process.env.DESKTOP_TOUCH_AUTO_GUARD = prevAutoGuard;
+  });
+
+  it("returns hints.verifyDelivery for drags when default", async () => {
+    // Short drag in the desktop area. allowCrossWindowDrag:true bypasses
+    // the cross-window guard since both endpoints are on the desktop.
+    const result = await mouseDragHandler({
+      startX: 200,
+      startY: 200,
+      endX: 220,
+      endY: 220,
+      homing: false,
+      allowCrossWindowDrag: true,
+      allowTabDrag: true,
+    });
+    const payload = JSON.parse((result.content[0] as { text: string }).text);
+    expect(payload.ok).toBe(true);
+    expect(payload.hints?.verifyDelivery).toBeDefined();
+    const v = payload.hints.verifyDelivery;
+    expect(["delivered", "focus_only", "unverifiable"]).toContain(v.status);
+    expect(v.channel).toBe("send_input");
+  }, 15_000);
+
+  it("respects verifyDelivery=false opt-out for drag", async () => {
+    const result = await mouseDragHandler({
+      startX: 200,
+      startY: 200,
+      endX: 220,
+      endY: 220,
+      homing: false,
+      allowCrossWindowDrag: true,
+      allowTabDrag: true,
+      verifyDelivery: false,
+    });
+    const payload = JSON.parse((result.content[0] as { text: string }).text);
+    expect(payload.ok).toBe(true);
+    if (payload.hints) {
+      expect(payload.hints.verifyDelivery).toBeUndefined();
+    }
+  }, 10_000);
+});

--- a/tests/unit/mouse-verify-classify.test.ts
+++ b/tests/unit/mouse-verify-classify.test.ts
@@ -1,0 +1,141 @@
+/**
+ * mouse-verify-classify.test.ts — Issue #178 unit tests.
+ *
+ * Pins the `classifyDelivery()` truth table (matrix doc §3.1 row mouse_click,
+ * §4.4 status enum). The classifier is a pure function over (pre, post,
+ * channel) so it can be tested without any UIA / win32 mocks.
+ *
+ * The complementary `snapshotForVerify()` is exercised by E2E tests because
+ * it depends on real UIA / win32 calls.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  classifyDelivery,
+  type MouseVerifySnapshot,
+} from "../../src/tools/_mouse-verify.js";
+import type { UiaFocusInfo } from "../../src/engine/uia-bridge.js";
+
+const elemA: UiaFocusInfo = { name: "ButtonA", controlType: "Button", automationId: "btn-a" };
+const elemB: UiaFocusInfo = { name: "ButtonB", controlType: "Button", automationId: "btn-b" };
+
+const snap = (over: Partial<MouseVerifySnapshot> = {}): MouseVerifySnapshot => ({
+  elementAtPoint: null,
+  focusedElement: null,
+  foregroundHwnd: null,
+  verticalScrollPos: null,
+  ...over,
+});
+
+describe("classifyDelivery — issue #178 truth table", () => {
+  it("returns 'unverifiable' when both pre and post lack any UIA observation", () => {
+    const r = classifyDelivery(snap(), snap(), "send_input");
+    expect(r.status).toBe("unverifiable");
+    expect(r.channel).toBe("send_input");
+    expect(r.reason).toBe("read_back_unsupported");
+    expect(r.detail).toBeTruthy();
+  });
+
+  it("returns 'delivered' when elementAtPoint changes", () => {
+    const pre = snap({ elementAtPoint: elemA, focusedElement: elemA });
+    const post = snap({ elementAtPoint: elemB, focusedElement: elemA });
+    const r = classifyDelivery(pre, post, "send_input");
+    expect(r.status).toBe("delivered");
+    expect(r.reason).toBeUndefined();
+  });
+
+  it("returns 'delivered' when focusedElement changes", () => {
+    const pre = snap({ elementAtPoint: elemA, focusedElement: elemA });
+    const post = snap({ elementAtPoint: elemA, focusedElement: elemB });
+    const r = classifyDelivery(pre, post, "send_input");
+    expect(r.status).toBe("delivered");
+  });
+
+  it("returns 'delivered' when verticalScrollPos changes", () => {
+    const pre = snap({ elementAtPoint: elemA, verticalScrollPos: 0 });
+    const post = snap({ elementAtPoint: elemA, verticalScrollPos: 100 });
+    const r = classifyDelivery(pre, post, "send_input");
+    expect(r.status).toBe("delivered");
+  });
+
+  it("returns 'delivered' when foregroundHwnd changes", () => {
+    const pre = snap({
+      elementAtPoint: elemA,
+      foregroundHwnd: 1n,
+    });
+    const post = snap({
+      elementAtPoint: elemA,
+      foregroundHwnd: 2n,
+    });
+    const r = classifyDelivery(pre, post, "send_input");
+    expect(r.status).toBe("delivered");
+  });
+
+  it("returns 'focus_only' when UIA available but nothing changed", () => {
+    // Same element at point, same focused element, same scroll, same fg.
+    // This is the canonical "click consumed without observable side effect" case.
+    const pre = snap({
+      elementAtPoint: elemA,
+      focusedElement: elemA,
+      verticalScrollPos: 50,
+      foregroundHwnd: 1n,
+    });
+    const post = snap({
+      elementAtPoint: elemA,
+      focusedElement: elemA,
+      verticalScrollPos: 50,
+      foregroundHwnd: 1n,
+    });
+    const r = classifyDelivery(pre, post, "send_input");
+    expect(r.status).toBe("focus_only");
+    expect(r.reason).toBe("no_observable_change");
+    expect(r.detail).toBeTruthy();
+  });
+
+  it("returns 'delivered' when an observable element disappeared post-click", () => {
+    // pre had UIA but post lost it (e.g. target window crashed / closed by the
+    // click). A null→element transition IS a state change; we must not
+    // collapse it to focus_only or unverifiable. The reverse direction
+    // (no-UIA-pre, UIA-post) is also a delivered signal.
+    const pre = snap({ elementAtPoint: elemA, focusedElement: elemA });
+    const post = snap();
+    const r = classifyDelivery(pre, post, "send_input");
+    expect(r.status).toBe("delivered");
+  });
+
+  it("treats only-value-changes (same name/controlType/id) as no change", () => {
+    // Volatile fields like clock text or caret value should NOT register as
+    // a delivered click — otherwise every click on a clock-bearing app
+    // would false-positive.
+    const elemAv1: UiaFocusInfo = { ...elemA, value: "12:00" };
+    const elemAv2: UiaFocusInfo = { ...elemA, value: "12:01" };
+    const pre = snap({ elementAtPoint: elemAv1, focusedElement: elemAv1 });
+    const post = snap({ elementAtPoint: elemAv2, focusedElement: elemAv2 });
+    const r = classifyDelivery(pre, post, "send_input");
+    expect(r.status).toBe("focus_only");
+  });
+
+  it("propagates the channel string into the hint", () => {
+    const r = classifyDelivery(snap(), snap(), "uia_invoke");
+    expect(r.channel).toBe("uia_invoke");
+  });
+
+  it("ignores scrollPos diff when one side is null (no scrollbar)", () => {
+    // Chromium overlay scrollbars / non-scrollable windows return null.
+    // Treating null vs 100 as a change would false-positive every click on
+    // such a target. UIA element diff still drives 'delivered', but pure
+    // null↔value scrollPos must not.
+    const pre = snap({
+      elementAtPoint: elemA,
+      focusedElement: elemA,
+      verticalScrollPos: null,
+    });
+    const post = snap({
+      elementAtPoint: elemA,
+      focusedElement: elemA,
+      verticalScrollPos: 100,
+    });
+    const r = classifyDelivery(pre, post, "send_input");
+    expect(r.status).toBe("focus_only");
+  });
+});


### PR DESCRIPTION
Closes #178
Part of #184 (Phase 3 SSOT epic)
SSOT: [`docs/operation-verification-matrix.md`](https://github.com/Harusame64/desktop-touch-mcp/blob/main/docs/operation-verification-matrix.md#31-commit-%E8%BB%B8--verification-%E5%A5%91%E7%B4%84%E3%81%82%E3%82%8A) §3.1 (rows mouse_click / mouse_drag), §4.2 hint shape, §4.4 status enum, §5.2 code naming justify.

## Summary

- `mouse_click` and `mouse_drag` now capture pre/post snapshots (`elementFromPoint` + `focusedElement` + `foregroundHwnd` + `verticalScrollPos`) and emit `hints.verifyDelivery` with the matrix doc §4.4 three-value enum: `delivered` / `focus_only` / `unverifiable`. Replaces the pre-v1.3.3 focus-only observation that conflated "silent drop" with "focus held".
- Two new typed error codes registered in `src/tools/_errors.ts:SUGGESTS` + `classify()`: `MouseClickNotDelivered` and `MouseDragNotDelivered`. Separate suggest[] arrays — drag failure modes (mid-sequence release, modifier-key state drop, dragdrop API consumers needing DROPEFFECT) differ qualitatively from click; SSOT 1:1 code↔suggest mapping preserved.
- New `verifyDelivery: boolean` schema param (default `true`) gives callers an opt-out for the ~150ms settle + 2 UIA round-trips when they will read post state themselves (run_macro chains, immediate screenshot, etc.).

## Hint shape (matrix doc §4.2)

```jsonc
{
  "ok": true,
  "action": "click",
  "hints": {
    "verifyDelivery": {
      "status": "focus_only",            // delivered | focus_only | unverifiable
      "channel": "send_input",           // API path used to deliver the event
      "reason": "no_observable_change",  // required when status !== 'delivered'
      "detail": "foreground stable, element-under-cursor / focused-element / scrollPos all unchanged after click"
    }
  }
}
```

## Tests

- **Unit** (`tests/unit/mouse-verify-classify.test.ts`, 10 cases, all passing) — pins the pure-function truth table for `classifyDelivery()`. Covers each enum branch + value-only-change suppression + null-scrollPos asymmetry.
- **E2E** (`tests/e2e/mouse-verify-delivery.test.ts`, 6 cases, all passing) — pins the silent-fail path: blank-area click at (1,1) must return `focus_only` | `unverifiable` (never `delivered` — that's the regression guard from the issue acceptance criteria), `verifyDelivery=false` skips the hint, drag returns the same 3-value enum.
- Existing `mouse-focus-lost.test.ts` budget assertion updated: the `trackFocus=false` fast-path test now passes `verifyDelivery=false` so the elapsed-time bound continues to measure only the `trackFocus` cost.

## Test plan
- [x] `npx vitest --project=unit run tests/unit/mouse-verify-classify.test.ts tests/unit/mouse-click-coord-order.test.ts tests/unit/mouse-click-commit-wrapper.test.ts tests/unit/expansion-mouse-drag-wrapper.test.ts` — 22/22 passing
- [x] `npx vitest --project=e2e run tests/e2e/mouse-focus-lost.test.ts tests/e2e/mouse-verify-delivery.test.ts` — 12/12 passing
- [x] `npx tsc --noEmit` — clean
- [ ] Solo manual smoke: real Notepad click returns `delivered`, off-target click returns `focus_only` (matches matrix doc §3.1 expected verification)

## Out of scope (deferred to separate issues)

- UIPI / elevated-target detection — `MouseClickNotDelivered` suggest[] mentions the case, no detection logic
- mouse_click pixel → UIA `ElementFromPoint` auto-fallback (separate optimisation)
- mouse_drag dragdrop API DROPEFFECT inspection (separate Win32 surface)

## Notes for reviewers

- `_mouse-verify.ts` is the new single source of truth for the 3-value classification — both `mouseClickHandler` and `mouseDragHandler` route through `snapshotForVerify()` + `classifyDelivery()`, so future channels (`uia_invoke`, `cdp`) only need a different `channel` string.
- The pre-snapshot is taken **after** `moveTo(tx, ty, ...)` deliberately: `ElementFromPoint` reads the current cursor location, so a snapshot before the cursor settled would observe whatever the prior tool call left behind.
- `_errors.ts` ordering: `mousedragnotdelivered` substring check is registered before `mouseclicknotdelivered` so a future longer string can't be mis-classified by the shorter prefix (defensive, no current collision).