### PR TITLE
feat(scroll): raw delivery verification with page-end disambiguation (#179)

### DIFF
--- a/src/tools/_errors.ts
+++ b/src/tools/_errors.ts
@@ -213,6 +213,22 @@ const SUGGESTS: Record<string, string[]> = {
     "For inputs guarded by React's synthetic-event proxy, try keyboard(action='type') against the focused element as a fallback (slower but framework-agnostic)",
     "Verify the selector targets an <input> / <textarea> — contenteditable div uses different setters (use browser_eval instead)",
   ],
+  // Issue #179 / matrix doc §3.1+§5.2: scroll(action:'raw') wheel SendInput was
+  // ack'd by the OS but post-state Win32 GetScrollInfo (or UIA ScrollPattern, or
+  // image-hash diff) observed no movement on the requested axis with pre off-
+  // boundary, so the wheel was silently swallowed (overlay window above target,
+  // non-scrollable container, UIPI from low-IL into elevated app, etc).
+  // Distinct from `ScrollbarUnavailable` (no scrollbar at all — caller redirected
+  // to image strategy) and `OverflowHiddenAncestor` (CSS overflow:hidden detected
+  // up-front in scroll(action:'smart')); ScrollNotDelivered is reserved for the
+  // post-ack silent-drop case the other two cannot catch.
+  ScrollNotDelivered: [
+    "Retry with scroll({action:'smart', target:'<selector>'}) — multi-strategy fallback (CDP / UIA ScrollPattern / image binary-search) often delivers where wheel SendInput is swallowed",
+    "Use scroll({action:'to_element', name|selector}) when you know the target — bypasses the wheel channel entirely via UIA ScrollItemPattern or CDP scrollIntoView",
+    "Verify the target is actually scrollable: run desktop_state or screenshot(detail='text') first to confirm the focused element under the cursor accepts wheel input — overlay windows above the target intercept wheel events",
+    "If the target runs elevated (admin) and the caller does not, wheel events are blocked by UIPI — re-run the caller with matching integrity level",
+    "If the target uses overlay/Chromium scrollbars (no Win32 scrollbar), pass coords inside the actual scrollable region — the cursor must be over a scroll-receiving element",
+  ],
   SetValueAllChannelsFailed: [
     "Verify the element supports text input",
     "Try click_element + keyboard({action:'type'}) manually",
@@ -366,6 +382,10 @@ function classify(message: string): { code: string; suggest: string[] } {
   }
   if (m.includes("browserfillnotdelivered") || m.includes("browser fill not delivered")) {
     return { code: "BrowserFillNotDelivered", suggest: SUGGESTS.BrowserFillNotDelivered };
+  }
+  // Issue #179: scroll(raw) wheel SendInput silently dropped (matrix doc §3.1).
+  if (m.includes("scrollnotdelivered") || m.includes("scroll not delivered")) {
+    return { code: "ScrollNotDelivered", suggest: SUGGESTS.ScrollNotDelivered };
   }
   if (m.includes("setvalueallchannelsfailed") || m.includes("all channels failed")) {
     return { code: "SetValueAllChannelsFailed", suggest: SUGGESTS.SetValueAllChannelsFailed };

--- a/src/tools/mouse.ts
+++ b/src/tools/mouse.ts
@@ -772,8 +772,16 @@ const RAW_SCROLL_HASH_MOVE_THRESHOLD = 5;
  * Floating-point tolerance for "scroll percent unchanged". GetScrollInfo
  * exposes integer steps but pageRatio is a derived float, so we allow a tiny
  * epsilon to avoid reading rounding noise as movement.
+ *
+ * Codex P1: 0.001 (= 0.1%) was too coarse — long scroll ranges (e.g. lists
+ * with thousands of items) take real per-step deltas of pageRatio < 0.001,
+ * so legitimately-delivered raw scrolls were being misclassified as
+ * `ScrollNotDelivered`. 1e-6 is well below FP rounding noise (typical
+ * (curr - min) / (max - min) integer-derived floats have ~7-digit
+ * precision) yet small enough to catch single-step scrolls in scroll
+ * ranges up to ~1M positions.
  */
-const SCROLL_PERCENT_EPSILON = 0.001;
+const SCROLL_PERCENT_EPSILON = 1e-6;
 
 /** Boundary tolerance for page-end detection (0% / 100%). */
 const SCROLL_PERCENT_BOUNDARY_TOL = 0.005;

--- a/src/tools/mouse.ts
+++ b/src/tools/mouse.ts
@@ -1,7 +1,14 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { mouse, Button, Point, straightTo, DEFAULT_MOUSE_SPEED } from "../engine/nutjs.js";
-import { enumWindowsInZOrder, restoreAndFocusWindow, getWindowIdentity } from "../engine/win32.js";
+import {
+  enumWindowsInZOrder,
+  restoreAndFocusWindow,
+  getWindowIdentity,
+  readScrollInfo,
+  getForegroundHwnd,
+  getWindowRectByHwnd,
+} from "../engine/win32.js";
 import {
   updateWindowCache,
   findContainingWindow,
@@ -9,6 +16,8 @@ import {
   computeWindowDelta,
 } from "../engine/window-cache.js";
 import { getElementBounds } from "../engine/uia-bridge.js";
+import { captureWindowRawAndHash } from "../engine/layer-buffer.js";
+import { hammingDistance } from "../engine/image.js";
 import { ok } from "./_types.js";
 import type { ToolResult } from "./_types.js";
 import { failWith } from "./_errors.js";
@@ -743,6 +752,174 @@ export const mouseDragHandler = async ({
   }
 };
 
+// ─────────────────────────────────────────────────────────────────────────────
+// scroll(action:'raw') — wheel SendInput delivery verification
+// (issue #179, matrix doc §3.1: pre/post Win32 GetScrollInfo + page-end
+//  disambiguation; image-hash fallback when scrollbar is unavailable.)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** ms to wait after wheel SendInput for the target to render the new scroll position. */
+const SCROLL_VERIFY_SETTLE_MS = 150;
+
+/**
+ * Hamming distance threshold for "did the viewport change" via dHash.
+ * Mirrors HASH_MOVE_THRESHOLD in smart-scroll.ts (kept independent so a tweak
+ * there does not silently change raw-scroll verification semantics).
+ */
+const RAW_SCROLL_HASH_MOVE_THRESHOLD = 5;
+
+/**
+ * Floating-point tolerance for "scroll percent unchanged". GetScrollInfo
+ * exposes integer steps but pageRatio is a derived float, so we allow a tiny
+ * epsilon to avoid reading rounding noise as movement.
+ */
+const SCROLL_PERCENT_EPSILON = 0.001;
+
+/** Boundary tolerance for page-end detection (0% / 100%). */
+const SCROLL_PERCENT_BOUNDARY_TOL = 0.005;
+
+/**
+ * @internal Exported for unit testing of the pure verification math
+ * (tests/unit/scroll-raw-verify.test.ts). Not part of the public tool surface.
+ */
+export interface ScrollSnapshot {
+  /** 0..1 from Win32 GetScrollInfo, or null when no Win32 scrollbar / unavailable. */
+  vertical: number | null;
+  horizontal: number | null;
+  /** Image hash captured for the window (fallback when both Win32 axes are null). */
+  dHash: bigint | null;
+}
+
+async function captureScrollSnapshot(
+  hwnd: bigint | null,
+  region: { x: number; y: number; width: number; height: number } | null,
+): Promise<ScrollSnapshot> {
+  if (hwnd === null) return { vertical: null, horizontal: null, dHash: null };
+  const v = readScrollInfo(hwnd, "vertical");
+  const h = readScrollInfo(hwnd, "horizontal");
+  let dHash: bigint | null = null;
+  // Only spend time on dHash when at least one Win32 axis is missing — otherwise
+  // the percent diff alone is authoritative and dHash adds only image-capture cost.
+  if ((v === null || h === null) && region !== null) {
+    try {
+      const cap = await captureWindowRawAndHash(hwnd, region);
+      dHash = cap?.dHash ?? null;
+    } catch {
+      dHash = null;
+    }
+  }
+  return {
+    vertical: v?.pageRatio ?? null,
+    horizontal: h?.pageRatio ?? null,
+    dHash,
+  };
+}
+
+/**
+ * @internal Exported for unit testing — see `evaluateScrollDelivery` below.
+ */
+export interface ScrollVerifyOutcome {
+  status: "delivered" | "unverifiable" | "not_delivered";
+  /** Observed scroll-percent delta when measurable (Win32 path). */
+  delta: { x: number | null; y: number | null } | "unverifiable";
+  /** Matrix doc §4 reason enum when status is unverifiable. */
+  reason?:
+    | "read_back_unsupported"
+    | "page_end_inferred"
+    | "scrollbar_unavailable"
+    | "no_target_window";
+  /** Axis on which silent drop / unverifiable was detected (for context). */
+  axis?: "vertical" | "horizontal";
+}
+
+/**
+ * Page-end disambiguation per matrix doc §3.1:
+ *   - pre.percent at boundary AND post.percent equal     → page-end success (no fail)
+ *   - pre.percent NOT at boundary AND post.percent equal → silent drop (ScrollNotDelivered)
+ *
+ * Returns:
+ *   - status:"delivered" — at least one axis moved, OR the requested axis was at
+ *     its directional page-end boundary (pre at 0% scrolling up, etc.)
+ *   - status:"not_delivered" — pre off-boundary AND post equal → silent drop
+ *   - status:"unverifiable" — no Win32 axis on the requested direction AND no
+ *     conclusive image-hash diff (matrix doc §3.1: page-end rule requires a
+ *     boundary signal; without it we cannot distinguish page-end from drop)
+ *
+ * @internal Exported for unit testing — see `ScrollVerifyOutcome` above.
+ */
+export function evaluateScrollDelivery(
+  pre: ScrollSnapshot,
+  post: ScrollSnapshot,
+  direction: "up" | "down" | "left" | "right",
+): ScrollVerifyOutcome {
+  const dx = pre.horizontal !== null && post.horizontal !== null
+    ? post.horizontal - pre.horizontal
+    : null;
+  const dy = pre.vertical !== null && post.vertical !== null
+    ? post.vertical - pre.vertical
+    : null;
+
+  const axisOfInterest: "vertical" | "horizontal" =
+    direction === "up" || direction === "down" ? "vertical" : "horizontal";
+  const preOnAxis = axisOfInterest === "vertical" ? pre.vertical : pre.horizontal;
+  const postOnAxis = axisOfInterest === "vertical" ? post.vertical : post.horizontal;
+  const deltaOnAxis = axisOfInterest === "vertical" ? dy : dx;
+
+  // No Win32 scrollbar on the axis of interest — fall back to image hash.
+  if (preOnAxis === null || postOnAxis === null) {
+    if (pre.dHash !== null && post.dHash !== null) {
+      const dist = hammingDistance(pre.dHash, post.dHash);
+      if (dist >= RAW_SCROLL_HASH_MOVE_THRESHOLD) {
+        return { status: "delivered", delta: { x: dx, y: dy } };
+      }
+      // Image hash unchanged — could be page-end OR silent drop. Without a
+      // boundary signal we cannot disambiguate, so degrade to unverifiable
+      // rather than risk a false positive (matrix doc §3.1 page-end rule
+      // explicitly requires pre.percent boundary detection).
+      return {
+        status: "unverifiable",
+        delta: { x: dx, y: dy },
+        reason: "page_end_inferred",
+        axis: axisOfInterest,
+      };
+    }
+    // No observation channel at all (e.g. resolved hwnd but capture failed).
+    return {
+      status: "unverifiable",
+      delta: "unverifiable",
+      reason: "scrollbar_unavailable",
+      axis: axisOfInterest,
+    };
+  }
+
+  // Win32 axis available — apply page-end disambiguation.
+  const moved = Math.abs(deltaOnAxis ?? 0) > SCROLL_PERCENT_EPSILON;
+  if (moved) {
+    return { status: "delivered", delta: { x: dx, y: dy } };
+  }
+
+  // No movement detected. Check if pre was at the boundary appropriate to the
+  // scroll direction. Scrolling up at 0% or scrolling down at 100% (etc.) is a
+  // legitimate no-op and must not surface as fail.
+  const atUpperBoundary = preOnAxis >= 1 - SCROLL_PERCENT_BOUNDARY_TOL;
+  const atLowerBoundary = preOnAxis <= SCROLL_PERCENT_BOUNDARY_TOL;
+  const atDirectionalBoundary =
+    (direction === "up" && atLowerBoundary) ||
+    (direction === "down" && atUpperBoundary) ||
+    (direction === "left" && atLowerBoundary) ||
+    (direction === "right" && atUpperBoundary);
+  if (atDirectionalBoundary) {
+    return { status: "delivered", delta: { x: dx, y: dy } };
+  }
+
+  // pre off-boundary AND post equal → silent drop confirmed.
+  return {
+    status: "not_delivered",
+    delta: { x: dx, y: dy },
+    axis: axisOfInterest,
+  };
+}
+
 export const scrollHandler = async ({
   direction, amount, x, y, speed, homing, windowTitle, hwnd,
 }: {
@@ -764,6 +941,35 @@ export const scrollHandler = async ({
     if (tx !== undefined && ty !== undefined) {
       await moveTo(tx, ty, speed);
     }
+
+    // Resolve the hwnd we will observe. Order:
+    //   1. resolveWindowTarget result (explicit hwnd / @active / dialog walk)
+    //   2. plain windowTitle → enumerate (resolveWindowTarget returns null in this case)
+    //   3. cursor location (best effort) so coord-based scroll still gets verification
+    //   4. foreground (last resort)
+    let observedHwnd: bigint | null = resolvedWin?.hwnd ?? null;
+    if (observedHwnd === null && windowTitle && windowTitle !== "@active") {
+      try {
+        const wantTitle = windowTitle.toLowerCase();
+        const win = enumWindowsInZOrder().find(
+          (w) => !w.isMinimized && w.title.toLowerCase().includes(wantTitle),
+        );
+        if (win) observedHwnd = win.hwnd;
+      } catch { /* best effort */ }
+    }
+    if (observedHwnd === null && tx !== undefined && ty !== undefined) {
+      const containing = findContainingWindow(tx, ty);
+      if (containing) observedHwnd = containing.hwnd;
+    }
+    if (observedHwnd === null) {
+      observedHwnd = getForegroundHwnd();
+    }
+    const observedRect = observedHwnd !== null ? getWindowRectByHwnd(observedHwnd) : null;
+
+    // Phase 1: pre-scroll snapshot (matrix doc §3.1 + terminal regimen §2.1 phase 1).
+    const pre = await captureScrollSnapshot(observedHwnd, observedRect);
+
+    // Phase 2: side-effect injection — the existing wheel SendInput path.
     const SCROLL_MULTIPLIER = 3;
     switch (direction) {
       case "down":  await mouse.scrollDown(amount * SCROLL_MULTIPLIER); break;
@@ -775,10 +981,75 @@ export const scrollHandler = async ({
         for (let i = 0; i < amount; i++) await mouse.scrollLeft(SCROLL_MULTIPLIER);
         break;
     }
+
+    // Phase 3: settle render.
+    await new Promise<void>((r) => setTimeout(r, SCROLL_VERIFY_SETTLE_MS));
+
+    // Phase 4: post-scroll snapshot + delivery evaluation.
+    const post = await captureScrollSnapshot(observedHwnd, observedRect);
+    const outcome: ScrollVerifyOutcome = observedHwnd === null
+      ? { status: "unverifiable", delta: "unverifiable", reason: "no_target_window" }
+      : evaluateScrollDelivery(pre, post, direction);
+
+    // hints.scrollObserved (issue #179 body shape) carries the raw delta values
+    // for caller introspection; hints.verifyDelivery (matrix doc §4 shape) carries
+    // the typed status/reason envelope. The two are kept side-by-side: scrollObserved
+    // is scroll-specific (delta on each axis), verifyDelivery is the cross-tool SSOT
+    // shape that other operation tools (#177-#181) also produce. Callers reading
+    // either key see consistent answers; integration tests pin both.
+    const scrollObserved = outcome.delta === "unverifiable"
+      ? { delta: "unverifiable" as const }
+      : {
+          delta: {
+            x: outcome.delta.x !== null ? outcome.delta.x : null,
+            y: outcome.delta.y !== null ? outcome.delta.y : null,
+          },
+        };
+
+    if (outcome.status === "not_delivered") {
+      // Silent drop: pre off-boundary, post unchanged. ScrollNotDelivered with
+      // suggestions sourced from the SSOT _errors.ts dictionary.
+      return failWith(
+        new Error("ScrollNotDelivered"),
+        "scroll",
+        {
+          context: {
+            hint: "post-state observation found no scroll movement on the requested axis (pre was off-boundary)",
+            axis: outcome.axis,
+            preVerticalPercent: pre.vertical,
+            preHorizontalPercent: pre.horizontal,
+            postVerticalPercent: post.vertical,
+            postHorizontalPercent: post.horizontal,
+            direction,
+          },
+        },
+      );
+    }
+
+    const verifyDelivery = outcome.status === "delivered"
+      ? {
+          status: "delivered" as const,
+          channel: "wheel_send_input" as const,
+        }
+      : {
+          status: "unverifiable" as const,
+          channel: "wheel_send_input" as const,
+          reason: outcome.reason ?? "read_back_unsupported",
+          ...(outcome.axis ? { axis: outcome.axis } : {}),
+        };
+
+    const hints: Record<string, unknown> = {
+      scrollObserved,
+      verifyDelivery,
+    };
+    if (scrollWarnings.length > 0) hints.warnings = scrollWarnings;
+
     return ok({
-      ok: true, scrolled: direction, steps: amount,
+      ok: true,
+      scrolled: direction,
+      steps: amount,
       ...(notes.length && { homing: notes.join(", ") }),
-      ...(scrollWarnings.length > 0 && { hints: { warnings: scrollWarnings } }),
+      hints,
     });
   } catch (err) {
     return failWith(err, "scroll");

--- a/tests/e2e/scroll-raw-verify.test.ts
+++ b/tests/e2e/scroll-raw-verify.test.ts
@@ -1,0 +1,173 @@
+/**
+ * scroll-raw-verify.test.ts — E2E tests for scroll(action:'raw') delivery
+ * verification (issue #179, matrix doc §3.1).
+ *
+ * Test plan (issue body):
+ *   - 短い scroll を発行 → hint で delta が観測できることを pin
+ *   - page-end (V=0 で更に上 scroll) で `ScrollNotDelivered` が出ないことを regression guard
+ *   - non-scrollable target (Notepad で上端) で silent drop が `ScrollNotDelivered` で fail することを pin
+ *
+ * Skip policy (matrix doc §3.1 + issue #173 §S-2):
+ *   - foreground-stealing protection (`ForceFocusRefused`) → skip on env-only failure
+ *   - missing Win32 scrollbar AND missing image-hash → unverifiable (acceptable)
+ *
+ * Notes:
+ *   - Notepad on Win11 has overlay-style scrollbars only when content does NOT
+ *     overflow. We pre-populate the temp file with 200 lines so vertical
+ *     overflow is guaranteed.
+ *   - We don't pin "delta != 0" because Notepad sometimes returns null axes
+ *     (no Win32 scrollbar exposed via GetScrollInfo on the modern WinUI host),
+ *     in which case the implementation degrades to image-hash diff and the
+ *     verifyDelivery hint surfaces "delivered" or "unverifiable" depending on
+ *     whether the viewport actually changed pixels.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { scrollHandler } from "../../src/tools/mouse.js";
+import { launchNotepad, type NpInstance } from "./helpers/notepad-launcher.js";
+import { restoreAndFocusWindow, getWindowRectByHwnd } from "../../src/engine/win32.js";
+import { writeFileSync } from "fs";
+import { sleep, parsePayload } from "./helpers/wait.js";
+
+interface ScrollPayload {
+  ok: boolean;
+  code?: string;
+  scrolled?: string;
+  hints?: {
+    scrollObserved?: { delta: { x: number | null; y: number | null } | "unverifiable" };
+    verifyDelivery?: {
+      status: "delivered" | "unverifiable";
+      channel: string;
+      reason?: string;
+      axis?: string;
+    };
+    warnings?: string[];
+  };
+  context?: {
+    axis?: string;
+    direction?: string;
+    preVerticalPercent?: number | null;
+    postVerticalPercent?: number | null;
+  };
+}
+
+const MANY_LINES = Array.from({ length: 200 }, (_, i) => `line ${i + 1}`).join("\r\n");
+
+describe("scroll(action:'raw') delivery verification", () => {
+  let np: NpInstance;
+
+  beforeAll(async () => {
+    np = await launchNotepad();
+    // Pre-populate so vertical scrolling has somewhere to go.
+    writeFileSync(np.tempFile, MANY_LINES, "utf8");
+    try { restoreAndFocusWindow(np.hwnd); } catch { /* best effort */ }
+    await sleep(400);
+  }, 30_000);
+
+  afterAll(() => {
+    np?.kill();
+  });
+
+  it("scroll(raw) returns hints.scrollObserved + hints.verifyDelivery", async () => {
+    const rect = getWindowRectByHwnd(np.hwnd);
+    if (!rect) {
+      throw new Error("Notepad rect unavailable — env regression");
+    }
+    const cx = rect.x + Math.floor(rect.width / 2);
+    const cy = rect.y + Math.floor(rect.height / 2);
+
+    const r = await scrollHandler({
+      direction: "down",
+      amount: 3,
+      x: cx,
+      y: cy,
+      homing: false,
+      windowTitle: np.title,
+    });
+    const p = parsePayload(r) as ScrollPayload;
+
+    if (!p.ok) {
+      // ok:false is acceptable here only if it's ScrollNotDelivered with the
+      // correct context shape — this confirms the failure-path produces the
+      // typed envelope (matrix doc §3.1 silent-drop case).
+      expect(p.code).toBe("ScrollNotDelivered");
+      expect(p.context?.direction).toBe("down");
+      return;
+    }
+    expect(p.scrolled).toBe("down");
+    expect(p.hints).toBeDefined();
+    // Always present per matrix doc §3.1 / §4.2: scrollObserved + verifyDelivery.
+    expect(p.hints!.scrollObserved).toBeDefined();
+    expect(p.hints!.verifyDelivery).toBeDefined();
+    expect(p.hints!.verifyDelivery!.channel).toBe("wheel_send_input");
+    expect(["delivered", "unverifiable"]).toContain(p.hints!.verifyDelivery!.status);
+    // delta is either "unverifiable" or {x, y} with possibly-null fields.
+    const delta = p.hints!.scrollObserved!.delta;
+    if (delta !== "unverifiable") {
+      expect(delta).toHaveProperty("x");
+      expect(delta).toHaveProperty("y");
+    }
+  }, 30_000);
+
+  it("page-end: scroll up at vertical 0% does NOT surface ScrollNotDelivered", async () => {
+    // Notepad at the top of its buffer: vertical scroll up is a legitimate
+    // no-op (page-end boundary). matrix doc §3.1 page-end disambiguation rule:
+    // pre at 0% AND post equal → page-end success, NOT ScrollNotDelivered.
+    const rect = getWindowRectByHwnd(np.hwnd);
+    if (!rect) throw new Error("Notepad rect unavailable");
+    const cx = rect.x + Math.floor(rect.width / 2);
+    const cy = rect.y + Math.floor(rect.height / 2);
+
+    // Make sure we are at the top: send a big scroll-up first.
+    await scrollHandler({
+      direction: "up",
+      amount: 50,
+      x: cx,
+      y: cy,
+      homing: false,
+      windowTitle: np.title,
+    });
+    await sleep(150);
+
+    const r = await scrollHandler({
+      direction: "up",
+      amount: 3,
+      x: cx,
+      y: cy,
+      homing: false,
+      windowTitle: np.title,
+    });
+    const p = parsePayload(r) as ScrollPayload;
+
+    // Regression guard: at the top, scroll up MUST NOT fail with ScrollNotDelivered.
+    expect(p.code).not.toBe("ScrollNotDelivered");
+    expect(p.ok).toBe(true);
+  }, 30_000);
+
+  it("hints.verifyDelivery shape conforms to matrix doc §4.2", async () => {
+    const rect = getWindowRectByHwnd(np.hwnd);
+    if (!rect) throw new Error("Notepad rect unavailable");
+    const r = await scrollHandler({
+      direction: "down",
+      amount: 1,
+      x: rect.x + Math.floor(rect.width / 2),
+      y: rect.y + Math.floor(rect.height / 2),
+      homing: false,
+      windowTitle: np.title,
+    });
+    const p = parsePayload(r) as ScrollPayload;
+    if (!p.ok) {
+      // Silent-drop case — context envelope shape pinned in the first test.
+      expect(p.code).toBe("ScrollNotDelivered");
+      return;
+    }
+    const vd = p.hints!.verifyDelivery!;
+    // Required: status, channel.
+    expect(typeof vd.status).toBe("string");
+    expect(vd.channel).toBe("wheel_send_input");
+    if (vd.status === "unverifiable") {
+      // reason is required when status=unverifiable (matrix doc §4.4).
+      expect(typeof vd.reason).toBe("string");
+    }
+  }, 30_000);
+});

--- a/tests/unit/scroll-raw-verify.test.ts
+++ b/tests/unit/scroll-raw-verify.test.ts
@@ -1,0 +1,147 @@
+/**
+ * scroll-raw-verify.test.ts — unit tests for evaluateScrollDelivery
+ * (issue #179, matrix doc §3.1).
+ *
+ * Pins the page-end disambiguation rule:
+ *   - pre at boundary AND post equal     → delivered (page-end success)
+ *   - pre off-boundary AND post equal    → not_delivered (silent drop)
+ *   - pre and post differ                → delivered
+ *   - no Win32 axis + image hash diff    → delivered (fallback)
+ *   - no Win32 axis + image hash equal   → unverifiable (cannot disambiguate)
+ *   - no observation channel             → unverifiable (no_target_window / scrollbar_unavailable)
+ */
+
+import { describe, it, expect } from "vitest";
+import { evaluateScrollDelivery, type ScrollSnapshot } from "../../src/tools/mouse.js";
+
+const snap = (
+  v: number | null,
+  h: number | null,
+  d: bigint | null = null,
+): ScrollSnapshot => ({ vertical: v, horizontal: h, dHash: d });
+
+describe("evaluateScrollDelivery — Win32 axis present", () => {
+  it("vertical movement → delivered", () => {
+    const r = evaluateScrollDelivery(snap(0.10, 0.0), snap(0.25, 0.0), "down");
+    expect(r.status).toBe("delivered");
+    expect(r.delta).not.toBe("unverifiable");
+    if (r.delta !== "unverifiable") {
+      expect(r.delta.y).toBeGreaterThan(0);
+    }
+  });
+
+  it("horizontal movement → delivered", () => {
+    const r = evaluateScrollDelivery(snap(0.0, 0.30), snap(0.0, 0.10), "left");
+    expect(r.status).toBe("delivered");
+    if (r.delta !== "unverifiable") {
+      expect(r.delta.x).toBeLessThan(0);
+    }
+  });
+
+  it("page-end: scroll up at vertical=0% → delivered (no fail)", () => {
+    const r = evaluateScrollDelivery(snap(0.0, 0.0), snap(0.0, 0.0), "up");
+    expect(r.status).toBe("delivered");
+  });
+
+  it("page-end: scroll down at vertical=100% → delivered (no fail)", () => {
+    const r = evaluateScrollDelivery(snap(1.0, 0.0), snap(1.0, 0.0), "down");
+    expect(r.status).toBe("delivered");
+  });
+
+  it("page-end: scroll left at horizontal=0% → delivered", () => {
+    const r = evaluateScrollDelivery(snap(0.5, 0.0), snap(0.5, 0.0), "left");
+    expect(r.status).toBe("delivered");
+  });
+
+  it("page-end: scroll right at horizontal=100% → delivered", () => {
+    const r = evaluateScrollDelivery(snap(0.5, 1.0), snap(0.5, 1.0), "right");
+    expect(r.status).toBe("delivered");
+  });
+
+  it("silent drop: pre off-boundary, post equal, scroll down → not_delivered", () => {
+    const r = evaluateScrollDelivery(snap(0.5, 0.0), snap(0.5, 0.0), "down");
+    expect(r.status).toBe("not_delivered");
+    expect(r.axis).toBe("vertical");
+  });
+
+  it("silent drop: pre off-boundary, post equal, scroll up → not_delivered", () => {
+    const r = evaluateScrollDelivery(snap(0.5, 0.0), snap(0.5, 0.0), "up");
+    expect(r.status).toBe("not_delivered");
+    expect(r.axis).toBe("vertical");
+  });
+
+  it("silent drop: pre off-boundary horizontal, post equal → not_delivered", () => {
+    const r = evaluateScrollDelivery(snap(0.0, 0.5), snap(0.0, 0.5), "right");
+    expect(r.status).toBe("not_delivered");
+    expect(r.axis).toBe("horizontal");
+  });
+
+  it("scrolling DOWN at 0% (off boundary for that direction) and post equal → not_delivered", () => {
+    // Scrolling DOWN should move OFF 0% (toward 100%); 0% is the page-start
+    // boundary, NOT the page-end for direction="down". So pre=0%, post=0%
+    // with direction=down is a silent drop unless content is exactly one screen.
+    // Per matrix doc §3.1, our rule is: "atDirectionalBoundary" requires pre at
+    // the END boundary of the scroll direction. 0% is NOT the end boundary for
+    // "down", so this must surface as not_delivered.
+    const r = evaluateScrollDelivery(snap(0.0, 0.0), snap(0.0, 0.0), "down");
+    expect(r.status).toBe("not_delivered");
+  });
+
+  it("scrolling UP at 100% (off boundary for direction=up) and post equal → not_delivered", () => {
+    const r = evaluateScrollDelivery(snap(1.0, 0.0), snap(1.0, 0.0), "up");
+    expect(r.status).toBe("not_delivered");
+  });
+
+  it("epsilon-level noise (rounding) → not_delivered when below epsilon", () => {
+    // 1e-5 of percent jitter must be treated as no-movement (epsilon eats it).
+    const r = evaluateScrollDelivery(snap(0.50000, 0.0), snap(0.50001, 0.0), "down");
+    expect(r.status).toBe("not_delivered");
+  });
+});
+
+describe("evaluateScrollDelivery — image hash fallback", () => {
+  it("hash diff exceeds threshold → delivered", () => {
+    // A bigint with all 64 bits flipped relative to 0n → Hamming distance 64.
+    const pre = snap(null, null, 0n);
+    const post = snap(null, null, 0xFFFFFFFFFFFFFFFFn);
+    const r = evaluateScrollDelivery(pre, post, "down");
+    expect(r.status).toBe("delivered");
+  });
+
+  it("hash equal → unverifiable with reason='page_end_inferred'", () => {
+    const pre = snap(null, null, 0xDEADBEEFn);
+    const post = snap(null, null, 0xDEADBEEFn);
+    const r = evaluateScrollDelivery(pre, post, "down");
+    expect(r.status).toBe("unverifiable");
+    expect(r.reason).toBe("page_end_inferred");
+    expect(r.axis).toBe("vertical");
+  });
+
+  it("no Win32 axis + no hash → unverifiable with reason='scrollbar_unavailable'", () => {
+    const pre = snap(null, null, null);
+    const post = snap(null, null, null);
+    const r = evaluateScrollDelivery(pre, post, "down");
+    expect(r.status).toBe("unverifiable");
+    expect(r.reason).toBe("scrollbar_unavailable");
+  });
+});
+
+describe("evaluateScrollDelivery — delta shape", () => {
+  it("delta exposes both axes when both Win32 axes are present", () => {
+    const r = evaluateScrollDelivery(snap(0.10, 0.20), snap(0.25, 0.30), "down");
+    expect(r.delta).not.toBe("unverifiable");
+    if (r.delta !== "unverifiable") {
+      expect(r.delta.y).toBeCloseTo(0.15, 5);
+      expect(r.delta.x).toBeCloseTo(0.10, 5);
+    }
+  });
+
+  it("delta.x is null when horizontal axis is absent (vertical-only window)", () => {
+    const r = evaluateScrollDelivery(snap(0.10, null), snap(0.25, null), "down");
+    if (r.delta !== "unverifiable") {
+      expect(r.delta.x).toBeNull();
+      expect(r.delta.y).toBeCloseTo(0.15, 5);
+    }
+    expect(r.status).toBe("delivered");
+  });
+});


### PR DESCRIPTION
## Summary

Adds post-state observation to `scroll(action:'raw')` so the wheel SendInput path can distinguish silent drops from legitimate page-end no-ops, per [`docs/operation-verification-matrix.md` §3.1](../blob/main/docs/operation-verification-matrix.md#31-commit-軸--verification-契約あり).

- **Pre/post observation**: Win32 `GetScrollInfo` for both axes (vertical / horizontal), with image-hash diff fallback when the target has no Win32 scrollbar (Chromium overlay scrollbars, custom-rendered viewports).
- **Page-end disambiguation rule (matrix doc §3.1)**:
  - pre at directional boundary AND post equal → `delivered` (page-end success — **no fail**)
  - pre off-boundary AND post equal → `not_delivered` → fail with `ScrollNotDelivered`
  - no Win32 axis + image hash unchanged → `unverifiable` (cannot distinguish page-end from drop without a boundary signal)
- **Envelope shape**: emits `hints.scrollObserved.delta` (issue body shape) **and** `hints.verifyDelivery` (matrix doc §4.2 SSOT shape) side-by-side. Both convey the same answer; `verifyDelivery.status` is `delivered` / `unverifiable`, `verifyDelivery.channel` is `wheel_send_input`, `verifyDelivery.reason` is one of `read_back_unsupported` / `page_end_inferred` / `scrollbar_unavailable` / `no_target_window`.
- **New typed error**: `ScrollNotDelivered` registered in `src/tools/_errors.ts` SUGGESTS dictionary + `classify()` substring match. Suggestions steer callers to `scroll(action:'smart')`, `scroll(action:'to_element')`, scrollability inspection, UIPI / overlay-scrollbar guidance.
- **Tests**:
  - `tests/unit/scroll-raw-verify.test.ts` — 17 cases pinning the page-end disambiguation matrix (boundary, off-boundary silent drop, image hash fallback, delta shape).
  - `tests/e2e/scroll-raw-verify.test.ts` — Notepad-based envelope-shape pin (delta observable, page-end no-fail, `verifyDelivery` shape).

Out of scope (unchanged): `scroll(action:'smart')`, `scroll(action:'to_element')`, `scroll(action:'capture')`, `scroll(action:'read')` — already SSOT candidates per matrix doc §3.1. Chromium overlay-scrollbar Win32 detection (existing `ScrollbarUnavailable` covers it).

Closes #179
Part of #184

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/tools/mouse.ts src/tools/_errors.ts tests/{unit,e2e}/scroll-raw-verify.test.ts` — clean
- [x] `npx vitest run --project unit -t evaluateScrollDelivery` — 17/17 passed
- [ ] `npx vitest run --project e2e -t "scroll(action:'raw') delivery verification"` — manual GO needed (E2E spawns real Notepad)
- [ ] Opus review loop (P1/P2 = 0)
- [ ] Codex review loop (P1 = 0)