### PR TITLE
fix(image): drop dead null initializer flagged by no-useless-assignment (CI lint fix)

### DIFF
--- a/src/engine/image.ts
+++ b/src/engine/image.ts
@@ -332,14 +332,15 @@ export async function captureWindowRawWithFallback(
   flags = 2,
 ): Promise<CaptureWindowRawResult> {
   const raw = captureWindowRawPrintWindow(hwnd, flags);
-  let fallbackReason: CaptureFallbackReason = null;
+  // Definite-assignment analysis: every path through this block either
+  // assigns fallbackReason or returns, so no initializer is needed (and an
+  // initial `null` would be dead code per eslint no-useless-assignment).
+  let fallbackReason: CaptureFallbackReason;
   if (!raw) {
     fallbackReason = "printwindow-failed";
   } else {
     const blank = isLikelyBlankCapture(raw.rawPixels, raw.width, raw.height, raw.channels);
-    if (blank.isBlank) {
-      fallbackReason = blank.reason;
-    } else {
+    if (!blank.isBlank) {
       return {
         rawPixels: raw.rawPixels,
         width: raw.width,
@@ -349,6 +350,7 @@ export async function captureWindowRawWithFallback(
         fallbackReason: null,
       };
     }
+    fallbackReason = blank.reason;
   }
   // BitBlt fallback grabs the full window rect, NOT a sub-region. Sub-region
   // crops are applied uniformly at encode time via opts.crop (window-local


### PR DESCRIPTION
## Summary

CI lint on main (run [25671930997](https://github.com/Harusame64/desktop-touch-mcp/actions/runs/25671930997)) failed on `src/engine/image.ts:335` with:

\`\`\`
error  The value assigned to 'fallbackReason' is not used in subsequent statements  no-useless-assignment
\`\`\`

The initial `let fallbackReason: CaptureFallbackReason = null` is dead code — every code path through the surrounding if/else either reassigns it or returns early. Restructured to rely on TypeScript's definite-assignment analysis: PrintWindow-success becomes an early return, blank-detected assigns at the end of the else, and the declaration is left uninitialised so TS + eslint both agree there is no dead value.

Behaviour identical, no public API or hint surface change. Hotfix only — does not warrant a new patch release.

## Verification

- [x] `npm run lint` — 0 errors (was 1)
- [x] `npm run build` — clean
- [x] `tests/unit/screenshot-printwindow-default.test.ts` — 14/14 pass (regression pins for sub-region + fallback still hold)

The remaining `npm run lint` warning at `tests/unit/issue-211-typeviaclipboard-readback-pin.test.ts:53` (unused eslint-disable directive) is pre-existing on main and unrelated to this PR / to the v1.4.4 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)