### PR TITLE
fix(test): close CodeQL alert #119 — mkdtempSync for Notepad tempfile

### DIFF
--- a/tests/e2e/helpers/notepad-launcher.ts
+++ b/tests/e2e/helpers/notepad-launcher.ts
@@ -6,7 +6,7 @@
  */
 
 import { spawn, type ChildProcess } from "child_process";
-import { writeFileSync, unlinkSync } from "fs";
+import { mkdtempSync, rmSync, unlinkSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { enumWindowsInZOrder } from "../../../src/engine/win32.js";
@@ -34,7 +34,15 @@ function findNotepadByTag(tag: string): { hwnd: bigint; title: string } | null {
 
 export async function launchNotepad(): Promise<NpInstance> {
   const tag = `np-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
-  const tempFile = join(tmpdir(), `${tag}.txt`);
+  // mkdtempSync allocates a fresh, kernel-randomised directory under tmpdir()
+  // (the suffix is process-private and unpredictable to other users on the
+  // box), so writing `<tag>.txt` inside it cannot race with a pre-existing
+  // file at a guessable path. The dir + its file are both removed in kill()
+  // below. Using a fixed `tmpdir()/<tag>.txt` would trip the
+  // `js/insecure-temporary-file` CodeQL rule (alert #119, same pattern as
+  // PR #192 powershell-launcher fix).
+  const tempDir = mkdtempSync(join(tmpdir(), "dtm-np-"));
+  const tempFile = join(tempDir, `${tag}.txt`);
   writeFileSync(tempFile, "", "utf8");
   const proc = spawn("notepad.exe", [tempFile], { detached: true, stdio: "ignore" });
 
@@ -48,6 +56,7 @@ export async function launchNotepad(): Promise<NpInstance> {
   if (!found) {
     try { proc.kill(); } catch { /* ignore */ }
     try { unlinkSync(tempFile); } catch { /* ignore */ }
+    try { rmSync(tempDir, { recursive: true, force: true }); } catch { /* ignore */ }
     throw new Error(`Notepad window with tag "${tag}" did not appear within 20s`);
   }
 
@@ -69,7 +78,10 @@ export async function launchNotepad(): Promise<NpInstance> {
       if (!proc.killed) {
         try { proc.kill(); } catch { /* ignore */ }
       }
+      // Remove the file first, then the now-empty per-launch directory.
+      // Best-effort so a leftover never blocks a future test run.
       try { unlinkSync(tempFile); } catch { /* ignore */ }
+      try { rmSync(tempDir, { recursive: true, force: true }); } catch { /* ignore */ }
     },
   };
 }


### PR DESCRIPTION
## Summary

CodeQL alert [#119](https://github.com/Harusame64/desktop-touch-mcp/security/code-scanning/119) (`js/insecure-temporary-file`, severity: warning) reports an insecure tempfile creation flowing into `tests/e2e/scroll-raw-verify.test.ts:62`. The data flow originates from `tests/e2e/helpers/notepad-launcher.ts:37` where `join(tmpdir(), '<tag>.txt')` builds a predictable path, leaving a symlink-attack window before `writeFileSync` runs.

This PR replaces the predictable path with a per-launch `mkdtempSync(join(tmpdir(), 'dtm-np-'))` directory and writes `<tag>.txt` inside it. The kernel-allocated dir suffix is unpredictable to other users on the box, so the race is structurally impossible — same pattern that closed the matching rule for the WT host launcher in PR #192 (`powershell-launcher.ts`).

The `kill()` cleanup now removes the tempfile first, then the now-empty per-launch directory (best-effort, mirrors `powershell-launcher` cleanup).

Closes alert #119.

## Changes
- `tests/e2e/helpers/notepad-launcher.ts`: `mkdtempSync` + per-launch dir, `rmSync` cleanup in `kill()` + the early-failure path
- 1 file changed, 14 insertions(+), 2 deletions(-)

## Test plan
- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [x] `npm run test:unit -- tests/unit/scroll-raw-verify` — only the pre-existing `epsilon-level noise` failure remains (verified the same failure exists on `main`; out of scope per CLAUDE.md trial-error rule)
- [ ] Re-run CodeQL on this branch to confirm alert #119 closes (auto-fires on push)

## Out of scope
- `tests/unit/scroll-raw-verify.test.ts` epsilon-level noise pre-existing failure
- Other `tmpdir()` usages elsewhere in the repo (PR scope: alert #119 only)
- Production code (`src/`)