### PR TITLE
Prepare release v1.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.4.4] - 2026-05-11 — Window-targeted screenshots use PrintWindow by default (recovers RDP + GPU-composited captures)
+
 ### Changed
 
 - **Window-targeted screenshots now use Win32 PrintWindow by default, which

--- a/bin/launcher.js
+++ b/bin/launcher.js
@@ -18,13 +18,13 @@ import path from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 
-const PACKAGE_VERSION = "1.4.3";
+const PACKAGE_VERSION = "1.4.4";
 const RELEASE_TAG = `v${PACKAGE_VERSION}`;
 const REPO_API_URL = `https://api.github.com/repos/Harusame64/desktop-touch-mcp/releases/tags/${RELEASE_TAG}`;
 const ASSET_NAME = "desktop-touch-mcp-windows.zip";
 const RELEASE_METADATA_FILE = ".desktop-touch-release.json";
 const RELEASE_MANIFEST = {
-  tagName: "v1.4.3",
+  tagName: "v1.4.4",
   assetName: ASSET_NAME,
   sha256: "PENDING",
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harusame64/desktop-touch-mcp",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@harusame64/desktop-touch-mcp",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "license": "MIT",
       "bin": {
         "desktop-touch-mcp": "bin/launcher.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harusame64/desktop-touch-mcp",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "mcpName": "io.github.Harusame64/desktop-touch-mcp",
   "description": "LLM-native Windows computer-use MCP server with 28 tools for screenshots, UIA, mouse/keyboard, Chrome CDP, terminal, SmartScroll, and perception guards",
   "engines": {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const SERVER_VERSION = "1.4.3";
+export const SERVER_VERSION = "1.4.4";


### PR DESCRIPTION
## Summary

- Bump v1.4.3 → v1.4.4 (patch).
- CHANGELOG `[Unreleased]` section graduated to `[1.4.4] - 2026-05-11` with the existing window-targeted PrintWindow default entry already curated to user-facing English (no internal jargon — strict per 強制命令 10).

## What's in v1.4.4

Single visible change: window-targeted `screenshot(detail='image')` / `screenshot(diffMode=true)` now route through PrintWindow first with BitBlt auto-fallback. Fixes RDP-session black-screen captures and recovers GPU-composited apps (Chrome / Electron / WinUI3) that the legacy BitBlt-of-screen path was returning empty.

Full implementation and review history: PR #251 (merged as commit `3334b02`, 2 review rounds with Opus + Codex, all P1/P2/P3 resolved).

## Verification

- [x] `node --check bin/launcher.js` — OK
- [x] `npm run build` — clean
- [x] `npm publish --dry-run` — 32.9 kB package, 5 files, identical layout to v1.4.3
- [x] `npm version` synced src/version.ts, bin/launcher.js, package.json, package-lock.json

## Post-merge flow (strict order per docs/release-process.md)

1. Merge this PR.
2. `git tag v1.4.4 && git push origin v1.4.4`.
3. Wait for GH Actions release.yml to produce `desktop-touch-mcp-windows.zip`.
4. Verify the zip exists via `gh release view v1.4.4 --json assets`.
5. **Only then** `npm publish` (2FA browser auth).
6. Smoke test from a clean cache.
7. Separate commit `chore(server.json): bump to v1.4.4 for MCP Registry publish` after `mcp-publisher publish` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)