### PR TITLE
fix(e2e): WT graceful kill — WM_CLOSE to WT window prevents leaked WT windows (#204)

### DIFF
--- a/src/engine/win32.ts
+++ b/src/engine/win32.ts
@@ -570,6 +570,15 @@ export function readScrollInfo(
 export const WM_CHAR    = 0x0102;
 export const WM_KEYDOWN = 0x0100;
 export const WM_KEYUP   = 0x0101;
+/**
+ * WM_CLOSE — request that a window close. Used by `tests/e2e/helpers/
+ * powershell-launcher.ts` (issue #204) to gracefully shut down the WT
+ * window we own; WT then disconnects the ConPTY, the hosted PowerShell
+ * exits with code 0, and WT's `closeOnExit:graceful` (default) auto-
+ * closes the window. Exported as a single source of truth so any future
+ * caller that posts WM_CLOSE shares the same constant.
+ */
+export const WM_CLOSE   = 0x0010;
 export const VK_RETURN  = 0x0D;
 export const VK_BACK    = 0x08;
 export const VK_DELETE  = 0x2E;

--- a/tests/e2e/helpers/powershell-launcher.ts
+++ b/tests/e2e/helpers/powershell-launcher.ts
@@ -71,6 +71,58 @@ export async function isWindowsTerminalAvailable(): Promise<boolean> {
 
 export type TerminalHost = "default" | "conhost" | "wt";
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Graceful-kill state machine (issue #204)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// kill() does graceful-first to avoid leaving WT (Windows Terminal) tabs
+// behind. Background:
+//   - `taskkill /F /PID <pid>` calls TerminateProcess → exit code 1
+//   - WT default `closeOnExit: graceful` keeps the tab open on non-zero exit
+//   - launcher uses `-w dtm_e2e_<tag>` (per-launch unique window), so each
+//     residue accumulates as a top-level window, not just a tab
+// Net effect prior to this fix: every `host:'wt'` test run leaked a WT
+// window with the "[プロセスはコード 1 で終了しました]" prompt.
+//
+// The new flow:
+//   1. `taskkill /PID <pid>` (no /F) sends CTRL_CLOSE_EVENT → PS exits 0 →
+//      WT `closeOnExit:graceful` auto-closes the tab AND the unique window.
+//   2. Poll process existence with `process.kill(pid, 0)` (the standard
+//      Unix-style "is this PID alive" probe — Node maps it to OpenProcess
+//      on Windows). ESRCH means the process is gone.
+//   3. If the budget elapses without ESRCH, fall through to `/F` so test
+//      cleanup never hangs on a misbehaving PS.
+//
+// `/T` is still forbidden across both paths — see kill() comment.
+
+/**
+ * Pure decision helper for the graceful-kill polling loop. Isolates the
+ * scheduling logic from real process / clock so unit tests can pin all
+ * three transitions (`wait` / `exited` / `force`) without driving a real
+ * PowerShell. (Codex P2 / P3 follow-up pattern from PR #203 — fixture
+ * injection difficulty was the original blocker on testing kill paths.)
+ */
+export type GracefulKillState = "wait" | "exited" | "force";
+export interface GracefulKillInput {
+  /** Whether the target process is currently alive (i.e. `process.kill(pid, 0)` did not throw ESRCH). */
+  isAlive: boolean;
+  /** Current wall-clock time (ms). Allows the test to inject a deterministic clock. */
+  now: number;
+  /** Wall-clock deadline (ms). Once `now >= deadline`, the helper returns "force". */
+  deadline: number;
+}
+export function evaluateGracefulKillState(input: GracefulKillInput): GracefulKillState {
+  // ESRCH took effect — the graceful taskkill landed and PS unwound cleanly.
+  // No further action; /F fallback is unnecessary.
+  if (!input.isAlive) return "exited";
+  // Past the budget — PS is still alive. Stop polling and force-kill.
+  // The boundary is `>=` so a deadline of `now+0` immediately escalates,
+  // matching the polling loop's "check before sleep" structure.
+  if (input.now >= input.deadline) return "force";
+  // Inside the budget and PS is alive — sleep one tick and re-check.
+  return "wait";
+}
+
 export interface PsInstance {
   proc: ChildProcess;
   tag: string;
@@ -346,7 +398,55 @@ export async function launchPowerShell(opts?: {
         const pidStr = readFileSync(pidFile, "utf-8").trim();
         const pid = parseInt(pidStr, 10);
         if (pid > 0 && !isNaN(pid)) {
-          execSync(`taskkill /F /PID ${pid}`, { stdio: "ignore" });
+          // === Issue #204: graceful first ===
+          // Why: `taskkill /F /PID <pid>` ends PS with exit code 1
+          // (TerminateProcess), and WT default closeOnExit:graceful keeps the
+          // tab open on non-zero exit. With our per-launch `-w dtm_e2e_<tag>`
+          // unique window, each residual tab becomes a leaked top-level
+          // window. Sending CTRL_CLOSE_EVENT via plain `taskkill` lets PS
+          // exit 0 and WT auto-close the window before we move on.
+          let exitedGracefully = false;
+          try {
+            execSync(`taskkill /PID ${pid}`, { stdio: "ignore" });
+            const POLL_INTERVAL_MS = 100;
+            const GRACE_BUDGET_MS = 1500;
+            const deadline = Date.now() + GRACE_BUDGET_MS;
+            // Polling loop: check liveness, sleep, re-check until exit or
+            // deadline. `process.kill(pid, 0)` is Node's idiom for "does
+            // this PID exist" — it throws ESRCH when the OS no longer holds
+            // the handle, which is exactly our "graceful exit landed" signal.
+            while (true) {
+              let isAlive = true;
+              try {
+                process.kill(pid, 0);
+              } catch (e) {
+                if ((e as NodeJS.ErrnoException).code === "ESRCH") isAlive = false;
+                // Other errors (EPERM, EINVAL) leave isAlive=true so the
+                // helper falls back to /F rather than declaring graceful
+                // success on a probe we could not interpret.
+              }
+              const state = evaluateGracefulKillState({
+                isAlive,
+                now: Date.now(),
+                deadline,
+              });
+              if (state === "exited") { exitedGracefully = true; break; }
+              if (state === "force") break;
+              // state === "wait" — sync sleep so the kill() contract
+              // (used from afterAll without await) stays unchanged.
+              // Atomics.wait on a SharedArrayBuffer is the standard
+              // CPU-friendly sync sleep pattern in Node.
+              const sab = new SharedArrayBuffer(4);
+              Atomics.wait(new Int32Array(sab), 0, 0, POLL_INTERVAL_MS);
+            }
+          } catch { /* graceful path failed — fall through to /F */ }
+          // === /F fallback ===
+          // Reached when graceful taskkill returned non-zero, the polling
+          // loop hit the budget, or the liveness probe errored on something
+          // other than ESRCH. /T remains forbidden — single-PID only.
+          if (!exitedGracefully) {
+            try { execSync(`taskkill /F /PID ${pid}`, { stdio: "ignore" }); } catch { /* gave up */ }
+          }
           killedByPid = true;
         }
       } catch { /* best-effort */ }

--- a/tests/e2e/helpers/powershell-launcher.ts
+++ b/tests/e2e/helpers/powershell-launcher.ts
@@ -35,7 +35,22 @@ import { promisify } from "util";
 import { mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { enumWindowsInZOrder, clearWindowTopmost } from "../../../src/engine/win32.js";
+import {
+  enumWindowsInZOrder,
+  clearWindowTopmost,
+  postMessageToHwnd,
+} from "../../../src/engine/win32.js";
+
+/**
+ * `WM_CLOSE` (0x0010): Posting this to a WT window asks Windows Terminal to
+ * close the window. WT then disconnects the ConPTY, which delivers a console
+ * close signal to the hosted PowerShell — PS unwinds with exit code 0, and
+ * WT's `closeOnExit: graceful` (default) auto-closes the window. Using
+ * `WM_CLOSE` on the host PowerShell PID via `taskkill` (no /F) does NOT
+ * work for WT-hosted PS because the PS process owns no top-level window —
+ * WT does. Issue #204.
+ */
+const WM_CLOSE = 0x0010;
 import { sleep } from "./wait.js";
 
 const execFileAsync = promisify(execFile);
@@ -405,9 +420,28 @@ export async function launchPowerShell(opts?: {
           // unique window, each residual tab becomes a leaked top-level
           // window. Sending CTRL_CLOSE_EVENT via plain `taskkill` lets PS
           // exit 0 and WT auto-close the window before we move on.
+          //
+          // Initial implementation used `taskkill /PID <pid>` (no /F) which
+          // posts WM_CLOSE to the **process's main window**. That works for
+          // conhost (the conhost.exe process owns the console window), but
+          // is a no-op for WT-hosted PowerShell because the PS process
+          // itself has no top-level window — WT.exe does. Real-machine
+          // verification on 2026-05-08 showed WT residue persisted with
+          // taskkill-based graceful first. The fix splits by host:
+          //
+          //   - host:'wt'    → WM_CLOSE direct to the WT window hwnd
+          //                    (postMessageToHwnd, captured.hwnd). WT
+          //                    disconnects the ConPTY, PS exits 0, and the
+          //                    unique `-w` window auto-closes via graceful.
+          //   - other hosts  → existing `taskkill /PID <pid>` path, which
+          //                    posts WM_CLOSE to conhost / cmd / etc.
           let exitedGracefully = false;
           try {
-            execSync(`taskkill /PID ${pid}`, { stdio: "ignore" });
+            if (host === "wt") {
+              postMessageToHwnd(captured.hwnd, WM_CLOSE, 0, 0);
+            } else {
+              execSync(`taskkill /PID ${pid}`, { stdio: "ignore" });
+            }
             const POLL_INTERVAL_MS = 100;
             const GRACE_BUDGET_MS = 1500;
             const deadline = Date.now() + GRACE_BUDGET_MS;

--- a/tests/e2e/helpers/powershell-launcher.ts
+++ b/tests/e2e/helpers/powershell-launcher.ts
@@ -39,18 +39,8 @@ import {
   enumWindowsInZOrder,
   clearWindowTopmost,
   postMessageToHwnd,
+  WM_CLOSE,
 } from "../../../src/engine/win32.js";
-
-/**
- * `WM_CLOSE` (0x0010): Posting this to a WT window asks Windows Terminal to
- * close the window. WT then disconnects the ConPTY, which delivers a console
- * close signal to the hosted PowerShell — PS unwinds with exit code 0, and
- * WT's `closeOnExit: graceful` (default) auto-closes the window. Using
- * `WM_CLOSE` on the host PowerShell PID via `taskkill` (no /F) does NOT
- * work for WT-hosted PS because the PS process owns no top-level window —
- * WT does. Issue #204.
- */
-const WM_CLOSE = 0x0010;
 import { sleep } from "./wait.js";
 
 const execFileAsync = promisify(execFile);
@@ -388,6 +378,13 @@ export async function launchPowerShell(opts?: {
     hwnd: captured.hwnd,
     host,
     kill() {
+      // DO NOT reorder: the host==='wt' graceful path below posts WM_CLOSE
+      // to the SAME `captured.hwnd`. clearWindowTopmost is a SetWindowPos
+      // (HWND_NOTOPMOST) call that does NOT invalidate the hwnd, so the
+      // ordering is safe today; but moving the WM_CLOSE post BEFORE this
+      // line would flip the contract — once WT receives WM_CLOSE the
+      // window starts disappearing and the topmost-clear becomes a
+      // race against window destruction. Keep this call first.
       try { clearWindowTopmost(captured.hwnd); } catch { /* ignore */ }
 
       // Kill by PowerShell PID only — NEVER use /T (descendant-tree) flag.
@@ -435,11 +432,32 @@ export async function launchPowerShell(opts?: {
           //                    unique `-w` window auto-closes via graceful.
           //   - other hosts  → existing `taskkill /PID <pid>` path, which
           //                    posts WM_CLOSE to conhost / cmd / etc.
+          //
+          // Side effect note (Codex / Opus review on PR #205, P2-2):
+          // `postMessageToHwnd` records every successful PostMessage call
+          // into the L1 input ring (`engine/win32.ts:592-594`) so the
+          // perception pipeline can replay/inspect input. This means the
+          // cleanup path of an `host:'wt'` test posts WM_CLOSE = 0x0010
+          // to the ring. Today's e2e suites do not assert on the ring,
+          // so no test is affected; but if a future ring-asserting suite
+          // is added, it MUST whitelist the cleanup-induced WM_CLOSE
+          // event to avoid a spurious "unexpected ring entry" failure.
           let exitedGracefully = false;
           try {
+            // Two-stage graceful (Opus PR #205 P1-1):
+            // postMessageToHwnd returns false on hwnd-not-bigint / native
+            // throw / PostMessageW failure. Without this guard, a failed
+            // post left the loop polling for the full 1500ms budget before
+            // /F escalation — i.e. WT residue still leaked whenever the
+            // hwnd happened to be invalidated mid-cleanup. Falling back to
+            // `taskkill /PID <pid>` here gives conhost-style graceful close
+            // a second chance before /F. Combined cost is at most one
+            // taskkill call; no extra polling time.
+            let postSucceeded = false;
             if (host === "wt") {
-              postMessageToHwnd(captured.hwnd, WM_CLOSE, 0, 0);
-            } else {
+              postSucceeded = postMessageToHwnd(captured.hwnd, WM_CLOSE, 0, 0);
+            }
+            if (!postSucceeded) {
               execSync(`taskkill /PID ${pid}`, { stdio: "ignore" });
             }
             const POLL_INTERVAL_MS = 100;

--- a/tests/unit/issue-204-wt-graceful-kill.test.ts
+++ b/tests/unit/issue-204-wt-graceful-kill.test.ts
@@ -1,0 +1,90 @@
+/**
+ * issue-204-wt-graceful-kill.test.ts
+ *
+ * Pure-helper unit tests for the kill() polling loop in
+ * tests/e2e/helpers/powershell-launcher.ts.
+ *
+ * Background (issue #204): `taskkill /F /PID <pid>` ends PowerShell with
+ * exit code 1 (TerminateProcess). Windows Terminal's default
+ * `closeOnExit: graceful` keeps the tab open on non-zero exits, and the
+ * launcher's per-launch `-w dtm_e2e_<tag>` unique window means each
+ * residue is a leaked top-level WT window — not just a tab. The fix
+ * sends a graceful taskkill first, polls process liveness, and falls
+ * through to /F only when the budget elapses.
+ *
+ * `evaluateGracefulKillState` is the pure decision helper that drives
+ * the polling loop. Testing it directly avoids the in-module-call /
+ * real-process fixture problem that blocked similar coverage on
+ * PR #203 (issue #196).
+ */
+
+import { describe, it, expect } from "vitest";
+import { evaluateGracefulKillState } from "../e2e/helpers/powershell-launcher.js";
+
+describe("issue #204: evaluateGracefulKillState — graceful-kill polling state machine", () => {
+  it("returns 'exited' immediately when the process is gone (ESRCH)", () => {
+    // First poll iteration: graceful taskkill landed, ESRCH already.
+    // No further /F escalation needed.
+    const state = evaluateGracefulKillState({
+      isAlive: false,
+      now: 1_000,
+      deadline: 2_500,
+    });
+    expect(state).toBe("exited");
+  });
+
+  it("returns 'wait' while the process is alive and the budget has time left", () => {
+    const state = evaluateGracefulKillState({
+      isAlive: true,
+      now: 1_500,
+      deadline: 2_500,
+    });
+    // Inside the 1500ms budget: poll again before forcing.
+    expect(state).toBe("wait");
+  });
+
+  it("returns 'force' when the budget has elapsed and the process is still alive", () => {
+    const state = evaluateGracefulKillState({
+      isAlive: true,
+      now: 2_500,
+      deadline: 2_500,
+    });
+    // Boundary is `>=` — exact deadline triggers escalation, matching
+    // the loop's "check before sleep" ordering. (If `>` were used, a
+    // hung PS at the exact deadline would consume one extra sleep
+    // cycle before escalating.)
+    expect(state).toBe("force");
+  });
+
+  it("returns 'force' when the budget overshoots, irrespective of how far past", () => {
+    const state = evaluateGracefulKillState({
+      isAlive: true,
+      now: 5_000,
+      deadline: 2_500,
+    });
+    expect(state).toBe("force");
+  });
+
+  it("returns 'exited' even past the deadline if the process did exit (race-safe)", () => {
+    // Edge case: graceful exit landed *just* as the deadline elapsed.
+    // The "exited" check must take priority over the deadline check —
+    // otherwise we would emit a /F that hits a stale PID and (worse)
+    // could collide with whatever Windows reassigned that PID to.
+    const state = evaluateGracefulKillState({
+      isAlive: false,
+      now: 5_000,
+      deadline: 2_500,
+    });
+    expect(state).toBe("exited");
+  });
+
+  it("returns 'wait' on the first poll when isAlive=true and now < deadline", () => {
+    // Sanity: a fresh poll loop with a healthy budget waits.
+    const state = evaluateGracefulKillState({
+      isAlive: true,
+      now: 0,
+      deadline: 1_500,
+    });
+    expect(state).toBe("wait");
+  });
+});

--- a/tests/unit/issue-204-wt-graceful-kill.test.ts
+++ b/tests/unit/issue-204-wt-graceful-kill.test.ts
@@ -21,6 +21,13 @@
 import { describe, it, expect } from "vitest";
 import { evaluateGracefulKillState } from "../e2e/helpers/powershell-launcher.js";
 
+// The fixture numbers in this file (e.g. 1_500 / 2_500 for `now` and
+// `deadline`) are illustrative; the actual launcher uses
+// GRACE_BUDGET_MS=1500 + POLL_INTERVAL_MS=100 (powershell-launcher.ts).
+// `evaluateGracefulKillState` is value-agnostic — it only compares
+// `now` against `deadline` and reads `isAlive` — so test fixtures
+// pick whatever numbers make the transitions easy to read. If the
+// launcher constants change, this file does not need to follow.
 describe("issue #204: evaluateGracefulKillState — graceful-kill polling state machine", () => {
   it("returns 'exited' immediately when the process is gone (ESRCH)", () => {
     // First poll iteration: graceful taskkill landed, ESRCH already.


### PR DESCRIPTION
## Summary

Closes #204 — e2e tests using `host:'wt'` left Windows Terminal windows behind after each run, accumulating across runs with the `[プロセスはコード 1 (0x00000001) で終了しました]` prompt visible.

### Root cause (3-axis, all confirmed by real-machine verification)

1. **`taskkill /F /PID <PS>` produces exit code 1** (`tests/e2e/helpers/powershell-launcher.ts:349` pre-fix). Windows `TerminateProcess` is hard-coded to give exit code 1 on force kill.
2. **WT `closeOnExit: graceful` (default) keeps the tab open on non-zero exit**. Verified by grepping the user's WT `settings.json` — no `closeOnExit` override.
3. **`-w dtm_e2e_<tag>` per-launch unique window** turns each residual tab into a leaked top-level window, not just a tab inside a shared WT instance.

### Why graceful-first via `taskkill /PID` (no /F) was NOT enough

`taskkill` (no /F) posts `WM_CLOSE` to the **target process's main window**. That works for conhost (the conhost.exe process owns the console window), but is a no-op for WT-hosted PowerShell — the PS process itself has no top-level window; WT.exe does, and PS only sees a close signal once WT disconnects the ConPTY.

**Confirmed empirically**: real-machine run with `taskkill /PID` graceful-first still left 1 residual WT window per execution.

### Fix

Split graceful-first behaviour by host:

- **`host:'wt'`** → `postMessageToHwnd(captured.hwnd, WM_CLOSE, 0, 0)` posts `WM_CLOSE` directly to the WT window we own. WT disconnects the ConPTY → PS exits 0 → WT `closeOnExit:graceful` auto-closes the unique `-w dtm_e2e_<tag>` window.
- **other hosts (conhost / default)** → existing `taskkill /PID <pid>` path (effective for conhost-owned console window).

Polling loop drives the wait via the new pure helper `evaluateGracefulKillState({isAlive, now, deadline})` returning `"wait" | "exited" | "force"`. `/F` fallback fires on budget elapse. `/T` (descendant tree) remains forbidden — see existing `kill()` comment for the 2026-05-08 incident background.

### Real-machine verification

| Phase | WT window count |
|---|---|
| Baseline (Claude session only) | **1** |
| Pre-fix: 1 WT-scenario test run | 2 (1 residual) |
| WM_CLOSE switch: 1 test run | **1** ✅ |
| WM_CLOSE switch: 3 consecutive test runs | **1** ✅ (no accumulation) |

Verified using `EnumWindows` + `GetWindowThreadProcessId` filter for visible WT-owned windows (PowerShell + Win32 P/Invoke).

### Test coverage

- `tests/unit/issue-204-wt-graceful-kill.test.ts` (new, 6 cases): pins all `evaluateGracefulKillState` transitions (`wait` / `exited` / `force`) plus a race-safe edge case where the process exits exactly at the deadline boundary. Pure helper sidesteps the in-module-call / real-process fixture problem flagged on PR #203.

Local: `npx vitest run --project=unit tests/unit/issue-204-wt-graceful-kill.test.ts` → **6/6 pass**.

## Test plan

- [x] Pure helper unit tests pass (6/6)
- [x] `npm run build` clean
- [x] Real-machine: 3 consecutive WT-scenario test runs leave 0 WT residue
- [ ] CI: full unit suite no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)