### PR TITLE
docs(scenario): F5 launcher-macro.md §1.1 truly single-instance app fix (Phase 7)

### DIFF
--- a/docs/llm-audit/dogfood-scenarios/launcher-macro.md
+++ b/docs/llm-audit/dogfood-scenarios/launcher-macro.md
@@ -15,7 +15,7 @@
 **目的**: matrix §3.1 line 156 の "single-instance apps that reuse an existing window will not register as a new HWND" が実機で完全に再現されることを確認。description caveats に既に明示されているが、LLM が回避手順 (`desktop_discover` で既存検出) を実行する flow を end-to-end 観測。
 
 **対象 app の選定**:
-- **truly single-instance**: `chrome.exe` / `outlook.exe` / `vscode.exe` (line 136 共通 note 参照)。本 scenario は chrome.exe を例に記述。
+- **truly single-instance**: `chrome.exe` / `outlook.exe` / `vscode.exe` (§3 末尾の「共通操作上の note」参照)。本 scenario は chrome.exe を例に記述。
 - **multi-instance (本 scenario 対象外)**: Win11 New Notepad は毎起動で新 HWND 採番、本 scenario の reuse 期待を満たさない (production は新 HWND を正しく検出、silent ok:true regression なし — Phase 6 dogfood F5 検証で確認済)。`notepad.exe` を本シナリオの対象に使うと multi-instance 採番で「reuse 失敗 → 新 HWND 検出成功」の正常 path に流れ、reuse 観測ができない。
 
 **手順**:
@@ -41,6 +41,8 @@
 ### 1.3 workspace_launch → focus_window chain (Tier 2 inter-tool)
 
 **目的**: matrix §3.1 line 156 の prefer pattern "Follow with focus_window(windowTitle) to interact with the launched app" を実機 chain で確認。
+
+**対象 app の note**: 本 scenario は **新規 HWND 採番 path** のテストなので、§1.1 で対象外とした multi-instance Win11 New Notepad は逆に適合する (毎起動で新 HWND 採番)。chain 観測の対象として標準的に使用可能。
 
 **手順**:
 1. `workspace_launch({command: 'notepad.exe', windowTitle: 'Notepad'})` で新規 Notepad 起動

--- a/docs/llm-audit/dogfood-scenarios/launcher-macro.md
+++ b/docs/llm-audit/dogfood-scenarios/launcher-macro.md
@@ -14,10 +14,14 @@
 
 **目的**: matrix §3.1 line 156 の "single-instance apps that reuse an existing window will not register as a new HWND" が実機で完全に再現されることを確認。description caveats に既に明示されているが、LLM が回避手順 (`desktop_discover` で既存検出) を実行する flow を end-to-end 観測。
 
+**対象 app の選定**:
+- **truly single-instance**: `chrome.exe` / `outlook.exe` / `vscode.exe` (line 136 共通 note 参照)。本 scenario は chrome.exe を例に記述。
+- **multi-instance (本 scenario 対象外)**: Win11 New Notepad は毎起動で新 HWND 採番、本 scenario の reuse 期待を満たさない (production は新 HWND を正しく検出、silent ok:true regression なし — Phase 6 dogfood F5 検証で確認済)。`notepad.exe` を本シナリオの対象に使うと multi-instance 採番で「reuse 失敗 → 新 HWND 検出成功」の正常 path に流れ、reuse 観測ができない。
+
 **手順**:
-1. 既に Notepad が開いている状態で `workspace_launch({command: 'notepad.exe', windowTitle: 'Notepad'})` 呼出
-2. response 観測: 内部 enum スナップショット で既存 Notepad HWND が前から存在 → 新 HWND 検出されず → `code:'WaitTimeout'` (wait_until 経由) または empty foundWindow
-3. **回避**: `desktop_discover` で既存 Notepad を先に発見 → 既存 HWND を target にして次 tool
+1. 既に Chrome (or vscode / outlook) が開いている状態で `workspace_launch({command: 'chrome.exe', windowTitle: 'Chrome'})` 呼出
+2. response 観測: 内部 enum スナップショット で既存 Chrome HWND が前から存在 → 新 HWND 検出されず → `code:'WaitTimeout'` (wait_until 経由) または empty foundWindow
+3. **回避**: `desktop_discover` で既存 Chrome を先に発見 → 既存 HWND を target にして次 tool
 
 **期待**: timeout/error path で actionable suggest (例: "Call desktop_discover first to check if the window is already open")。
 **Anti-pattern**: silent ok:true で foundWindow に古い HWND を返す → caller が新規プロセスと誤認 → focus / state stale。

--- a/docs/llm-audit/phase6-dogfood-findings.md
+++ b/docs/llm-audit/phase6-dogfood-findings.md
@@ -120,10 +120,11 @@ Phase 5 closure では北極星「silent-success / contract drift = 0」を **au
 - §1.1 の対象 app を `chrome.exe` / `outlook.exe` / `vscode.exe` 等 truly single-instance app に変更
 - または Win11 Notepad multi-instance に合わせて scenario rewrite
 
-**修正反映** (Phase 7 v1.4.1 patch、本 PR):
-- §1.1 対象 app を `notepad.exe` → `chrome.exe` に変更 (line 136 共通 note 整合)
+**修正反映** (Phase 7 patch、本 PR):
+- §1.1 対象 app を `notepad.exe` → `chrome.exe` に変更 (§3 末尾の「共通操作上の note」整合)
 - §1.1 に「対象 app の選定」subsection を追加し truly single-instance / multi-instance の区別を明示
 - 「Win11 New Notepad は multi-instance、本 scenario の対象外」note を追加 (将来の dogfood 担当が同じ罠を踏まないため)
+- §1.3 にも「本 scenario は新規 HWND 採番 path のテストなので multi-instance Notepad は適合」note 追加 (§1.1 → §1.3 順読時の見かけ矛盾を解消)
 
 ---
 

--- a/docs/llm-audit/phase6-dogfood-findings.md
+++ b/docs/llm-audit/phase6-dogfood-findings.md
@@ -105,7 +105,9 @@ Phase 5 closure では北極星「silent-success / contract drift = 0」を **au
 
 ---
 
-## F5 (doc only): scenario doc が Win11 Notepad multi-instance を反映していない
+## F5 (doc only, **FIXED Phase 7**): scenario doc が Win11 Notepad multi-instance を反映していない
+
+**Status**: **Fixed** (Phase 7 patch、対象 app を `chrome.exe` に変更 + Win11 Notepad multi-instance note 追加)
 
 **Location**: `docs/llm-audit/dogfood-scenarios/launcher-macro.md` §1.1
 
@@ -117,6 +119,11 @@ Phase 5 closure では北極星「silent-success / contract drift = 0」を **au
 **修正方針**:
 - §1.1 の対象 app を `chrome.exe` / `outlook.exe` / `vscode.exe` 等 truly single-instance app に変更
 - または Win11 Notepad multi-instance に合わせて scenario rewrite
+
+**修正反映** (Phase 7 v1.4.1 patch、本 PR):
+- §1.1 対象 app を `notepad.exe` → `chrome.exe` に変更 (line 136 共通 note 整合)
+- §1.1 に「対象 app の選定」subsection を追加し truly single-instance / multi-instance の区別を明示
+- 「Win11 New Notepad は multi-instance、本 scenario の対象外」note を追加 (将来の dogfood 担当が同じ罠を踏まないため)
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 7 carry-over fix #1 (F5、docs only): launcher-macro.md §1.1 を Win11 New Notepad multi-instance に対応するため対象 app を `notepad.exe` → `chrome.exe` に変更。

- §1.1 対象 app を `notepad.exe` (Win11 New Notepad で multi-instance) → `chrome.exe` (truly single-instance、line 136 共通 note 整合) に変更
- 「対象 app の選定」subsection 新設で truly single-instance / multi-instance の区別を明示
- 「Win11 New Notepad は multi-instance、本 scenario の対象外」note 追加 (将来の dogfood 担当が同じ罠を踏まないため)
- `docs/llm-audit/phase6-dogfood-findings.md` §F5 を Status: Fixed に更新、修正反映 subsection 追加

## Why this matters

§1.1 の本来の目的は「single-instance app reuses existing window (HWND 不変)、新 HWND 検出されず WaitTimeout」を実機観測すること。Win11 New Notepad は **multi-instance** で毎起動で新 HWND を採番するため、本 scenario で `notepad.exe` を使うと「reuse 失敗 → 新 HWND 検出成功」の正常 path に流れ、reuse 観測が**できない**。production 動作は正しい (新 HWND を正しく検出、silent ok:true regression なし、Phase 6 dogfood F5 で確認済) が、scenario doc の前提が outdated。

`chrome.exe` は line 136 の「single-instance app pattern」共通 note で既に列挙済の truly single-instance app。Phase 6 PR-A merge 後の dogfood 実機実行で発見した 5 件の findings (F1-F5) のうち最後の docs-only fix。

## Scope

- Production code: **未変更**
- Test: 未変更 (dogfood scenario は manual / docs only)
- 影響: 将来の dogfood 担当が §1.1 を実行する際に正しい app で reuse 観測ができる

## Test plan

- [ ] Opus phase-boundary review (1 round、docs only fix なので軽量)
- [ ] CI green (docs-only PR で機械チェック軽量)
- [ ] User reviewer 補正 window (CLAUDE.md §3.3 Step 4)
- [ ] Squash merge (Opus 判断 merge 委譲、自動進行モード)

## Path A 進捗

Phase 7 carry-over の v1.4.1 patch release に向けた 4 PR のうち 1 PR 目:

- [x] **F5 (本 PR)**: scenario doc fix (docs only)
- [ ] ADR-010 §5.4 catalog reconcile (docs only、累積 14 entries cascade sync)
- [ ] F3: workspace_launch SpawnFailed typed code (production code)
- [ ] F4: keyboard verifyDelivery ValuePattern fallback (production code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)