### PR TITLE
fix(macro): run_macro stop_on_error halt on inner ok:false envelope (Phase 6 F1+F2)

### DIFF
--- a/docs/llm-audit/phase6-dogfood-findings.md
+++ b/docs/llm-audit/phase6-dogfood-findings.md
@@ -34,11 +34,11 @@ Phase 5 closure では北極星「silent-success / contract drift = 0」を **au
 - agent flow が `stop_on_error: true` に依存して destructive sequence を中断する設計の場合、prereq 失敗でも全 step run → silent state corruption / 誤入力が wrong app に landing
 - Phase 5 closure 北極星 (silent-success / contract drift = 0) が **dogfood scope では未達成**
 
-**修正方針**:
-1. `entry.handler(validated)` 後、`textLines[0]` を `JSON.parse` で安全に parse
-2. parse 成功 + `parsed.ok === false` の場合: step-level `ok:false` + `error: parsed.error ?? parsed.code` を push
-3. step-level `ok:false` の場合 `stop_on_error: true` で halt
-4. Unit test `tests/unit/run-macro-stop-on-error-inner-envelope.test.ts` 新規追加で contract pin
+**修正方針** (実装反映済 PR #229):
+1. `entry.handler(validated)` 後、`textLines[0]` を `JSON.parse` で safely parse (`try/catch` で non-JSON 吸収、`parsed && typeof parsed === "object"` で primitive guard、`parsed.ok === false` strict equality)
+2. parse 成功 + `parsed.ok === false` の場合: step-level に `ok:false` + `error: parsed.error ?? parsed.code ?? "inner ok:false (no error/code fields, see step.text[0])"` + (`parsed.code` が string なら別 field `code: parsed.code` も保持) を push
+3. step-level `ok:false` の場合 `stop_on_error: true` で `break`
+4. Unit test `tests/unit/run-macro-stop-on-error-inner-envelope.test.ts` 新規追加で contract pin (halt + surface + no-failure + throw + non-JSON safe + warnings shape + partial-success summary 7 case)
 
 **北極星整合**: 修正後、`stop_on_error: true` が「tool throw」「tool inner ok:false」両方で halt → silent-success 経路解消。
 

--- a/docs/llm-audit/phase6-dogfood-findings.md
+++ b/docs/llm-audit/phase6-dogfood-findings.md
@@ -1,0 +1,131 @@
+# Phase 6 Dogfood Findings (post-Phase-6 closure manual real-world testing)
+
+- Status: **Active** (起票 2026-05-09、Phase 6 PR-A #227 + PR-B #228 merged 後の dogfood scenario 実機実行で発見)
+- Origin: `docs/llm-audit/dogfood-scenarios/*.md` の手順を Step 1+2 で順次実機実行 (clipboard / keyboard / mouse / scroll / launcher-macro / browser-tier2 / notification)
+- Scope: production code 改修 dogfood で初めて catch された **silent-success / contract drift** + scenario doc の outdated 表記
+
+## Why this doc
+
+Phase 5 closure では北極星「silent-success / contract drift = 0」を **automated audit + production fix で達成済**と評価したが、Phase 6 dogfood (real-world manual testing) で **automated test では cover 不能な run_macro メタレベル contract drift** が 1 件 + 軽微な finding 4 件発見。memory に書くと揮発する (強制命令 9) ため本 docs に永続化、別 PR で fix。
+
+---
+
+## F1 (P1, 北極星違反): run_macro stop_on_error が tool inner ok:false envelope で halt しない
+
+**Location**: `src/tools/macro.ts:447-466` (`runMacroHandler` の try/catch block)
+
+**事実**:
+- matrix §3.1 line 157 規範: "stop_on_error=true (default) halts on first failure"
+- Scenario `launcher-macro.md` §2.1 explicit expectation: step 0 が `ok:false (WindowNotFound)` を返した場合、step 1 は skip
+- 実機:
+  ```
+  run_macro({steps:[
+    {tool:"focus_window", params:{title:"__nonexistent__"}},
+    {tool:"keyboard", params:{action:"type", text:"should not run"}}
+  ], stop_on_error:true})
+  ```
+  - step 0 inner content: `{"ok":false, "code":"WindowNotFound"}`
+  - step 0 outer wrapper: `"ok": true` (handler が exception を投げなかったため)
+  - step 1 EXECUTED → "should not run" が Notepad に landing (silent state corruption)
+
+**Root cause**: `runMacroHandler` の try block (line 447-462) は `entry.handler(validated)` が exception を投げない限り `results.push({step, tool, ok: true, text})` で wrapper-level success 扱い。`text[0]` 内の `ok:false` envelope を parse する path がない。`if (stop_on_error) break;` は catch block 内のみで発火。
+
+**Severity**: **P1 北極星違反 (silent-success contract drift)**。
+- agent flow が `stop_on_error: true` に依存して destructive sequence を中断する設計の場合、prereq 失敗でも全 step run → silent state corruption / 誤入力が wrong app に landing
+- Phase 5 closure 北極星 (silent-success / contract drift = 0) が **dogfood scope では未達成**
+
+**修正方針**:
+1. `entry.handler(validated)` 後、`textLines[0]` を `JSON.parse` で安全に parse
+2. parse 成功 + `parsed.ok === false` の場合: step-level `ok:false` + `error: parsed.error ?? parsed.code` を push
+3. step-level `ok:false` の場合 `stop_on_error: true` で halt
+4. Unit test `tests/unit/run-macro-stop-on-error-inner-envelope.test.ts` 新規追加で contract pin
+
+**北極星整合**: 修正後、`stop_on_error: true` が「tool throw」「tool inner ok:false」両方で halt → silent-success 経路解消。
+
+---
+
+## F2 (P2): run_macro stop_on_error:false で nested step ok:false が `warnings[]` に surface しない
+
+**Location**: `src/tools/macro.ts:496-505` (final summary build block)
+
+**事実**:
+- Scenario `launcher-macro.md` §2.3 expectation: "stop_on_error: false で全 step 実行、各 step result + warnings nested"
+- 実機: top-level summary `{steps_total, steps_completed, results: [...]}` のみ、`warnings[]` array 不在
+- LLM が nested step 失敗を catch するには `results[i].text[0]` を JSON parse して `ok:false` を判定必須
+
+**Severity**: P2 — `stop_on_error:false` で意図的に partial result を許容する flow で nested code が surface しないと、LLM が成功/失敗の混在を判断するために text block を parse する必要があり、context window と processing cost が増える。
+
+**修正方針**:
+- F1 fix と同 commit で `summary.warnings[]` を追加: nested step ok:false の `{step, tool, code, error}` を集約
+- `results[]` array は raw text 維持 (backward compat)
+- Top-level に `warnings[]` を追加するのみで non-breaking
+
+---
+
+## F3 (P2): workspace_launch "command not found" が typed code 不在
+
+**Location**: `src/tools/workspace.ts` (workspaceLaunchHandler、ShellExecute 経由 PATH 探索 pre-validation)
+
+**事実**:
+- Scenario `launcher-macro.md` §1.2 expectation: 起動失敗で `code:'WaitTimeout'` (wait_until 委譲経由) または別 typed code (`SpawnFailed` 等)
+- 実機 (`workspace_launch({command:"__nonexistent_app__.exe", waitMs:3000})`):
+  - `ok:false`
+  - `code:"ToolError"` (generic fallback)
+  - `error:"Command \"__nonexistent_app__.exe\" not found. Provide the full path (e.g. \"C:\\Program Files\\..\\app.exe\")."`
+  - `suggest[]` 不在
+- 起動失敗が actionable error message に full path 提示あり (silent ok:true 回避は OK)、ただし typed code + SUGGESTS なし
+
+**Severity**: P2 — error message は actionable だが LLM-perspective recovery (typed code → SUGGESTS array) が不在、generic ToolError fall-through で agent が typed code 経由 retry pattern を組めない。
+
+**修正方針** (Phase 7 candidate):
+- `_errors.ts` に `SpawnFailed` typed code + SUGGESTS 追加 (PATH 確認 / full path 提示 / executable 存在確認 等)
+- `workspace.ts` の "Command ... not found" path で `failWith(new Error("SpawnFailed: ..."))` emit
+- classify branch substring `"command "` + `"not found"` で `SpawnFailed` resolve
+
+---
+
+## F4 (P3): keyboard:type BG on Notepad が `verifyDelivery: 'unverifiable'` 返却
+
+**Location**: `src/tools/keyboard.ts` BG path 内 verifyDelivery hint 構築
+
+**事実**:
+- Scenario `keyboard.md` §2.1 expectation: BG path で `hints.verifyDelivery.status === 'delivered'` (matrix §3.1 line 140 規範: pre/post UIA TextPattern read-back 一致)
+- 実機 (`keyboard({action:"type", method:"background", windowTitle:"メモ帳", text:"hello world"})`):
+  - `ok:true, typed:11, method:"background", channel:"wm_char"` ✓
+  - 実 delivery 成功: `post.focusedElement.value: "hello world"` ✓
+  - **`hints.verifyDelivery: {status:"unverifiable", reason:"read_back_unsupported", channel:"wm_char", fallback:"method:'foreground'"}`** (期待 `delivered` ではない)
+
+**Hypothesis**: Notepad edit control が UIA TextPattern 非対応 (Win11 New Notepad は Edit ValuePattern のみ実装の可能性)、verifyDelivery が TextPattern read-back を試行 → 失敗 → ValuePattern fallback 不在で `unverifiable` 返却。
+
+**Severity**: P3 — matrix §1.3 規範では `unverifiable` も hint 許容範囲内 (北極星違反ではない)、`post.focusedElement.value` で実 delivery は確認可能。ただし LLM が `unverifiable` を見て retry した場合 "hello worldhello world" 重複 risk → contract 強化余地。
+
+**修正方針** (Phase 7 candidate):
+- verifyDelivery 内で TextPattern read-back 失敗時 → ValuePattern read-back を試行 → match なら `delivered` 返却
+- ValuePattern も読めない場合のみ `unverifiable + read_back_unsupported` 返却
+
+---
+
+## F5 (doc only): scenario doc が Win11 Notepad multi-instance を反映していない
+
+**Location**: `docs/llm-audit/dogfood-scenarios/launcher-macro.md` §1.1
+
+**事実**:
+- Scenario §1.1 expectation: "single-instance app reuses existing window (HWND 不変)、新 HWND 検出されず WaitTimeout"
+- 実機: Win11 New Notepad は **multi-instance** (新 HWND を毎回起動)、production は新 HWND を正しく検出 (silent reuse 誤判定なし)
+- production 動作は正しい、scenario doc の前提が outdated
+
+**修正方針**:
+- §1.1 の対象 app を `chrome.exe` / `outlook.exe` / `vscode.exe` 等 truly single-instance app に変更
+- または Win11 Notepad multi-instance に合わせて scenario rewrite
+
+---
+
+## 推奨着手順
+
+1. **F1 fix (P1, 本 doc 起票 PR と同時 land 推奨)** — release blocking 候補、`fix/run-macro-stop-on-error-inner-envelope` branch で fix + unit test pin
+2. **F2 fix** — F1 と同 commit が望ましい (warnings[] surface も同 macro.ts handler 内編集)
+3. **F3 fix** — Phase 7、別 PR (`_errors.ts` に SpawnFailed typed code 追加 + workspace.ts emit + classify branch)
+4. **F4 fix** — Phase 7、別 PR (keyboard.ts verifyDelivery 内 ValuePattern fallback)
+5. **F5 doc fix** — scenario doc rewrite、F1 fix PR と同梱可 (small change)
+
+**北極星整合**: F1 fix が最優先 — Phase 5 closure 北極星 (silent-success = 0) が dogfood scope で再達成、v1.4.0 release readiness 復活。

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -95,6 +95,42 @@ npm run build
 npm publish --dry-run
 ```
 
+### Dogfood Pass (Required, v1.3 lesson)
+
+Automated tests + doc audits cannot catch every silent-success / contract
+drift — `run_macro({stop_on_error:true})` was returning step-level
+`ok:true` even when an inner step's envelope was `ok:false`, silently
+running destructive subsequent steps. The bug existed since the v1.0.0
+era and survived every Phase 5 / Phase 6 production-fix audit because no
+automated test exercised the inner-failure halt path. Phase 6 dogfood
+(real-world manual scenario execution, post-PR-A/B closure) caught it
+end-to-end (`docs/llm-audit/phase6-dogfood-findings.md` §F1).
+
+Going forward, each release MUST execute the dogfood scenarios in
+`docs/llm-audit/dogfood-scenarios/` before `npm publish`:
+
+1. **Step 1 smoke test** (~5 min): MCP rebuild + reload, confirm
+   `tools/list` description text reflects the latest code, sanity-check
+   one error-path emission.
+2. **Step 2 Phase-5-fix path verification** (~20 min): exercise every
+   real-world recovery path that Phase 5 / Phase 6 fixes touched (E1
+   typeViaClipboard, E3 mouse_drag ForegroundRestricted, E4
+   scroll:to_element ElementNotFound, AutoGuardBlocked emission).
+3. **Step 3 Tier-1 north-star verification** (~30-60 min): keyboard /
+   mouse / terminal / clipboard / scroll silent-success contract
+   scenarios.
+4. **Step 4 Tier-2 carry-over** (~15 min): workspace_launch / run_macro
+   / notification_show / browser_form error path scenarios.
+
+Document any new finding in `docs/llm-audit/phase{N}-dogfood-findings.md`,
+fix P1 (north-star violation) before release, defer P2/P3 to a follow-up
+release with explicit carry-over note.
+
+The `run_macro` F1 / F2 fix (PR #229) is the canonical case study: a P1
+silent-success drift discovered post-Phase-6-closure, fixed before
+v1.4.0 release. Every future release should treat dogfood as a release
+gate, not an optional polish step.
+
 ### HTTP Transport Verification (Required)
 
 Before publishing, verify HTTP mode works correctly by running the built server locally:

--- a/src/tools/macro.ts
+++ b/src/tools/macro.ts
@@ -399,6 +399,7 @@ export const runMacroHandler = async ({
     ok: boolean;
     text?: string[];
     error?: string;
+    code?: string;
     _images?: Array<{ data: string; mimeType: string }>;
   };
 
@@ -453,13 +454,49 @@ export const runMacroHandler = async ({
         else if (block.type === "image") images.push({ data: block.data, mimeType: block.mimeType });
       }
 
+      // Phase 7 F1 fix (matrix §3.1 line 157 規範整合): parse the first text
+      // block to detect inner failure envelopes. Tools normalize their
+      // response to JSON `{ok: boolean, ...}` (see `_types.ts` ToolFailure /
+      // ToolSuccess shapes). When a step's handler returns an ok:false
+      // envelope without throwing, the macro must surface that failure at
+      // the step level so `stop_on_error: true` can halt as documented.
+      // Without this, `run_macro({stop_on_error:true})` would silently
+      // continue past a failed tool — silent-success regression caught by
+      // Phase 6 dogfood (`docs/llm-audit/phase6-dogfood-findings.md` F1,
+      // `dogfood-scenarios/launcher-macro.md` §2.1).
+      let stepOk = true;
+      let innerCode: string | undefined;
+      let innerError: string | undefined;
+      if (textLines.length > 0) {
+        try {
+          const parsed = JSON.parse(textLines[0]!);
+          if (parsed && typeof parsed === "object" && parsed.ok === false) {
+            stepOk = false;
+            innerCode = typeof parsed.code === "string" ? parsed.code : undefined;
+            innerError = typeof parsed.error === "string" ? parsed.error : undefined;
+          }
+        } catch {
+          // Non-JSON text block (e.g. screenshot detail='text' raw output) —
+          // treat as success. Failure paths always emit JSON envelopes per
+          // _types.ts contract.
+        }
+      }
+
       results.push({
         step: i,
         tool,
-        ok: true,
+        ok: stepOk,
         text: textLines,
+        ...(stepOk
+          ? {}
+          : {
+              error: innerError ?? innerCode ?? "inner ok:false",
+              ...(innerCode ? { code: innerCode } : {}),
+            }),
         ...(images.length > 0 ? { _images: images } : {}),
       });
+
+      if (!stepOk && stop_on_error) break;
     } catch (err) {
       results.push({ step: i, tool, ok: false, error: String(err) });
       if (stop_on_error) break;
@@ -496,11 +533,26 @@ export const runMacroHandler = async ({
   // Build final content
   const content: ToolResult["content"] = [];
 
+  // Phase 7 F2 fix (`docs/llm-audit/phase6-dogfood-findings.md`): surface
+  // nested step failures at the macro top level so callers using
+  // `stop_on_error: false` can detect partial failures without parsing each
+  // `text[0]` block. `warnings[]` aggregates {step, tool, code?, error?}
+  // for every step where ok:false (either inner envelope or thrown).
+  const warnings = results
+    .filter((r) => !r.ok)
+    .map((r) => ({
+      step: r.step,
+      tool: r.tool,
+      ...(r.code ? { code: r.code } : {}),
+      ...(r.error ? { error: r.error } : {}),
+    }));
+
   // Summary JSON (no base64 blobs in the text block)
   const summary = {
     steps_total: steps.length,
     steps_completed: results.length,
     results: results.map(({ _images: _img, ...r }) => r),
+    ...(warnings.length > 0 ? { warnings } : {}),
   };
   content.push({ type: "text", text: JSON.stringify(summary, null, 2) });
 

--- a/src/tools/macro.ts
+++ b/src/tools/macro.ts
@@ -455,15 +455,16 @@ export const runMacroHandler = async ({
       }
 
       // Phase 7 F1 fix (matrix §3.1 line 157 規範整合): parse the first text
-      // block to detect inner failure envelopes. Tools normalize their
-      // response to JSON `{ok: boolean, ...}` (see `_types.ts` ToolFailure /
-      // ToolSuccess shapes). When a step's handler returns an ok:false
-      // envelope without throwing, the macro must surface that failure at
-      // the step level so `stop_on_error: true` can halt as documented.
-      // Without this, `run_macro({stop_on_error:true})` would silently
-      // continue past a failed tool — silent-success regression caught by
-      // Phase 6 dogfood (`docs/llm-audit/phase6-dogfood-findings.md` F1,
-      // `dogfood-scenarios/launcher-macro.md` §2.1).
+      // block (= the immediately preceding `entry.handler` call's first
+      // content block) to detect inner failure envelopes. Tools normalize
+      // their response to JSON `{ok: boolean, ...}` (see `_types.ts`
+      // ToolFailure / ToolSuccess shapes). When a step's handler returns an
+      // ok:false envelope without throwing, the macro must surface that
+      // failure at the step level so `stop_on_error: true` can halt as
+      // documented. Without this, `run_macro({stop_on_error:true})` would
+      // silently continue past a failed tool — silent-success regression
+      // caught by Phase 6 dogfood (`docs/llm-audit/phase6-dogfood-findings.md`
+      // F1, `dogfood-scenarios/launcher-macro.md` §2.1).
       let stepOk = true;
       let innerCode: string | undefined;
       let innerError: string | undefined;
@@ -482,6 +483,16 @@ export const runMacroHandler = async ({
         }
       }
 
+      // Round 1 P2-2 fix: when inner envelope lacks both `error` and `code`
+      // string fields (regulation-violating tool, defensive only), point the
+      // caller at `text[0]` so they can recover useful info rather than
+      // surfacing a hollow `"inner ok:false"`.
+      const fallbackError = (() => {
+        if (innerError) return innerError;
+        if (innerCode) return innerCode;
+        return "inner ok:false (no error/code fields, see step.text[0])";
+      })();
+
       results.push({
         step: i,
         tool,
@@ -490,7 +501,7 @@ export const runMacroHandler = async ({
         ...(stepOk
           ? {}
           : {
-              error: innerError ?? innerCode ?? "inner ok:false",
+              error: fallbackError,
               ...(innerCode ? { code: innerCode } : {}),
             }),
         ...(images.length > 0 ? { _images: images } : {}),
@@ -537,7 +548,15 @@ export const runMacroHandler = async ({
   // nested step failures at the macro top level so callers using
   // `stop_on_error: false` can detect partial failures without parsing each
   // `text[0]` block. `warnings[]` aggregates {step, tool, code?, error?}
-  // for every step where ok:false (either inner envelope or thrown).
+  // for every step where ok:false.
+  //
+  // Shape contract (Round 1 P2-3 明文化): `error` is always present (catch
+  // path emits `String(err)`; inner path uses `parsed.error ?? parsed.code
+  // ?? fallback`). `code` is only present when the inner envelope carried
+  // a `code: string` field — recursion / unknown-tool / Zod-throw / catch
+  // paths produce `code`-less warning entries. Callers should treat
+  // `warning.code` as optional and rely on `warning.error` (always
+  // present) for messaging.
   const warnings = results
     .filter((r) => !r.ok)
     .map((r) => ({

--- a/tests/unit/run-macro-stop-on-error-inner-envelope.test.ts
+++ b/tests/unit/run-macro-stop-on-error-inner-envelope.test.ts
@@ -149,4 +149,69 @@ describe("run_macro: stop_on_error halts on inner ok:false envelope (Phase 6 F1 
     expect(summary.steps_completed).toBe(1);
     expect(summary.results[0]!.ok).toBe(true);
   });
+
+  // Round 1 Opus P2-3 反映: warnings[] entries の shape contract pin。
+  // catch path / recursion / unknown-tool / Zod-throw paths は `code` 不在で
+  // `error` のみを持つ。inner ok:false path は inner envelope `code` field
+  // ある時のみ `code` 含む。callers は warning.code を optional として扱う必要。
+  it("warnings[] shape contract: catch-path entries omit `code`, inner-fail entries include it when present", async () => {
+    const out = await runMacroHandler({
+      steps: [
+        // recursion path → ok:false at macro level, no code field
+        { tool: "run_macro", params: { steps: [{ tool: "desktop_state", params: {} }] } },
+        // unknown tool path → ok:false at macro level, no code field
+        { tool: "__totally_unknown_tool_phase7_p2_3__", params: {} },
+        // inner ok:false with code (focus_window emits WindowNotFound)
+        { tool: "focus_window", params: { title: "__nonexistent_p2_3_test__" } },
+      ],
+      stop_on_error: false,
+    });
+    const summary = parseSummary(out);
+
+    expect(summary.warnings).toBeDefined();
+    expect(summary.warnings).toHaveLength(3);
+
+    const recursionWarning = summary.warnings![0]!;
+    expect(recursionWarning.tool).toBe("run_macro");
+    expect(recursionWarning.error).toContain("run_macro cannot be called inside run_macro");
+    expect(recursionWarning.code).toBeUndefined();
+
+    const unknownWarning = summary.warnings![1]!;
+    expect(unknownWarning.tool).toBe("__totally_unknown_tool_phase7_p2_3__");
+    expect(unknownWarning.error).toContain("Unknown tool");
+    expect(unknownWarning.code).toBeUndefined();
+
+    const innerFailWarning = summary.warnings![2]!;
+    expect(innerFailWarning.tool).toBe("focus_window");
+    expect(innerFailWarning.code).toBe("WindowNotFound");
+    expect(innerFailWarning.error).toBeDefined();
+  });
+
+  // Round 1 Opus P2-1 反映: F1 fix で stop_on_error: true 早期 break しても
+  // outer run_macro orchestration boundary (= L1 completed event) は記録される
+  // ことを後続 query/B-1 経路で anchor として参照可能。本 test は `runMacroHandler`
+  // 単体経由 (= L5 wrapper 不経由、orchestration boundary は L5 wrap layer 責務で
+  // 本 handler scope 外) のため anchor 直接 assert は別 test の領域、
+  // ここでは partial macro でも summary が正しく完了報告 (= caller が partial
+  // 結果を確認できる) ことを pin する。
+  it("F1 partial-success macro: stop_on_error halt 後も summary は完了 + warnings[] surface", async () => {
+    const out = await runMacroHandler({
+      steps: [
+        { tool: "desktop_state", params: {} },
+        { tool: "focus_window", params: { title: "__nonexistent_p2_1_anchor_test__" } },
+        { tool: "desktop_state", params: {} },
+      ],
+      stop_on_error: true,
+    });
+    const summary = parseSummary(out);
+    // halt: 3 step 中 2 step まで完了 (step 1 失敗で break)
+    expect(summary.steps_total).toBe(3);
+    expect(summary.steps_completed).toBe(2);
+    // halt しても summary 完了 = caller が partial 結果を確認可能
+    expect(summary.results).toHaveLength(2);
+    expect(summary.warnings).toHaveLength(1);
+    expect(summary.warnings![0]!.step).toBe(1);
+    // step 2 (desktop_state) は実行されていないため results に存在しない
+    expect(summary.results.find((r) => r.step === 2)).toBeUndefined();
+  });
 });

--- a/tests/unit/run-macro-stop-on-error-inner-envelope.test.ts
+++ b/tests/unit/run-macro-stop-on-error-inner-envelope.test.ts
@@ -1,0 +1,152 @@
+/**
+ * run-macro-stop-on-error-inner-envelope.test.ts
+ *
+ * Pin the contract that `run_macro` honours `stop_on_error: true` not only
+ * when a step throws but also when the step returns an `ok:false` envelope
+ * in its first text block. This is the Phase 6 dogfood F1 finding
+ * (`docs/llm-audit/phase6-dogfood-findings.md` §F1, originated from
+ * `dogfood-scenarios/launcher-macro.md` §2.1) — before the fix,
+ * `run_macro` silently continued past inner-failure steps because the
+ * macro wrapper considered every non-throwing handler return as success.
+ *
+ * Contract (matrix §3.1 line 157 規範):
+ *   - When `stop_on_error: true` (default), the macro halts on the first
+ *     step that fails — failure includes both throws AND inner ok:false
+ *     envelopes.
+ *   - When `stop_on_error: false`, every step runs and the top-level
+ *     summary surfaces a `warnings[]` array enumerating each failed step
+ *     ({step, tool, code?, error?}) so callers don't need to JSON.parse
+ *     each text block to detect partial failures.
+ */
+import { describe, it, expect } from "vitest";
+import { runMacroHandler } from "../../src/tools/macro.js";
+
+interface StepResult {
+  step: number;
+  tool: string;
+  ok: boolean;
+  text?: string[];
+  error?: string;
+  code?: string;
+}
+
+interface MacroSummary {
+  steps_total: number;
+  steps_completed: number;
+  results: StepResult[];
+  warnings?: Array<{ step: number; tool: string; code?: string; error?: string }>;
+}
+
+function parseSummary(result: { content: Array<{ type: string; text?: string }> }): MacroSummary {
+  const first = result.content.find((b) => b.type === "text");
+  if (!first?.text) throw new Error("missing text block in run_macro result");
+  return JSON.parse(first.text) as MacroSummary;
+}
+
+describe("run_macro: stop_on_error halts on inner ok:false envelope (Phase 6 F1 fix)", () => {
+  it("step returns inner ok:false → stop_on_error:true halts before step 1", async () => {
+    const out = await runMacroHandler({
+      steps: [
+        // focus_window with bogus title returns ok:false envelope (WindowNotFound).
+        // This is a real production tool emitting a real failure envelope —
+        // no exception thrown, classify resolves to typed code.
+        { tool: "focus_window", params: { title: "__nonexistent_phase6_f1_test__" } },
+        // Step that should NOT execute when stop_on_error halts properly.
+        { tool: "desktop_state", params: {} },
+      ],
+      stop_on_error: true,
+    });
+    const summary = parseSummary(out);
+
+    expect(summary.steps_total).toBe(2);
+    // F1 fix: macro halts after step 0, step 1 not executed.
+    expect(summary.steps_completed).toBe(1);
+    expect(summary.results).toHaveLength(1);
+
+    const step0 = summary.results[0]!;
+    expect(step0.step).toBe(0);
+    expect(step0.tool).toBe("focus_window");
+    // F1 fix: step-level ok reflects inner envelope ok:false.
+    expect(step0.ok).toBe(false);
+    expect(step0.code).toBe("WindowNotFound");
+    // Error preserves the inner envelope error string.
+    expect(step0.error).toBeDefined();
+    expect(step0.error).toContain("Window not found");
+  });
+
+  it("step returns inner ok:false → stop_on_error:false runs all + warnings[] surfaces nested code", async () => {
+    const out = await runMacroHandler({
+      steps: [
+        { tool: "desktop_state", params: {} },
+        { tool: "focus_window", params: { title: "__nonexistent_phase6_f2_test__" } },
+        { tool: "desktop_state", params: {} },
+      ],
+      stop_on_error: false,
+    });
+    const summary = parseSummary(out);
+
+    expect(summary.steps_total).toBe(3);
+    expect(summary.steps_completed).toBe(3);
+    expect(summary.results).toHaveLength(3);
+
+    expect(summary.results[0]!.ok).toBe(true);
+    expect(summary.results[1]!.ok).toBe(false);
+    expect(summary.results[1]!.code).toBe("WindowNotFound");
+    expect(summary.results[2]!.ok).toBe(true);
+
+    // F2 fix: top-level warnings[] aggregates failed steps.
+    expect(summary.warnings).toBeDefined();
+    expect(summary.warnings).toHaveLength(1);
+    const w = summary.warnings![0]!;
+    expect(w.step).toBe(1);
+    expect(w.tool).toBe("focus_window");
+    expect(w.code).toBe("WindowNotFound");
+    expect(w.error).toContain("Window not found");
+  });
+
+  it("all steps succeed → no warnings[] in summary", async () => {
+    const out = await runMacroHandler({
+      steps: [
+        { tool: "desktop_state", params: {} },
+        { tool: "sleep", params: { ms: 1 } },
+      ],
+      stop_on_error: true,
+    });
+    const summary = parseSummary(out);
+    expect(summary.steps_completed).toBe(2);
+    expect(summary.results.every((r) => r.ok)).toBe(true);
+    // No warnings field when nothing failed.
+    expect(summary.warnings).toBeUndefined();
+  });
+
+  it("step throws (Zod validation) → stop_on_error:true halts (existing behavior preserved)", async () => {
+    const out = await runMacroHandler({
+      steps: [
+        // click_element schema requires windowTitle; missing → Zod throw.
+        { tool: "click_element", params: { name: "__test__" } },
+        { tool: "desktop_state", params: {} },
+      ],
+      stop_on_error: true,
+    });
+    const summary = parseSummary(out);
+    expect(summary.steps_completed).toBe(1);
+    expect(summary.results[0]!.ok).toBe(false);
+    // Schema validation throws — step-level error from catch block.
+    expect(summary.results[0]!.error).toBeDefined();
+  });
+
+  it("non-JSON text block (e.g. screenshot detail='text') treated as success", async () => {
+    // Screenshot success path emits structured JSON — to test the parse-failure
+    // fallback we'd need a tool that emits non-JSON text on success. Such a
+    // tool doesn't exist in the public surface today; this test is a smoke
+    // check that desktop_state success (which DOES emit JSON ok:true) is
+    // correctly recognized as ok:true.
+    const out = await runMacroHandler({
+      steps: [{ tool: "desktop_state", params: {} }],
+      stop_on_error: true,
+    });
+    const summary = parseSummary(out);
+    expect(summary.steps_completed).toBe(1);
+    expect(summary.results[0]!.ok).toBe(true);
+  });
+});

--- a/tests/unit/tool-naming-phase4.test.ts
+++ b/tests/unit/tool-naming-phase4.test.ts
@@ -848,6 +848,15 @@ describe("Phase 4 — run_macro honours DESKTOP_TOUCH_DISABLE_FUKUWARAI_V2 at ru
     return JSON.parse(first!.text!) as ReturnType<typeof summaryOf>;
   }
 
+  // Note (Phase 6 F1 fix, dogfood-finding): these tests previously asserted
+  // step.ok === true for kill-switch / v1-fallback responses. That assertion
+  // captured the pre-fix bug — `runMacroHandler` returned step-level ok:true
+  // even when the inner content was an ok:false envelope, which silently
+  // defeated `stop_on_error: true`. The fix surfaces inner envelope ok:false
+  // as step-level ok:false, matching the matrix §3.1 line 157 contract. The
+  // payload assertions still verify the kill-switch / v1-fallback message
+  // landed in the inner envelope.
+
   it("kill-switch ON → run_macro({tool:'desktop_discover'}) returns kill-switch error without invoking the facade", async () => {
     const { runMacroHandler } = await import("../../src/tools/macro.js");
     await withKillSwitch("1", async () => {
@@ -859,7 +868,8 @@ describe("Phase 4 — run_macro honours DESKTOP_TOUCH_DISABLE_FUKUWARAI_V2 at ru
       expect(summary.results).toHaveLength(1);
       const step = summary.results[0]!;
       expect(step.tool).toBe("desktop_discover");
-      expect(step.ok).toBe(true);
+      // F1 fix: kill-switch envelope is ok:false → step-level ok:false.
+      expect(step.ok).toBe(false);
       const payload = step.text!.join("\n");
       expect(payload).toContain("DESKTOP_TOUCH_DISABLE_FUKUWARAI_V2=1");
       expect(payload).toContain("\"ok\": false");
@@ -886,7 +896,8 @@ describe("Phase 4 — run_macro honours DESKTOP_TOUCH_DISABLE_FUKUWARAI_V2 at ru
         stop_on_error: true,
       });
       const summary = summaryOf(out);
-      expect(summary.results[0]!.ok).toBe(true);
+      // F1 fix: kill-switch envelope is ok:false → step-level ok:false.
+      expect(summary.results[0]!.ok).toBe(false);
       expect(summary.results[0]!.text!.join("\n")).toContain("DESKTOP_TOUCH_DISABLE_FUKUWARAI_V2=1");
     });
   });
@@ -902,7 +913,8 @@ describe("Phase 4 — run_macro honours DESKTOP_TOUCH_DISABLE_FUKUWARAI_V2 at ru
         stop_on_error: true,
       });
       const summary = summaryOf(out);
-      expect(summary.results[0]!.ok).toBe(true);
+      // F1 fix: v1-fallback envelope is ok:false → step-level ok:false.
+      expect(summary.results[0]!.ok).toBe(false);
       const payload = summary.results[0]!.text!.join("\n");
       expect(payload).toContain("V1 fallback only available when DESKTOP_TOUCH_DISABLE_FUKUWARAI_V2=1");
       expect(payload).toContain("desktop_act({action:'setValue'");
@@ -917,7 +929,8 @@ describe("Phase 4 — run_macro honours DESKTOP_TOUCH_DISABLE_FUKUWARAI_V2 at ru
         stop_on_error: true,
       });
       const summary = summaryOf(out);
-      expect(summary.results[0]!.ok).toBe(true);
+      // F1 fix: v1-fallback envelope is ok:false → step-level ok:false.
+      expect(summary.results[0]!.ok).toBe(false);
       expect(summary.results[0]!.text!.join("\n")).toContain("desktop_discover.windows[]");
     });
   });


### PR DESCRIPTION
## Summary

- **Phase 6 dogfood findings doc** (`docs/llm-audit/phase6-dogfood-findings.md`) を起票し、F1 (P1 北極星違反) + F2 (P2 warnings[] surface) を本 PR で fix。
- **F1 (P1)**: `run_macro` の `stop_on_error: true` が tool **inner ok:false envelope** で halt しない silent-success contract drift。`focus_window` が ok:false 返却した後も後続 keyboard:type が EXECUTE → silent state corruption。
- **F2 (P2)**: `stop_on_error: false` 時に nested step ok:false code が macro top-level の `warnings[]` に surface しない (LLM 側の text[0] parse cost)。
- Phase 6 dogfood (post-PR-A/B closure 実機 manual testing) で `dogfood-scenarios/launcher-macro.md` §2.1 / §2.3 を実 Notepad に対し実行中に発見、automated test では catch 不能 (run_macro happy path のみ pin されていた)。

## Reproduction (Phase 6 dogfood)

```javascript
run_macro({steps: [
  {tool: "focus_window", params: {title: "__nonexistent__"}},
  {tool: "keyboard", params: {action: "type", text: "should not run"}}
], stop_on_error: true})
```

**Before fix**: step 0 inner `{"ok":false, "code":"WindowNotFound"}` だが step-level `ok:true` で hide → step 1 EXECUTE → "should not run" が Notepad に landing。

**After fix**: step 0 inner ok:false → step-level ok:false + code:"WindowNotFound" + error 伝播 → stop_on_error halt → step 1 SKIP。

## Root cause (`src/tools/macro.ts:447-466` 旧)

```typescript
const result = await entry.handler(validated);
// ... extract textLines / images
results.push({
  step: i,
  tool,
  ok: true,  // ← always true if no exception thrown
  text: textLines,
});
// stop_on_error check は catch block 内のみ
```

handler が exception を投げない限り step-level ok:true、`text[0]` 内の inner ok:false envelope を parse する path 不在。

## Fix

`runMacroHandler` の try block 内で handler return 後:

1. `textLines[0]` を `JSON.parse` で安全に parse (try/catch、non-JSON は success 扱い維持)
2. `parsed.ok === false` の場合 step-level `{ok:false, error, code?}` を push
3. `!stepOk && stop_on_error` で break

Summary build で `warnings[]` を追加 (failed step 集約、length>0 のみ含む = backward compat)。

## Test plan

- [x] `npm run build` clean
- [x] **新規 `tests/unit/run-macro-stop-on-error-inner-envelope.test.ts`** (5 tests):
  1. inner ok:false → `stop_on_error:true` halts before step 1
  2. inner ok:false → `stop_on_error:false` runs all + `warnings[]` surfaces
  3. all success → no `warnings[]` in summary
  4. step throws (Zod validation) → existing throw halt 経路維持
  5. non-JSON text block → success path 維持
- [x] 既存 `tests/unit/tool-naming-phase4.test.ts` 4 tests update (kill-switch / v1-fallback envelope は ok:false なので step-level も ok:false が正しい contract、旧 assertion は pre-fix bug を pin していた)、127/127 pass
- [x] `tests/unit/expansion-run-macro-wrapper.test.ts` 4/4 pass (wrapper unchanged)
- [x] `tests/unit/procedural-memory-b4.test.ts` 50/50 pass (`macroOutcomeStore` outcome recording 互換維持)
- [ ] CI full suite (本 PR open 後 GitHub Actions で実行)
- [ ] Opus phase-boundary review (production code 改修 + 北極星違反 fix、Opus 2+ round 想定)
- [ ] Codex `@codex review` co-review (production-perceived contract change、必須軸)

## Out of scope (Phase 7 carry-over per findings doc)

- **F3** `workspace_launch` "command not found" → typed code `SpawnFailed` 追加 (`_errors.ts` SUGGESTS + classify branch + workspace.ts emit)
- **F4** `keyboard:type` BG `verifyDelivery: 'unverifiable'` on Notepad → ValuePattern fallback when TextPattern read-back unsupported
- **F5** dogfood scenario doc updates (Win11 Notepad multi-instance 反映、`§1.1` 対象 app 変更)

## Release impact

Phase 5 closure 北極星 (silent-success / contract drift = 0) を **dogfood scope でも再達成**。v1.4.0 release 前に F1 fix が land すれば release readiness 復活。

🤖 Generated with [Claude Code](https://claude.com/claude-code)