### PR TITLE
feat(keyboard): ValuePattern fallback for BG verifyDelivery (Phase 7 F4)

### DIFF
--- a/docs/llm-audit/phase6-dogfood-findings.md
+++ b/docs/llm-audit/phase6-dogfood-findings.md
@@ -84,7 +84,9 @@ Phase 5 closure では北極星「silent-success / contract drift = 0」を **au
 
 ---
 
-## F4 (P3): keyboard:type BG on Notepad が `verifyDelivery: 'unverifiable'` 返却
+## F4 (P3, **FIXED Phase 7**): keyboard:type BG on Notepad が `verifyDelivery: 'unverifiable'` 返却
+
+**Status**: **Fixed** (Phase 7 patch、`getTextViaValuePattern` helper 新設 + keyboard.ts BG type path で TextPattern 失敗時 ValuePattern delta 比較 fallback 追加)
 
 **Location**: `src/tools/keyboard.ts` BG path 内 verifyDelivery hint 構築
 
@@ -102,6 +104,12 @@ Phase 5 closure では北極星「silent-success / contract drift = 0」を **au
 **修正方針** (Phase 7 candidate):
 - verifyDelivery 内で TextPattern read-back 失敗時 → ValuePattern read-back を試行 → match なら `delivered` 返却
 - ValuePattern も読めない場合のみ `unverifiable + read_back_unsupported` 返却
+
+**修正反映** (Phase 7 patch、本 PR):
+- `src/engine/uia-bridge.ts` に `getTextViaValuePattern(windowTitle)` helper 新設。focused element の ValuePattern.Value を返す PowerShell-backed 関数、TreeWalker で focused 要素が target window の toplevel HWND 内に居ることを scoping (focus が外部に逃げた場合は null で無視)。
+- `src/tools/keyboard.ts` BG type path で TextPattern baseline / post-read が両方 null の case に ValuePattern delta 比較 fallback 追加。`postValue.includes(checkText)` AND (`delta > 0` OR `!baseline.includes(checkText)`) で delivered 判定、両者一致で length 不変は `unverifiable` 維持 (false-positive 防止)。
+- 10 unit case (`tests/unit/phase7-f4-value-pattern-fallback.test.ts`) で classify decision logic を pin: empty baseline / non-empty baseline / replaceAll / partial / 不変 / 重複 baseline + 拡大 / multi-line などの shape を網羅。
+- contract 強化により Win11 New Notepad / RichEdit / TextBox / Edit など ValuePattern-only な control での北極星整合 hint surface が向上 (旧: unverifiable → 新: delivered when ValuePattern fallback succeeds)。
 
 ---
 

--- a/src/engine/uia-bridge.ts
+++ b/src/engine/uia-bridge.ts
@@ -1236,6 +1236,13 @@ try {
  * delivers WM_CHAR to the focused HWND/element (matrix doc §3.1 line 140
  * + §4.2 verifyDelivery 規範). The TreeWalker scoping guards against
  * reading an unrelated app's value when focus is elsewhere.
+ *
+ * Best-effort caveat (Phase 7 F4 P2-2): focus race during the read is not
+ * detected. If the focus moves away → reads → moves back during the
+ * `runPS` round-trip, the Value returned is whichever element was focused
+ * at the instant `vp.Current.Value` evaluated. Callers (keyboard.ts BG
+ * type path) compose this with a post-injection comparison, so a transient
+ * focus race produces an `unverifiable` hint rather than a false delivered.
  */
 export async function getTextViaValuePattern(windowTitle: string, timeoutMs = 6000): Promise<string | null> {
   const safeTitle = escapeLike(windowTitle);
@@ -1290,7 +1297,13 @@ try {
     $payload = @{ ok=$true; text=$val } | ConvertTo-Json -Compress
     Write-Output $payload
 } catch {
-    Write-Output ('{"ok":false,"error":"' + ($_.Exception.Message -replace '"','\\"') + '"}')
+    # Phase 7 F4 P2-4 (Round 1 review): normalize CR/LF in the exception
+    # message before splicing into a JSON string literal. Multi-line
+    # InvalidOperationException messages (e.g. disposed AutomationElement)
+    # would otherwise emit raw newlines into the JSON body and break
+    # JSON.parse on the TS side, masking the real error as a generic null.
+    $msg = $_.Exception.Message -replace '"','\\"' -replace "[\r\n]+",' '
+    Write-Output ('{"ok":false,"error":"' + $msg + '"}')
 }
 `;
   try {

--- a/src/engine/uia-bridge.ts
+++ b/src/engine/uia-bridge.ts
@@ -1215,6 +1215,95 @@ try {
 }
 
 /**
+ * Read the focused element's ValuePattern.Value.
+ *
+ * Phase 7 F4 fallback for `getTextViaTextPattern` (Phase 6 dogfood F4):
+ * Win11 New Notepad's RichEditD2DPT control implements ValuePattern but
+ * not TextPattern, so the existing TextPattern read-back returns
+ * `unverifiable / read_back_unsupported` even though delivery actually
+ * succeeded. ValuePattern is supported by Edit / RichEdit / TextBox /
+ * standard Win32 input controls, complementing TextPattern coverage.
+ *
+ * Returns the focused element's `ValuePattern.Value` string, or null
+ * when:
+ * - The window cannot be located by title
+ * - No focused element exists
+ * - The focused element lives outside the target window's toplevel HWND
+ *   (focus moved away — caller should rely on FocusLostDuringType detection)
+ * - The focused element does not implement ValuePattern
+ *
+ * Targets the FOCUSED element specifically because BG WM_CHAR injection
+ * delivers WM_CHAR to the focused HWND/element (matrix doc §3.1 line 140
+ * + §4.2 verifyDelivery 規範). The TreeWalker scoping guards against
+ * reading an unrelated app's value when focus is elsewhere.
+ */
+export async function getTextViaValuePattern(windowTitle: string, timeoutMs = 6000): Promise<string | null> {
+  const safeTitle = escapeLike(windowTitle);
+  const script = `
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+Add-Type -AssemblyName UIAutomationClient
+Add-Type -AssemblyName UIAutomationTypes
+
+$root = [System.Windows.Automation.AutomationElement]::RootElement
+$trueC = [System.Windows.Automation.Condition]::TrueCondition
+
+# Find the target toplevel window by title substring.
+$target = $null
+$allWins = $root.FindAll([System.Windows.Automation.TreeScope]::Children, $trueC)
+foreach ($w in $allWins) {
+    if ($w.Current.Name -like '*${safeTitle}*') { $target = $w; break }
+}
+if (-not $target) { Write-Output '{"ok":false,"error":"Window not found"}'; exit }
+
+# Get the system focused element. If none, nothing to read back.
+$focused = [System.Windows.Automation.AutomationElement]::FocusedElement
+if (-not $focused) { Write-Output '{"ok":false,"error":"No focused element"}'; exit }
+
+# Walk up from focused via ControlViewWalker, recording the last non-zero
+# NativeWindowHandle — this is the toplevel HWND of the focused element.
+# Compare against $target.NativeWindowHandle so we only read back when the
+# focused element belongs to our target window (defends against reading an
+# unrelated app's ValuePattern when focus moved during BG injection).
+$walker = [System.Windows.Automation.TreeWalker]::ControlViewWalker
+$probe = $focused
+$focusedTopHwnd = 0
+$guard = 0
+while ($probe -and $guard -lt 64) {
+    $hwnd = $probe.Current.NativeWindowHandle
+    if ($hwnd -ne 0 -and $null -ne $hwnd) { $focusedTopHwnd = $hwnd }
+    $probe = $walker.GetParent($probe)
+    $guard = $guard + 1
+}
+$targetHwnd = $target.Current.NativeWindowHandle
+if ($focusedTopHwnd -ne $targetHwnd) {
+    Write-Output '{"ok":false,"error":"Focused element outside target window"}'; exit
+}
+
+# Try ValuePattern on the focused element. Edit / RichEdit / TextBox
+# typically support this; complex hosts that only expose TextPattern
+# (e.g. console buffers) will fail here and the caller falls back.
+try {
+    $vp = $focused.GetCurrentPattern([System.Windows.Automation.ValuePattern]::Pattern)
+    if ($null -eq $vp) { Write-Output '{"ok":false,"error":"ValuePattern not available"}'; exit }
+    $val = $vp.Current.Value
+    if ($null -eq $val) { $val = '' }
+    $payload = @{ ok=$true; text=$val } | ConvertTo-Json -Compress
+    Write-Output $payload
+} catch {
+    Write-Output ('{"ok":false,"error":"' + ($_.Exception.Message -replace '"','\\"') + '"}')
+}
+`;
+  try {
+    const out = await runPS(script, timeoutMs);
+    const parsed = JSON.parse(out) as { ok: boolean; text?: string; error?: string };
+    if (!parsed.ok) return null;
+    return parsed.text ?? "";
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Find a UI element and return its bounding rectangle + basic properties.
  * Used by scope_element to know which screen region to screenshot.
  */

--- a/src/tools/keyboard.ts
+++ b/src/tools/keyboard.ts
@@ -713,11 +713,18 @@ export const keyboardTypeHandler = async ({
           // baseline reads in parallel via Promise.all, so the causal window
           // between baseline capture and injection stays close to
           // max(textPattern, valuePattern) ms instead of summing both PowerShell
-          // round-trips on the cold path. The hot path (TextPattern succeeds)
-          // pays an extra parallel ValuePattern PS spawn cost which is wasted,
-          // but the total wall-clock latency does not increase. Win11 New
-          // Notepad RichEditD2DPT (the F4 target) only has ValuePattern, so
-          // the cold path is where users actually live.
+          // round-trips on the cold path. Win11 New Notepad RichEditD2DPT
+          // (the F4 target) only has ValuePattern, so the cold path is where
+          // users actually live.
+          //
+          // Wall-clock trade-off (Round 2 P3-1):
+          //   * Both legs PS (no nativeUia)  → max ≈ either ≈ baseline cost
+          //   * nativeUia loaded for TextPattern only (current state, line 1118
+          //     of uia-bridge.ts) → max = ValuePattern PS spawn ≈ +PS wall-clock
+          //     on the hot path. The cold-path improvement (Win11 Notepad) and
+          //     reduced false-negative rate on the F4 target outweigh the hot-
+          //     path PS cost. Future work: native ValuePattern binding to
+          //     close the gap.
           const shouldReadBaselines =
             verificationNeeded && checkText.length > 0 && !hasEmbeddedNewline;
           const [baselineRaw, valueBaselineRaw] = shouldReadBaselines

--- a/src/tools/keyboard.ts
+++ b/src/tools/keyboard.ts
@@ -709,27 +709,29 @@ export const keyboardTypeHandler = async ({
           // already know we can't compare).
           const checkText = effectiveText.replace(/[\r\n]+$/, "");
           const hasEmbeddedNewline = /[\r\n]/.test(checkText);
-          const baselineRaw =
-            verificationNeeded && checkText.length > 0 && !hasEmbeddedNewline
-              ? await getTextViaTextPattern(target.title)
-              : null;
+          // Phase 7 F4 P2-1 (Round 1 review): run TextPattern + ValuePattern
+          // baseline reads in parallel via Promise.all, so the causal window
+          // between baseline capture and injection stays close to
+          // max(textPattern, valuePattern) ms instead of summing both PowerShell
+          // round-trips on the cold path. The hot path (TextPattern succeeds)
+          // pays an extra parallel ValuePattern PS spawn cost which is wasted,
+          // but the total wall-clock latency does not increase. Win11 New
+          // Notepad RichEditD2DPT (the F4 target) only has ValuePattern, so
+          // the cold path is where users actually live.
+          const shouldReadBaselines =
+            verificationNeeded && checkText.length > 0 && !hasEmbeddedNewline;
+          const [baselineRaw, valueBaselineRaw] = shouldReadBaselines
+            ? await Promise.all([
+                getTextViaTextPattern(target.title),
+                getTextViaValuePattern(target.title),
+              ])
+            : [null, null];
           const baselineMarker =
             baselineRaw !== null ? makeKeyboardBaselineMarker(stripAnsi(baselineRaw)) : null;
-
-          // Phase 7 F4 fallback: when TextPattern is unavailable on the focused
-          // element (e.g. Win11 New Notepad RichEditD2DPT control implements
-          // ValuePattern but not TextPattern), capture the focused element's
-          // ValuePattern.Value as a baseline so we can do post-injection delta
-          // comparison. Only collected when the TextPattern path is missing
-          // (avoids paying double UIA round-trip cost on the common path).
-          // Phase 6 dogfood F4 finding (`docs/llm-audit/phase6-dogfood-findings.md`).
-          const valueBaseline =
-            verificationNeeded &&
-            baselineMarker === null &&
-            checkText.length > 0 &&
-            !hasEmbeddedNewline
-              ? await getTextViaValuePattern(target.title)
-              : null;
+          // valueBaseline is only consulted when the TextPattern path is
+          // unavailable (baselineMarker === null). When TextPattern works,
+          // the parallel-fetched ValuePattern baseline is discarded.
+          const valueBaseline = baselineMarker === null ? valueBaselineRaw : null;
 
           if (replaceAll) postKeyComboToHwnd(target.hwnd, "ctrl+a");
           const result = postCharsToHwnd(target.hwnd, effectiveText);
@@ -817,8 +819,12 @@ export const keyboardTypeHandler = async ({
                 if (containsText) {
                   // Delivered if length grew (text appended) OR baseline did
                   // not previously contain checkText (replaceAll / focus-fresh
-                  // shape). Otherwise both sides contain checkText with no
-                  // length change — undetermined, fall back to unverifiable.
+                  // shape; e.g. ctrl+a then type replaces the buffer so post
+                  // length can shrink yet the typed text is what landed).
+                  // Otherwise both sides contain checkText with no length
+                  // change — undetermined (could be a re-type of identical
+                  // content), fall back to unverifiable rather than
+                  // false-positive delivered.
                   if (delta > 0 || !valueBaseline.includes(checkText)) {
                     verifiedDelivery = true;
                   } else {

--- a/src/tools/keyboard.ts
+++ b/src/tools/keyboard.ts
@@ -16,7 +16,7 @@ import {
   isBgAutoEnabled,
   TERMINAL_WINDOW_CLASSES,
 } from "../engine/bg-input.js";
-import { getTextViaTextPattern } from "../engine/uia-bridge.js";
+import { getTextViaTextPattern, getTextViaValuePattern } from "../engine/uia-bridge.js";
 import { stripAnsi } from "../engine/ansi.js";
 import { ok } from "./_types.js";
 import type { ToolResult } from "./_types.js";
@@ -716,6 +716,21 @@ export const keyboardTypeHandler = async ({
           const baselineMarker =
             baselineRaw !== null ? makeKeyboardBaselineMarker(stripAnsi(baselineRaw)) : null;
 
+          // Phase 7 F4 fallback: when TextPattern is unavailable on the focused
+          // element (e.g. Win11 New Notepad RichEditD2DPT control implements
+          // ValuePattern but not TextPattern), capture the focused element's
+          // ValuePattern.Value as a baseline so we can do post-injection delta
+          // comparison. Only collected when the TextPattern path is missing
+          // (avoids paying double UIA round-trip cost on the common path).
+          // Phase 6 dogfood F4 finding (`docs/llm-audit/phase6-dogfood-findings.md`).
+          const valueBaseline =
+            verificationNeeded &&
+            baselineMarker === null &&
+            checkText.length > 0 &&
+            !hasEmbeddedNewline
+              ? await getTextViaValuePattern(target.title)
+              : null;
+
           if (replaceAll) postKeyComboToHwnd(target.hwnd, "ctrl+a");
           const result = postCharsToHwnd(target.hwnd, effectiveText);
           if (!result.full) {
@@ -784,10 +799,43 @@ export const keyboardTypeHandler = async ({
               verifyReason = "read_back_unsupported";
             }
           } else if (verificationNeeded) {
-            // verifiable=false reasons (matrix §4.3 enum): TextPattern
-            // baseline missing → read_back_unsupported; embedded newline →
-            // embedded_newline. Empty checkText falls through silently.
-            if (baselineMarker === null && checkText.length > 0) {
+            // Phase 7 F4 fallback: TextPattern baseline missing → try
+            // ValuePattern delta comparison on the focused element. This
+            // catches Win11 New Notepad / RichEdit / other ValuePattern-only
+            // controls that the TextPattern path cannot read.
+            if (
+              baselineMarker === null &&
+              checkText.length > 0 &&
+              !hasEmbeddedNewline &&
+              valueBaseline !== null
+            ) {
+              await new Promise<void>((r) => setTimeout(r, 150));
+              const postValue = await getTextViaValuePattern(target.title);
+              if (postValue !== null) {
+                const containsText = postValue.includes(checkText);
+                const delta = postValue.length - valueBaseline.length;
+                if (containsText) {
+                  // Delivered if length grew (text appended) OR baseline did
+                  // not previously contain checkText (replaceAll / focus-fresh
+                  // shape). Otherwise both sides contain checkText with no
+                  // length change — undetermined, fall back to unverifiable.
+                  if (delta > 0 || !valueBaseline.includes(checkText)) {
+                    verifiedDelivery = true;
+                  } else {
+                    verifyReason = "read_back_unsupported";
+                  }
+                } else {
+                  // postValue does not contain checkText → injection did not
+                  // land in the focused ValuePattern element. Treat as
+                  // not-delivered so caller surfaces BackgroundInputNotDelivered.
+                  verifiedDelivery = false;
+                }
+              } else {
+                verifyReason = "read_back_unsupported";
+              }
+            } else if (baselineMarker === null && checkText.length > 0) {
+              // Both TextPattern and ValuePattern paths unavailable, OR fallback
+              // disabled by guard above (empty checkText / embedded newline).
               verifyReason = "read_back_unsupported";
             } else if (hasEmbeddedNewline) {
               verifyReason = "embedded_newline";

--- a/tests/unit/phase7-f4-value-pattern-fallback.test.ts
+++ b/tests/unit/phase7-f4-value-pattern-fallback.test.ts
@@ -13,6 +13,14 @@
  * is heavy (mocks for spawn, win32, bg-input, perception) — these tests
  * cover the **decision logic** that the integration glue implements.
  *
+ * **Bit-equal invariant (Phase 7 F4 P3-1 Round 1 review)**: the
+ * `classifyValuePatternDelivery` helper below MUST stay bit-equal to
+ * `keyboard.ts:817-832` (BG type path verifiable=false branch). This
+ * file is a copy-test by design (avoids exporting the helper from
+ * keyboard.ts and growing the public API surface for a P3-tier
+ * verification path). If the keyboard.ts logic is touched, mirror the
+ * change here in the same PR.
+ *
  * matrix doc §3.1 line 140 (BG path delivery verification) + §4.2
  * (verifyDelivery hint shape), `docs/llm-audit/phase6-dogfood-findings.md` §F4.
  */

--- a/tests/unit/phase7-f4-value-pattern-fallback.test.ts
+++ b/tests/unit/phase7-f4-value-pattern-fallback.test.ts
@@ -13,10 +13,22 @@
  * is heavy (mocks for spawn, win32, bg-input, perception) — these tests
  * cover the **decision logic** that the integration glue implements.
  *
- * **Bit-equal invariant (Phase 7 F4 P3-1 Round 1 review)**: the
- * `classifyValuePatternDelivery` helper below MUST stay bit-equal to
- * `keyboard.ts:817-832` (BG type path verifiable=false branch). This
- * file is a copy-test by design (avoids exporting the helper from
+ * **Semantic-equivalent invariant (Phase 7 F4 P3-1 Round 1 / P3-2 Round 2
+ * review)**: the `classifyValuePatternDelivery` helper below MUST stay
+ * semantically equivalent to `keyboard.ts:817-838` (BG type path
+ * verifiable=false branch's outer if/else). The mapping is:
+ *   keyboard.ts side                     → test helper return
+ *   ─────────────────────────────────── → ──────────────────
+ *   `verifiedDelivery = true`            → `true`
+ *   `verifyReason = "read_back_unsupported"` (verifiedDelivery stays at
+ *     function-default `"unverifiable"`)  → `"unverifiable"`
+ *   `verifiedDelivery = false`           → `false`
+ * Strictly speaking the source side mutates two variables while the test
+ * helper returns a single discriminated value, so the wording "bit-equal"
+ * is not literally true. Behavior at the caller boundary is identical
+ * (the wrapping handler observes the same `verifiedDelivery` /
+ * `verifyDelivery.reason` pair).
+ * This file is a copy-test by design (avoids exporting the helper from
  * keyboard.ts and growing the public API surface for a P3-tier
  * verification path). If the keyboard.ts logic is touched, mirror the
  * change here in the same PR.

--- a/tests/unit/phase7-f4-value-pattern-fallback.test.ts
+++ b/tests/unit/phase7-f4-value-pattern-fallback.test.ts
@@ -1,0 +1,108 @@
+/**
+ * phase7-f4-value-pattern-fallback.test.ts — Phase 7 F4 unit tests.
+ *
+ * Pins the Phase 6 dogfood F4 fix: when `getTextViaTextPattern` is
+ * unavailable on the focused element (Win11 New Notepad RichEditD2DPT
+ * implements ValuePattern but not TextPattern), the keyboard:type BG
+ * verifyDelivery path now falls back to `getTextViaValuePattern` for
+ * delta-based delivery verification (instead of returning
+ * `unverifiable / read_back_unsupported`).
+ *
+ * The integration glue lives inline in `src/tools/keyboard.ts` BG type
+ * path (post-injection branch). Pure unit testing of the full handler
+ * is heavy (mocks for spawn, win32, bg-input, perception) — these tests
+ * cover the **decision logic** that the integration glue implements.
+ *
+ * matrix doc §3.1 line 140 (BG path delivery verification) + §4.2
+ * (verifyDelivery hint shape), `docs/llm-audit/phase6-dogfood-findings.md` §F4.
+ */
+
+import { describe, it, expect } from "vitest";
+
+/**
+ * Pure helper mirroring the inline ValuePattern fallback logic in
+ * keyboard.ts BG type path. Extracted as a pure function so the
+ * branching can be unit tested independently of the heavy handler
+ * surroundings (spawn / win32 / bg-input / perception mocks).
+ *
+ * Returns:
+ *  - true       — delivered (postValue includes checkText AND length grew
+ *                 OR baseline did not previously contain checkText)
+ *  - false      — not delivered (postValue does NOT include checkText)
+ *  - "unverifiable" — both sides contain checkText with no length change
+ *                 (corner case: user re-typed same content; treat as undetermined)
+ */
+function classifyValuePatternDelivery(
+  valueBaseline: string,
+  postValue: string,
+  checkText: string,
+): true | false | "unverifiable" {
+  const containsText = postValue.includes(checkText);
+  const delta = postValue.length - valueBaseline.length;
+  if (containsText) {
+    if (delta > 0 || !valueBaseline.includes(checkText)) {
+      return true;
+    }
+    return "unverifiable";
+  }
+  return false;
+}
+
+describe("Phase 7 F4: ValuePattern fallback delivery classification", () => {
+  it("empty baseline + checkText appended → delivered (Win11 Notepad common case)", () => {
+    // Win11 New Notepad scenario: TextPattern returns null, ValuePattern works.
+    // baseline = "" (empty buffer), post = "hello world" (typed text).
+    expect(classifyValuePatternDelivery("", "hello world", "hello world")).toBe(true);
+  });
+
+  it("non-empty baseline + checkText appended → delivered (length grew)", () => {
+    expect(classifyValuePatternDelivery("existing\n", "existing\nhello world", "hello world")).toBe(true);
+  });
+
+  it("replaceAll case (baseline replaced by checkText) → delivered (baseline did not contain text)", () => {
+    // Ctrl+A then type "hello world" replaces previous content. delta < 0
+    // (length shrunk), but baseline did not contain "hello world".
+    expect(classifyValuePatternDelivery("existing", "hello world", "hello world")).toBe(true);
+  });
+
+  it("postValue does not contain checkText → not delivered (BackgroundInputNotDelivered)", () => {
+    // Buffer unchanged or unrelated content remained — surface
+    // BackgroundInputNotDelivered to caller.
+    expect(classifyValuePatternDelivery("existing", "existing", "hello world")).toBe(false);
+  });
+
+  it("postValue partially contains checkText (delivery dropped chars) → not delivered", () => {
+    // Caller sent "hello world", post-state shows "hell" — clearly partial.
+    expect(classifyValuePatternDelivery("", "hell", "hello world")).toBe(false);
+  });
+
+  it("baseline already contains checkText AND length unchanged → unverifiable (corner case)", () => {
+    // User re-typed exactly what was already there. Cannot disambiguate
+    // delivery from no-op without an edit-event observer.
+    expect(classifyValuePatternDelivery("hello world", "hello world", "hello world")).toBe("unverifiable");
+  });
+
+  it("baseline already contains checkText AND length grew → delivered (re-type, content appended)", () => {
+    // Defensive: even if baseline contained checkText, growth means new
+    // content was actually appended somewhere.
+    expect(classifyValuePatternDelivery("hello world", "hello worldhello world", "hello world")).toBe(true);
+  });
+
+  it("checkText with embedded substring of baseline (no growth) → unverifiable", () => {
+    // baseline = "hello", post = "hello", checkText = "hello" — same value.
+    // Cannot tell if the user pressed Backspace then re-typed "hello" or
+    // just kept the original. Mark unverifiable rather than false-positive.
+    expect(classifyValuePatternDelivery("hello", "hello", "hello")).toBe("unverifiable");
+  });
+
+  it("multi-line growth with checkText included → delivered", () => {
+    expect(classifyValuePatternDelivery("line1\n", "line1\nhello world\nmore", "hello world")).toBe(true);
+  });
+});
+
+describe("Phase 7 F4: getTextViaValuePattern shape", () => {
+  it("uia-bridge exports getTextViaValuePattern", async () => {
+    const mod = await import("../../src/engine/uia-bridge.js");
+    expect(typeof mod.getTextViaValuePattern).toBe("function");
+  });
+});


### PR DESCRIPTION
## Summary

Phase 7 carry-over fix #4 (final): Phase 6 dogfood F4 finding を production code 改修で fix。`keyboard({action:'type', method:'background'})` BG path で TextPattern が focused element 上で利用不可な control (Win11 New Notepad の RichEditD2DPT 等 ValuePattern-only な surface) において、verifyDelivery が `unverifiable / read_back_unsupported` で degrade してしまう contract 弱点を解消。

## Why this matters (北極星 silent-success / contract drift = 0)

Phase 6 dogfood で観察された Win11 New Notepad scenario:
- 旧 behavior:
  - `ok:true, typed:11, method:\"background\", channel:\"wm_char\"` ✓
  - 実 delivery 成功: `post.focusedElement.value: \"hello world\"` ✓
  - **`hints.verifyDelivery: {status:\"unverifiable\", reason:\"read_back_unsupported\"}`** (ValuePattern を読みに行かないため degraded hint)
- 新 behavior (本 PR):
  - `ok:true, typed:11, method:\"background\", channel:\"wm_char\"` ✓
  - **`hints.verifyDelivery: {status:\"delivered\", channel:\"wm_char\"}`** (ValuePattern fallback で delta 比較成功)

matrix doc §3.1 line 140 の forward-looking 記述「UIA TextPattern / ValuePattern read-back」が本 PR で initial alignment 達成。

## Changes

### Production code

| File | Change |
|---|---|
| `src/engine/uia-bridge.ts:1217-1295` | 新 helper `getTextViaValuePattern(windowTitle)` 追加。focused element の ValuePattern.Value を返す PowerShell-backed 関数、TreeWalker で focused 要素が target window の toplevel HWND 内に居ることを scoping、64-step parent walk guard で無限ループ防御 |
| `src/tools/keyboard.ts:712+786` | BG type path で valueBaseline を pre-injection 時に capture (TextPattern baseline 失敗時のみ、double UIA round-trip cost 回避)、verifiable=false 経路で ValuePattern delta 比較 fallback 実装 |

### Decision logic (pure helper、unit test pin)

ValuePattern fallback の delivery 判定:
- `postValue.includes(checkText)` AND (`delta > 0` OR `!baseline.includes(checkText)`) → **delivered**
- `postValue.includes(checkText)` AND `delta == 0` AND baseline 既含 → **unverifiable** (corner case)
- `!postValue.includes(checkText)` → **not delivered** (BackgroundInputNotDelivered surface)

### Tests

- `tests/unit/phase7-f4-value-pattern-fallback.test.ts` 新規 10 case で classify decision logic + uia-bridge export shape を pin
- 既存 keyboard tests 48/48 維持
- F3 + producer pin 8/8 維持

## Path A 完了

Phase 7 carry-over 4 PR 全完了:

- [x] **F5**: launcher-macro.md scenario doc fix (PR #230)
- [x] **catalog reconcile**: ADR-010 §5.4 14 entries cascade sync (PR #231)
- [x] **F3**: workspace_launch SpawnFailed typed code (PR #232)
- [x] **F4 (本 PR)**: keyboard verifyDelivery ValuePattern fallback

Merge 後 v1.4.1 patch release を実施 (`docs/release-process.md` 8 step protocol)、その後 ISSUE 整理。

## Test plan

- [x] vitest F4 unit (10 case): pass
- [x] vitest existing keyboard (48 case): pass
- [ ] CI build / CodeQL / docker-build pass
- [ ] Opus phase-boundary review (production code 改修 PR、§3.3 Step 0 = Opus 1+ round + Codex 推奨)
- [ ] Codex review (production code 改修なので推奨、@codex review)
- [ ] dogfood gate (release-process.md Preflight): v1.4.1 release 前に Win11 Notepad で実機検証

## Caveats / risk

- **実機検証は v1.4.1 release dogfood gate で実施予定**: Win11 New Notepad での `keyboard({action:'type', method:'background'})` 実行で `hints.verifyDelivery.status === 'delivered'` 取得を確認
- **scope shrink check (§3.2)**: ValuePattern fallback は **既存 caller の挙動を破壊しない** (TextPattern path 成功時は完全 untouched、失敗時のみ追加の verification path)。`BackgroundInputNotDelivered` surface 経路も既存と同型。

🤖 Generated with [Claude Code](https://claude.com/claude-code)