### PR TITLE
feat(engine-vba-bridge): Phase 1 — Rust primitives + variant bridge unit tests (ADR-015)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,6 +498,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "engine-vba-bridge"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "windows",
+ "windows-core",
+]
+
+[[package]]
 name = "esaxx-rs"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
-members = [".", "crates/engine-perception"]
-default-members = [".", "crates/engine-perception"]
+members = [".", "crates/engine-perception", "crates/engine-vba-bridge"]
+default-members = [".", "crates/engine-perception", "crates/engine-vba-bridge"]
 resolver = "3"
 
 [package]

--- a/crates/engine-vba-bridge/Cargo.toml
+++ b/crates/engine-vba-bridge/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "engine-vba-bridge"
+version = "0.1.0"
+edition = "2024"
+license = "MIT"
+description = "VBA Extensibility COM bridge (Excel.Application IDispatch late-binding) for desktop-touch-mcp (ADR-015)"
+publish = false
+
+# ADR-015 §3.2: this crate exposes Rust API surface only. The napi
+# binding lives in the root `desktop-touch-engine` cdylib, which wires
+# the public functions of this crate to JS via napi-derive (mirrors the
+# `engine-perception` integration pattern).
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+# ADR-015 §3.3: IDispatch late-binding requires COM + VARIANT + (for
+# `Excel.Application` ProgID resolution) the Ole feature for VARIANT
+# struct exposure. windows-rs is pinned at the workspace's 0.62 (matches
+# the root crate's pin). Registry features are required for the HKCU
+# AccessVBOM read in `registry.rs` (§3.7, Phase 2 — listed now so the
+# Phase 2 PR doesn't need to bump features).
+[target.'cfg(windows)'.dependencies]
+windows-core = "0.62"
+windows = { version = "0.62", features = [
+    "Win32_System_Com",
+    "Win32_System_Variant",
+    "Win32_System_Ole",
+    "Win32_System_Registry",
+    "Win32_Foundation",
+] }
+
+[dev-dependencies]
+# Unit-test fixtures for VARIANT round-trip + JSON conversion (no Excel
+# required). Phase 2 integration tests gate Excel-required code behind a
+# feature flag (see [features] below).
+serde_json = "1"
+
+[features]
+# Phase 2 integration tests are gated behind `excel-installed`. CI does
+# not enable this feature; local dev / release-machine tests enable it
+# explicitly when Excel is available.
+excel-installed = []

--- a/crates/engine-vba-bridge/src/apartment.rs
+++ b/crates/engine-vba-bridge/src/apartment.rs
@@ -1,0 +1,71 @@
+//! STA worker thread management (ADR-015 §3.4).
+//!
+//! `Excel.Application` is a single-threaded apartment (STA) COM
+//! object. All calls must originate from a thread that has called
+//! `CoInitializeEx(COINIT_APARTMENTTHREADED)`. The structural pattern
+//! mirrors `src/uia/thread.rs:1-50` (dedicated worker thread + a
+//! crossbeam-channel command pump), with two intentional differences:
+//!
+//! 1. Apartment model: `src/uia/thread.rs` uses MTA
+//!    (`COINIT_MULTITHREADED`); this module uses STA because Excel
+//!    strictly requires it
+//! 2. Lifetime: the UIA worker is a process-singleton (`OnceLock`);
+//!    `ExcelSession` is per-instance so callers can hold multiple
+//!    independent Excel.Application objects if they need to (e.g.
+//!    parallel headless macro runs)
+//!
+//! ## Phase 1 scope
+//!
+//! Phase 1 ships the module skeleton + the `ExcelSession` handle type
+//! signature. The actual worker spawn (`CoInitializeEx` + command
+//! channel + `CoCreateInstance("Excel.Application")` + Drop-time
+//! `CoUninitialize`) lands in Phase 2 alongside `excel.rs`. Phase 1
+//! acceptance is `cargo build` + `cargo test` green; the stub here
+//! compiles and exposes the type so Phase 2 can build on it without
+//! re-shaping the public API.
+
+use std::marker::PhantomData;
+
+/// Owns one STA worker thread + the `IDispatch` pointer to
+/// `Excel.Application` for the worker's lifetime.
+///
+/// Phase 1: opaque handle, only `new_stub()` constructor exposed so
+/// downstream code (e.g. future Phase 2 `excel.rs`) can begin to
+/// reference the type. Phase 2 replaces the body with the real worker
+/// spawn + COM pointer + command channel.
+pub struct ExcelSession {
+    // Phase 2 will replace this with:
+    //   - JoinHandle<()> for the STA worker thread
+    //   - crossbeam_channel::Sender<Cmd> for the command pump
+    //   - Atomic shutdown flag
+    // See ADR-015 §3.4 for the design and `src/uia/thread.rs:1-100` for
+    // the analogous (MTA) worker pattern.
+    _phantom: PhantomData<*const ()>,
+}
+
+impl ExcelSession {
+    /// Phase 1 stub constructor. Real spawn (`CoInitializeEx` +
+    /// `CoCreateInstance`) lands in Phase 2.
+    pub fn new_stub() -> Self {
+        Self {
+            _phantom: PhantomData,
+        }
+    }
+}
+
+// `ExcelSession` is not `Send` (the `PhantomData<*const ()>` makes it
+// !Send + !Sync). Phase 2 will make it `Send` (the worker thread owns
+// COM state; the handle just routes commands), but Phase 1 keeps it
+// strictly !Send to prevent accidental misuse before the worker exists.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn phase1_stub_constructs() {
+        let _s = ExcelSession::new_stub();
+        // Phase 1 acceptance: the type compiles + constructs.
+        // Phase 2 will add real spawn / shutdown / drop tests.
+    }
+}

--- a/crates/engine-vba-bridge/src/dispatch.rs
+++ b/crates/engine-vba-bridge/src/dispatch.rs
@@ -35,7 +35,11 @@ pub fn invoke_get(
     // so the call site is exercised end-to-end against a real
     // Excel.Application IDispatch.
     Err(VbaBridgeError::ComCallFailed {
-        hresult: 0,
+        // E_NOTIMPL = 0x80004001 (= -2147467263 as i32). Phase 1 stub
+        // returns E_NOTIMPL deliberately so future diagnostic paths
+        // cannot misinterpret hresult=0 (= S_OK = success). Phase 2
+        // replaces this entirely with real Invoke() calls.
+        hresult: -2147467263,
         context: format!("invoke_get({name}): Phase 1 stub — implementation lands in Phase 2"),
     })
 }
@@ -51,7 +55,11 @@ pub fn invoke_call(
     _args: &[VARIANT],
 ) -> VbaBridgeResult<VARIANT> {
     Err(VbaBridgeError::ComCallFailed {
-        hresult: 0,
+        // E_NOTIMPL = 0x80004001 (= -2147467263 as i32). Phase 1 stub
+        // returns E_NOTIMPL deliberately so future diagnostic paths
+        // cannot misinterpret hresult=0 (= S_OK = success). Phase 2
+        // replaces this entirely with real Invoke() calls.
+        hresult: -2147467263,
         context: format!("invoke_call({name}): Phase 1 stub — implementation lands in Phase 2"),
     })
 }
@@ -62,7 +70,11 @@ pub fn invoke_call(
 /// Phase 2 will use this for `Application.Visible = true`, etc.
 pub fn invoke_put(_disp: &IDispatch, name: &str, _value: VARIANT) -> VbaBridgeResult<()> {
     Err(VbaBridgeError::ComCallFailed {
-        hresult: 0,
+        // E_NOTIMPL = 0x80004001 (= -2147467263 as i32). Phase 1 stub
+        // returns E_NOTIMPL deliberately so future diagnostic paths
+        // cannot misinterpret hresult=0 (= S_OK = success). Phase 2
+        // replaces this entirely with real Invoke() calls.
+        hresult: -2147467263,
         context: format!("invoke_put({name}): Phase 1 stub — implementation lands in Phase 2"),
     })
 }

--- a/crates/engine-vba-bridge/src/dispatch.rs
+++ b/crates/engine-vba-bridge/src/dispatch.rs
@@ -1,0 +1,68 @@
+//! `IDispatch` late-binding helpers (ADR-015 §3.3).
+//!
+//! Three thin helpers (`invoke_get`, `invoke_call`, `invoke_put`) that
+//! wrap the Win32 `IDispatch::GetIDsOfNames` + `IDispatch::Invoke`
+//! dance. Resolves a method / property name string into a DISPID at
+//! call site (late binding), so the bridge does not require a compiled
+//! type-library import.
+//!
+//! ## Phase 1 scope
+//!
+//! Phase 1 ships the module skeleton + signatures so the public API
+//! surface is fixed. The actual `Invoke` implementation is deferred to
+//! Phase 2 (where it lands alongside `excel.rs`'s Excel.Application
+//! wrapper that exercises it end-to-end). Phase 1 acceptance is
+//! `cargo build -p engine-vba-bridge` + `cargo test -p engine-vba-bridge`
+//! green; the dispatch helpers compile as stubs that return a
+//! `ComCallFailed` placeholder until Phase 2 lands the real call.
+
+use windows::Win32::System::Com::IDispatch;
+use windows::Win32::System::Variant::VARIANT;
+
+use crate::errors::{VbaBridgeError, VbaBridgeResult};
+
+/// Read a property by name from an `IDispatch`.
+///
+/// Wraps `GetIDsOfNames(name)` + `Invoke(DISPATCH_PROPERTYGET)`.
+/// Phase 2 will use this for `Excel.Application.VBE`,
+/// `Workbook.VBProject`, `VBComponent.CodeModule`, etc.
+pub fn invoke_get(
+    _disp: &IDispatch,
+    name: &str,
+    _args: &[VARIANT],
+) -> VbaBridgeResult<VARIANT> {
+    // Phase 1: stub — implementation lands in Phase 2 alongside excel.rs
+    // so the call site is exercised end-to-end against a real
+    // Excel.Application IDispatch.
+    Err(VbaBridgeError::ComCallFailed {
+        hresult: 0,
+        context: format!("invoke_get({name}): Phase 1 stub — implementation lands in Phase 2"),
+    })
+}
+
+/// Call a method by name on an `IDispatch`.
+///
+/// Wraps `GetIDsOfNames(name)` + `Invoke(DISPATCH_METHOD)`.
+/// Phase 2 will use this for `Application.Run`, `VBComponents.Add`,
+/// `CodeModule.AddFromString`, etc.
+pub fn invoke_call(
+    _disp: &IDispatch,
+    name: &str,
+    _args: &[VARIANT],
+) -> VbaBridgeResult<VARIANT> {
+    Err(VbaBridgeError::ComCallFailed {
+        hresult: 0,
+        context: format!("invoke_call({name}): Phase 1 stub — implementation lands in Phase 2"),
+    })
+}
+
+/// Write a property by name on an `IDispatch`.
+///
+/// Wraps `GetIDsOfNames(name)` + `Invoke(DISPATCH_PROPERTYPUT)`.
+/// Phase 2 will use this for `Application.Visible = true`, etc.
+pub fn invoke_put(_disp: &IDispatch, name: &str, _value: VARIANT) -> VbaBridgeResult<()> {
+    Err(VbaBridgeError::ComCallFailed {
+        hresult: 0,
+        context: format!("invoke_put({name}): Phase 1 stub — implementation lands in Phase 2"),
+    })
+}

--- a/crates/engine-vba-bridge/src/errors.rs
+++ b/crates/engine-vba-bridge/src/errors.rs
@@ -1,0 +1,200 @@
+//! Typed errors for the VBA Extensibility bridge (ADR-015 §4.4).
+//!
+//! Naming follows the `Vba*` PascalCase single-cap-acronym convention
+//! that the project's existing `pascalToSnake` boundary rule
+//! (`src/tools/_envelope.ts`) handles cleanly. Round-trip examples:
+//!
+//! | PascalCase | snake_case |
+//! |---|---|
+//! | `VbaAccessNotTrusted` | `vba_access_not_trusted` |
+//! | `VbaAccessLockedByPolicy` | `vba_access_locked_by_policy` |
+//! | `VbaModuleAuthoringFailed` | `vba_module_authoring_failed` |
+//! | `VbaMacroExecutionFailed` | `vba_macro_execution_failed` |
+//! | `VbaMacroNotFound` | `vba_macro_not_found` |
+//! | `VbaUnsupportedArgumentType` | `vba_unsupported_argument_type` |
+//! | `VbaWorkbookProtected` | `vba_workbook_protected` |
+//! | `ExcelNotInstalled` | `excel_not_installed` |
+//!
+//! Mixed-case acronyms (`VBOM`, `HKCU`) are deliberately avoided
+//! because `pascalToSnake` only splits at `[a-z][A-Z]` boundaries —
+//! `VbaAccessNotTrusted` works, `AccessVBOMNotTrusted` would become
+//! `access_vbomnot_trusted` (missing underscore before `not`).
+
+use std::fmt;
+
+pub type VbaBridgeResult<T> = std::result::Result<T, VbaBridgeError>;
+
+/// Typed errors for the VBA bridge surface.
+///
+/// Each variant maps to a `_errors.ts` SUGGESTS entry with the same
+/// PascalCase name (ADR-015 §4.4). Variants are kept thin: callers
+/// receive an error code + a free-form context message that the napi
+/// binding maps into the MCP envelope's `failure.reason` /
+/// `failure.context` fields.
+#[derive(Debug)]
+pub enum VbaBridgeError {
+    /// HKCU AccessVBOM is 0 and HKLM does not override it to 1.
+    /// User must run the setup CLI (`scripts/enable-access-vbom.mjs`).
+    VbaAccessNotTrusted,
+
+    /// HKLM forces AccessVBOM to 0 (group policy). The MCP cannot
+    /// override this; user must contact IT.
+    VbaAccessLockedByPolicy,
+
+    /// `CLSIDFromProgID("Excel.Application")` returned
+    /// `REGDB_E_CLASSNOTREG`. Excel is not installed (or not registered).
+    ExcelNotInstalled,
+
+    /// `CodeModule::AddFromString` returned a non-zero HRESULT. The
+    /// `code` argument is typically malformed VBA source. The context
+    /// carries the underlying HRESULT description from the COM error
+    /// info if available.
+    VbaModuleAuthoringFailed(String),
+
+    /// `Application::Run` returned a non-zero HRESULT.
+    VbaMacroExecutionFailed(String),
+
+    /// The caller's `code` does not declare a `Sub` matching the
+    /// (defaulted) `macroName`. Detected at the wrapper level before
+    /// invoking COM, so it surfaces cleanly without VBE involvement.
+    VbaMacroNotFound { expected: String },
+
+    /// Caller passed a JSON type that the VARIANT bridge does not
+    /// support in v1 (`object` / `array` / dispatch). The caller can
+    /// fall back to serializing into a worksheet cell.
+    VbaUnsupportedArgumentType { json_type: &'static str },
+
+    /// Workbook-level VBA password blocks `VBProject` access entirely.
+    /// User must unlock the workbook manually before the bridge can
+    /// add modules.
+    VbaWorkbookProtected,
+
+    /// A COM call returned an unexpected HRESULT. Used as a fallback
+    /// when no more specific variant applies. The context carries the
+    /// HRESULT code + the operation name at the failure site.
+    ComCallFailed { hresult: i32, context: String },
+}
+
+impl VbaBridgeError {
+    /// Returns the PascalCase code name for the error variant. This is
+    /// the exact string the MCP envelope uses in `failure.reason`
+    /// (after `pascalToSnake` projection in `src/tools/_envelope.ts`).
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::VbaAccessNotTrusted => "VbaAccessNotTrusted",
+            Self::VbaAccessLockedByPolicy => "VbaAccessLockedByPolicy",
+            Self::ExcelNotInstalled => "ExcelNotInstalled",
+            Self::VbaModuleAuthoringFailed(_) => "VbaModuleAuthoringFailed",
+            Self::VbaMacroExecutionFailed(_) => "VbaMacroExecutionFailed",
+            Self::VbaMacroNotFound { .. } => "VbaMacroNotFound",
+            Self::VbaUnsupportedArgumentType { .. } => "VbaUnsupportedArgumentType",
+            Self::VbaWorkbookProtected => "VbaWorkbookProtected",
+            Self::ComCallFailed { .. } => "ComCallFailed",
+        }
+    }
+}
+
+impl fmt::Display for VbaBridgeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::VbaAccessNotTrusted => write!(
+                f,
+                "VbaAccessNotTrusted: HKCU AccessVBOM is 0; run scripts/enable-access-vbom.mjs"
+            ),
+            Self::VbaAccessLockedByPolicy => write!(
+                f,
+                "VbaAccessLockedByPolicy: HKLM group policy forces AccessVBOM=0; contact your IT department"
+            ),
+            Self::ExcelNotInstalled => write!(
+                f,
+                "ExcelNotInstalled: Excel.Application CLSID is not registered on this machine"
+            ),
+            Self::VbaModuleAuthoringFailed(ctx) => {
+                write!(f, "VbaModuleAuthoringFailed: {ctx}")
+            }
+            Self::VbaMacroExecutionFailed(ctx) => {
+                write!(f, "VbaMacroExecutionFailed: {ctx}")
+            }
+            Self::VbaMacroNotFound { expected } => write!(
+                f,
+                "VbaMacroNotFound: code does not declare Sub {expected}(...)"
+            ),
+            Self::VbaUnsupportedArgumentType { json_type } => write!(
+                f,
+                "VbaUnsupportedArgumentType: JSON {json_type} is not supported in args; \
+                 serialize into a worksheet cell or pass a primitive (null / boolean / number / string)"
+            ),
+            Self::VbaWorkbookProtected => write!(
+                f,
+                "VbaWorkbookProtected: workbook-level VBA password blocks VBProject access; unlock manually"
+            ),
+            Self::ComCallFailed { hresult, context } => {
+                write!(f, "ComCallFailed: HRESULT=0x{hresult:08x} at {context}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for VbaBridgeError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// All error codes must round-trip cleanly through the
+    /// `pascalToSnake` boundary rule in `src/tools/_envelope.ts`
+    /// (Codex Round 1 P2). The rule splits at every `[a-z][A-Z]`
+    /// boundary, so any code containing a multi-uppercase run (`VBOM`,
+    /// `HKCU`, etc.) would tokenize incorrectly. This test pins the
+    /// invariant that all our codes have at most one uppercase letter
+    /// per word.
+    #[test]
+    fn all_error_codes_are_single_cap_acronym_style() {
+        let codes = [
+            "VbaAccessNotTrusted",
+            "VbaAccessLockedByPolicy",
+            "ExcelNotInstalled",
+            "VbaModuleAuthoringFailed",
+            "VbaMacroExecutionFailed",
+            "VbaMacroNotFound",
+            "VbaUnsupportedArgumentType",
+            "VbaWorkbookProtected",
+            "ComCallFailed",
+        ];
+        for code in codes {
+            assert!(
+                !has_multi_uppercase_run(code),
+                "code {code} contains a multi-uppercase run; pascalToSnake will tokenize incorrectly"
+            );
+        }
+    }
+
+    /// Returns true if `s` contains two consecutive uppercase letters.
+    /// Mirrors the failure condition for `pascalToSnake` (which only
+    /// splits at `[a-z][A-Z]` boundaries, so `VV` stays merged).
+    fn has_multi_uppercase_run(s: &str) -> bool {
+        let mut prev_upper = false;
+        for c in s.chars() {
+            let is_upper = c.is_ascii_uppercase();
+            if is_upper && prev_upper {
+                return true;
+            }
+            prev_upper = is_upper;
+        }
+        false
+    }
+
+    #[test]
+    fn code_method_matches_variant_name() {
+        // Spot-check a few variants.
+        assert_eq!(VbaBridgeError::VbaAccessNotTrusted.code(), "VbaAccessNotTrusted");
+        assert_eq!(VbaBridgeError::ExcelNotInstalled.code(), "ExcelNotInstalled");
+        assert_eq!(
+            VbaBridgeError::VbaMacroNotFound {
+                expected: "Foo".into()
+            }
+            .code(),
+            "VbaMacroNotFound"
+        );
+    }
+}

--- a/crates/engine-vba-bridge/src/lib.rs
+++ b/crates/engine-vba-bridge/src/lib.rs
@@ -1,0 +1,37 @@
+//! VBA Extensibility COM bridge (ADR-015).
+//!
+//! Late-binding `IDispatch` wrapper around `Excel.Application` that
+//! lets Rust callers author and run VBA macros without touching the
+//! VBA Editor UI. Implements ADR-015 Phase 1 primitives:
+//!
+//! - [`variant`]: `serde_json::Value` ↔ `VARIANT` round-trip with the
+//!   `null → VT_NULL` semantic (NOT `VT_EMPTY`; see ADR-015 §3.5)
+//! - [`dispatch`]: three thin helpers on `IDispatch`
+//!   (`invoke_get` / `invoke_call` / `invoke_put`) that resolve names
+//!   via `GetIDsOfNames` then call `Invoke` with the appropriate
+//!   `DISPATCH_FLAGS`
+//! - [`apartment`]: STA worker-thread management
+//!   (`CoInitializeEx(COINIT_APARTMENTTHREADED)` + crossbeam-channel
+//!   command pump). Mirrors the existing `src/uia/thread.rs` MTA worker
+//!   pattern at the structural level; uses STA because Excel.Application
+//!   strictly requires it
+//! - [`errors`]: typed errors mapped from HRESULT, named per the
+//!   `Vba*` PascalCase convention (Codex Round 1 P2 — must round-trip
+//!   through `src/tools/_envelope.ts::pascalToSnake` cleanly)
+//!
+//! Phase 2 adds [`excel`] (Excel-specific wrapper) and [`registry`]
+//! (read-only HKCU `AccessVBOM` check). Phase 3 adds the napi binding
+//! in the root crate.
+
+#![cfg_attr(not(windows), allow(unused))]
+
+pub mod errors;
+pub mod variant;
+
+#[cfg(windows)]
+pub mod dispatch;
+
+#[cfg(windows)]
+pub mod apartment;
+
+pub use errors::{VbaBridgeError, VbaBridgeResult};

--- a/crates/engine-vba-bridge/src/variant.rs
+++ b/crates/engine-vba-bridge/src/variant.rs
@@ -137,7 +137,7 @@ mod win {
     //! surface (`json_to_variant` / `variant_to_json`) can be referenced
     //! by future Phase 2 code without further crate-level wiring.
 
-    use super::{VariantKind, VbaBridgeError, VbaBridgeResult, Value};
+    use super::{VariantKind, VbaBridgeResult, Value};
 
     /// Construct a `VARIANT` from a JSON value.
     ///
@@ -168,10 +168,6 @@ mod win {
         }
     }
 
-    #[allow(dead_code)]
-    fn _phase2_placeholder(_: &VbaBridgeError) {
-        // Suppresses unused-import warnings on Phase 1 cdylib builds.
-    }
 }
 
 #[cfg(windows)]

--- a/crates/engine-vba-bridge/src/variant.rs
+++ b/crates/engine-vba-bridge/src/variant.rs
@@ -1,0 +1,326 @@
+//! `serde_json::Value` ↔ `VARIANT` bridge (ADR-015 §3.5).
+//!
+//! VBA macro arguments and return values flow through `VARIANT`. This
+//! module provides:
+//!
+//! - A pure-function classifier ([`classify_json`]) that maps a JSON
+//!   value to its target VARIANT type tag ([`VariantKind`]). The
+//!   classifier is testable on every platform (no Windows dependency)
+//!   and is the centre of the `null → VT_NULL` semantic invariant
+//!   that Round 1 of ADR-015 incorrectly mapped to `VT_EMPTY`
+//! - On Windows, the actual `VARIANT` construction routines
+//!   ([`json_to_variant`] / [`variant_to_json`]) that consume / produce
+//!   `windows::Win32::System::Variant::VARIANT`
+//!
+//! ## Supported types
+//!
+//! | JSON | VARIANT | Notes |
+//! |---|---|---|
+//! | `null` | `VT_NULL` | Matches VBA `IsNull()`. NOT `VT_EMPTY`. |
+//! | `true` / `false` | `VT_BOOL` | `VARIANT_TRUE` = -1, `VARIANT_FALSE` = 0 |
+//! | integer | `VT_I4` | Clamped to `i32` range |
+//! | float | `VT_R8` | |
+//! | string | `VT_BSTR` (default) | |
+//! | `{__type:"date", value:"<ISO-8601>"}` | `VT_DATE` | Explicit opt-in per ADR-015 §3.5; JSON has no native Date type and ISO autodetect would silently change semantics (Codex Round 2 axis) |
+//!
+//! Object / array / null-typed nested structures return
+//! [`VbaBridgeError::VbaUnsupportedArgumentType`]; callers serialize
+//! complex data into a worksheet cell instead.
+
+use serde_json::Value;
+
+use crate::errors::{VbaBridgeError, VbaBridgeResult};
+
+/// Target VARIANT type for a given JSON value.
+///
+/// Returned by [`classify_json`]. The variants intentionally carry the
+/// already-validated payload so the windows-side conversion code in
+/// [`json_to_variant`] does not have to re-extract it from the
+/// `serde_json::Value`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum VariantKind {
+    /// `VT_NULL` — VBA `IsNull()` is true.
+    Null,
+    /// `VT_BOOL` — VBA `True` / `False`.
+    Bool(bool),
+    /// `VT_I4` — VBA `Long` (32-bit signed integer).
+    I4(i32),
+    /// `VT_R8` — VBA `Double` (64-bit float).
+    R8(f64),
+    /// `VT_BSTR` — VBA `String`.
+    Bstr(String),
+    /// `VT_DATE` — VBA `Date`. The value is the ISO-8601 string the
+    /// caller tagged with `{__type:"date", value:"..."}`; the windows-side
+    /// conversion parses it into the OLE Automation date (days since
+    /// 1899-12-30) format. The parsing is deferred to the windows-side
+    /// code (or to a future helper) — Phase 1 only classifies.
+    Date(String),
+}
+
+/// Classifies a JSON value to its target VARIANT kind.
+///
+/// This is a pure function with no Windows dependency, so the unit
+/// tests in this module cover it on every platform. The actual
+/// `windows::Win32::System::Variant::VARIANT` construction lives in
+/// [`json_to_variant`] (Windows only).
+///
+/// ## Rules
+///
+/// - `Value::Null` → `VariantKind::Null` (NOT `Empty`).
+///   The `VT_NULL` vs `VT_EMPTY` distinction matters in VBA: `IsNull()`
+///   tests for `VT_NULL`, `IsEmpty()` tests for `VT_EMPTY`. Mapping a
+///   JSON `null` to `VT_EMPTY` would make `IsNull()` return false in
+///   macros that branch on null-handling, which is the opposite of
+///   caller intent. Round 1 of ADR-015 had this wrong; Round 2 fixed it.
+///
+/// - `Value::Bool` → `VariantKind::Bool(b)`.
+///
+/// - `Value::Number(i)` where i fits in `i32` → `VariantKind::I4(i)`.
+///   Numbers outside `i32` range fall through to `VT_R8` via the float
+///   path below — they round-trip lossily but preserve the value.
+///
+/// - `Value::Number(f)` → `VariantKind::R8(f)`.
+///
+/// - `Value::String(s)` → `VariantKind::Bstr(s)` (default).
+///
+/// - `Value::Object` with shape `{__type:"date", value:"<ISO>"}` →
+///   `VariantKind::Date(value)`. **This is the only date path**; ISO
+///   autodetect on plain strings is intentionally not supported (it
+///   would silently change macro semantics — Codex Round 2 axis).
+///
+/// - `Value::Object` (other shapes) → error.
+/// - `Value::Array` → error.
+pub fn classify_json(v: &Value) -> VbaBridgeResult<VariantKind> {
+    match v {
+        Value::Null => Ok(VariantKind::Null),
+        Value::Bool(b) => Ok(VariantKind::Bool(*b)),
+        Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                if (i32::MIN as i64..=i32::MAX as i64).contains(&i) {
+                    return Ok(VariantKind::I4(i as i32));
+                }
+                // Out-of-range integer falls through to R8.
+            }
+            if let Some(f) = n.as_f64() {
+                Ok(VariantKind::R8(f))
+            } else {
+                // Number that fits in neither i64 nor f64; treat as
+                // unsupported rather than panicking.
+                Err(VbaBridgeError::VbaUnsupportedArgumentType {
+                    json_type: "number-out-of-range",
+                })
+            }
+        }
+        Value::String(s) => Ok(VariantKind::Bstr(s.clone())),
+        Value::Object(map) => {
+            // Date wrapper: {__type: "date", value: "<ISO-8601>"}
+            if let Some(Value::String(t)) = map.get("__type") {
+                if t == "date" {
+                    if let Some(Value::String(val)) = map.get("value") {
+                        return Ok(VariantKind::Date(val.clone()));
+                    }
+                }
+            }
+            Err(VbaBridgeError::VbaUnsupportedArgumentType { json_type: "object" })
+        }
+        Value::Array(_) => Err(VbaBridgeError::VbaUnsupportedArgumentType { json_type: "array" }),
+    }
+}
+
+#[cfg(windows)]
+mod win {
+    //! Windows-only `VARIANT` construction. Phase 1 ships the
+    //! classifier + unit tests; the actual `windows::Win32::System::Variant::VARIANT`
+    //! construction comes online in Phase 2 alongside `excel.rs`.
+    //!
+    //! Phase 1 keeps this submodule as a stub so the public API
+    //! surface (`json_to_variant` / `variant_to_json`) can be referenced
+    //! by future Phase 2 code without further crate-level wiring.
+
+    use super::{VariantKind, VbaBridgeError, VbaBridgeResult, Value};
+
+    /// Construct a `VARIANT` from a JSON value.
+    ///
+    /// Phase 1: stub that classifies and returns the kind. The actual
+    /// `VARIANT` construction (allocating BSTRs, packing into the
+    /// VARIANT union, etc.) lands in Phase 2 alongside `excel.rs`.
+    pub fn json_to_variant_kind(v: &Value) -> VbaBridgeResult<VariantKind> {
+        super::classify_json(v)
+    }
+
+    /// Stub for the reverse direction. Phase 2 implements VARIANT
+    /// extraction from `IDispatch::Invoke` return values.
+    pub fn variant_kind_to_json(kind: VariantKind) -> VbaBridgeResult<Value> {
+        match kind {
+            VariantKind::Null => Ok(Value::Null),
+            VariantKind::Bool(b) => Ok(Value::Bool(b)),
+            VariantKind::I4(i) => Ok(Value::Number(i.into())),
+            VariantKind::R8(f) => Ok(serde_json::Number::from_f64(f)
+                .map(Value::Number)
+                .unwrap_or(Value::Null)),
+            VariantKind::Bstr(s) => Ok(Value::String(s)),
+            VariantKind::Date(iso) => {
+                // Round-trip a date as the same {__type:"date", value:...}
+                // wrapper the caller used on the way in, so callers do
+                // not need to special-case the return-value shape.
+                Ok(serde_json::json!({"__type": "date", "value": iso}))
+            }
+        }
+    }
+
+    #[allow(dead_code)]
+    fn _phase2_placeholder(_: &VbaBridgeError) {
+        // Suppresses unused-import warnings on Phase 1 cdylib builds.
+    }
+}
+
+#[cfg(windows)]
+pub use win::{json_to_variant_kind as json_to_variant, variant_kind_to_json as variant_to_json};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn null_maps_to_vt_null_not_vt_empty() {
+        // Round 1 of ADR-015 had this wrong (mapped to VT_EMPTY).
+        // This test pins the corrected semantic per ADR-015 §3.5.
+        let v = Value::Null;
+        let kind = classify_json(&v).unwrap();
+        assert_eq!(kind, VariantKind::Null);
+        // Belt-and-suspenders: confirm the enum has no Empty variant
+        // (compile-time check — if someone later adds VariantKind::Empty
+        // and routes Null to it, this match will still pin Null → Null).
+        match kind {
+            VariantKind::Null => {}
+            _ => panic!("null must classify to VariantKind::Null"),
+        }
+    }
+
+    #[test]
+    fn boolean_maps_to_bool() {
+        assert_eq!(
+            classify_json(&Value::Bool(true)).unwrap(),
+            VariantKind::Bool(true)
+        );
+        assert_eq!(
+            classify_json(&Value::Bool(false)).unwrap(),
+            VariantKind::Bool(false)
+        );
+    }
+
+    #[test]
+    fn small_integer_maps_to_i4() {
+        assert_eq!(classify_json(&json!(0)).unwrap(), VariantKind::I4(0));
+        assert_eq!(classify_json(&json!(42)).unwrap(), VariantKind::I4(42));
+        assert_eq!(classify_json(&json!(-100)).unwrap(), VariantKind::I4(-100));
+        // i32 boundaries
+        assert_eq!(
+            classify_json(&json!(i32::MAX)).unwrap(),
+            VariantKind::I4(i32::MAX)
+        );
+        assert_eq!(
+            classify_json(&json!(i32::MIN)).unwrap(),
+            VariantKind::I4(i32::MIN)
+        );
+    }
+
+    #[test]
+    fn large_integer_falls_through_to_r8() {
+        // i32::MAX + 1 cannot fit in I4, so the classifier falls
+        // through to R8 (lossless for this exact value).
+        let big = (i32::MAX as i64) + 1;
+        match classify_json(&json!(big)).unwrap() {
+            VariantKind::R8(f) => assert_eq!(f as i64, big),
+            other => panic!("expected R8, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn float_maps_to_r8() {
+        match classify_json(&json!(1.5)).unwrap() {
+            VariantKind::R8(f) => assert!((f - 1.5).abs() < f64::EPSILON),
+            other => panic!("expected R8, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn string_maps_to_bstr_by_default() {
+        // Plain string stays BSTR — ISO-looking strings DO NOT
+        // auto-promote to VT_DATE (Codex Round 2 P2: avoid silently
+        // changing argument semantics).
+        let iso_looking = "2026-05-12T00:00:00Z";
+        assert_eq!(
+            classify_json(&json!(iso_looking)).unwrap(),
+            VariantKind::Bstr(iso_looking.into())
+        );
+    }
+
+    #[test]
+    fn date_wrapper_maps_to_vt_date() {
+        // Caller-tagged date wrapper opts in to VT_DATE.
+        let v = json!({"__type": "date", "value": "2026-05-12T00:00:00Z"});
+        assert_eq!(
+            classify_json(&v).unwrap(),
+            VariantKind::Date("2026-05-12T00:00:00Z".into())
+        );
+    }
+
+    #[test]
+    fn object_without_date_wrapper_is_unsupported() {
+        let v = json!({"foo": "bar"});
+        match classify_json(&v) {
+            Err(VbaBridgeError::VbaUnsupportedArgumentType { json_type }) => {
+                assert_eq!(json_type, "object");
+            }
+            other => panic!("expected VbaUnsupportedArgumentType, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn object_with_wrong_type_tag_is_unsupported() {
+        // Wrapper-looking object with a non-"date" __type is rejected
+        // (no future-compatibility hole that silently accepts unknown
+        // types).
+        let v = json!({"__type": "unknown", "value": "x"});
+        assert!(matches!(
+            classify_json(&v),
+            Err(VbaBridgeError::VbaUnsupportedArgumentType { json_type: "object" })
+        ));
+    }
+
+    #[test]
+    fn array_is_unsupported() {
+        let v = json!([1, 2, 3]);
+        match classify_json(&v) {
+            Err(VbaBridgeError::VbaUnsupportedArgumentType { json_type }) => {
+                assert_eq!(json_type, "array");
+            }
+            other => panic!("expected VbaUnsupportedArgumentType, got {other:?}"),
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_round_trip_via_kind() {
+        // Phase 1 windows path is a thin pass-through to the
+        // classifier. This test pins that path so Phase 2 cannot
+        // accidentally diverge the windows and non-windows views.
+        let v = Value::Null;
+        let round_trip = win::variant_kind_to_json(win::json_to_variant_kind(&v).unwrap()).unwrap();
+        assert_eq!(round_trip, Value::Null);
+
+        let v = json!(42);
+        let round_trip = win::variant_kind_to_json(win::json_to_variant_kind(&v).unwrap()).unwrap();
+        assert_eq!(round_trip, json!(42));
+
+        let v = json!("hello");
+        let round_trip = win::variant_kind_to_json(win::json_to_variant_kind(&v).unwrap()).unwrap();
+        assert_eq!(round_trip, json!("hello"));
+
+        let v = json!({"__type": "date", "value": "2026-05-12"});
+        let round_trip = win::variant_kind_to_json(win::json_to_variant_kind(&v).unwrap()).unwrap();
+        assert_eq!(round_trip, json!({"__type": "date", "value": "2026-05-12"}));
+    }
+}

--- a/scripts/enable-access-vbom.mjs
+++ b/scripts/enable-access-vbom.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+// ADR-015 §3.7 — one-shot CLI that sets HKCU
+// Software\Microsoft\Office\16.0\Excel\Security\AccessVBOM = 1
+// so the `excel` MCP tool can access Excel.Application.VBE.VBProjects
+// via COM late binding.
+//
+// Why a CLI (not an MCP tool action)?
+//
+// Round 1 of ADR-015 proposed an MCP tool action `excel.enable_access_vbom`.
+// Opus Round 1 P2-1 + R8 concluded that any MCP client should not be able
+// to silently lower Office trust for the user. The CLI runs in an explicit
+// user context where execution intent is unambiguous (the user typed the
+// command on a terminal); MCP tool calls do not carry that guarantee.
+//
+// The matching MCP tool action `excel({action: "check_access_vbom"})` is
+// read-only and exposes a `suggest` field pointing at THIS script when
+// AccessVBOM is 0.
+//
+// Behaviour:
+//
+//  - Reads HKCU AccessVBOM. If it's already 1, exit 0 with a confirmation.
+//  - Reads HKLM (the group-policy override). If HKLM forces 0, exit 1
+//    with a typed error message and a "contact your IT department" hint.
+//  - Otherwise, writes HKCU AccessVBOM=1 (DWORD) using `reg add`.
+//    The script does NOT touch HKLM under any circumstance.
+//  - Reports whether Excel is currently running (so the caller knows
+//    that the setting takes effect only after Excel restart).
+
+import { execSync, spawnSync } from "node:child_process";
+import { argv, platform, exit } from "node:process";
+
+const OFFICE_VERSION_KEY = "16.0"; // Office 365 / 2019 / 2021 / 2024
+const KEY_HKCU = `HKCU\\Software\\Microsoft\\Office\\${OFFICE_VERSION_KEY}\\Excel\\Security`;
+const KEY_HKLM = `HKLM\\Software\\Microsoft\\Office\\${OFFICE_VERSION_KEY}\\Excel\\Security`;
+const VALUE_NAME = "AccessVBOM";
+
+function logInfo(msg) {
+  console.log(`[enable-access-vbom] ${msg}`);
+}
+
+function logWarn(msg) {
+  console.warn(`[enable-access-vbom] WARN: ${msg}`);
+}
+
+function logErr(code, msg) {
+  console.error(`[enable-access-vbom] ${code}: ${msg}`);
+}
+
+// Read a REG_DWORD value via `reg query`. Returns null if the key/value
+// does not exist or the value is non-numeric. Returns the integer
+// otherwise. Uses spawnSync (no shell) for safe argument passing.
+function readDword(keyPath, valueName) {
+  const result = spawnSync("reg", ["query", keyPath, "/v", valueName], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) return null;
+  // Sample output line:
+  //   "    AccessVBOM    REG_DWORD    0x1"
+  const lines = result.stdout.split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith(valueName)) continue;
+    const m = trimmed.match(/REG_DWORD\s+0x([0-9a-fA-F]+)/);
+    if (m) return parseInt(m[1], 16);
+  }
+  return null;
+}
+
+// Write HKCU AccessVBOM=1 via `reg add`. Returns true on success.
+function writeHkcuDword(value) {
+  const result = spawnSync(
+    "reg",
+    [
+      "add",
+      KEY_HKCU,
+      "/v",
+      VALUE_NAME,
+      "/t",
+      "REG_DWORD",
+      "/d",
+      String(value),
+      "/f",
+    ],
+    { encoding: "utf8" },
+  );
+  if (result.status !== 0) {
+    logErr(
+      "VbaAccessNotTrusted",
+      `Failed to write ${KEY_HKCU}\\${VALUE_NAME} = ${value}. \n` +
+        `  stderr: ${result.stderr || "(empty)"}\n` +
+        `  Try running this script from an elevated terminal if the failure mentions access denied.`,
+    );
+    return false;
+  }
+  return true;
+}
+
+// Is Excel running right now? The setting only takes effect after Excel
+// restarts (Excel reads the value at process startup and caches it).
+function isExcelRunning() {
+  try {
+    const out = execSync("tasklist /FI \"IMAGENAME eq EXCEL.EXE\" /FO CSV /NH", {
+      encoding: "utf8",
+    });
+    return out.toLowerCase().includes("excel.exe");
+  } catch {
+    return false; // tasklist failure is non-fatal
+  }
+}
+
+function main() {
+  if (platform !== "win32") {
+    logErr(
+      "VbaAccessNotTrusted",
+      "This script is Windows-only. Run it on the machine where Excel + the MCP server are installed.",
+    );
+    exit(1);
+  }
+
+  if (argv.includes("--help") || argv.includes("-h")) {
+    console.log(
+      `enable-access-vbom — set HKCU AccessVBOM=1 for Excel ${OFFICE_VERSION_KEY}\n` +
+        `\n` +
+        `Usage: node scripts/enable-access-vbom.mjs [--check-only]\n` +
+        `\n` +
+        `  --check-only   print the current HKCU + HKLM state and exit 0\n` +
+        `  -h / --help    show this help`,
+    );
+    exit(0);
+  }
+
+  const checkOnly = argv.includes("--check-only");
+
+  const hklm = readDword(KEY_HKLM, VALUE_NAME);
+  if (hklm === 0) {
+    logErr(
+      "VbaAccessLockedByPolicy",
+      `Group policy forces HKLM\\...\\AccessVBOM = 0. No MCP-side workaround exists; \n` +
+        `  contact your IT department to allow programmatic access to the VBA project object model.`,
+    );
+    exit(1);
+  }
+
+  const hkcuBefore = readDword(KEY_HKCU, VALUE_NAME);
+  logInfo(
+    `Current HKCU AccessVBOM: ${
+      hkcuBefore === null ? "(not set)" : hkcuBefore
+    }${hklm === 1 ? " (HKLM also forces 1)" : ""}`,
+  );
+
+  if (checkOnly) {
+    if (hkcuBefore === 1 || hklm === 1) {
+      logInfo("AccessVBOM is trusted. The `excel` MCP tool will work.");
+      exit(0);
+    }
+    logInfo(
+      "AccessVBOM is NOT trusted. Re-run without --check-only to enable HKCU=1.",
+    );
+    exit(0);
+  }
+
+  if (hkcuBefore === 1) {
+    logInfo("HKCU AccessVBOM is already 1. No change needed.");
+    exit(0);
+  }
+
+  const ok = writeHkcuDword(1);
+  if (!ok) exit(1);
+
+  const hkcuAfter = readDword(KEY_HKCU, VALUE_NAME);
+  if (hkcuAfter !== 1) {
+    logErr(
+      "VbaAccessNotTrusted",
+      `Post-write read returned ${
+        hkcuAfter === null ? "(not set)" : hkcuAfter
+      }, expected 1. \n` +
+        `  Check whether group policy is reverting the value, or run this script as Administrator.`,
+    );
+    exit(1);
+  }
+
+  logInfo(`HKCU AccessVBOM set to 1.`);
+
+  if (isExcelRunning()) {
+    logWarn(
+      "Excel is currently running. The new AccessVBOM value takes effect only AFTER Excel restarts. \n" +
+        "  Close all Excel windows before running the `excel` MCP tool, or it will continue to use the cached \n" +
+        "  (old) trust state and return VbaAccessNotTrusted.",
+    );
+  }
+
+  logInfo("Done. The `excel` MCP tool can now access Excel.Application.VBE.VBProjects.");
+  exit(0);
+}
+
+main();


### PR DESCRIPTION
## Summary

ADR-015 Phase 1 implementation. New `crates/engine-vba-bridge/` Rust crate scaffold + variant-bridge classifier + typed errors. The `IDispatch` invoker bodies and the STA worker thread spawn are deliberately Phase 1 stubs; Phase 2 will replace them alongside the Excel.Application wrapper.

## Phase 1 acceptance (all green)

- `cargo build -p engine-vba-bridge`   GREEN
- `cargo test -p engine-vba-bridge`    14 / 14 PASS
- `cargo check --workspace`            GREEN

## Critical regression pins (unit tests)

- **`null_maps_to_vt_null_not_vt_empty`** — guards the ADR-015 §3.5 correction over Round 1's incorrect `VT_EMPTY` mapping. VBA `IsNull()` vs `IsEmpty()` semantics matter; mapping JSON `null → VT_EMPTY` would make `IsNull()` return false in macros that branch on null-handling
- **`all_error_codes_are_single_cap_acronym_style`** — guards against introducing ALL-CAPS acronyms (e.g. `VBOM`, `HKCU`) that would break the `pascalToSnake` boundary rule in `src/tools/_envelope.ts` (Codex Round 1 P2 — `AccessVBOMNotTrusted` would tokenize to `access_vbomnot_trusted` with the wrong underscore boundaries)
- **`string_maps_to_bstr_by_default`** — guards against ISO-looking strings auto-promoting to `VT_DATE` (Codex Round 2 P2 — would silently change macro semantics)
- **`date_wrapper_maps_to_vt_date`** — pins the `{__type:"date", value:"..."}` opt-in convention

## What is NOT in Phase 1

- Actual `IDispatch::Invoke` bodies (Phase 2)
- STA worker thread spawn with `CoInitializeEx(COINIT_APARTMENTTHREADED)` (Phase 2)
- Excel-specific wrapper (`excel.rs`) (Phase 2)
- `registry.rs` HKCU AccessVBOM read (Phase 2)
- napi-rs binding in root cdylib (Phase 3)
- `src/tools/excel.ts` + Zod schema + `_errors.ts` entries (Phase 4)
- Cascade sweep (28 → 29) + CHANGELOG + version bump + release (Phase 5)

These will follow in separate commits on this branch (or as follow-up PRs depending on review feedback).

## Test plan

- [x] `cargo build -p engine-vba-bridge`
- [x] `cargo test -p engine-vba-bridge`
- [x] `cargo check --workspace`
- [ ] Opus phase-boundary review per CLAUDE.md §3.3 Step 1
- [ ] Codex review per CLAUDE.md §3.3 Step 2 (production code = Codex mandatory)

🤖 Auto-mode per user instruction "1.5.0 リリースまでオートモードで"