### PR TITLE
test(e2e): skip path classification (productBugCandidate / envOnly) (#182)

### DIFF
--- a/tests/e2e/clipboard-readback.test.ts
+++ b/tests/e2e/clipboard-readback.test.ts
@@ -47,7 +47,11 @@ async function powershellAvailable(): Promise<boolean> {
 describe("clipboard write read-back verification (#180)", () => {
   it("normal write succeeds and round-trips through Get-Clipboard -Raw", async ({ skip }) => {
     if (!(await powershellAvailable())) {
-      skip("powershell.exe unavailable on this host");
+      // envOnly (issue #182): clipboard tool wraps Set/Get-Clipboard via
+      // powershell.exe; without it on PATH (non-Windows host or stripped
+      // image) the Strict read-back contract from matrix doc §3.1 can't
+      // be exercised at all. Skipping is correct — no contract violated.
+      skip("envOnly: powershell.exe unavailable on this host");
     }
 
     const payload = `dtm-issue-180-${Date.now().toString(36)}-いろはにほへと`;
@@ -64,7 +68,14 @@ describe("clipboard write read-back verification (#180)", () => {
 
   it("returns ClipboardWriteNotDelivered when post-write bytes do not match", async ({ skip }) => {
     if (!(await powershellAvailable())) {
-      skip("powershell.exe unavailable on this host (productBugCandidate: read-back verification cannot be exercised)");
+      // envOnly (issue #182): the simulation that proves the
+      // ClipboardWriteNotDelivered branch is wired correctly is itself a
+      // PowerShell pipeline. Without powershell.exe we can't run it.
+      // (The original comment labelled this "productBugCandidate" because
+      // the underlying contract IS Strict per matrix doc §3.1, but the
+      // skip itself is purely environmental — PS missing is not a product
+      // bug, it's a host-shape constraint.)
+      skip("envOnly: powershell.exe unavailable on this host — cannot run the read-back mismatch simulation");
     }
 
     // We cannot deterministically race two clipboard:write calls inside the
@@ -126,7 +137,9 @@ describe("clipboard write read-back verification (#180)", () => {
 
   it("read-back overhead stays within budget (informational)", async ({ skip }) => {
     if (!(await powershellAvailable())) {
-      skip("powershell.exe unavailable on this host");
+      // envOnly (issue #182): perf measurement requires the same PS
+      // pipeline as the handler itself.
+      skip("envOnly: powershell.exe unavailable on this host");
     }
 
     // Warm the PowerShell startup cost before measuring.

--- a/tests/e2e/context-consistency.test.ts
+++ b/tests/e2e/context-consistency.test.ts
@@ -206,7 +206,13 @@ describe("C3: hasModal real dialog detection", () => {
     if (dialogTitles.length === 0) {
       // Dismiss any opened dialog and skip
       await keyboardPressHandler({ keys: "escape", trackFocus: false, settleMs: 200 });
-      skip("Save-As dialog did not appear (file may have auto-saved) — skipping C3 dialog test");
+      // envOnly (issue #182): C3 needs a Save-As dialog with a locale-
+      // specific title ("名前を付けて保存" / "Save As"). Some Notepad
+      // builds auto-save instead of opening a dialog when ctrl+s is hit
+      // on a dirty buffer that already has a path. Premise unmet =>
+      // skip is correct; matrix doc §3.2 lists get_context as query-axis
+      // so there is no Strict/Indirect contract to violate.
+      skip("envOnly: Save-As dialog did not appear (file may have auto-saved or locale title differs) — C3 dialog premise unmet");
       return;
     }
 

--- a/tests/e2e/error-quality.test.ts
+++ b/tests/e2e/error-quality.test.ts
@@ -44,15 +44,27 @@ describe("G1: click_element on non-InvokePattern element → InvokePatternNotSup
       const p = parsePayload(result);
 
       if (p.ok === false && p.code === "ElementNotFound") {
+        // envOnly (issue #182): G1 needs a specific Win11 Notepad fixture
+        // (status-bar Text controls with automationId="ContentTextBlock").
+        // Older Notepad versions / non-jp locales don't expose this id.
+        // Without the fixture the InvokePatternNotSupported error path
+        // can't be reached. Matrix doc §3.1 click_element row pins the
+        // contract; this test just can't access the inputs.
         skip(
-          "ContentTextBlock not found — Notepad version or locale differs. " +
+          "envOnly: ContentTextBlock not found — Notepad version or locale differs. " +
           "This element exists in Win11 Notepad status bar."
         );
       }
 
       if (p.ok) {
-        // Unexpectedly supports InvokePattern — not a failure, skip error-path assertions.
-        skip("click_element succeeded (ContentTextBlock supports InvokePattern) — G1 error path not triggered");
+        // envOnly (issue #182): on this host, ContentTextBlock unexpectedly
+        // exposes InvokePattern (theme/locale variant — Win11 Notepad has
+        // shifted UIA exposure between feature updates). The error path
+        // we want to test isn't reachable here. NOT a product bug:
+        // InvokePatternNotSupported is one branch of click_element's error
+        // surface; if this Notepad build supports invoke on the status
+        // bar, that's a fixture mismatch, not an invariant violation.
+        skip("envOnly: click_element succeeded (ContentTextBlock supports InvokePattern on this Notepad build) — G1 error path not triggered");
       }
 
       expect(p.ok).toBe(false);

--- a/tests/e2e/focus-integrity.test.ts
+++ b/tests/e2e/focus-integrity.test.ts
@@ -96,8 +96,14 @@ describe("A1-armed: keyboard_type with windowTitle arms focusLost detection", ()
         expect(typeof p.focusLost.stolenByTitle).toBe("string");
       }
     } else {
-      // If no focusLost returned, that's acceptable in this edge case
-      skip("focusLost not triggered with mismatched windowTitle — environment-dependent");
+      // envOnly (issue #182): mismatched windowTitle is intended to provoke
+      // focusLost, but on hosts where another foreground window happens to
+      // include the fake substring, detectFocusLoss won't fire. The
+      // contract under test is the SHAPE of focusLost when it triggers,
+      // not whether it triggers — without a foreground steal we can't
+      // exercise that branch. Per matrix doc §3.1 keyboard(type FG) Indirect
+      // verification, this is a documented Indirect-limit case.
+      skip("envOnly: focusLost not triggered with mismatched windowTitle (foreground state dependent)");
     }
   });
 });
@@ -222,7 +228,14 @@ describe("A2: terminal_send(restoreFocus:true) restores caller's focus", () => {
     const { enumWindowsInZOrder } = await import("../../src/engine/win32.js");
     const active = enumWindowsInZOrder().find(w => w.isActive);
     if (!active?.title.includes(np.tag)) {
-      skip("Could not transfer focus to Notepad (foreground-stealing protection) — skipping A2");
+      // envOnly (issue #182): Windows foreground-stealing protection refused
+      // to hand focus to Notepad before the terminal_send call. The A2
+      // contract (focusRestored:true after restoreFocus:true) requires that
+      // Notepad WAS the previous foreground; without that precondition,
+      // the test premise is unmet. Not a product invariant violation —
+      // matrix doc §3.1 documents focus_window's ForceFocusRefused as
+      // expected OS-side degradation.
+      skip("envOnly: foreground-stealing protection refused focus to Notepad — A2 precondition unmet");
       return;
     }
 
@@ -253,7 +266,10 @@ describe("A2: terminal_send(restoreFocus:true) restores caller's focus", () => {
     const { enumWindowsInZOrder } = await import("../../src/engine/win32.js");
     const active = enumWindowsInZOrder().find(w => w.isActive);
     if (!active?.title.includes(np.tag)) {
-      skip("Could not transfer focus to Notepad — skipping A2 restoreFocus:false test");
+      // envOnly (issue #182): same precondition as the previous case —
+      // foreground-stealing protection blocked focus transfer to Notepad.
+      // restoreFocus:false branch can't be exercised without that setup.
+      skip("envOnly: foreground-stealing protection refused focus to Notepad — A2 restoreFocus:false precondition unmet");
       return;
     }
 

--- a/tests/e2e/force-focus.test.ts
+++ b/tests/e2e/force-focus.test.ts
@@ -98,11 +98,15 @@ describe("forceFocus param — structural tests", () => {
     expect(warnings2).not.toContain("ForceFocusRefused");
   });
 
-  it.skip("foreground-stealing test — requires pinned CLI window to reproduce", async () => {
-    // This test requires a pinned CLI that steals focus.
-    // Without that setup, ForceFocusRefused will not appear.
-    // Skipped: would require dock_window pinned CLI setup.
-    //
+  // envOnly (issue #182): reliably reproducing Windows foreground-stealing
+  // protection requires a pinned CLI window racing focus mid-test, which
+  // depends on dock_window setup that isn't present in CI. Per matrix doc
+  // §3.1 mouse_click row, the Indirect verification (focus_only /
+  // delivered / unverifiable hint) covers the contract; this test would
+  // only pin a specific OS-side degradation case (ForceFocusRefused
+  // warning suppression when forceFocus=true). No product invariant is
+  // silently passed — it.skip is documenting an unreachable branch.
+  it.skip("foreground-stealing test — requires pinned CLI window to reproduce (envOnly)", async () => {
     // If we could reproduce: mouse_click with forceFocus=true on a target window
     // should NOT have ForceFocusRefused in warnings.
   });

--- a/tests/e2e/helpers/skip-classifications.ts
+++ b/tests/e2e/helpers/skip-classifications.ts
@@ -1,0 +1,108 @@
+/**
+ * skip-classifications.ts — issue #182 (Phase 3 follow-up)
+ *
+ * Encodes the two skip categories used across `tests/e2e/`:
+ *
+ *   - **envOnly**         The premise of the test is unmet by the environment
+ *                         (file/app/UI fixture not present, OS protection fired,
+ *                         locale-dependent label missing). Skipping is the
+ *                         correct response: the product invariant the test
+ *                         would have checked is not exercised, but no
+ *                         contract violation is implied.
+ *
+ *   - **productBugCandidate** The test premise IS met but the product behaved
+ *                         in a way that violates `docs/operation-verification-matrix.md`
+ *                         §3.1 (Strict / Indirect contract for the relevant tool).
+ *                         These must NOT be silently skipped — they should fail
+ *                         the test, or at minimum carry a `// FIXME` with a
+ *                         tracking issue so the regression is not silently
+ *                         absorbed (this is exactly the failure mode that
+ *                         issue #173 §S-1 caught for `terminal({action:'send'})`).
+ *
+ * Usage pattern (envOnly):
+ *
+ *   import { skipIfNoPowerShell, skipIfNoVsCode } from "./helpers/skip-classifications.js";
+ *
+ *   it("X", async ({ skip }) => {
+ *     if (await skipIfNoPowerShell(skip)) return;
+ *     // … real assertions …
+ *   });
+ *
+ * Usage pattern (productBugCandidate, no helper):
+ *
+ *   // After a wait_until(window_appears) success, focus_window MUST NOT
+ *   // return WindowNotFound. Per docs/operation-verification-matrix.md §3.1
+ *   // (focus_window: Indirect verification, post enum isActive). Failing
+ *   // hard here is the point — silently skipping would resurrect the
+ *   // silent-success failure mode the matrix doc was written to prevent.
+ *   expect(p.code).not.toBe("WindowNotFound");
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+// `vitest` `skip` parameter is exposed via the test context callback as
+// `({ skip }) => …`. The helper is parameterised with that callback so we
+// stay decoupled from how the suite imports skip.
+export type SkipFn = (reason?: string) => void;
+
+/**
+ * envOnly: powershell.exe not on PATH (non-Windows host or stripped image).
+ * Used by clipboard-readback / any test that shells out to PS.
+ */
+export async function skipIfNoPowerShell(skip: SkipFn): Promise<boolean> {
+  try {
+    await execFileAsync(
+      "powershell.exe",
+      ["-NoProfile", "-NonInteractive", "-Command", "exit 0"],
+      { timeout: 4000 }
+    );
+    return false;
+  } catch {
+    skip("envOnly: powershell.exe unavailable on this host (Windows-only fixture)");
+    return true;
+  }
+}
+
+/**
+ * envOnly: VS Code window not currently open. Required by F2
+ * (screenshot detail:'text' on Electron) suite.
+ *
+ * @returns the resolved VS Code window title if open, otherwise null after
+ *   calling skip(). Caller is expected to early-return on null.
+ */
+export async function findVsCodeWindow(skip: SkipFn): Promise<string | null> {
+  const { enumWindowsInZOrder } = await import("../../../src/engine/win32.js");
+  const vsc = enumWindowsInZOrder().find((w) =>
+    w.title.includes("Visual Studio Code")
+  );
+  if (!vsc) {
+    skip("envOnly: VS Code not open (Electron sparse-UIA fixture missing)");
+    return null;
+  }
+  return vsc.title;
+}
+
+/**
+ * envOnly: VS Code accessibility mode is active so UIA returns a rich
+ * actionable tree, breaking F2's premise (actionable=[]). When the user
+ * sets `editor.accessibilitySupport: 'on'` or runs a screen reader, the
+ * default-auto / never-OCR paths cannot be exercised.
+ */
+export function skipIfAccessibilityActive(
+  skip: SkipFn,
+  active: boolean,
+  reasonSuffix = ""
+): boolean {
+  if (active) {
+    skip(
+      `envOnly: VS Code accessibility mode active — actionable=[] premise not met${
+        reasonSuffix ? ` (${reasonSuffix})` : ""
+      }`
+    );
+    return true;
+  }
+  return false;
+}

--- a/tests/e2e/rich-narration-edge.test.ts
+++ b/tests/e2e/rich-narration-edge.test.ts
@@ -37,7 +37,14 @@ describe("B1: Chromium narrate:rich → chromium_sparse", () => {
     // Chrome がアクティブ foreground かつ可視 (非最小化) のときだけ run。それ以外は title 変動で
     // focus 失敗 → ok=false の flaky を生むため skip。カバレッジは Chrome アクティブ環境でのみ取得。
     if (!chromeWin || chromeWin.isMinimized || !chromeWin.isActive) {
-      skip("No active foreground Chromium window — skipping B1 (avoid flaky)");
+      // envOnly (issue #182): B1 requires Chrome (or another Chromium
+      // variant) to be the active foreground window. Without that the
+      // chromium guard doesn't engage end-to-end (post-state read-back
+      // can't fire on a minimized window). Premise unmet ⇒ skip is
+      // correct. This is NOT a verification gap: rich-narration's
+      // chromium_sparse degradation contract is unit-tested in
+      // tests/unit/* — this E2E only pins the live integration path.
+      skip("envOnly: No active foreground Chromium window — B1 chromium_sparse premise unmet");
     }
 
     const result = await richKeyboardPress({

--- a/tests/e2e/screenshot-electron.test.ts
+++ b/tests/e2e/screenshot-electron.test.ts
@@ -77,11 +77,18 @@ beforeAll(async () => {
 describe("F2: screenshot(detail:'text') on VS Code → OCR fallback for Electron", () => {
 
   it("returns OCR-sourced actionable elements (UIA Electron path)", async ({ skip }) => {
-    if (!vscTitle) { skip("VS Code not open — skipping F2"); return; }
+    // envOnly (issue #182): F2 needs VS Code open as a sparse-UIA Electron
+    // fixture. Per matrix doc §3.2, screenshot is a query-axis tool with no
+    // verification contract, so missing fixture is purely environmental.
+    if (!vscTitle) { skip("envOnly: VS Code not open — F2 sparse-UIA Electron fixture unavailable"); return; }
     if (accessibilityModeActive) {
+      // envOnly (issue #182): when accessibility mode is on, UIA exposes a
+      // rich actionable tree, breaking F2's actionable=[] premise. Real env
+      // (user setting / screen reader). The OCR fallback contract still
+      // holds — this test just can't exercise the specific branch.
       skip(
-        "VS Code accessibility mode appears to be active (UIA returned actionable elements). " +
-        "F2 tests the actionable=[] fallback path — not applicable in this configuration."
+        "envOnly: VS Code accessibility mode active (UIA returned actionable elements). " +
+        "F2 tests the actionable=[] fallback path — premise not met in this configuration."
       );
       return;
     }
@@ -143,9 +150,12 @@ describe("F2: screenshot(detail:'text') on VS Code → OCR fallback for Electron
 
 
   it("ocrFallback:'never' returns empty actionable for VS Code (LLM risk scenario)", async ({ skip }) => {
-    if (!vscTitle) { skip("VS Code not open"); return; }
+    // envOnly (issue #182): VS Code Electron fixture missing — query-axis tool, no contract violated.
+    if (!vscTitle) { skip("envOnly: VS Code not open — F2 fixture unavailable"); return; }
     if (accessibilityModeActive) {
-      skip("VS Code accessibility mode active — actionable≠[] premise not met"); return;
+      // envOnly (issue #182): accessibility-mode UIA tree breaks the
+      // actionable=[] premise (user / screen-reader setting).
+      skip("envOnly: VS Code accessibility mode active — actionable=[] premise not met"); return;
     }
 
     const result = await screenshotHandler({
@@ -170,7 +180,8 @@ describe("F2: screenshot(detail:'text') on VS Code → OCR fallback for Electron
 
 
   it("ocrFallback:'always' forces OCR even when called redundantly", async ({ skip }) => {
-    if (!vscTitle) { skip("VS Code not open"); return; }
+    // envOnly (issue #182): VS Code Electron fixture missing — query-axis tool, no contract violated.
+    if (!vscTitle) { skip("envOnly: VS Code not open — F2 fixture unavailable"); return; }
 
     const result = await screenshotHandler({
       ...BASE_ARGS,
@@ -188,9 +199,12 @@ describe("F2: screenshot(detail:'text') on VS Code → OCR fallback for Electron
 
 
   it("ocrFallback default (omitted = auto) behaves the same as auto for VS Code", async ({ skip }) => {
-    if (!vscTitle) { skip("VS Code not open"); return; }
+    // envOnly (issue #182): VS Code Electron fixture missing — query-axis tool, no contract violated.
+    if (!vscTitle) { skip("envOnly: VS Code not open — F2 fixture unavailable"); return; }
     if (accessibilityModeActive) {
-      skip("Accessibility mode active — default-auto path not testable"); return;
+      // envOnly (issue #182): accessibility-mode UIA tree breaks the
+      // default-auto path's actionable=[] premise.
+      skip("envOnly: VS Code accessibility mode active — default-auto path actionable=[] premise not met"); return;
     }
 
     // Schema default for ocrFallback is 'auto'.
@@ -210,7 +224,10 @@ describe("F2: screenshot(detail:'text') on VS Code → OCR fallback for Electron
 
 
   it("hints.target is populated (identity tracking works for Electron)", async ({ skip }) => {
-    if (!vscTitle) { skip("VS Code not open"); return; }
+    // envOnly (issue #182): VS Code Electron fixture missing — identity
+    // tracking contract is generic, only the Electron-specific case needs
+    // VS Code to be open.
+    if (!vscTitle) { skip("envOnly: VS Code not open — F2 Electron fixture unavailable"); return; }
 
     const result = await screenshotHandler({
       ...BASE_ARGS,

--- a/tests/e2e/tool-chain.test.ts
+++ b/tests/e2e/tool-chain.test.ts
@@ -186,9 +186,15 @@ describe("H3: mouse_click → get_context focus propagates within 300ms", () => 
       clickX = firstClickable.clickAt.x;
       clickY = firstClickable.clickAt.y;
     } else {
-      // Fallback: use Notepad window center region
-      // (If no UIA elements, we can't get coords from screenshot without OCR)
-      skip("No UIA actionable elements in Notepad — cannot derive click coords without OCR");
+      // envOnly (issue #182): a fresh Notepad with no text content has no
+      // UIA actionable elements, so screenshot(detail:'text', ocrFallback:'never')
+      // returns actionable=[]. Without OCR enabled we can't derive click
+      // coords from the screenshot. The mouse_click → desktop_state chain
+      // contract (matrix doc §3.1 mouse_click row, Indirect verification
+      // via focus / element diff) is unaffected — we just lack a click
+      // target on this fixture. envOnly because Notepad-content state is
+      // a fixture concern, not a product invariant.
+      skip("envOnly: No UIA actionable elements in fresh Notepad — cannot derive click coords without OCR");
       return;
     }
 

--- a/tests/e2e/ui-elements-cache.test.ts
+++ b/tests/e2e/ui-elements-cache.test.ts
@@ -142,7 +142,14 @@ describe("F1-dialog: stale automationId after dialog closes → ElementNotFound"
 
   it("stale dialog automationId → ElementNotFound on Notepad window (if dialog opened)", async ({ skip }) => {
     if (!dialogAutomationId) {
-      skip("Save-As dialog did not appear or had no automationId — skipping F1-dialog stale test");
+      // envOnly (issue #182): F1-dialog needs the Save-As dialog to expose
+      // an automationId-bearing element. Some Notepad builds open a dialog
+      // with no stable automationIds on its descendants; others auto-save
+      // without ever opening the dialog (locale + version dependent).
+      // Without an id captured during setup, the "stale id after dialog
+      // closed" assertion has nothing to feed in. matrix doc §3.2 lists
+      // get_ui_elements as query-axis (no Strict/Indirect contract).
+      skip("envOnly: Save-As dialog did not appear or had no automationId — F1-dialog premise unmet");
       return;
     }
 
@@ -158,8 +165,13 @@ describe("F1-dialog: stale automationId after dialog closes → ElementNotFound"
     // Either ElementNotFound (element was in dialog, not in Notepad) or
     // the automationId happens to exist in Notepad too — log and accept both cases
     if (p.code !== "ElementNotFound") {
-      // automationId coincidentally exists in Notepad — this is valid, test is inconclusive
-      skip(`automationId "${dialogAutomationId}" coincidentally exists in Notepad — skip stale check`);
+      // envOnly (issue #182): the captured automationId from the Save-As
+      // dialog happens to also exist in the main Notepad window tree
+      // (e.g. shared common-control id). The "stale" check premise (id
+      // present in dialog, absent in window) is broken by coincidence,
+      // not by the product. Notepad's UIA tree composition is locale /
+      // version dependent. Not a click_element invariant violation.
+      skip(`envOnly: automationId "${dialogAutomationId}" coincidentally exists in Notepad too — stale-check premise unmet`);
       return;
     }
     expect(p.code).toBe("ElementNotFound");

--- a/tests/e2e/workspace-chain.test.ts
+++ b/tests/e2e/workspace-chain.test.ts
@@ -127,19 +127,33 @@ describe("H1-chain: workspace_launch + wait_until + focus_window happy path", ()
   }, 30_000);
 
   it("focus_window succeeds after wait_until confirms window is present", async ({ skip }) => {
-    if (!np) { skip("Notepad not launched in previous test"); return; }
+    // envOnly: the test setup (`wait_until` happy-path) failed before this
+    // case ran. We can't run the contract assertion at all without a
+    // launched Notepad, so skipping here is correct.
+    if (!np) { skip("envOnly: Notepad not launched in previous test (setup precondition unmet)"); return; }
 
     const result = await focusWindowHandler({ title: np.tag });
     const p = parsePayload(result);
 
-    // If focus-stealing is blocked by OS, focused may fail but window exists.
-    // The key assertion is that it doesn't return WindowNotFound (window IS present).
-    if (p.ok === false && p.code === "WindowNotFound") {
-      // This means the window somehow disappeared — unusual but possible on slow CI
-      skip(`focus_window returned WindowNotFound for "${np.tag}" — window may have closed`);
-      return;
-    }
-    // ok:true or ok:false for other reasons (focus-stealing blocked) are both acceptable
+    // productBugCandidate (issue #182):
+    // The previous test (`wait_until(window_appears)`) just succeeded with
+    // ok:true at line 126 against the same `np.tag`. Per
+    // docs/operation-verification-matrix.md §3.1, focus_window is "Indirect
+    // verification — post enum `isActive` 確認". Returning WindowNotFound
+    // immediately after wait_until acknowledged the window's presence
+    // contradicts that contract: either wait_until lied (silent-success in a
+    // pure-observation tool) or focus_window's enum lost the window in
+    // <5ms. Both are product invariants we want surfaced as failures —
+    // matrix doc §1.1 / issue #173 §S-1 is exactly the silent-success
+    // failure mode this PR (#182) is removing. Hard fail instead of skip.
+    expect(
+      p.code,
+      `focus_window returned WindowNotFound for "${np.tag}" right after wait_until succeeded — invariant violation per matrix §3.1`
+    ).not.toBe("WindowNotFound");
+    // ok:true or ok:false for other reasons (focus-stealing blocked, e.g.
+    // ForceFocusRefused) are both acceptable — only WindowNotFound is the
+    // contract violation surfaced above. The remainder of the contract
+    // (focused title contains tag) is asserted next.
     expect(p.ok).toBe(true);
     expect(p.focused).toContain(np.tag);
   }, 10_000);


### PR DESCRIPTION
Closes #182
Part of #184

## Summary

Per `docs/operation-verification-matrix.md` §3.1 (SSOT for tool verification contracts), every `skip()` call inside `tests/e2e/` is now explicitly classified as either `envOnly` (premise unreachable on this host) or `productBugCandidate` (premise met but product violates the matrix-doc contract). The latter must NOT silently pass — that is exactly the silent-success failure mode issue #173 §S-1 was written to prevent.

- Issue body said **21 残**; actual grep produced **22** in-test `skip()` calls outside `terminal.test.ts` (which #174 already covered and #175 is parallel-touching). Reporting the discrepancy as required by the task.
- 21 / 22 are `envOnly` — comments rewritten with `envOnly:` prefix + one-line matrix-doc justification.
- 1 / 22 is `productBugCandidate` — converted from `skip()` to a hard `expect(...).not.toBe(...)`.
- Added `tests/e2e/helpers/skip-classifications.ts` to encode the two categories and ship reusable env helpers (`skipIfNoPowerShell`, `findVsCodeWindow`, `skipIfAccessibilityActive`). Existing call sites left inline so the diff is reviewable; new tests can adopt the helpers.

## Classification table (22 sites)

| # | File:Line | Tool / matrix row | Skip reason (was) | Class | Justification |
|---|---|---|---|---|---|
| 1 | error-quality.test.ts:55 | click_element (§3.1 InvokePatternNotSupported) | ContentTextBlock supports InvokePattern | envOnly | Notepad build / locale variance — error-path fixture, contract not violated |
| 2 | clipboard-readback.test.ts:50 | clipboard.write (§3.1 Strict) | powershell.exe unavailable | envOnly | PS missing on this host (Windows-only fixture) |
| 3 | clipboard-readback.test.ts:67 | clipboard.write (§3.1 Strict) | PS unavailable (was mislabelled productBug) | envOnly | Skip itself is env (no PS to run mismatch simulator). Comment rewritten to match the actual gate |
| 4 | clipboard-readback.test.ts:129 | clipboard.write perf | powershell.exe unavailable | envOnly | Same |
| 5 | context-consistency.test.ts:209 | get_context (§3.2 query-axis) | Save-As dialog did not appear | envOnly | Notepad locale / version dependent — query-axis tool, no Strict/Indirect contract |
| 6 | focus-integrity.test.ts:100 | keyboard_type (§3.1 Indirect FG) | focusLost not triggered | envOnly | Cannot deterministically force a 3rd-party focus steal |
| 7 | focus-integrity.test.ts:225 | terminal.send restoreFocus | Could not focus Notepad | envOnly | Windows foreground-stealing protection fired (`ForceFocusRefused` is documented OS-side degradation) |
| 8 | focus-integrity.test.ts:256 | terminal.send restoreFocus:false | Could not focus Notepad | envOnly | Same |
| 9 | force-focus.test.ts:101 | mouse_click forceFocus (§3.1 Indirect) | requires pinned CLI window | envOnly | `it.skip` documenting an unreachable foreground-stealing fixture |
| 10 | rich-narration-edge.test.ts:40 | rich-narration on Chromium | No active foreground Chromium window | envOnly | Requires Chrome to be active foreground — chromium_sparse degradation also unit-tested |
| 11 | screenshot-electron.test.ts:80 | screenshot detail:'text' (§3.2 query-axis) | VS Code not open | envOnly | Optional Electron fixture |
| 12 | screenshot-electron.test.ts:146 | screenshot ocrFallback:'never' | VS Code not open | envOnly | Same |
| 13 | screenshot-electron.test.ts:148 | screenshot ocrFallback:'never' | accessibility mode active | envOnly | actionable=[] premise broken by user/screen-reader setting |
| 14 | screenshot-electron.test.ts:173 | screenshot ocrFallback:'always' | VS Code not open | envOnly | Same |
| 15 | screenshot-electron.test.ts:191 | screenshot default ocrFallback | VS Code not open | envOnly | Same |
| 16 | screenshot-electron.test.ts:193 | screenshot default ocrFallback | accessibility mode active | envOnly | Same as #13 |
| 17 | screenshot-electron.test.ts:213 | screenshot hints.target | VS Code not open | envOnly | Same |
| 18 | tool-chain.test.ts:191 | mouse_click → desktop_state | No UIA actionable in Notepad | envOnly | Empty Notepad — fixture-content concern, not invariant |
| 19 | ui-elements-cache.test.ts:145 | get_ui_elements (§3.2 query-axis) | dialog/automationId missing | envOnly | Locale/version variance |
| 20 | ui-elements-cache.test.ts:162 | click_element stale check | dialog id coincides with Notepad id | envOnly | UIA tree composition variance — premise unmet |
| 21 | workspace-chain.test.ts:130 | focus_window setup | Notepad not launched in previous test | envOnly | Inter-test setup precondition unmet |
| **22** | **workspace-chain.test.ts:139** | **focus_window (§3.1 Indirect)** | **WindowNotFound after wait_until succeeded** | **productBugCandidate** | **wait_until(window_appears) was just verified ok:true at line 126; focus_window returning WindowNotFound on the same `np.tag` immediately after is a direct contract violation per matrix §3.1 (Indirect: post enum `isActive` 確認). Either wait_until silently lied (silent-success) or the window vanished in <5ms — both are product invariants and must fail loud. Now `expect(p.code).not.toBe("WindowNotFound")` with a descriptive message instead of skip.** |

## envOnly helper

Yes — added `tests/e2e/helpers/skip-classifications.ts`:

- `skipIfNoPowerShell(skip)` — PS gate
- `findVsCodeWindow(skip)` — returns title or null after skipping
- `skipIfAccessibilityActive(skip, active, suffix?)` — accessibility-mode gate

Existing call sites are left inline to keep the diff scoped to classification (the helpers are available for future tests to consume).

## productBugCandidate not silently downgraded to FIXME

Site #22 is converted to a hard expect, not a `// FIXME`. Rationale: this is the exact silent-success class issue #173 §S-1 was written to surface, and we have a fully reachable assertion for it. Downgrading to FIXME would re-open the door.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint <touched files>` — clean
- [x] `npx vitest list --project=e2e` — all suites still load
- [ ] **Not run**: full `vitest run --project=e2e` (per memory feedback_e2e_test_announce.md, E2E touches the live desktop and must not be triggered without a GO). Reviewer can run `npx vitest run --project=e2e tests/e2e/workspace-chain.test.ts` locally to observe the productBugCandidate assertion fail / pass on their host.
- [ ] If site #22 fails on a clean Notepad host, that is the intentional surface — open a new product-bug issue per matrix §3.1 (focus_window Indirect verification breach). If it passes (the most likely outcome), the contract is now actively guarded instead of silently skipped.

## Out of scope

- Real product-bug fix for site #22 (this PR is classification only)
- WT host coverage restoration — owned by issue #175
- terminal.test.ts skip paths — already covered by PR #174 / parallel #175