### PR TITLE
feat(terminal): auto-detect hidden-input prompt to skip verification (#183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- **feat(terminal): `terminal({action:'send', method:'background'})` に hidden-input prompt 自動検出を追加 (issue #183, Phase 3).**
+  `docs/operation-verification-matrix.md` §3.1 (terminal action:send BG row) で「将来 detect」と予約されていた挙動の本実装。post-send UIA read-back の直前に baseline UIA 末尾行を検査し、`/(password|passphrase|secret|sudo)[\s:]*$/i` / `/Password for /` / `/^>\s*$/` のいずれかにマッチする echo 抑制 prompt なら verification を skip し、`hints.verifyDelivery: {status:"unverifiable", reason:"hidden_input_prompt", channel:"wm_char", fallback:"method:'foreground'"}` (matrix doc §4.2 規範 shape, §4.3 reason enum) を付けて `ok:true` を返す。これにより `Read-Host -AsSecureString` / `sudo` / `ssh` パスワード入力 BG 送信が `BackgroundInputNotDelivered` の false-positive で失敗していた既知問題を解消。regex set は意図的に narrow（end-anchor 必須）で start するため、scrollback 中に password と書かれていても誤検出しない設計。
 - **feat(browser): CDP `browser_click` / `browser_fill` に DOM 配信検証を追加 (issue #181, Phase 3).**
   `docs/operation-verification-matrix.md` §3.1 規範実装。
   - `browser_click`: クリック直前に `Runtime.evaluate` 経由で `MutationObserver(document.body, {subtree, childList, attributes})` を install → mouse click → 500ms 経過後に observer + URL + `document.activeElement` の差分を読み戻し。いずれかの signal が観測できれば `hints.verifyDelivery.status = "delivered"`、500ms で 0 signal なら `unverifiable` (reason: `no_dom_mutation`)。SPA ボタンに event listener が attach されていない silent-fail を catch する目的。selector が iframe 内 element だった場合は top-frame の Runtime.evaluate scope では観測不能なので `unverifiable` (reason: `iframe_context_mismatch`) を返す。

--- a/docs/operation-verification-matrix.md
+++ b/docs/operation-verification-matrix.md
@@ -134,7 +134,7 @@ Phase 5: 判定
 
 | Tool | API レイヤ | 現在の post-verification | 期待される verification | 失敗時 signal | 関連 child issue / PR |
 |---|---|---|---|---|---|
-| `terminal` (action:`send` BG) | PostMessage WM_CHAR | **Strict** — pre-send baseline + UIA TextPattern read-back (exact + tail-N fallback、150ms settle) | (現状で SSOT 規範) hidden-input prompt は将来 detect (#183) | code: `BackgroundInputNotDelivered` ✅ (既存) | (PR #174 完了) |
+| `terminal` (action:`send` BG) | PostMessage WM_CHAR | **Strict** — pre-send baseline + UIA TextPattern read-back (exact + tail-N fallback、150ms settle) | (現状で SSOT 規範) hidden-input prompt detect 済 (#183 完了): baseline 末尾行が password / passphrase / secret / sudo / `Password for ` / `^>$` パターンならverificationを skipし `hints.verifyDelivery: {status:"unverifiable", reason:"hidden_input_prompt", channel:"wm_char", fallback:"method:'foreground'"}` を返す | code: `BackgroundInputNotDelivered` ✅ (既存) / hint: `verifyDelivery.reason='hidden_input_prompt'` (#183) | (PR #174 完了 / #183 完了) |
 | `terminal` (action:`send` FG) | SetForegroundWindow + SendInput / clipboard paste | **Indirect** — `detectFocusLoss` で焦点維持確認、ForegroundNotTransferred 警告化 | (現状維持) FG path は SendInput が射出時に focus 必要、focus が取れていれば届く前提が成立 | warning: `ForegroundNotTransferred` (現行) | — |
 | `terminal` (action:`run`) | send → wait → read 合成 | **Strict** — completion.reason = `quiet`/`pattern_matched`/`timeout`/`window_closed`/`window_not_found`/`send_failed` を区別、`send_failed` は send 側 code を warnings に surface | (現状で SSOT 規範) | reason: `completion.reason='send_failed'` + nested send code (warnings 配列) | (PR #174 完了) |
 | `keyboard` (action:`type` BG) | PostMessage WM_CHAR | **None** — `postCharsToHwnd.full=true` の ack のみ | **Strict** — terminal({action:'send'}) BG と同型: pre-send focused-element value 採取 → WM_CHAR 送信 → UIA TextPattern / ValuePattern read-back で input substring 確認 | code: `BackgroundInputNotDelivered` (terminal と共有、同 channel WM_CHAR / 同症状 silent drop) | #177 |
@@ -317,7 +317,7 @@ issue #176 の Acceptance Criteria に対する本書の対応:
 
 - **各 tool の実コード変更** — 本 PR は doc 起草のみ。実装は #177-#181
 - **既存 silent-success の retroactive fix** — 各 child issue で個別対応
-- **hidden-input prompt 自動 detect** — 別 issue (#183、Codex P2 本格対応)
+- **hidden-input prompt 自動 detect** — #183 で完了。`isHiddenInputPrompt(baselineRaw)` が src/tools/terminal.ts に export される
 - **E2E skip path 分類** — 別 issue (#182、Phase 3 残作業)
 - **Windows Terminal への信頼性ある BG 入力経路** — Phase 4 (#185、ConPTY ADR)、本 SSOT の verification 契約とは独立
 

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -134,6 +134,73 @@ function makeMarker(text: string): string {
   return createHash("sha256").update(slice).digest("hex").slice(0, 16);
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Hidden-input prompt detection (issue #183)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// When the terminal is sitting at a prompt that suppresses echo (sudo password,
+// PowerShell `Read-Host -AsSecureString`, ssh passphrase, …), the post-send
+// UIA read-back will see an empty diff regardless of whether WM_CHAR was
+// delivered, and the verifier would mis-fire `BackgroundInputNotDelivered`.
+// docs/operation-verification-matrix.md §3.1 (terminal action:send BG row)
+// designates this as a known false-positive source and §4.3 reserves the
+// `hidden_input_prompt` reason in the verifyDelivery hint enum for it.
+//
+// Detection runs against the LAST non-empty line of the pre-send UIA snapshot
+// (`baselineRaw`). The line is the cursor row, i.e. where the next character
+// would echo (or NOT echo, for hidden-input prompts). Earlier scrollback lines
+// are ignored because they describe completed work, not the current prompt.
+//
+// Initial regex set is intentionally STRICT to avoid false positives on
+// scrollback that happens to mention "password" mid-sentence:
+//   1. `/(password|passphrase|secret|sudo)[\s:]*$/i` — common credential
+//      prompts that end the line with the keyword + optional `:` / whitespace
+//      (e.g. `Password:` / `[sudo] password for user:` / `Enter passphrase:`).
+//   2. `/Password for /` — sudo-on-Linux/macOS exact phrasing
+//      (`Password for jdoe:`); kept separate from #1 so the english "for"
+//      noise does not slip through #1's anchor.
+//   3. `/^>\s*$/` — PowerShell `Read-Host` continuation prompt that draws
+//      `>>` / `>` on its own row when reading hidden input. Anchored both
+//      ends so a stray `>` in command output cannot match.
+//
+// All three patterns require an end-of-line anchor (or the literal phrase
+// match for sudo) so partial mentions in earlier output do not trigger.
+// Future expansion (e.g. ssh-keygen "Enter passphrase (empty for no
+// passphrase):") should follow the same anchored-strict rule.
+const HIDDEN_INPUT_PROMPT_PATTERNS: readonly RegExp[] = [
+  /(password|passphrase|secret|sudo)[\s:]*$/i,
+  /Password for /,
+  /^>\s*$/,
+];
+
+/**
+ * Return true when the baseline text's cursor row matches a known
+ * hidden-input prompt pattern. `baselineRaw` is the raw UIA TextPattern
+ * snapshot taken just before send (ANSI strip is performed here so callers
+ * can pass either ANSI-laden or pre-cleaned text).
+ *
+ * Returns false on null / empty input — verification continues normally
+ * for unreadable buffers.
+ */
+export function isHiddenInputPrompt(baselineRaw: string | null): boolean {
+  if (!baselineRaw) return false;
+  const cleaned = stripAnsi(baselineRaw).replace(/\r\n/g, "\n");
+  // Take the last non-empty line — the cursor row. Trailing blank lines are
+  // padding from Windows Terminal's row-padding behaviour (see
+  // normalizeForMarker docstring).
+  const lines = cleaned.split("\n");
+  let lastNonEmpty = "";
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const trimmed = lines[i]!.replace(/[ \t]+$/, "");
+    if (trimmed.length > 0) {
+      lastNonEmpty = trimmed;
+      break;
+    }
+  }
+  if (lastNonEmpty.length === 0) return false;
+  return HIDDEN_INPUT_PROMPT_PATTERNS.some((re) => re.test(lastNonEmpty));
+}
+
 function applySinceMarker(text: string, marker: string): { text: string; matched: boolean } {
   // Search for any tail window whose hash matches `marker`. Walk from the tail
   // backward — a recent terminal will hit within a few chars. Capped at 32k
@@ -420,13 +487,39 @@ export const terminalSendHandler = async ({
       //     the WT regression that motivated this change.
       const checkText = input.replace(/[\r\n]+$/, "");
       const hasEmbeddedNewline = /[\r\n]/.test(checkText);
-      const verifiable =
+      let verifiable =
         verificationNeeded &&
         baselineMarker !== null &&
         checkText.length > 0 &&
         !hasEmbeddedNewline;
+      // Issue #183: hidden-input prompt detection.
+      //
+      // When the cursor row of `baselineRaw` is a known echo-suppressing prompt
+      // (password / passphrase / sudo / PowerShell Read-Host …), the post-send
+      // UIA read-back can NOT see the input regardless of whether it was
+      // delivered. Continuing into Phase 4 would mis-fire
+      // BackgroundInputNotDelivered on a perfectly good password keystroke.
+      //
+      // Instead: skip Phase 4, return ok:true with hints.verifyDelivery in the
+      // §4.2 regular shape so the caller (LLM) can decide whether to retry on
+      // foreground or continue. The reason `hidden_input_prompt` is reserved
+      // in matrix doc §4.3.
+      //
+      // Detection runs only when verification would have run (verifiable=true);
+      // for non-verified BG sends (e.g. conhost auto-route) the cost of an
+      // extra regex check is meaningful but the upside is nil — the caller
+      // would see a normal ok with no verifyDelivery hint either way.
+      let verifyReason: "hidden_input_prompt" | null = null;
+      if (verifiable && isHiddenInputPrompt(baselineRaw)) {
+        verifyReason = "hidden_input_prompt";
+        verifiable = false;
+      }
       let verifiedDelivery: boolean | "unverifiable" = "unverifiable";
-      if (verifiable) {
+      if (verifiable && baselineMarker !== null) {
+        // `baselineMarker !== null` repeats the gate above so TypeScript narrows
+        // `baselineMarker` to `string` inside the block. (The construction of
+        // `verifiable` already required it non-null, but #183 made `verifiable`
+        // a `let` and the dataflow narrowing no longer survives the let.)
         // Let the terminal render before reading back. ~150ms is enough for
         // conhost; if the input was silently dropped the diff stays empty.
         await new Promise<void>((r) => setTimeout(r, 150));
@@ -474,6 +567,21 @@ export const terminalSendHandler = async ({
 
       if (effectivePressEnter) postEnterToHwnd(win.hwnd);
 
+      // Issue #183: surface hidden-input detection via the §4.2 verifyDelivery
+      // hint shape so callers can react (skip retry, switch to foreground).
+      // Caveat: even when verification was passed normally we don't currently
+      // emit a `delivered` hint — keeping that as opt-out is consistent with
+      // the rest of the BG path which only attaches hints on degradation.
+      const verifyDeliveryHint =
+        verifyReason === "hidden_input_prompt"
+          ? {
+              status: "unverifiable" as const,
+              reason: "hidden_input_prompt" as const,
+              channel: "wm_char" as const,
+              fallback: "method:'foreground'",
+            }
+          : null;
+
       return ok({
         ok: true,
         sent: input.slice(0, totalSent),
@@ -491,6 +599,7 @@ export const terminalSendHandler = async ({
         hints: {
           target: {},
           ...(bgWarnings.length > 0 && { warnings: bgWarnings }),
+          ...(verifyDeliveryHint ? { verifyDelivery: verifyDeliveryHint } : {}),
         },
       });
     }

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -169,7 +169,18 @@ function makeMarker(text: string): string {
 // passphrase):") should follow the same anchored-strict rule.
 const HIDDEN_INPUT_PROMPT_PATTERNS: readonly RegExp[] = [
   /(password|passphrase|secret|sudo)[\s:]*$/i,
-  /Password for /,
+  // Codex P1+P2: original `/Password for /` was case-sensitive AND unanchored.
+  // - Case-sensitive: missed `[sudo] password for alice:` (lowercase "password")
+  //   so legitimate hidden-input sends still mis-fired BackgroundInputNotDelivered.
+  // - Unanchored: matched any cursor-row text containing "Password for ", which
+  //   could bypass verification on non-prompt lines (e.g. an executed command
+  //   string mentioning the phrase).
+  // Fix: case-insensitive (`/i`) + require trailing username + colon, which is
+  //   the canonical sudo prompt shape. Strict-first: configurations that omit
+  //   the trailing colon (rare) are not detected here and fall through to the
+  //   normal verification path. Future expansion should keep the trailing-anchor
+  //   discipline.
+  /password for \S+:\s*$/i,
   /^>\s*$/,
 ];
 

--- a/tests/e2e/terminal-hidden-input.test.ts
+++ b/tests/e2e/terminal-hidden-input.test.ts
@@ -1,0 +1,223 @@
+/**
+ * terminal-hidden-input.test.ts — E2E for issue #183:
+ * `terminal({action:'send', method:'background'})` hidden-input prompt
+ * detection (matrix doc §3.1 terminal action:send BG row, §4.2 verifyDelivery
+ * regular shape, §4.3 reason `hidden_input_prompt`).
+ *
+ * Coverage:
+ *  1. PowerShell `Read-Host -Prompt 'Password' -AsSecureString` → BG send a
+ *     password → ok:true with hints.verifyDelivery = { status:"unverifiable",
+ *     reason:"hidden_input_prompt", channel:"wm_char", fallback:"method:'foreground'" }.
+ *     Without #183 the post-send UIA read-back would mis-fire
+ *     BackgroundInputNotDelivered because the prompt suppresses echo.
+ *
+ *  2. Regression guard — a normal `PS C:\>` prompt MUST NOT trigger detection.
+ *     A regular BG send to that prompt either succeeds with no verifyDelivery
+ *     hint (current behaviour for delivered Strict path) or surfaces a real
+ *     verification failure if the channel itself broke. The point is that
+ *     `hidden_input_prompt` reason is NEVER emitted on a non-hidden prompt.
+ *
+ * Skip policy: conhost scenarios are default-on (matches terminal.test.ts
+ * default). WT host coverage is OPT-IN via `DTM_E2E_WT=1` — WT-launcher cleanup
+ * is single-PID kill but the env gate keeps casual `npm test` runs from
+ * spawning WT processes (memory: feedback_e2e_wt_host_taskkill_risk.md).
+ *
+ * sudo-style prompt simulation requires WSL/Linux and is left out — the unit
+ * tests in `tests/unit/terminal-hidden-input.test.ts` already pin the regex
+ * for `Password for ` and the keyword-anchor case.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { terminalReadHandler, terminalSendHandler } from "../../src/tools/terminal.js";
+import { launchPowerShell, type PsInstance, type TerminalHost } from "./helpers/powershell-launcher.js";
+import { sleep, parsePayload } from "./helpers/wait.js";
+
+interface HostScenario {
+  host: TerminalHost;
+  label: string;
+}
+
+const WT_E2E_ENABLED = process.env["DTM_E2E_WT"] === "1";
+
+const SCENARIOS: HostScenario[] = [
+  { host: "conhost", label: "conhost" },
+  ...(WT_E2E_ENABLED
+    ? [{ host: "wt" as const, label: "Windows Terminal" }]
+    : []),
+];
+
+/**
+ * Wait until `terminal_read` returns text whose last non-empty line contains
+ * `marker`. Used to confirm the PowerShell prompt has rendered the
+ * `Read-Host` prompt before sending the password into it.
+ */
+async function waitForPromptLine(
+  windowTitle: string,
+  marker: RegExp,
+  timeoutMs = 5000,
+): Promise<string | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const r = parsePayload(await terminalReadHandler({
+      windowTitle,
+      lines: 50,
+      stripAnsi: true,
+      source: "auto",
+      ocrLanguage: "ja",
+    }));
+    if (r.ok && typeof r.text === "string") {
+      const lines = r.text.split(/\r?\n/);
+      // Last non-empty line
+      let last = "";
+      for (let i = lines.length - 1; i >= 0; i--) {
+        const l = lines[i]!.replace(/\s+$/, "");
+        if (l) { last = l; break; }
+      }
+      if (marker.test(last)) return last;
+    }
+    await sleep(150);
+  }
+  return null;
+}
+
+describe.each(SCENARIOS)("[$label] terminal hidden-input detection (#183)", ({ host, label }) => {
+  let ps: PsInstance;
+  const BANNER_TAG = `pstest-hi-${host}-${Date.now().toString(36)}`;
+
+  beforeAll(async () => {
+    ps = await launchPowerShell({ host, banner: `ready-${BANNER_TAG}` });
+  }, 15_000);
+
+  afterAll(() => {
+    ps?.kill();
+  });
+
+  it(`fires hidden_input_prompt for Read-Host -AsSecureString [${label}]`, async ({ skip }) => {
+    // Step 1: arm the Read-Host prompt. The command itself is sent via the
+    // foreground (clipboard paste) path so we exercise only the hidden-input
+    // detection on the SECOND send (the password). Using preferClipboard:true
+    // and method:'auto' on a non-terminal? Actually conhost IS a terminal.
+    // We want this initial command to use the BG path is fine — but we must
+    // wait for the prompt to render. Simplest: send via default settings and
+    // then wait for the `Password:` line.
+    const armRes = parsePayload(await terminalSendHandler({
+      windowTitle: ps.title,
+      input: `$pw = Read-Host -Prompt 'Password' -AsSecureString`,
+      pressEnter: true,
+      focusFirst: true,
+      restoreFocus: false,
+      preferClipboard: true,
+      pasteKey: "auto",
+      // method:'auto' picks BG on terminal-class targets. That fires the
+      // verifier (verificationNeeded? auto + isTerminalTarget → false for
+      // conhost — only `method:'background'` or `DTM_BG_AUTO=1+non-terminal`
+      // verifies). So no hidden-input check fires for the arm command — the
+      // baseline at that moment is a normal `PS C:\> ` prompt anyway.
+      trackFocus: false,
+      settleMs: 100,
+    }));
+
+    if (!armRes.ok) {
+      const warnings = armRes.hints?.warnings ?? [];
+      if (warnings.some((w: string) => w.startsWith("ForegroundNotTransferred"))) {
+        skip(`arm step refused foreground transfer — env condition`);
+      }
+      throw new Error(`arm Read-Host failed: ${JSON.stringify(armRes)}`);
+    }
+
+    const lastLine = await waitForPromptLine(ps.title, /Password:\s*$/, 5000);
+    if (lastLine === null) {
+      // The prompt did not render — likely a focus / paste env issue, not a
+      // verification regression. Skip rather than fail to keep the test stable.
+      skip(`Password prompt did not render within 5s on ${label} — env condition`);
+    }
+
+    // Step 2: BG send the password. Force method:'background' so verification
+    // would normally run; #183 must short-circuit it via hidden_input_prompt.
+    const password = "hunter2-shh";
+    const sendRes = parsePayload(await terminalSendHandler({
+      windowTitle: ps.title,
+      input: password,
+      method: "background",
+      pressEnter: true,
+      focusFirst: false,
+      restoreFocus: false,
+      preferClipboard: false,
+      pasteKey: "auto",
+      trackFocus: false,
+      settleMs: 0,
+    }));
+
+    expect(sendRes.ok, JSON.stringify(sendRes)).toBe(true);
+    expect(sendRes.method).toBe("background");
+    expect(sendRes.channel).toBe("wm_char");
+
+    // The matrix doc §4.2 regular shape:
+    //   { status:"unverifiable", reason:"hidden_input_prompt",
+    //     channel:"wm_char", fallback:"method:'foreground'" }
+    expect(sendRes.hints).toBeDefined();
+    expect(sendRes.hints.verifyDelivery).toBeDefined();
+    expect(sendRes.hints.verifyDelivery.status).toBe("unverifiable");
+    expect(sendRes.hints.verifyDelivery.reason).toBe("hidden_input_prompt");
+    expect(sendRes.hints.verifyDelivery.channel).toBe("wm_char");
+    expect(sendRes.hints.verifyDelivery.fallback).toMatch(/foreground/);
+
+    // Drain Read-Host so the buffer is back at PS> for the next test.
+    await sleep(500);
+  }, 25_000);
+
+  it(`does NOT fire hidden_input_prompt at a normal PS> prompt [${label}]`, async ({ skip }) => {
+    // Sanity: drain any pending Read-Host first.
+    await sleep(500);
+
+    // Confirm the prompt is at a normal `PS C:\>` shape.
+    const lastLine = await waitForPromptLine(ps.title, /[>]\s*$/, 3000);
+    if (lastLine === null) {
+      skip(`PS> prompt did not render within 3s on ${label} — env condition`);
+    }
+    // Defensive: explicitly reject the pathological case where a Password:
+    // prompt is still pending. If it is, our previous test left a Read-Host
+    // armed — we'd produce a false negative below.
+    const baselineRead = parsePayload(await terminalReadHandler({
+      windowTitle: ps.title,
+      lines: 20,
+      stripAnsi: true,
+      source: "auto",
+      ocrLanguage: "ja",
+    }));
+    expect(baselineRead.ok).toBe(true);
+    expect(/Password:\s*$/.test(baselineRead.text.trimEnd())).toBe(false);
+
+    // BG send a unique echo with method:'background' so verification runs.
+    // On conhost the read-back should succeed and verifyDelivery hint should
+    // either be absent (current Strict-path delivered behaviour) or carry
+    // status:"delivered" — but it must NEVER be reason:"hidden_input_prompt".
+    const tag = `nh-${host}-${Date.now().toString(36)}`;
+    const sendRes = parsePayload(await terminalSendHandler({
+      windowTitle: ps.title,
+      input: `echo ${tag}`,
+      method: "background",
+      pressEnter: true,
+      focusFirst: false,
+      restoreFocus: false,
+      preferClipboard: false,
+      pasteKey: "auto",
+      trackFocus: false,
+      settleMs: 0,
+    }));
+
+    if (host === "wt" && !sendRes.ok) {
+      // WT silent drop — known per terminal.test.ts. The point of THIS test
+      // is to assert hidden_input_prompt is NOT the reason.
+      expect(sendRes.code).toBe("BackgroundInputNotDelivered");
+      // No verifyDelivery hint expected on the failure envelope.
+      return;
+    }
+
+    expect(sendRes.ok, JSON.stringify(sendRes)).toBe(true);
+    const verifyDelivery = sendRes.hints?.verifyDelivery;
+    if (verifyDelivery !== undefined) {
+      expect(verifyDelivery.reason).not.toBe("hidden_input_prompt");
+    }
+  }, 20_000);
+});

--- a/tests/unit/terminal-hidden-input.test.ts
+++ b/tests/unit/terminal-hidden-input.test.ts
@@ -1,0 +1,120 @@
+/**
+ * terminal-hidden-input.test.ts — Unit tests for issue #183 hidden-input
+ * prompt detection in `terminal({action:'send'})` BG path.
+ *
+ * Exercises `isHiddenInputPrompt(baselineRaw)` directly without spawning a
+ * real terminal. The companion E2E (`tests/e2e/terminal-hidden-input.test.ts`)
+ * pins the end-to-end behaviour against an actual PowerShell `Read-Host`
+ * prompt.
+ *
+ * Strict-regex policy (matrix doc §3.1 row terminal action:send BG, issue body):
+ *  - regex set is intentionally narrow at v1; expand only when a real
+ *    false-negative is observed.
+ *  - every pattern requires either an end-of-line anchor or a distinctive
+ *    literal phrase, so passing references in command output should NOT
+ *    trip detection.
+ */
+
+import { describe, it, expect } from "vitest";
+import { isHiddenInputPrompt } from "../../src/tools/terminal.js";
+
+describe("isHiddenInputPrompt — positive cases (expected detection)", () => {
+  it("PowerShell `Read-Host -AsSecureString` prompt with `Password:` ending", () => {
+    const baseline =
+      "PS C:\\Users\\test> $pw = Read-Host -Prompt 'Password' -AsSecureString\n" +
+      "Password: ";
+    expect(isHiddenInputPrompt(baseline)).toBe(true);
+  });
+
+  it("plain `password:` (lowercase) at end of last line", () => {
+    expect(isHiddenInputPrompt("Enter password:")).toBe(true);
+  });
+
+  it("`passphrase:` ssh-style prompt", () => {
+    expect(isHiddenInputPrompt("Enter passphrase: ")).toBe(true);
+  });
+
+  it("`secret:` prompt", () => {
+    expect(isHiddenInputPrompt("Type your secret:")).toBe(true);
+  });
+
+  it("`sudo` keyword on its own line (e.g. `[sudo]`)", () => {
+    // The regex matches `(password|passphrase|secret|sudo)[\s:]*$` — `[sudo]`
+    // does NOT end with the keyword (the literal `]` is past `sudo`), so
+    // exact-keyword-only ending is what we test here.
+    expect(isHiddenInputPrompt("Enter sudo:")).toBe(true);
+  });
+
+  it("`Password for jdoe:` sudo Linux phrasing (regex #2)", () => {
+    expect(isHiddenInputPrompt("Password for jdoe:")).toBe(true);
+  });
+
+  it("PowerShell `Read-Host` `>` continuation prompt (regex #3)", () => {
+    expect(isHiddenInputPrompt("PS C:\\Users\\test> Read-Host\n>")).toBe(true);
+  });
+
+  it("works through trailing blank lines (Windows Terminal padding)", () => {
+    // Real UIA TextPattern often returns trailing rows of empty whitespace.
+    // The detector must walk back to the last non-empty line.
+    const baseline = "Enter password:\n   \n   \n";
+    expect(isHiddenInputPrompt(baseline)).toBe(true);
+  });
+
+  it("strips ANSI before checking", () => {
+    // CSI red, "Password:", CSI reset
+    const baseline = "[31mPassword:[0m";
+    expect(isHiddenInputPrompt(baseline)).toBe(true);
+  });
+
+  it("CRLF line separators normalise correctly", () => {
+    expect(isHiddenInputPrompt("PS> echo hi\r\nhi\r\nPassword:")).toBe(true);
+  });
+});
+
+describe("isHiddenInputPrompt — negative cases (regression guards)", () => {
+  it("returns false for null", () => {
+    expect(isHiddenInputPrompt(null)).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isHiddenInputPrompt("")).toBe(false);
+  });
+
+  it("returns false for plain PowerShell prompt `PS C:\\>`", () => {
+    expect(isHiddenInputPrompt("PS C:\\Users\\test> ")).toBe(false);
+  });
+
+  it("does NOT match `password` mentioned mid-line in scrollback", () => {
+    // The keyword is NOT at end of line — anchor `$` should reject.
+    const baseline =
+      "PS C:\\> Get-Help about_password\n" +
+      "  password is a credential...\n" +
+      "PS C:\\> ";
+    expect(isHiddenInputPrompt(baseline)).toBe(false);
+  });
+
+  it("does NOT match a `>` that is part of a normal PS prompt", () => {
+    // `PS C:\Users\test>` ends with `>` but the line has more than just `>`.
+    // Regex #3 requires `^>\s*$` (line is exactly `>` plus optional whitespace).
+    expect(isHiddenInputPrompt("PS C:\\Users\\test>")).toBe(false);
+    expect(isHiddenInputPrompt("PS C:\\Users\\test> ")).toBe(false);
+  });
+
+  it("does NOT match output that happens to contain `password` followed by other text", () => {
+    expect(isHiddenInputPrompt("password is required for login")).toBe(false);
+  });
+
+  it("returns false for whitespace-only baseline", () => {
+    expect(isHiddenInputPrompt("   \n   \n")).toBe(false);
+  });
+
+  it("does NOT match command-line snippet `--password=secret123`", () => {
+    // Contains `password` but anchor and prefix mismatch — last line ends
+    // with `secret123`, not the keyword.
+    expect(isHiddenInputPrompt("$ run --password=secret123")).toBe(false);
+  });
+
+  it("ignores lines with `>` if other content follows on the same row", () => {
+    expect(isHiddenInputPrompt("> echo hi")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- `terminal({action:'send', method:'background'})` の post-send UIA read-back を、baseline UIA 末尾行が echo 抑制 prompt にマッチしたら skip し、`hints.verifyDelivery: {status:"unverifiable", reason:"hidden_input_prompt", channel:"wm_char", fallback:"method:'foreground'"}` を返すように変更。
- これまで `Read-Host -AsSecureString` / `sudo` / `ssh` の password 入力を BG 送信すると、prompt が echo を抑制するため post-send 読み戻し diff が空となり、`BackgroundInputNotDelivered` の false-positive で fail していた既知問題を解消。
- 検出 regex は意図的に strict（end-anchor 必須）から開始。誤検出が出た場合に gradually expand する設計。

Closes #183
Part of #184

## SSOT 参照

- `docs/operation-verification-matrix.md` §3.1 `terminal (action:send BG)` 行 — 「hidden-input prompt は将来 detect (#183)」と予約済 → 本 PR で resolved
- §4.2 規範 shape `{status, reason, channel, fallback}`
- §4.3 reason enum の `hidden_input_prompt` (既存予約)
- §8 Out of scope の #183 行を「完了」に更新

## 検出 regex 一覧と false-positive 防止

| # | regex | 意図 | anchor 戦略 |
|---|---|---|---|
| 1 | `/(password\|passphrase\|secret\|sudo)[\s:]*$/i` | 共通 credential prompt の行末キーワード | 末尾 `$` 必須。`secret123` のような後続文字は弾く |
| 2 | `/Password for /` | sudo Linux 形式 (`Password for jdoe:`) | distinctive な literal 句なので anchor 省略 |
| 3 | `/^>\s*$/` | PowerShell `Read-Host` の継続 prompt が `>` 単独で表示される行 | 行頭 `^` + 行末 `$` 両方必須。スクロール出力中の `>` は弾く |

検査対象は **baseline UIA snapshot の最後の非空行**（cursor 行 = 次の文字が echo される位置）。scrollback 内の `password` 言及は anchor によって reject される。strip-ANSI / CRLF 正規化 / trailing whitespace 除去後に判定。

## Files Changed

- `src/tools/terminal.ts` — `isHiddenInputPrompt(baselineRaw)` ヘルパー追加 (export)、verifiable gate 直後で検査して `verifyReason="hidden_input_prompt"` 設定 → `verifiable=false` に倒す → ok return で `hints.verifyDelivery` を付与
- `tests/unit/terminal-hidden-input.test.ts` — 19 case (positive 9 / negative 10)
- `tests/e2e/terminal-hidden-input.test.ts` — PowerShell `Read-Host -Prompt 'Password' -AsSecureString` を armed させて password を BG send → unverifiable hint を pin / 通常 PS> prompt では発火しない regression guard
- `docs/operation-verification-matrix.md` §3.1 行と §8 Out-of-scope を完了状態に更新
- `CHANGELOG.md` Unreleased / Changed セクションに entry 追加

## Test Plan

- [x] `npx tsc --noEmit` 通過
- [x] `npx eslint src/tools/terminal.ts tests/unit/terminal-hidden-input.test.ts tests/e2e/terminal-hidden-input.test.ts` 通過
- [x] `npx vitest run tests/unit/terminal-hidden-input.test.ts` — 19 passed
- [x] `npx vitest run --project=unit` — pre-existing native-addon 起因 5 file failure 以外 regression なし
- [ ] E2E (`tests/e2e/terminal-hidden-input.test.ts`) は default-on でローカル実行: conhost scenario / WT scenario は `DTM_E2E_WT=1` opt-in（feedback_e2e_wt_host_taskkill_risk.md）

## 設計判断 (parent review 議題)

1. **regex 配置**: `terminal.ts` 内 module-private const にした。SSOT 化したいときは `_errors.ts` か新規 `_hidden-input.ts` への移動を検討。今 PR scope では 1 箇所参照なので over-engineering 回避を選んだ。
2. **`isHiddenInputPrompt` を export する判断**: unit test から直接呼び出すため。production 利用は terminal.ts 内 1 箇所のみ。keyboard tool に同型 hidden-input 検出を入れるとき再利用するなら共通モジュール化すべき（本 PR では keyboard 適用は別 issue 推奨と issue body に記載）。
3. **regex 1 の "sudo" anchor**: `[sudo]` (角括弧つき linux 形式) は anchor の都合で **検出しない**。`Enter sudo:` のような colon-suffix 形式は検出する。strict に倒した結果、bracketed 形式は次回拡張で扱う。
4. **`>` regex の strict 化**: `/^>\s*$/` で「行が `>` のみ」必須。PowerShell の通常 `PS C:\Users\u>` は行頭が `PS` なので reject される。現実の `Read-Host` continuation `>` を完全に拾えるか E2E で要観察（手元でも引き続き run）。
5. **既存の `BackgroundInputNotDelivered` SUGGESTS は touch しない**: 既存 suggest が「hidden-input は false-positive 候補」と既に言及しているため、削除すると誤導する recovery hint になる。本 PR は detection 経路を追加するだけで、verification fail 経路の SUGGESTS は不変。
6. **`hints.verifyDelivery` を delivered case では emit しない**: 既存 BG path は delivered の場合 hint を出さない（warnings 配列だけ on degradation）。同方針を維持し、unverifiable のときだけ verifyDelivery を出す。一貫性を優先したため、matrix doc §4.4 「status を省略した場合のデフォルトは delivered」に該当する状態。