### PR TITLE
spike(wt-bg): Round 3 — NO-GO for AttachConsole + WriteConsoleInputW

### DIFF
--- a/docs/adr-013-wt-bg-input.md
+++ b/docs/adr-013-wt-bg-input.md
@@ -153,6 +153,14 @@ pub fn wt_close(handle: TerminalHandle) -> Result<(), WtError>;
 
 参考: <https://learn.microsoft.com/en-us/windows/console/createpseudoconsole> — `CreatePseudoConsole` は新規 console 作成専用、既存への write は別途 API 探索が必要。
 
+**Phase 0 preliminary findings (issue #185 spike `AttachConsole + WriteConsoleInputW`、2026-05-10、commit `d8b3c07` + Round 3 PeekConsoleInputW 裏取り)**:
+
+- conhost.exe を直接 invoke した cmd.exe (Win11 25H2 build 26200、DefTerm CLSID `{00000000-0000-0000-0000-000000000000}` "Let Windows decide") でも legacy `WriteConsoleInputW` 経路は consumer に届かず:
+  - Round 1 (UnicodeChar only): `records_written=64/64`, sentinel 不在
+  - Round 2 (proper VK + scan code、両 encoding): `records_written=92/92` (keydown_keyup) / `60/60` (keydown)、両者 sentinel 不在
+  - Round 3 (PeekConsoleInputW 裏取り、Opus 判定 (C)): `records_written=92/92` で API success だが直後 `pending_events=0` / `peeked_records=0` (書込直後即 drained、consumer 未到達を構造的に証明)
+- 結論: `AttachConsole + CONIN$ + WriteConsoleInputW` は WT BG input 候補として **NO-GO 確定**。Day 0 gate 探索は (1) `ITerminalConnection::WriteInput` 相当の WinRT 公式 API、(2) Microsoft.Terminal.Core の attach surface に絞り込む。詳細は `docs/wt-attachconsole-spike-results.md`
+
 ### 3.2 Option B: UIA writable pattern inventory POC
 
 **重要な API 訂正**: UIA `TextPattern` は **基本的に読み取り系** (`GetText` / `RangeFromPoint` 等)、書き込み系は **`ValuePattern.SetValue`** が canonical。Microsoft docs でも複数行 / Document 系コントロールは ValuePattern 非対応になる傾向 (TerminalControl のような complex control では特に該当)。
@@ -312,6 +320,7 @@ Phase 0 (Option D 検証) 完了後に本表を re-ranking。現時点 (Phase 0 
 ## 7. Open Questions
 
 1. **Option A Day 0 gate**: `microsoft/terminal` repo / WinRT metadata で「既存 WT tab への公式 write 経路」(`ITerminalConnection::WriteInput` 相当) は存在するか? 不在なら Option A は即 Rejected
+   - 本 OQ の探索範囲から legacy `WriteConsoleInputW` 経路を **除外** (Phase 0 preliminary findings、2026-05-10 spike `docs/wt-attachconsole-spike-results.md` で NO-GO 確定済)
 2. **Option B Phase 1 inventory**: TerminalControl で writable UIA pattern (`ValuePattern` / `TextEditPattern` / `SynchronizedInputPattern` / その他) は実装されているか? 実機 inspect.exe / UIA Spy で確認
 3. **Option D Phase 0 evidence matrix**: m13v 提案の crash / AV / 署名 / 権限 / WT 更新の 5 軸検証結果は採用判断にどう寄与する? 「許容できる」閾値を §5.0 で具体化必要 (例: AV 警告ゼロ / WT 1 minor 更新 5 回連続でも broken なし / etc.)
 4. **複数 WT window への BG injection は対応するか?** 単一 WT process が複数 top-level window + 各 window 内複数 tab を持つ構造 (本 session 2026-05-10 の dogfood で screenshot 観測)、targeting policy (windowTitle 優先 / hwnd 必須化 / process+tab 階層 ID) を別途設計
@@ -344,6 +353,7 @@ Phase 0 (Option D 検証) 完了後に本表を re-ranking。現時点 (Phase 0 
 | 2026-05-10 | Draft (v1) | Claude (Sonnet draft) | issue #185 Phase 4 stretch tracking、4 option (A/B/C/D) 起草 |
 | 2026-05-10 | Draft (v1.1、Round 1 Opus review apply) | Claude (Sonnet) + Opus (Round 1 review) | P1×2 (PR #237 mis-citation / wt_xaml_pipeline SSOT cross-ref) + P2×5 (Option A Pros hedging / Option B 工数 / 再 review 日付 / §4 directive tone / silent-success 構造的証明) + P3×3 (Authors / Phase 5 工数 / Decision History / licensing) を反映 |
 | 2026-05-10 | Draft (v1.2、user review apply) | Claude (Sonnet) + user review | P1×2 (Option A の `WritePseudoConsole` 公式 API 不在訂正 + Option D を Rejected → Phase 0 m13v validation POC へ position 変更) + P2×3 (DTM_E2E_WT default-on 化 issue #175 反映 / TextPattern.SetValue → ValuePattern.SetValue API 訂正 + UIA writable pattern inventory POC 化 / canInjectViaPostMessage 復帰ではなく `backgroundChannel` discriminator field) を反映、Roadmap を 4 phase (Phase 0 D 検証 → Phase 1 A/B/C 再ランキング → Phase 2 選定 POC → Phase 3 本実装) に restructure。提案者 m13v 氏に敬意を払い、Phase 0 を「採用ではなく実験で評価」と明示 |
+| 2026-05-10 | Draft (v1.3、Option A spike preliminary findings embed) | Claude (Sonnet) + Opus reviewer | spike `AttachConsole + WriteConsoleInputW` (`spike/wt-attachconsole-input` branch、commit `d8b3c07` + Round 3) で NO-GO 確定。§3.1 末尾に preliminary findings embed + §7 OQ #1 に「legacy 経路除外」追記。詳細 `docs/wt-attachconsole-spike-results.md`。Option B/C/D の ranking には影響なし |
 | (future) | Draft → Accepted/Rejected | (TBD) | Phase 0 evidence + Phase 1 ranking 結果に応じて昇格 / Reject |
 | (future) | Re-review trigger | 2026-11-10 | header の binding marker、本日に達した時点で必須 |
 

--- a/docs/wt-attachconsole-spike-prompt.md
+++ b/docs/wt-attachconsole-spike-prompt.md
@@ -1,0 +1,262 @@
+# Windows Terminal BG Input Spike Prompt — AttachConsole + WriteConsoleInputW
+
+> 2026-05-10
+>
+> Purpose: give Claude/Codex enough context, evidence, and guardrails to run a
+> short spike for issue #185's last live-session input candidate:
+> `AttachConsole(shellPid)` + `CONIN$` + `WriteConsoleInputW`.
+
+---
+
+## Copy-Paste Prompt For Claude
+
+You are working in `D:\git\desktop-touch-mcp`.
+
+Please run a focused spike for Windows Terminal background input using
+`AttachConsole` + `CONIN$` + `WriteConsoleInputW`.
+
+### Context
+
+`terminal({action:'send'})` used to treat Windows Terminal
+(`CASCADIA_HOSTING_WINDOW_CLASS`) as compatible with background `WM_CHAR`
+`PostMessage`. That was wrong: WT's WinUI/XAML input pipeline silently swallows
+those messages. The current code intentionally rejects WT for the `wm_char`
+background path and falls back to foreground input.
+
+Issue #185 is the stretch follow-up: can we recover a foreground-independent
+input path for an existing live Windows Terminal pane?
+
+Prior alternatives:
+
+- UIA writable text path is effectively ruled out. WT exposes readable
+  `TextPattern` for terminal content, but not a writable text surface.
+- Direct ConPTY handle access is unattractive because desktop-touch-mcp is a
+  sibling process of WT, not the ConPTY owner/parent. There is no clean
+  pseudo-console handle path without parent ownership, handle duplication from
+  the owner, elevation, injection, or a helper that created the session.
+- Remoting (`WSMan` / SSH PowerShell remoting) is clean for BG command
+  execution, but it is not live WT pane input.
+
+This spike investigates one remaining live-session idea:
+
+> If we can identify the real console client process behind the visible WT pane
+> (for example `pwsh.exe`, `powershell.exe`, or `cmd.exe`), can a helper process
+> call `AttachConsole(pid)`, open `CONIN$`, write `KEY_EVENT_RECORD`s with
+> `WriteConsoleInputW`, detach, and then verify through existing
+> `terminal_read`?
+
+This is explicitly uncertain. Treat it as a Go/No-Go experiment, not as a
+feature implementation.
+
+### Evidence To Use
+
+Use these references as the basis for the spike notes:
+
+- `AttachConsole` attaches the calling process to another process's console as
+  a client application:
+  https://learn.microsoft.com/en-us/windows/console/attachconsole
+- A process can attach to one console, and a console can have many attached
+  processes:
+  https://learn.microsoft.com/en-us/windows/console/attaching-to-a-console
+- A console consists of an input buffer and screen buffers; any number of
+  processes can share a console:
+  https://learn.microsoft.com/en-us/windows/console/consoles
+- `CONIN$` can be opened with `CreateFile` to get a handle to the console input
+  buffer, even when standard handles are redirected:
+  https://learn.microsoft.com/en-us/windows/console/console-handles
+- The console input buffer is a queue of input records. Low-level input
+  functions can read records from it or place records into it:
+  https://learn.microsoft.com/en-us/windows/console/console-input-buffer
+- `WriteConsoleInput` writes `INPUT_RECORD` data directly to the console input
+  buffer, but Microsoft marks it as legacy/not recommended for new products and
+  warns it can fail conceptually for remoting/cross-platform transports:
+  https://learn.microsoft.com/en-us/windows/console/writeconsoleinput
+- `GetConsoleProcessList` retrieves processes attached to the current console,
+  but Microsoft notes the state is local/session/privilege-context specific:
+  https://learn.microsoft.com/en-us/windows/console/getconsoleprocesslist
+- Pseudoconsole sessions are created by the host before the child character-mode
+  process is launched; this is why direct ConPTY access is not assumed available
+  from a sibling MCP process:
+  https://learn.microsoft.com/en-us/windows/console/creating-a-pseudoconsole-session
+- Current repo context:
+  - `src/tools/terminal.ts`
+  - `src/engine/bg-input.ts`
+  - `src/engine/win32.ts`
+  - `src/win32/input.rs`
+  - `src/win32/process.rs`
+  - `docs/terminal-integration-plan.md`
+  - issue #185: https://github.com/Harusame64/desktop-touch-mcp/issues/185
+
+### Non-Goals
+
+- Do not modify the production `terminal_send` behavior yet.
+- Do not wire a public MCP tool yet.
+- Do not inject into the user's arbitrary existing terminal before the
+  controlled launch scenario passes.
+- Do not require admin/elevation, DLL injection, handle stealing, or moving
+  existing tags/releases.
+- Do not treat WSMan/SSH remoting as the same thing as live WT pane input.
+
+### Safety Rules
+
+- Use only controlled terminals launched for this spike.
+- Send harmless sentinel commands only, such as:
+  - PowerShell: `Write-Output "__DTM_ATTACHCONSOLE_SPIKE_<guid>__"`
+  - cmd: `echo __DTM_ATTACHCONSOLE_SPIKE_<guid>__`
+- Never send secrets, destructive commands, credential prompts, or clipboard
+  content.
+- Always verify delivery by reading the terminal buffer after the write.
+- Always call `FreeConsole` after any `AttachConsole` attempt.
+- If a candidate process is elevated and the MCP/helper process is not, record
+  the privilege mismatch and skip.
+
+### Suggested Spike Shape
+
+1. Create a scratch branch or keep all code in an uncommitted scratch path.
+   Prefer a tiny helper under `scripts/spikes/` or a native-only temporary
+   export. Keep the production tool surface untouched.
+
+2. Establish a conhost baseline:
+   - Launch a controlled `cmd.exe` or `powershell.exe` in legacy conhost if
+     possible.
+   - Find its PID.
+   - `AttachConsole(pid)`.
+   - `CreateFileW(L"CONIN$", GENERIC_READ | GENERIC_WRITE,
+     FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0, NULL)`.
+   - Write a sentinel command using `WriteConsoleInputW`.
+   - Detach with `FreeConsole`.
+   - Verify the sentinel appears in the terminal using existing read logic.
+   - If this baseline fails, fix the helper before testing WT.
+
+3. Controlled Windows Terminal test:
+   - Launch a unique WT tab:
+     `wt.exe new-tab --title DTM-ATTACHCONSOLE-SPIKE -- powershell.exe -NoLogo -NoExit`
+   - Find the top-level WT window by title/class.
+   - Build the process parent map using the existing process helpers or
+     `Get-CimInstance Win32_Process` as temporary discovery.
+   - Enumerate candidate descendant/sibling processes around that WT window:
+     `WindowsTerminal.exe`, `OpenConsole.exe`, `conhost.exe`, `pwsh.exe`,
+     `powershell.exe`, `cmd.exe`, `wsl.exe`.
+   - For each plausible shell/client PID, attempt:
+     - `FreeConsole()` first, to clear any current attachment.
+     - `AttachConsole(candidatePid)`.
+     - `GetConsoleProcessList()` and log attached PIDs.
+     - Open `CONIN$`.
+     - Write a unique sentinel command.
+     - `FreeConsole()`.
+     - Verify via `terminal_read` / UIA read-back.
+
+4. Try at least these variants:
+   - `powershell.exe` in WT
+   - `cmd.exe` in WT
+   - `pwsh.exe` in WT, if installed
+   - WSL only as optional, likely No-Go or separate follow-up
+
+5. Try two `KEY_EVENT_RECORD` encodings:
+   - Key-down records only, with `UnicodeChar` set and `wRepeatCount = 1`.
+   - Key-down + key-up pairs, with `VK_RETURN` / `'\r'` for Enter.
+   Record which one works. Prefer the least surprising Windows-console shape
+   if both work.
+
+6. Record failure modes precisely:
+   - `AttachConsole` failed: `GetLastError` value and candidate PID/name.
+   - `CONIN$` open failed: `GetLastError`.
+   - `WriteConsoleInputW` failed or wrote fewer records than expected.
+   - Write API succeeded, but sentinel did not appear.
+   - Sentinel appeared in the wrong pane/window.
+   - Multi-pane/tab mapping is ambiguous.
+
+### Acceptance Criteria
+
+Go only if all of these are true:
+
+- A controlled WT PowerShell tab receives a sentinel command without WT becoming
+  foreground.
+- Delivery can be verified with current `terminal_read` / UIA read-back.
+- The candidate PID can be chosen deterministically for a normal single-pane WT
+  window.
+- Failures are observable as typed errors, not silent `ok:true`.
+- The path does not require elevation, injection, or being WT's parent process.
+
+No-Go if any of these are true:
+
+- We cannot map WT window/tab/pane to the correct console client process.
+- It works only for terminals created by our helper, not for user-created WT
+  sessions.
+- It can write to a console, but not the currently visible pane.
+- Multi-pane WT can silently route input to the wrong pane.
+- It depends on admin/elevation, injected helper code, or private WT internals.
+- It succeeds at the API layer but cannot be reliably verified.
+
+### Deliverable
+
+Write a concise result note, preferably `docs/wt-attachconsole-spike-results.md`,
+with:
+
+- environment details: Windows version, WT version if available, shell versions,
+  elevated vs non-elevated
+- test matrix:
+
+| host | shell | candidate PID strategy | AttachConsole | CONIN$ | WriteConsoleInputW | verified | notes |
+|---|---|---|---|---|---|---|---|
+
+- final recommendation:
+  - `GO`: propose a scoped implementation plan
+  - `NO-GO`: close this candidate and keep #185 ranking as remoting for BG-only
+    execution, foreground for live WT input
+  - `MAYBE`: list the single blocking unknown and the next shortest test
+
+Keep the write-up explicit about the distinction between:
+
+- live WT pane input
+- BG command execution through remoting
+- terminals created/owned by desktop-touch-mcp
+
+---
+
+## Design Notes For Reviewers
+
+### Why This Idea Exists
+
+The failed WT path was HWND-level `PostMessage(WM_CHAR)`. WT's UI pipeline does
+not consume those messages as terminal input. This spike deliberately moves down
+one layer: instead of sending messages to WT's top-level window, it tries to
+write keyboard records into the console input buffer associated with the shell
+process hosted by WT/ConPTY.
+
+The idea is plausible because the Windows Console documentation says a console
+has an input buffer, multiple processes can share a console, `AttachConsole`
+can attach a process to another process's console, and `WriteConsoleInputW` can
+place input records into that buffer.
+
+The idea is risky because Microsoft positions these low-level console APIs as
+legacy/local-console mechanisms, not a modern cross-platform transport. It may
+also be impossible to map a WT top-level window to the right active pane's
+console client process without WT-private state.
+
+### Expected Product Decision
+
+This should remain a spike until proven. Even if the API writes successfully,
+the product decision should be conservative:
+
+- `terminal_send(method:'auto')` must not switch to this path until delivery is
+  verified and routing is deterministic.
+- Any future implementation needs a post-send verification step, mirroring the
+  silent-success audit policy from #173/#184.
+- If pane mapping is ambiguous, the path can at most be an opt-in/debug-only
+  experimental route, not a default route.
+
+### Likely Implementation Location If It Works
+
+If the spike passes, the real implementation probably belongs in the native
+Win32 layer, not the TypeScript `bg-input.ts` PostMessage helper:
+
+- Rust/native exports under `src/win32/console.rs` or similar
+- TypeScript wrapper in `src/engine/win32.ts`
+- Routing logic in `src/tools/terminal.ts`
+- tests covering positive conhost, positive/negative WT, explicit failure
+  codes, and verification behavior
+
+Do not build this production surface until the result note demonstrates a
+controlled WT success.
+

--- a/docs/wt-attachconsole-spike-results.md
+++ b/docs/wt-attachconsole-spike-results.md
@@ -1,0 +1,127 @@
+# wt-attachconsole Spike Results — NO-GO
+
+> 2026-05-10
+>
+> Issue #185 / ADR-013 §3.1 Option A "ConPTY 経路" の preliminary investigation。
+> Spike prompt: `docs/wt-attachconsole-spike-prompt.md`、親 ADR: `docs/adr-013-wt-bg-input.md`。
+> Branch: `spike/wt-attachconsole-input`、commits: `6ccd9b5` (Round 1) → `d8b3c07` (Round 2) → Round 3 (PeekConsoleInputW 裏取り、本 PR で land 予定)。
+
+---
+
+## 1. Recommendation: **NO-GO**
+
+`AttachConsole(targetPid)` + `CONIN$` open + `WriteConsoleInputW` は Win11 25H2 で **既存 cmd.exe / pwsh.exe shell に input を inject する経路として機能しない**。conhost-baseline すら通らないため、spike prompt §"Suggested Spike Shape" step 2 gating clause により WT testing は skip。
+
+ADR-013 §3.1 Option A ("ConPTY 経路") の Day 0 gate 探索範囲から本経路を **除外** することを推奨。Option A の Day 0 gate は `ITerminalConnection::WriteInput` 相当の WinRT 公式 API / Microsoft.Terminal.Core attach surface に絞り込む。Option B (UIA writable pattern inventory) / Option C (PSRemoting) / Option D (m13v community proposal validation) は別 path のため本 NO-GO の影響を受けない。
+
+---
+
+## 2. Environment
+
+| 項目 | 値 |
+|---|---|
+| OS | Microsoft Windows 11 Home, 10.0.26200.8328 (25H2) |
+| Windows Terminal | 1.24.10921.0 (x64) |
+| pwsh | 7.6.1 |
+| cmd.exe | Windows Version 10.0.26200.8328 |
+| DefTerm CLSID (`HKCU:\Console\%%Startup` `DelegationConsole`) | `{00000000-0000-0000-0000-000000000000}` ("Let Windows decide") |
+| Session privilege | Non-elevated (`GAMING_PC\harus`) |
+| Helper / orchestrator host | pwsh 7.6.1 (Add-Type C# inline P/Invoke) |
+
+DefTerm CLSID `{00000000-0000-0000-0000-000000000000}` は Win11 default の "Let Windows decide" 状態。Win11 25H2 では実質 WT (= ConPTY backed) が default terminal application として選ばれることが多く、`Start-Process conhost.exe -ArgumentList @('cmd.exe', '/K', '...')` のように conhost.exe を直接 invoke しても **DefTerm 解決を経由する場合がある** (詳細は §4 Technical Explanation 参照)。
+
+---
+
+## 3. Test Matrix
+
+候補 PID strategy (conhost 行共通): `Get-CimInstance Win32_Process -Filter "ParentProcessId=$conhostPid AND Name='cmd.exe'"`、AttachConsole 結果 `attached_pids=[helper, target]`、CONIN$ handle 全 round で valid。UIA TextPattern 読戻し時の buffer 末尾は全 round で `D:\git\desktop-touch-mcp>` prompt のみ (sentinel 不在)。
+
+| # | host | shell | round | encoding | WriteConsoleInputW (records_written/attempted) | PeekConsoleInputW (post-write) | verified | notes |
+|---|---|---|---|---|---|---|---|---|
+| 1 | conhost (`Start-Process conhost.exe cmd.exe /K title <tag>`) | cmd.exe | Round 1 | UnicodeChar only (`VK=0`, `scan=0`, `wRepeatCount=1`) | ✓ 64/64 | (not measured、Round 1 は helper に未注入) | ✗ | 仮説: line reader が VK metadata を必要とする → 失敗で Round 2 の根拠化 |
+| 2 | conhost | cmd.exe | Round 2 | keydown_keyup (proper VK via `VkKeyScanW` + scan code via `MapVirtualKeyW`、必要時 Shift state) | ✓ 92/92 | (not measured、Round 3 で追加注入) | ✗ | sentinel 不在で encoding 仮説不成立、Opus 諮問で Round 3 (PeekConsoleInputW 裏取り) を判定 |
+| 3 | conhost | cmd.exe | Round 2 | keydown (proper VK + scan code、key_up なし) | ✓ 60/60 | (not measured) | ✗ | spike-prompt §"Suggested Spike Shape" step 5 で要求された両 encoding 比較、結果同型 |
+| 4 | conhost | cmd.exe | Round 3 | keydown_keyup + PeekConsoleInputW + GetNumberOfConsoleInputEvents | ✓ 92/92 | **`pending_events=0` / `peeked_records=0` / `peek_win32_error=0`** (書込直後即 drained) | ✗ | **decisive evidence**: API 層は全 success だが入力は consumer (cmd.exe line reader) に届かない。詳細 §4 |
+| 5 | WT (`wt.exe -w <unique> new-tab --title <tag> -- powershell.exe -NoLogo -NoExit`) | pwsh.exe | (not run) | — | — | — | — | **spike-prompt §"Suggested Spike Shape" step 2 gating clause で skip** (`If this baseline fails, fix the helper before testing WT.`)。conhost-baseline で同型 NO-GO 確定済のため WT を試す technical value ゼロ + candidate filter leak risk (orchestrator §wt-controlled の `Get-CimInstance Win32_Process -Filter "Name='powershell.exe' OR ..."` は user の既存 PS shells を leak する既知問題、§5 Carry-over) |
+
+### 3.1 Round 結果の意味
+
+- **Round 1 (UnicodeChar only encoding)**: `VirtualKeyCode = 0`, `wVirtualScanCode = 0`, `UnicodeChar = '<char>'`, `wRepeatCount = 1` の INPUT_RECORD。仮説: cooked-mode line reader が VK metadata を必要とする可能性 → 失敗
+- **Round 2 (proper VK + scan code)**: `VkKeyScanW(ch)` で proper VK、`MapVirtualKeyW(MAPVK_VK_TO_VSC)` で scan code、必要に応じて Shift state。`keydown_keyup` (key_down + key_up pair) と `keydown` (key_down のみ) 両 encoding を試行 → 両方失敗 (sentinel 不在)
+- **Round 3 (PeekConsoleInputW 裏取り)**: WriteConsoleInputW 直後に `GetNumberOfConsoleInputEvents` + `PeekConsoleInputW` で buffer 状態を確認 → `pending_events=0`, `peeked_records=0`, `peek_win32_error=0`。書いたはずの 92 records が即座に消えていることを **構造的に証明**
+
+### 3.2 Round 3 result JSON (decisive evidence、conhost-baseline keydown_keyup)
+
+```json
+{
+  "helper": {
+    "ok": true,
+    "step": "WriteConsoleInputW success",
+    "win32_error": 0,
+    "records_attempted": 92,
+    "records_written": 92,
+    "attached_pids": [20576, 31292],
+    "peek_ok": true,
+    "pending_events": 0,
+    "peeked_records": 0,
+    "peek_win32_error": 0,
+    "peeked_summary": [],
+    "key_encoding": "keydown_keyup"
+  },
+  "readback_observed": true,
+  "sentinel_found": false
+}
+```
+
+`records_written=92` は API 報告、`pending_events=0` / `peeked_records=0` は同 handle で immediately 後の peek 結果。**書込から peek まで PowerShell の同期実行で <1ms**、cmd.exe の line reader が consume するには時間が短すぎ、かつ buffer が空になっている事実は cmd.exe ではない別経路 (= ConPTY が swallowing) が drain していることを示唆。
+
+---
+
+## 4. Technical Explanation
+
+Win11 では cmd.exe / pwsh.exe を `conhost.exe` 経由で invoke しても、DefTerm 設定により実 host が WT (ConPTY backed) になることがある。本環境の DefTerm CLSID は `{00000000-0000-0000-0000-000000000000}` ("Let Windows decide") で、Win11 25H2 build 26200 では WT が default として解決される高い probability。
+
+ConPTY (Pseudo Console) model では shell プロセスは **pseudo-console pipe (stdin handle)** から input を読み、legacy `CONIN$` 経由 input buffer は ConPTY ホスト (WT) が forwarding しない限り **vestigial** になる。`AttachConsole(targetPid)` + `CONIN$` open + `WriteConsoleInputW` は API 層では全て success (ERROR_SUCCESS, `records_written = N attempted`) を返すが、書かれた INPUT_RECORD は ConPTY pipe に forward されず、shell の line reader / PSReadLine に届かない。
+
+Round 3 の PeekConsoleInputW 結果 (`pending_events=0` / `peeked_records=0`) は次のいずれかを示す:
+
+1. **CONIN$ handle が共有 input buffer の "old" alias** で、ConPTY environment では server-side で同期的に discarded (consumer 不在経路)
+2. ConPTY infrastructure が WriteConsoleInputW を hook して silently drain している (forwarding なしで ack)
+
+いずれにせよ、Round 1 (UnicodeChar only) と Round 2 (proper VK + scan code、両 encoding) で **encoding を変えても同じ symptom** が出ることから、これは encoding 不足ではなく **input buffer が consume 経路と切断されている** 構造的問題。Microsoft 公式 docs (`writeconsoleinput`) も「We do not recommend this function for new code.」+ 「[fails] conceptually... cross-platform transports」と明記、modern transport (ConPTY 含む) に対しては設計外。
+
+---
+
+## 5. Carry-over Open Questions
+
+本 spike scope を超える / 後続 follow-up に持ち越す未解決事項:
+
+- **OQ-1: orchestrator candidate filter leak (wt-controlled mode)**: `wt-attachconsole-orchestrator.ps1:318` の `Get-CimInstance Win32_Process -Filter "Name='powershell.exe' OR Name='pwsh.exe' OR Name='cmd.exe'"` は user の既存 PS shells を candidate に含めるため、process tree 確認で filter しないと user terminal を巻き込む risk。本 spike では NO-GO 確定で WT mode 不実行のため未顕在化、将来 ADR-013 §3.1 Option A の Day 0 gate pass で別 spike を走らせる場合は「spike launch 時刻以後に start した shell」+「process tree が spike WT process を含む」の 2 段 gate で構造的に解決必要
+- **OQ-2: Stop-ProcessTreeSafe cleanup miss (Win11 DefTerm 経由)**: `wt-attachconsole-orchestrator.ps1:255-257` で conhost / cmd.exe の PID を kill するが、DefTerm 経由で実 host が WT になっている場合 user の既存 WT (shared) を kill する選択は不適切 (本 spike は意図的に避けた)。将来 spike では `Get-Process -Id $X -ErrorAction SilentlyContinue` の冪等 sweep + WT process は kill 対象外の明示で解決
+- **OQ-3: 別 transport (Option B / D) との trade-off**: 本 NO-GO で ADR-013 §3.1 Option A の preliminary findings は確定したが、§3.2 Option B (UIA writable pattern inventory) と §3.4 Option D (m13v proposal Phase 0 validation) との ranking は未着手。Phase 1 acceptance (`adr-013-wt-bg-input.md` §5.1) で各 path の gate を順次走らせて再評価
+- **OQ-4: WSL / SSH terminal inside WT への AttachConsole**: 本 spike scope 外、Option C (別経路) の sub-case で別 issue 候補
+
+---
+
+## 6. Microsoft Documentation References
+
+- `WriteConsoleInput` API: <https://learn.microsoft.com/en-us/windows/console/writeconsoleinput>
+  - Microsoft 自身が "We do not recommend this function for new code." + remoting/cross-platform transport 非対応を明記
+- `AttachConsole` API: <https://learn.microsoft.com/en-us/windows/console/attachconsole>
+- ConPTY (Pseudo Console) session creation: <https://learn.microsoft.com/en-us/windows/console/creating-a-pseudoconsole-session>
+  - 新規 console 作成 API、既存 console への外部 write は別途 API 探索が必要 (ADR-013 §3.1 Day 0 gate 対象)
+- ConPTY 設計理念 (devblog): <https://devblogs.microsoft.com/commandline/windows-command-line-introducing-the-windows-pseudo-console-conpty/>
+  - legacy console API との関係、なぜ modern transport が pipe-based か
+- DefTerm 設定 (Win11): <https://learn.microsoft.com/en-us/windows/terminal/install#set-your-default-terminal-application>
+
+---
+
+## 7. Decision History
+
+| Date | Decision | Author | Rationale |
+|---|---|---|---|
+| 2026-05-10 | Round 1 実施 (UnicodeChar only encoding) | Claude (Sonnet) | spike prompt §Suggested Spike Shape §5 の最初 variant、最小実装 |
+| 2026-05-10 | Round 2 実施 (proper VK + scan code、両 encoding) | Claude (Sonnet) | Round 1 失敗、cooked-mode line reader が VK metadata を必要とする仮説 |
+| 2026-05-10 | Round 3 実施 (PeekConsoleInputW 裏取り) を Opus 諮問で決定 | Claude (Sonnet) + Opus reviewer | Round 1/2 連続失敗、CLAUDE.md 強制命令 4 (trial & error 2 回上限) で Opus 判定委譲。Opus 5 候補 ((A) parent tree / (B) GetConsoleMode / (C) PeekConsoleInputW / (D) explorer launched / (E) MOUSE_EVENT) のうち (C) のみ実施価値あり (vestigial-buffer hypothesis 構造的証明) と判定 |
+| 2026-05-10 | NO-GO 確定 | Claude (Sonnet) + Opus reviewer | Round 3 で `pending_events=0` / `peeked_records=0` を観測、書込直後 drain される構造を pin。conhost-baseline で再現性あるため WT mode は spike-prompt §2 gating clause で skip |
+| 2026-05-10 | ADR-013 §3.1 Option A 末尾に preliminary findings として embed + §7 OQ #1 に「legacy `WriteConsoleInputW` 経路除外」追記 | Claude (Sonnet) + Opus reviewer | Day 0 gate 探索の workload 削減、将来の reopen risk 構造的回避 |

--- a/scripts/spikes/README.md
+++ b/scripts/spikes/README.md
@@ -1,0 +1,33 @@
+# scripts/spikes/
+
+issue #185 の Phase 0 / Phase 4 stretch 用 spike scripts。
+
+**ここは production tool surface ではなく scratch experiment**。`docs/wt-attachconsole-spike-prompt.md` の Suggested Spike Shape に従って Go/No-Go 判定のため**だけ** に動作確認する。
+
+## 現在の spike
+
+- `wt-attachconsole-helper.ps1` — child PS で `FreeConsole` → `AttachConsole(targetPid)` → `CONIN$` 開く → `WriteConsoleInputW` → `FreeConsole`、結果 (Win32 GetLastError 含む) を JSON file に出力
+- `wt-attachconsole-orchestrator.ps1` — target 起動 → 候補 PID 解決 → helper 呼出 → buffer 読戻し検証 → cleanup → 結果 print
+
+## 実行方法
+
+```powershell
+# Phase A1: conhost baseline (cmd.exe legacy console)
+.\scripts\spikes\wt-attachconsole-orchestrator.ps1 -Mode conhost-baseline -Verbose
+
+# Phase A2: WT controlled (wt.exe new-tab で隔離 launch)
+.\scripts\spikes\wt-attachconsole-orchestrator.ps1 -Mode wt-controlled -Verbose
+```
+
+## 安全規則 (`docs/wt-attachconsole-spike-prompt.md` Safety Rules 引用)
+
+- Use only **controlled terminals launched for this spike** (user の既存 terminal は触らない)
+- Send **harmless sentinel commands only** (`Write-Output "__DTM_ATTACHCONSOLE_SPIKE_<guid>__"` / `echo __DTM_ATTACHCONSOLE_SPIKE_<guid>__`)
+- Never send secrets / destructive cmds / credential prompts
+- Always verify delivery via buffer read-back
+- Always call `FreeConsole` after `AttachConsole`
+- Privilege mismatch detected → record + skip (no elevation attempt)
+
+## Deliverable
+
+`docs/wt-attachconsole-spike-results.md` に test matrix + GO/NO-GO/MAYBE 推奨。

--- a/scripts/spikes/README.md
+++ b/scripts/spikes/README.md
@@ -6,7 +6,7 @@ issue #185 の Phase 0 / Phase 4 stretch 用 spike scripts。
 
 ## 現在の spike
 
-- `wt-attachconsole-helper.ps1` — child PS で `FreeConsole` → `AttachConsole(targetPid)` → `CONIN$` 開く → `WriteConsoleInputW` → `FreeConsole`、結果 (Win32 GetLastError 含む) を JSON file に出力
+- `wt-attachconsole-helper.ps1` — child PS で `FreeConsole` → `AttachConsole(targetPid)` → `CONIN$` 開く → `WriteConsoleInputW` → `GetNumberOfConsoleInputEvents` + `PeekConsoleInputW` (Round 3 vestigial-buffer hypothesis verification) → `FreeConsole`、結果 (Win32 GetLastError 含む) を JSON file に出力
 - `wt-attachconsole-orchestrator.ps1` — target 起動 → 候補 PID 解決 → helper 呼出 → buffer 読戻し検証 → cleanup → 結果 print
 
 ## 実行方法
@@ -31,3 +31,5 @@ issue #185 の Phase 0 / Phase 4 stretch 用 spike scripts。
 ## Deliverable
 
 `docs/wt-attachconsole-spike-results.md` に test matrix + GO/NO-GO/MAYBE 推奨。
+
+**現状**: NO-GO 確定 (`docs/wt-attachconsole-spike-results.md` 参照、2026-05-10)。Round 3 PeekConsoleInputW 裏取りで `pending_events=0` / `peeked_records=0` を観測、書込直後 drain される構造を pin。

--- a/scripts/spikes/wt-attachconsole-helper.ps1
+++ b/scripts/spikes/wt-attachconsole-helper.ps1
@@ -1,0 +1,238 @@
+# wt-attachconsole-helper.ps1
+#
+# Child-PS helper that performs the AttachConsole + WriteConsoleInputW spike
+# step in isolation from the calling Claude/orchestrator PS host. After
+# AttachConsole() the helper's stdout/stderr would route to the target's
+# console — we therefore communicate results via a JSON result file passed
+# as -ResultFile.
+#
+# Pipeline per docs/wt-attachconsole-spike-prompt.md "Suggested Spike Shape":
+#   1. Add-Type with P/Invoke definitions for Win32 console APIs
+#   2. FreeConsole (detach helper's own freshly-allocated console)
+#   3. AttachConsole(TargetPid) — capture GetLastError on failure
+#   4. GetConsoleProcessList — diagnostic, log all PIDs sharing target's console
+#   5. CreateFileW("CONIN$", GENERIC_RW, FILE_SHARE_RW, NULL, OPEN_EXISTING, 0, NULL)
+#   6. Build INPUT_RECORD[] for each Sentinel character + Enter (VK_RETURN)
+#   7. WriteConsoleInputW — capture written count + GetLastError on failure
+#   8. CloseHandle + FreeConsole
+#   9. Write JSON result to -ResultFile
+#
+# Safety: helper does NOT send anything but the user-supplied Sentinel +
+# Enter. Caller is responsible for sentinel uniqueness + non-destructive content.
+#
+# Exit codes: 0 on success, 1 on any Win32 step failure (details in JSON).
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][int]$TargetPid,
+    [Parameter(Mandatory = $true)][string]$Sentinel,
+    [Parameter(Mandatory = $true)][string]$ResultFile,
+    [ValidateSet('keydown', 'keydown_keyup')]
+    [string]$KeyEncoding = 'keydown_keyup'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$signature = @'
+using System;
+using System.Runtime.InteropServices;
+
+public static class ConsoleApi {
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern bool FreeConsole();
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern bool AttachConsole(uint dwProcessId);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern uint GetConsoleProcessList(uint[] lpdwProcessList, uint dwProcessCount);
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    public static extern IntPtr CreateFileW(
+        string lpFileName,
+        uint dwDesiredAccess,
+        uint dwShareMode,
+        IntPtr lpSecurityAttributes,
+        uint dwCreationDisposition,
+        uint dwFlagsAndAttributes,
+        IntPtr hTemplateFile);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern bool CloseHandle(IntPtr hObject);
+
+    // Win32 KEY_EVENT_RECORD: 16 bytes total
+    //   BOOL bKeyDown            (4 bytes, 4-byte BOOL via MarshalAs(UnmanagedType.Bool))
+    //   WORD wRepeatCount        (2)
+    //   WORD wVirtualKeyCode     (2)
+    //   WORD wVirtualScanCode    (2)
+    //   WCHAR UnicodeChar        (2)
+    //   DWORD dwControlKeyState  (4)
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    public struct KEY_EVENT_RECORD {
+        [MarshalAs(UnmanagedType.Bool)] public bool KeyDown;
+        public ushort RepeatCount;
+        public ushort VirtualKeyCode;
+        public ushort VirtualScanCode;
+        public ushort UnicodeChar;
+        public uint ControlKeyState;
+    }
+
+    // Win32 INPUT_RECORD: 20 bytes (WORD EventType + 2 bytes pad + 16 bytes union)
+    // We only ever use the KEY_EVENT branch in this spike.
+    [StructLayout(LayoutKind.Explicit, Size = 20)]
+    public struct INPUT_RECORD {
+        [FieldOffset(0)] public ushort EventType;
+        [FieldOffset(4)] public KEY_EVENT_RECORD KeyEvent;
+    }
+
+    public const ushort KEY_EVENT = 0x0001;
+
+    [DllImport("kernel32.dll", SetLastError = true, EntryPoint = "WriteConsoleInputW")]
+    public static extern bool WriteConsoleInputW(
+        IntPtr hConsoleInput,
+        INPUT_RECORD[] lpBuffer,
+        uint nLength,
+        out uint lpNumberOfEventsWritten);
+
+    public const uint GENERIC_READ = 0x80000000;
+    public const uint GENERIC_WRITE = 0x40000000;
+    public const uint FILE_SHARE_READ = 0x00000001;
+    public const uint FILE_SHARE_WRITE = 0x00000002;
+    public const uint OPEN_EXISTING = 3;
+}
+'@
+
+Add-Type -TypeDefinition $signature -Language CSharp
+
+function Write-Result {
+    param([hashtable]$Data, [int]$ExitCode)
+    $Data | ConvertTo-Json -Compress | Out-File -FilePath $ResultFile -Encoding utf8 -NoNewline
+    exit $ExitCode
+}
+
+# Step 2: detach from helper's own console (Start-Process -WindowStyle Hidden gives us one).
+# We ignore FreeConsole's return — if the helper has no console, FreeConsole returns FALSE
+# but that is not an error condition for our use case.
+[ConsoleApi]::FreeConsole() | Out-Null
+
+# Step 3: attach to target's console
+$attached = [ConsoleApi]::AttachConsole([uint32]$TargetPid)
+if (-not $attached) {
+    $err = [System.Runtime.InteropServices.Marshal]::GetLastWin32Error()
+    Write-Result @{
+        ok = $false
+        step = 'AttachConsole'
+        win32_error = $err
+        win32_error_hex = ('0x{0:X8}' -f $err)
+        target_pid = $TargetPid
+    } -ExitCode 1
+}
+
+# Step 4: enumerate attached console process list (diagnostic)
+$processList = New-Object 'uint32[]' 64
+[uint32]$count = [ConsoleApi]::GetConsoleProcessList($processList, [uint32]64)
+$attachedPids = @()
+if ($count -gt 0) {
+    for ($i = 0; $i -lt [Math]::Min($count, 64); $i++) {
+        $attachedPids += [int]$processList[$i]
+    }
+}
+
+# Step 5: open CONIN$
+$hConin = [ConsoleApi]::CreateFileW(
+    'CONIN$',
+    [ConsoleApi]::GENERIC_READ -bor [ConsoleApi]::GENERIC_WRITE,
+    [ConsoleApi]::FILE_SHARE_READ -bor [ConsoleApi]::FILE_SHARE_WRITE,
+    [System.IntPtr]::Zero,
+    [ConsoleApi]::OPEN_EXISTING,
+    0,
+    [System.IntPtr]::Zero)
+
+if ($hConin.ToInt64() -eq -1) {
+    $err = [System.Runtime.InteropServices.Marshal]::GetLastWin32Error()
+    [ConsoleApi]::FreeConsole() | Out-Null
+    Write-Result @{
+        ok = $false
+        step = 'CreateFileW(CONIN$)'
+        win32_error = $err
+        win32_error_hex = ('0x{0:X8}' -f $err)
+        target_pid = $TargetPid
+        attached_pids = $attachedPids
+    } -ExitCode 1
+}
+
+# Step 6: build INPUT_RECORD[] for sentinel chars + Enter
+$records = New-Object 'System.Collections.Generic.List[ConsoleApi+INPUT_RECORD]'
+
+function New-CharRecord {
+    param([bool]$KeyDown, [ushort]$Char)
+    $rec = New-Object 'ConsoleApi+INPUT_RECORD'
+    $rec.EventType = [ConsoleApi]::KEY_EVENT
+    $rec.KeyEvent.KeyDown = $KeyDown
+    $rec.KeyEvent.RepeatCount = [ushort]1
+    $rec.KeyEvent.VirtualKeyCode = [ushort]0
+    $rec.KeyEvent.VirtualScanCode = [ushort]0
+    $rec.KeyEvent.UnicodeChar = $Char
+    $rec.KeyEvent.ControlKeyState = [uint32]0
+    return $rec
+}
+
+function New-VkRecord {
+    param([bool]$KeyDown, [ushort]$VK, [ushort]$Char)
+    $rec = New-Object 'ConsoleApi+INPUT_RECORD'
+    $rec.EventType = [ConsoleApi]::KEY_EVENT
+    $rec.KeyEvent.KeyDown = $KeyDown
+    $rec.KeyEvent.RepeatCount = [ushort]1
+    $rec.KeyEvent.VirtualKeyCode = $VK
+    $rec.KeyEvent.VirtualScanCode = [ushort]0
+    $rec.KeyEvent.UnicodeChar = $Char
+    $rec.KeyEvent.ControlKeyState = [uint32]0
+    return $rec
+}
+
+foreach ($ch in $Sentinel.ToCharArray()) {
+    $cInt = [ushort][int]$ch
+    if ($KeyEncoding -eq 'keydown_keyup') {
+        $records.Add((New-CharRecord -KeyDown $true -Char $cInt))
+        $records.Add((New-CharRecord -KeyDown $false -Char $cInt))
+    } else {
+        $records.Add((New-CharRecord -KeyDown $true -Char $cInt))
+    }
+}
+
+# Append Enter (VK_RETURN = 0x0D) so the shell processes the sentinel as a command
+$VK_RETURN = [ushort]0x0D
+$CR = [ushort]0x0D
+if ($KeyEncoding -eq 'keydown_keyup') {
+    $records.Add((New-VkRecord -KeyDown $true -VK $VK_RETURN -Char $CR))
+    $records.Add((New-VkRecord -KeyDown $false -VK $VK_RETURN -Char $CR))
+} else {
+    $records.Add((New-VkRecord -KeyDown $true -VK $VK_RETURN -Char $CR))
+}
+
+$arr = $records.ToArray()
+
+# Step 7: write input
+[uint32]$written = 0
+$writeOk = [ConsoleApi]::WriteConsoleInputW($hConin, $arr, [uint32]$arr.Length, [ref]$written)
+$writeErr = if (-not $writeOk) { [System.Runtime.InteropServices.Marshal]::GetLastWin32Error() } else { 0 }
+
+# Step 8: cleanup
+[ConsoleApi]::CloseHandle($hConin) | Out-Null
+[ConsoleApi]::FreeConsole() | Out-Null
+
+# Step 9: report
+$resultExit = if ($writeOk) { 0 } else { 1 }
+$resultStep = if ($writeOk) { 'WriteConsoleInputW success' } else { 'WriteConsoleInputW failed' }
+Write-Result @{
+    ok = $writeOk
+    step = $resultStep
+    win32_error = $writeErr
+    win32_error_hex = ('0x{0:X8}' -f $writeErr)
+    records_attempted = $arr.Length
+    records_written = [int]$written
+    attached_pids = $attachedPids
+    target_pid = $TargetPid
+    sentinel = $Sentinel
+    key_encoding = $KeyEncoding
+} -ExitCode $resultExit

--- a/scripts/spikes/wt-attachconsole-helper.ps1
+++ b/scripts/spikes/wt-attachconsole-helper.ps1
@@ -60,6 +60,15 @@ public static class ConsoleApi {
     [DllImport("kernel32.dll", SetLastError = true)]
     public static extern bool CloseHandle(IntPtr hObject);
 
+    // Round 2: proper VK + scan code encoding
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern short VkKeyScanW(char ch);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern uint MapVirtualKeyW(uint uCode, uint uMapType);
+
+    public const uint MAPVK_VK_TO_VSC = 0;
+
     // Win32 KEY_EVENT_RECORD: 16 bytes total
     //   BOOL bKeyDown            (4 bytes, 4-byte BOOL via MarshalAs(UnmanagedType.Bool))
     //   WORD wRepeatCount        (2)
@@ -164,50 +173,80 @@ if ($hConin.ToInt64() -eq -1) {
 # Step 6: build INPUT_RECORD[] for sentinel chars + Enter
 $records = New-Object 'System.Collections.Generic.List[ConsoleApi+INPUT_RECORD]'
 
-function New-CharRecord {
-    param([bool]$KeyDown, [ushort]$Char)
-    $rec = New-Object 'ConsoleApi+INPUT_RECORD'
-    $rec.EventType = [ConsoleApi]::KEY_EVENT
-    $rec.KeyEvent.KeyDown = $KeyDown
-    $rec.KeyEvent.RepeatCount = [ushort]1
-    $rec.KeyEvent.VirtualKeyCode = [ushort]0
-    $rec.KeyEvent.VirtualScanCode = [ushort]0
-    $rec.KeyEvent.UnicodeChar = $Char
-    $rec.KeyEvent.ControlKeyState = [uint32]0
-    return $rec
-}
-
-function New-VkRecord {
-    param([bool]$KeyDown, [ushort]$VK, [ushort]$Char)
+function New-FullKeyRecord {
+    # Round 2: proper VirtualKeyCode + scan code + ControlKeyState. For ASCII
+    # characters this resolves to the same VK an OS keyboard event would
+    # produce; the input subsystem (cooked-mode line reader in cmd / PSReadLine
+    # in PowerShell) typically requires VK metadata, not just UnicodeChar.
+    param(
+        [bool]$KeyDown,
+        [ushort]$VK,
+        [ushort]$ScanCode,
+        [ushort]$Char,
+        [uint32]$ControlKeyState
+    )
     $rec = New-Object 'ConsoleApi+INPUT_RECORD'
     $rec.EventType = [ConsoleApi]::KEY_EVENT
     $rec.KeyEvent.KeyDown = $KeyDown
     $rec.KeyEvent.RepeatCount = [ushort]1
     $rec.KeyEvent.VirtualKeyCode = $VK
-    $rec.KeyEvent.VirtualScanCode = [ushort]0
+    $rec.KeyEvent.VirtualScanCode = $ScanCode
     $rec.KeyEvent.UnicodeChar = $Char
-    $rec.KeyEvent.ControlKeyState = [uint32]0
+    $rec.KeyEvent.ControlKeyState = $ControlKeyState
     return $rec
 }
 
+# ControlKeyState flags (winuser.h)
+$SHIFT_PRESSED = [uint32]0x10
+$VK_SHIFT = [ushort]0x10
+$VK_RETURN = [ushort]0x0D
+
+# Pre-compute SHIFT scan code (used for shifted chars)
+$shiftScan = [ushort][ConsoleApi]::MapVirtualKeyW([uint32]$VK_SHIFT, [ConsoleApi]::MAPVK_VK_TO_VSC)
+$enterScan = [ushort][ConsoleApi]::MapVirtualKeyW([uint32]$VK_RETURN, [ConsoleApi]::MAPVK_VK_TO_VSC)
+
 foreach ($ch in $Sentinel.ToCharArray()) {
     $cInt = [ushort][int]$ch
-    if ($KeyEncoding -eq 'keydown_keyup') {
-        $records.Add((New-CharRecord -KeyDown $true -Char $cInt))
-        $records.Add((New-CharRecord -KeyDown $false -Char $cInt))
+    $vkScan = [int][ConsoleApi]::VkKeyScanW([char]$ch)
+    if ($vkScan -eq -1) {
+        # Char not on default keyboard layout — fall back to UnicodeChar-only
+        $vk = [ushort]0
+        $scanCode = [ushort]0
+        $needShift = $false
     } else {
-        $records.Add((New-CharRecord -KeyDown $true -Char $cInt))
+        $vk = [ushort]($vkScan -band 0xFF)
+        $shiftState = ($vkScan -shr 8) -band 0xFF
+        $needShift = ($shiftState -band 0x01) -ne 0
+        $scanCode = [ushort][ConsoleApi]::MapVirtualKeyW([uint32]$vk, [ConsoleApi]::MAPVK_VK_TO_VSC)
+    }
+
+    $cks = if ($needShift) { $SHIFT_PRESSED } else { [uint32]0 }
+
+    if ($needShift) {
+        # SHIFT key down before the char
+        $records.Add((New-FullKeyRecord -KeyDown $true -VK $VK_SHIFT -ScanCode $shiftScan -Char ([ushort]0) -ControlKeyState $SHIFT_PRESSED))
+    }
+
+    if ($KeyEncoding -eq 'keydown_keyup') {
+        $records.Add((New-FullKeyRecord -KeyDown $true -VK $vk -ScanCode $scanCode -Char $cInt -ControlKeyState $cks))
+        $records.Add((New-FullKeyRecord -KeyDown $false -VK $vk -ScanCode $scanCode -Char $cInt -ControlKeyState $cks))
+    } else {
+        $records.Add((New-FullKeyRecord -KeyDown $true -VK $vk -ScanCode $scanCode -Char $cInt -ControlKeyState $cks))
+    }
+
+    if ($needShift) {
+        # SHIFT key up after the char
+        $records.Add((New-FullKeyRecord -KeyDown $false -VK $VK_SHIFT -ScanCode $shiftScan -Char ([ushort]0) -ControlKeyState ([uint32]0)))
     }
 }
 
-# Append Enter (VK_RETURN = 0x0D) so the shell processes the sentinel as a command
-$VK_RETURN = [ushort]0x0D
+# Append Enter (VK_RETURN = 0x0D)
 $CR = [ushort]0x0D
 if ($KeyEncoding -eq 'keydown_keyup') {
-    $records.Add((New-VkRecord -KeyDown $true -VK $VK_RETURN -Char $CR))
-    $records.Add((New-VkRecord -KeyDown $false -VK $VK_RETURN -Char $CR))
+    $records.Add((New-FullKeyRecord -KeyDown $true -VK $VK_RETURN -ScanCode $enterScan -Char $CR -ControlKeyState ([uint32]0)))
+    $records.Add((New-FullKeyRecord -KeyDown $false -VK $VK_RETURN -ScanCode $enterScan -Char $CR -ControlKeyState ([uint32]0)))
 } else {
-    $records.Add((New-VkRecord -KeyDown $true -VK $VK_RETURN -Char $CR))
+    $records.Add((New-FullKeyRecord -KeyDown $true -VK $VK_RETURN -ScanCode $enterScan -Char $CR -ControlKeyState ([uint32]0)))
 }
 
 $arr = $records.ToArray()

--- a/scripts/spikes/wt-attachconsole-helper.ps1
+++ b/scripts/spikes/wt-attachconsole-helper.ps1
@@ -103,6 +103,23 @@ public static class ConsoleApi {
         uint nLength,
         out uint lpNumberOfEventsWritten);
 
+    // Round 3 diagnostic (Opus-mandated, vestigial-buffer hypothesis verification):
+    // PeekConsoleInputW reads without removing — distinguishes between
+    //   (A) records live in CONIN$ (read-back returns our records)
+    //   (B) records were drained immediately (read-back returns 0)
+    //   (C) handle is decoupled from real input source (ReadFile-style failure)
+    [DllImport("kernel32.dll", SetLastError = true, EntryPoint = "PeekConsoleInputW")]
+    public static extern bool PeekConsoleInputW(
+        IntPtr hConsoleInput,
+        [Out] INPUT_RECORD[] lpBuffer,
+        uint nLength,
+        out uint lpNumberOfEventsRead);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern bool GetNumberOfConsoleInputEvents(
+        IntPtr hConsoleInput,
+        out uint lpcNumberOfEvents);
+
     public const uint GENERIC_READ = 0x80000000;
     public const uint GENERIC_WRITE = 0x40000000;
     public const uint FILE_SHARE_READ = 0x00000001;
@@ -256,6 +273,50 @@ $arr = $records.ToArray()
 $writeOk = [ConsoleApi]::WriteConsoleInputW($hConin, $arr, [uint32]$arr.Length, [ref]$written)
 $writeErr = if (-not $writeOk) { [System.Runtime.InteropServices.Marshal]::GetLastWin32Error() } else { 0 }
 
+# Step 7.5 (Round 3 diagnostic): peek the input buffer immediately after write
+# to verify whether the records actually land in CONIN$. Three outcomes:
+#   live  — records still in buffer (vestigial / not consumed)
+#   drained — buffer empty / fewer (consumer drained, but consumer != shell)
+#   peek_failed — handle is decoupled from real input source
+$peekErr = 0
+$pendingCount = 0
+$peekOk = $false
+$peekedRecords = 0
+$pendingOk = [ConsoleApi]::GetNumberOfConsoleInputEvents($hConin, [ref]$pendingCount)
+if (-not $pendingOk) {
+    $peekErr = [System.Runtime.InteropServices.Marshal]::GetLastWin32Error()
+}
+$peekBuf = New-Object 'ConsoleApi+INPUT_RECORD[]' 256
+[uint32]$peeked = 0
+$peekOk = [ConsoleApi]::PeekConsoleInputW($hConin, $peekBuf, [uint32]256, [ref]$peeked)
+if (-not $peekOk -and $peekErr -eq 0) {
+    $peekErr = [System.Runtime.InteropServices.Marshal]::GetLastWin32Error()
+}
+$peekedRecords = [int]$peeked
+
+# Capture first few peeked records' EventType + UnicodeChar for evidence
+$peekedSummary = @()
+$dumpN = [Math]::Min($peekedRecords, 8)
+for ($i = 0; $i -lt $dumpN; $i++) {
+    $r = $peekBuf[$i]
+    $et = [int]$r.EventType
+    $kd = $false
+    $vk = 0
+    $ch = 0
+    if ($et -eq [int][ConsoleApi]::KEY_EVENT) {
+        $kd = $r.KeyEvent.KeyDown
+        $vk = [int]$r.KeyEvent.VirtualKeyCode
+        $ch = [int]$r.KeyEvent.UnicodeChar
+    }
+    $peekedSummary += @{
+        idx = $i
+        event_type = $et
+        key_down = $kd
+        vk = $vk
+        unicode_char = $ch
+    }
+}
+
 # Step 8: cleanup
 [ConsoleApi]::CloseHandle($hConin) | Out-Null
 [ConsoleApi]::FreeConsole() | Out-Null
@@ -274,4 +335,11 @@ Write-Result @{
     target_pid = $TargetPid
     sentinel = $Sentinel
     key_encoding = $KeyEncoding
+    # Round 3 diagnostic
+    peek_ok = $peekOk
+    pending_events = [int]$pendingCount
+    peeked_records = $peekedRecords
+    peek_win32_error = $peekErr
+    peek_win32_error_hex = ('0x{0:X8}' -f $peekErr)
+    peeked_summary = $peekedSummary
 } -ExitCode $resultExit

--- a/scripts/spikes/wt-attachconsole-orchestrator.ps1
+++ b/scripts/spikes/wt-attachconsole-orchestrator.ps1
@@ -1,0 +1,416 @@
+# wt-attachconsole-orchestrator.ps1
+#
+# Spike orchestrator for issue #185 / Phase 0 m13v community proposal.
+# Pipeline:
+#   1. Mode selection (conhost-baseline | wt-controlled)
+#   2. Launch a controlled target shell + assign unique sentinel
+#   3. Resolve candidate PIDs (target shell PID + descendants)
+#   4. For each candidate PID + KeyEncoding, invoke helper as a child PS
+#      process (Start-Process so its console state is isolated)
+#   5. Read helper's JSON result file
+#   6. Read the target shell's visible buffer via UIA TextPattern,
+#      check whether the sentinel substring landed
+#   7. Stop-Process the controlled launch (Spike Safety §"Always cleanup")
+#   8. Print a single-line summary table row + machine-readable JSON tail
+#
+# This script does NOT modify production code. It only orchestrates the
+# helper script + target shell. Designed to be re-runnable.
+#
+# Usage:
+#   .\scripts\spikes\wt-attachconsole-orchestrator.ps1 -Mode conhost-baseline
+#   .\scripts\spikes\wt-attachconsole-orchestrator.ps1 -Mode wt-controlled
+#   .\scripts\spikes\wt-attachconsole-orchestrator.ps1 -Mode conhost-baseline -KeyEncoding keydown
+#
+# Output:
+#   - Human-readable progress to stdout
+#   - JSON summary block at end (parseable for the docs/wt-attachconsole-spike-results.md test matrix)
+#
+# Safety: only launches its own controlled processes; never targets a
+# user's pre-existing terminal. Cleanup is best-effort.
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('conhost-baseline', 'wt-controlled')]
+    [string]$Mode,
+
+    [ValidateSet('keydown', 'keydown_keyup')]
+    [string]$KeyEncoding = 'keydown_keyup',
+
+    [int]$ReadbackDelayMs = 600,
+
+    [int]$LaunchSettleMs = 800
+)
+
+$ErrorActionPreference = 'Stop'
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$helperPath = Join-Path $scriptRoot 'wt-attachconsole-helper.ps1'
+
+if (-not (Test-Path -LiteralPath $helperPath)) {
+    Write-Error "Helper not found at: $helperPath"
+    exit 2
+}
+
+function New-Sentinel {
+    $guid = [guid]::NewGuid().ToString('N').Substring(0, 12)
+    return "__DTM_SPIKE_${guid}__"
+}
+
+function Get-WindowTextViaUia {
+    param([string]$WindowTitleSubstring)
+    Add-Type -AssemblyName UIAutomationClient -ErrorAction SilentlyContinue
+    Add-Type -AssemblyName UIAutomationTypes -ErrorAction SilentlyContinue
+
+    $root = [System.Windows.Automation.AutomationElement]::RootElement
+    $trueC = [System.Windows.Automation.Condition]::TrueCondition
+    $children = $root.FindAll([System.Windows.Automation.TreeScope]::Children, $trueC)
+    $target = $null
+    foreach ($w in $children) {
+        if ($w.Current.Name -like "*$WindowTitleSubstring*") { $target = $w; break }
+    }
+    if (-not $target) { return @{ ok = $false; error = 'window not found'; text = '' } }
+
+    $desc = [System.Windows.Automation.TreeScope]::Descendants
+    $all = $target.FindAll($desc, $trueC)
+
+    $bestText = ''
+    $bestLen = -1
+    foreach ($el in $all) {
+        try {
+            $tp = $el.GetCurrentPattern([System.Windows.Automation.TextPattern]::Pattern)
+            if ($null -ne $tp) {
+                $txt = ''
+                try { $txt = $tp.DocumentRange.GetText(-1) } catch { continue }
+                if ($null -eq $txt) { $txt = '' }
+                if ($txt.Length -gt $bestLen) {
+                    $bestText = $txt
+                    $bestLen = $txt.Length
+                }
+            }
+        } catch {}
+    }
+    return @{ ok = $true; text = $bestText; length = $bestLen }
+}
+
+function Invoke-Helper {
+    param(
+        [int]$TargetPid,
+        [string]$Sentinel,
+        [string]$KeyEncoding
+    )
+    $resultFile = [System.IO.Path]::GetTempFileName()
+    Remove-Item -LiteralPath $resultFile -ErrorAction SilentlyContinue
+    $stdoutFile = [System.IO.Path]::GetTempFileName()
+    $stderrFile = [System.IO.Path]::GetTempFileName()
+    # Spawn helper as child PS so its console state is isolated.
+    # -WindowStyle Hidden gives the child a fresh hidden console; FreeConsole()
+    # in the helper detaches that, AttachConsole(target) attaches to target's.
+    #
+    # Use ProcessStartInfo.ArgumentList (per-arg list with proper escaping)
+    # instead of Start-Process -ArgumentList @(...) which joins with spaces
+    # and breaks args containing spaces (e.g. "echo __DTM_SPIKE_xxx__"). The
+    # earlier failure mode was: helper received `-Sentinel echo` + positional
+    # `__DTM_SPIKE_xxx__` and bombed with "positional parameter cannot be found".
+    $psi = [System.Diagnostics.ProcessStartInfo]::new()
+    $psi.FileName = 'pwsh.exe'
+    foreach ($a in @(
+        '-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass',
+        '-File', $helperPath,
+        '-TargetPid', "$TargetPid",
+        '-Sentinel', $Sentinel,
+        '-ResultFile', $resultFile,
+        '-KeyEncoding', $KeyEncoding
+    )) { $psi.ArgumentList.Add($a) }
+    $psi.UseShellExecute = $false
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.CreateNoWindow = $true
+    $proc = [System.Diagnostics.Process]::Start($psi)
+    $stdoutContent = $proc.StandardOutput.ReadToEnd()
+    $stderrContent = $proc.StandardError.ReadToEnd()
+    $proc.WaitForExit()
+    $exit = $proc.ExitCode
+    # stdout/stderr already captured directly via ReadToEnd above.
+    if (-not $stdoutContent) { $stdoutContent = '' }
+    if (-not $stderrContent) { $stderrContent = '' }
+    Remove-Item -LiteralPath $stdoutFile, $stderrFile -ErrorAction SilentlyContinue
+
+    if (-not (Test-Path -LiteralPath $resultFile)) {
+        return @{
+            ok = $false
+            step = 'helper did not write result file'
+            helper_exit = $exit
+            helper_stdout = $stdoutContent
+            helper_stderr = $stderrContent
+        }
+    }
+    $json = Get-Content -LiteralPath $resultFile -Raw -Encoding utf8
+    Remove-Item -LiteralPath $resultFile -ErrorAction SilentlyContinue
+    try {
+        $obj = $json | ConvertFrom-Json -AsHashtable
+        $obj.helper_exit = $exit
+        if ($stderrContent) { $obj.helper_stderr = $stderrContent }
+        return $obj
+    } catch {
+        return @{
+            ok = $false
+            step = 'helper JSON parse failed'
+            helper_exit = $exit
+            raw = $json
+            helper_stdout = $stdoutContent
+            helper_stderr = $stderrContent
+        }
+    }
+}
+
+function Stop-ProcessTreeSafe {
+    param([int]$Id)
+    try {
+        Stop-Process -Id $Id -Force -ErrorAction SilentlyContinue
+    } catch {}
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Mode: conhost-baseline
+# Launch `conhost.exe cmd.exe /K title DTM_SPIKE_BASELINE_<guid>` to FORCE
+# legacy conhost host (Win11 default may otherwise route cmd.exe into WT).
+# Send sentinel via helper, verify via UIA TextPattern read-back of the
+# conhost window.
+# ─────────────────────────────────────────────────────────────────────────────
+
+function Invoke-ConhostBaseline {
+    $sentinel = New-Sentinel
+    $titleTag = "DTM_SPIKE_BASELINE_$([guid]::NewGuid().ToString('N').Substring(0,8))"
+
+    Write-Host "[1/6] Launching controlled cmd.exe in conhost (title=$titleTag) ..." -ForegroundColor Cyan
+    # Force legacy conhost by invoking conhost.exe directly. On Win11 cmd.exe
+    # typically routes to WT when Start-Process'd plain — conhost.exe wraps it
+    # explicitly in legacy conhost.
+    $proc = Start-Process -FilePath 'conhost.exe' -ArgumentList @(
+        'cmd.exe', '/K', "title $titleTag"
+    ) -PassThru -WindowStyle Normal
+    Start-Sleep -Milliseconds $LaunchSettleMs
+
+    if ($proc.HasExited) {
+        Write-Host "  Launch failed: process exited immediately (code=$($proc.ExitCode))" -ForegroundColor Red
+        return @{ mode = 'conhost-baseline'; ok = $false; step = 'launch'; helper_exit = -1 }
+    }
+
+    # The cmd.exe we want is a CHILD of the launched conhost.exe (not the conhost itself)
+    Write-Host "[2/6] Resolving candidate cmd.exe PID under conhost(pid=$($proc.Id)) ..." -ForegroundColor Cyan
+    $cmdProc = Get-CimInstance Win32_Process -Filter "ParentProcessId=$($proc.Id) AND Name='cmd.exe'" -ErrorAction SilentlyContinue
+    if (-not $cmdProc) {
+        # Fallback: maybe Start-Process wrapped differently — find any cmd.exe with our title
+        Start-Sleep -Milliseconds 300
+        $allCmd = Get-CimInstance Win32_Process -Filter "Name='cmd.exe'" -ErrorAction SilentlyContinue
+        $cmdProc = $allCmd | Where-Object { $_.CommandLine -like "*$titleTag*" } | Select-Object -First 1
+    }
+    if (-not $cmdProc) {
+        Stop-ProcessTreeSafe -Id $proc.Id
+        Write-Host "  Could not resolve cmd.exe PID for $titleTag" -ForegroundColor Red
+        return @{ mode = 'conhost-baseline'; ok = $false; step = 'pid_resolve'; helper_exit = -1 }
+    }
+    $targetPid = [int]$cmdProc.ProcessId
+    Write-Host "  cmd.exe PID = $targetPid (parent conhost = $($proc.Id))" -ForegroundColor Gray
+
+    Write-Host "[3/6] Invoking helper (sentinel='$sentinel', encoding=$KeyEncoding) ..." -ForegroundColor Cyan
+    $sentinelCmd = "echo $sentinel"
+    $helperResult = Invoke-Helper -TargetPid $targetPid -Sentinel $sentinelCmd -KeyEncoding $KeyEncoding
+
+    Write-Host "  helper.ok      = $($helperResult.ok)" -ForegroundColor Gray
+    Write-Host "  helper.step    = $($helperResult.step)" -ForegroundColor Gray
+    Write-Host "  win32_error    = $($helperResult.win32_error_hex)" -ForegroundColor Gray
+    Write-Host "  records w/a    = $($helperResult.records_written) / $($helperResult.records_attempted)" -ForegroundColor Gray
+    Write-Host "  attached_pids  = $($helperResult.attached_pids -join ',')" -ForegroundColor Gray
+
+    Write-Host "[4/6] Sleeping ${ReadbackDelayMs}ms for shell to render echo output ..." -ForegroundColor Cyan
+    Start-Sleep -Milliseconds $ReadbackDelayMs
+
+    Write-Host "[5/6] Reading conhost window buffer via UIA TextPattern ..." -ForegroundColor Cyan
+    $readback = Get-WindowTextViaUia -WindowTitleSubstring $titleTag
+    $observed = $false
+    $sentinelFound = $false
+    if ($readback.ok) {
+        $observed = $true
+        $sentinelFound = $readback.text -like "*$sentinel*"
+        Write-Host "  buffer length  = $($readback.length)" -ForegroundColor Gray
+        $sentinelColor = if ($sentinelFound) { 'Green' } else { 'Yellow' }
+        Write-Host "  sentinel hit   = $sentinelFound" -ForegroundColor $sentinelColor
+        # Dump tail of buffer for debugging when sentinel missing.
+        if (-not $sentinelFound -and $readback.length -gt 0) {
+            $tail = $readback.text.Substring([Math]::Max(0, $readback.text.Length - 400))
+            Write-Host "  --- buffer tail (last 400 chars) ---" -ForegroundColor DarkGray
+            Write-Host $tail -ForegroundColor DarkGray
+            Write-Host "  --- end tail ---" -ForegroundColor DarkGray
+        }
+    } else {
+        Write-Host "  Read-back failed: $($readback.error)" -ForegroundColor Yellow
+    }
+
+    Write-Host "[6/6] Cleanup (Stop-Process conhost pid=$($proc.Id)) ..." -ForegroundColor Cyan
+    Stop-ProcessTreeSafe -Id $proc.Id
+    if ($cmdProc) { Stop-ProcessTreeSafe -Id $targetPid }
+
+    return @{
+        mode = 'conhost-baseline'
+        ok = ($helperResult.ok -and $sentinelFound)
+        helper = $helperResult
+        readback_observed = $observed
+        sentinel_found = $sentinelFound
+        target_pid = $targetPid
+        title_tag = $titleTag
+        sentinel = $sentinel
+    }
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Mode: wt-controlled
+# Launch wt.exe with a unique tab title, find the actual shell (pwsh.exe)
+# under the WT process tree, send sentinel, verify via UIA read-back of
+# the WT window with our unique title.
+# ─────────────────────────────────────────────────────────────────────────────
+
+function Invoke-WtControlled {
+    if (-not (Get-Command 'wt.exe' -ErrorAction SilentlyContinue)) {
+        Write-Host "wt.exe not found in PATH — skipping WT mode" -ForegroundColor Yellow
+        return @{ mode = 'wt-controlled'; ok = $false; step = 'wt_not_installed'; helper_exit = -1 }
+    }
+
+    $sentinel = New-Sentinel
+    $titleTag = "DTM-ATTACHCONSOLE-SPIKE-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+
+    Write-Host "[1/7] Launching controlled WT tab (title=$titleTag) ..." -ForegroundColor Cyan
+    # Use -w <unique> so this WT window is isolated from the user's existing WT.
+    $wtWindowName = "spike-$([guid]::NewGuid().ToString('N').Substring(0,6))"
+    Start-Process -FilePath 'wt.exe' -ArgumentList @(
+        '-w', $wtWindowName,
+        'new-tab', '--title', $titleTag,
+        '--', 'powershell.exe', '-NoLogo', '-NoExit'
+    ) -WindowStyle Normal
+    Start-Sleep -Milliseconds $LaunchSettleMs
+
+    Write-Host "[2/7] Locating WT window by title=$titleTag ..." -ForegroundColor Cyan
+    Add-Type -AssemblyName UIAutomationClient -ErrorAction SilentlyContinue
+    $root = [System.Windows.Automation.AutomationElement]::RootElement
+    $trueC = [System.Windows.Automation.Condition]::TrueCondition
+    $children = $root.FindAll([System.Windows.Automation.TreeScope]::Children, $trueC)
+    $wtWin = $null
+    foreach ($w in $children) {
+        if ($w.Current.Name -like "*$titleTag*") { $wtWin = $w; break }
+    }
+    if (-not $wtWin) {
+        Write-Host "  WT window with title '$titleTag' not found in UIA tree" -ForegroundColor Red
+        return @{ mode = 'wt-controlled'; ok = $false; step = 'wt_window_not_found'; helper_exit = -1 }
+    }
+    $wtHwnd = $wtWin.Current.NativeWindowHandle
+    Write-Host "  WT HWND = 0x$($wtHwnd.ToString('X8'))" -ForegroundColor Gray
+
+    Write-Host "[3/7] Enumerating candidate shell PIDs in WT process tree ..." -ForegroundColor Cyan
+    # WT model: WindowsTerminal.exe spawns OpenConsole.exe, OpenConsole.exe
+    # parents the actual shell (pwsh.exe / cmd.exe / wsl.exe). We enumerate
+    # all WindowsTerminal.exe + OpenConsole.exe + shells with our title-tag
+    # in their PowerShell window title (set via $Host.UI.RawUI.WindowTitle above).
+    $allShells = Get-CimInstance Win32_Process -Filter "Name='powershell.exe' OR Name='pwsh.exe' OR Name='cmd.exe'" -ErrorAction SilentlyContinue
+    # Heuristic: filter shells whose grand-parent is WindowsTerminal.exe
+    $wtPids = (Get-Process -Name WindowsTerminal -ErrorAction SilentlyContinue).Id
+    $candidates = @()
+    foreach ($s in $allShells) {
+        try {
+            $parent = Get-CimInstance Win32_Process -Filter "ProcessId=$($s.ParentProcessId)" -ErrorAction SilentlyContinue
+            if ($parent -and ($parent.Name -in @('OpenConsole.exe', 'WindowsTerminal.exe'))) {
+                $gp = if ($parent.Name -eq 'WindowsTerminal.exe') { $parent } else {
+                    Get-CimInstance Win32_Process -Filter "ProcessId=$($parent.ParentProcessId)" -ErrorAction SilentlyContinue
+                }
+                if ($gp -and $gp.Name -eq 'WindowsTerminal.exe' -and $wtPids -contains $gp.ProcessId) {
+                    $candidates += @{ Pid = [int]$s.ProcessId; Name = $s.Name; Started = $s.CreationDate }
+                }
+            }
+        } catch {}
+    }
+    # Prefer the most recently started candidate (our spike's launch is newest)
+    $candidates = $candidates | Sort-Object -Property Started -Descending
+    Write-Host "  candidates (most recent first):" -ForegroundColor Gray
+    foreach ($c in $candidates) {
+        Write-Host "    pid=$($c.Pid) name=$($c.Name) started=$($c.Started)" -ForegroundColor Gray
+    }
+
+    if (-not $candidates -or $candidates.Count -eq 0) {
+        Write-Host "  No WT-hosted shell candidates found" -ForegroundColor Red
+        return @{ mode = 'wt-controlled'; ok = $false; step = 'no_candidates'; helper_exit = -1 }
+    }
+
+    # Try each candidate in order, stop on first success
+    $sentinelCmd = "Write-Output `"$sentinel`""
+    $attempts = @()
+    $finalOk = $false
+    foreach ($c in $candidates) {
+        Write-Host "[4/7] Trying candidate pid=$($c.Pid) ($($c.Name)) ..." -ForegroundColor Cyan
+        $helperResult = Invoke-Helper -TargetPid $c.Pid -Sentinel $sentinelCmd -KeyEncoding $KeyEncoding
+        Write-Host "  helper.ok=$($helperResult.ok) win32_error=$($helperResult.win32_error_hex) attached_pids=$($helperResult.attached_pids -join ',')" -ForegroundColor Gray
+
+        Start-Sleep -Milliseconds $ReadbackDelayMs
+
+        # Re-read WT buffer for sentinel
+        $readback = Get-WindowTextViaUia -WindowTitleSubstring $titleTag
+        $sentinelFound = $false
+        if ($readback.ok) {
+            $sentinelFound = $readback.text -like "*$sentinel*"
+        }
+        $attempts += @{
+            candidate_pid = $c.Pid
+            candidate_name = $c.Name
+            helper = $helperResult
+            sentinel_found = $sentinelFound
+        }
+        if ($helperResult.ok -and $sentinelFound) {
+            Write-Host "  [hit] sentinel observed in WT buffer" -ForegroundColor Green
+            $finalOk = $true
+            break
+        }
+    }
+
+    Write-Host "[7/7] Cleanup ..." -ForegroundColor Cyan
+    foreach ($c in $candidates) { Stop-ProcessTreeSafe -Id $c.Pid }
+
+    return @{
+        mode = 'wt-controlled'
+        ok = $finalOk
+        title_tag = $titleTag
+        sentinel = $sentinel
+        attempts = $attempts
+    }
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Main
+# ─────────────────────────────────────────────────────────────────────────────
+
+Write-Host ""
+Write-Host "=== AttachConsole spike orchestrator ===" -ForegroundColor Magenta
+Write-Host "Mode = $Mode   KeyEncoding = $KeyEncoding" -ForegroundColor Magenta
+Write-Host ""
+
+$result = if ($Mode -eq 'conhost-baseline') {
+    Invoke-ConhostBaseline
+} else {
+    Invoke-WtControlled
+}
+
+Write-Host ""
+Write-Host "=== Result ===" -ForegroundColor Magenta
+$json = $result | ConvertTo-Json -Depth 10
+Write-Host $json
+Write-Host ""
+
+if ($result.ok) {
+    Write-Host "GO: spike succeeded for mode=$Mode encoding=$KeyEncoding" -ForegroundColor Green
+    exit 0
+} else {
+    Write-Host "NO-GO (this run): spike failed for mode=$Mode encoding=$KeyEncoding" -ForegroundColor Yellow
+    exit 1
+}


### PR DESCRIPTION
## Summary

issue #185 (Windows Terminal BG input 経路復元) Phase 0 spike `AttachConsole + WriteConsoleInputW` 経路の **NO-GO 確定**。Round 3 で `PeekConsoleInputW` + `GetNumberOfConsoleInputEvents` を helper に注入し、書込直後に input buffer が drain されている decisive evidence を取得。conhost-baseline で再現性ありのため WT mode は spike-prompt §\"Suggested Spike Shape\" step 2 gating clause で skip。

- **影響範囲**: production code 改修ゼロ (scratch experiment + docs only)
- **ADR-013 §3.1 Option A** ConPTY 経路 の preliminary findings を embed、§7 OQ #1 から legacy `WriteConsoleInputW` 経路を除外
- **Option B / C / D** には影響なし (別 path)

## Round 経緯

| Round | Encoding | helper API | Buffer 観測 | sentinel verified | 判定 |
|---|---|---|---|---|---|
| 1 | UnicodeChar only (VK=0/scan=0) | ✓ 64/64 written | (未注入) | ✗ | encoding 仮説不成立 |
| 2 | proper VK + scan code (keydown_keyup) | ✓ 92/92 written | (未注入) | ✗ | encoding 仮説不成立、Opus 諮問 |
| 2 | proper VK + scan code (keydown only) | ✓ 60/60 written | (未注入) | ✗ | spike-prompt step 5 比較完了 |
| **3** | keydown_keyup + PeekConsoleInputW | ✓ 92/92 written | **`pending=0` / `peeked=0`** | ✗ | **decisive evidence** |

Round 3 で書込直後 buffer が空 → ConPTY が forwarding なしに drain している構造を pin、Win11 25H2 (DefTerm `{0..0}` \"Let Windows decide\") では legacy `WriteConsoleInputW` 経路が consumer に届かないことを構造的に証明。詳細 `docs/wt-attachconsole-spike-results.md` §4。

## Files changed

- `docs/wt-attachconsole-spike-results.md` (新規) — test matrix + technical explanation + Microsoft docs references + carry-over OQ
- `docs/wt-attachconsole-spike-prompt.md` (引継ぎ時 user 作成、本 PR で land)
- `docs/adr-013-wt-bg-input.md` (modified) — §3.1 末尾 Phase 0 preliminary findings embed + §7 OQ #1 「legacy 経路除外」追記 + §9 Decision History v1.3 行追加
- `scripts/spikes/wt-attachconsole-helper.ps1` (modified) — Round 3 PeekConsoleInputW + GetNumberOfConsoleInputEvents 注入
- `scripts/spikes/README.md` (modified) — Round 3 + NO-GO status sync

## Opus review

- **Round 1**: Conditionally Approved (P1 ゼロ、P2×3 + P3×3) → P2 全件 + P3-1 反映
- **Round 2**: Approved (P+P+P ゼロ) + 軽量 cosmetic 1 件反映 (`Decision Log` → `Decision History` 統一)

CLAUDE.md §3.3 Step 0 で docs PR 分類、Codex は trivial scope (production code 改修ゼロ) で skip 可。

## Carry-over (`docs/wt-attachconsole-spike-results.md` §5)

- **OQ-1**: orchestrator candidate filter leak (wt-controlled mode、spike scope 外、将来別 spike で解決)
- **OQ-2**: Stop-ProcessTreeSafe cleanup miss (Win11 DefTerm 経由の場合、同上)
- **OQ-3**: Option B/C/D との trade-off ranking (ADR-013 §5.1 Phase 1 acceptance で順次)
- **OQ-4**: WSL / SSH terminal inside WT への AttachConsole (別 issue 候補)

## Test plan

本 PR は production code 改修ゼロのため自動テスト追加なし。手動再現:

- [ ] `pwsh ./scripts/spikes/wt-attachconsole-orchestrator.ps1 -Mode conhost-baseline -KeyEncoding keydown_keyup -ReadbackDelayMs 1500` を実行、result JSON で `helper.peeked_records=0` / `helper.pending_events=0` を確認
- [ ] `docs/wt-attachconsole-spike-results.md` §3 Test Matrix の Round 3 数値と一致確認
- [ ] `docs/adr-013-wt-bg-input.md` §3.1 末尾 + §7 OQ #1 + §9 Decision History の embed が正しい位置にあるか目視
- [ ] WT mode は spike-prompt §\"Suggested Spike Shape\" step 2 gating clause により未実行を確認 (走らせない)

## Merge strategy

Opus 推奨: **squash merge** (Round 1/2 spike commits + Round 3 land を 1 commit に集約)。spike scripts は将来 Day 0 gate (Microsoft.Terminal.Core 探索) 別 spike でも reference として残す価値あり、production code 反映は不要 (NO-GO のため反映項目なし)。

## Refs

- issue #185
- ADR-013 §3.1 (`docs/adr-013-wt-bg-input.md`)
- spike prompt: `docs/wt-attachconsole-spike-prompt.md`
- 結果: `docs/wt-attachconsole-spike-results.md`