### PR TITLE
feat(vba-bridge-napi): Phase 3 — napi-rs binding for engine-vba-bridge (ADR-015 §4.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,6 +452,7 @@ dependencies = [
  "crossbeam-channel",
  "crossbeam-queue",
  "engine-perception",
+ "engine-vba-bridge",
  "image",
  "napi",
  "napi-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,14 @@ serde = { version = "1", features = ["derive"] }
 # compile graph and break its "pure timely+DD compute crate" contract.
 engine-perception = { path = "crates/engine-perception" }
 
+# ADR-015 Phase 3: VBA Extensibility bridge — the root crate exposes
+# engine-vba-bridge's IDispatch-based Excel wrapper through napi-rs
+# (`src/vba_bridge.rs`). The bridge crate itself stays pure-COM with
+# no napi dependency so it can be reused outside the MCP host
+# (Phase 4 MCP tool / future Word/PowerPoint bridges) without
+# dragging the napi compile graph.
+engine-vba-bridge = { path = "crates/engine-vba-bridge" }
+
 # ── Visual GPU Phase 4 (ADR-005) ────────────────────────────────────────────
 # ORT 2.0.0-rc.12 (2026-03), pykeio/ort. directml feature で AMD/NVIDIA/Intel 全 DX12 GPU 対応。
 # WinML, ROCm/MIGraphX, CUDA, TensorRT, WebGPU, CoreML は build feature で opt-in。

--- a/docs/adr-015-vba-extensibility-bridge.md
+++ b/docs/adr-015-vba-extensibility-bridge.md
@@ -297,8 +297,8 @@ Acceptance:
 - Standard `check:native-types` / `check:stub-catalog` CI checks green
 
 Acceptance:
-- `npm run build` produces a `.node` that exports the 8 functions + `checkAccessVbom` (no `setAccessVbom` — CLI-only)
-- `src/engine/native-types.ts` matches `cargo build --bin generate-types` output bit-equal
+- `npm run build:rs` produces a `.node` that exports **11 functions**: the 8 §3.6 Phase-2c/d/e wrappers (`excelSetVisible` / `excelSetDisplayAlerts` / `excelWorkbookAddNew` / `excelVbaModuleAdd` / `excelWorkbookSaveAs` / `excelMacroRun` / `excelWorkbookClose` + `excelCheckAccessVbom`) **plus** 3 session-lifecycle helpers ergonomically required by the napi handle-ID pattern (`excelSessionSpawn` / `excelSessionClose` / `excelSessionIsAlive`). The 3 lifecycle helpers are NOT in §3.6 because `ExcelSession` cannot cross the napi FFI boundary by value — JS must address it through an integer handle. No `setAccessVbom` — CLI-only.
+- `index.d.ts` declares all 11 functions; `src/engine/native-types.ts` declares the `NativeExcelAccessVbomStatus` interface; `npm run check:native-types` enforces the drift gate (Rust `#[napi] pub fn` vs `index.d.ts` `export declare function` parity)
 
 ### 4.4 Phase 4 — MCP tool surface (½ day) — single `excel` tool with action dispatcher
 

--- a/docs/adr-015-vba-extensibility-bridge.md
+++ b/docs/adr-015-vba-extensibility-bridge.md
@@ -357,6 +357,14 @@ Typed errors (added to `src/tools/_errors.ts`, **PascalCase single-cap acronym p
 | `VbaUnsupportedArgumentType` | caller passed object / array / dispatch into `args` | `vba_unsupported_argument_type` |
 | `VbaWorkbookProtected` | `VBProject` access blocked by workbook-level password | `vba_workbook_protected` |
 
+**Binding-level typed codes** (Phase 3 napi shim — live in `src/vba_bridge.rs`, not in `engine_vba_bridge::errors`. The crate stays session-handle-agnostic; these surface only when the handle layer is in the call path):
+
+| Code | Meaning | snake_case form |
+|---|---|---|
+| `SessionNotFound` | the supplied session ID is not in the registry (already closed or never opened) | `session_not_found` |
+| `SessionIdExhausted` | the u32 monotonic session counter saturated at `2^32` spawns (practically unreachable) | `session_id_exhausted` |
+| `VbaUnsupportedFileFormat` | `excel_workbook_save_as` received a `file_format` numeric value other than `52` (xlOpenXMLWorkbookMacroEnabled) — v1 only accepts `.xlsm` | `vba_unsupported_file_format` |
+
 Acceptance:
 - Single `excel` tool registered in `src/tools/_registry.ts` and visible in `tools/list` as one tool
 - `tests/unit/excel-tool.test.ts` covers schema validation per action variant + `VbaMacroNotFound` regression case
@@ -411,7 +419,7 @@ Invariant 6 receives an explicit ADR-level carve-out (see §2.3). The invariant'
 - [ ] Issue #256 (F2 VBE UIA-blind) Resolved by structural bypass (not by improving UIA inspection of VBE)
 - [ ] `engine-vba-bridge` crate exists with the 8 functions from §3.6, all behind a single thread-local STA worker
 - [ ] `excel` tool succeeds end-to-end on a clean Win11 + Excel 365 install with `AccessVBOM=1` set by the bundled CLI script
-- [ ] All 8 new typed errors are catalogued in `_errors.ts` and surveyed in ADR-010 §5.4 (CLAUDE.md §3.1 cascade sweep)
+- [ ] All 8 crate-level + 3 binding-level = **11 typed errors** are catalogued in `_errors.ts` and surveyed in ADR-010 §5.4 (CLAUDE.md §3.1 cascade sweep) — crate-level: `VbaAccessNotTrusted` / `VbaAccessLockedByPolicy` / `ExcelNotInstalled` / `VbaModuleAuthoringFailed` / `VbaMacroExecutionFailed` / `VbaMacroNotFound` / `VbaUnsupportedArgumentType` / `VbaWorkbookProtected`; binding-level: `SessionNotFound` / `SessionIdExhausted` / `VbaUnsupportedFileFormat`
 - [ ] The new typed-error names pass the `pascalToSnake` round-trip used by `src/tools/_envelope.ts` (Codex Round 1 P2)
 - [ ] Cascade sweep landed per §4.5 table in a single atomic commit — invariant 6 rule text in `layer-constraints.md:330` literal-preserved; derivative numeric refs updated 28 → 29
 - [ ] No regression in `vitest run` or `cargo test --workspace`
@@ -447,6 +455,8 @@ Invariant 6 receives an explicit ADR-level carve-out (see §2.3). The invariant'
 - **OQ #7** — Should the Phase 4 MCP tool surface expose `set_display_alerts` as a public action, or only `workbook_save_as`-internal management? **Lean: only the internal guard in v1.** Rationale: Phase 4's `excel` MCP tool wraps the high-level demo path, not raw COM. Exposing `set_display_alerts` would re-introduce the R9 leak hazard at the MCP envelope layer. If Phase 4 review identifies a concrete caller need (e.g. a long-running session interleaving SaveAs with user-visible interactions), reintroduce as a manual toggle with a matching `excel.reset_display_alerts` cleanup action documented in `_errors.ts` suggestions.
 - **OQ #8** *(opened by Opus Round 3 P3 review; defer-recommended)* — `readTrustedLocationAllowSubFolders` in `scripts/enable-access-vbom.mjs` duplicates the REG_DWORD parse logic of the existing `readDword`. DRY opportunity: factor the helper to call `readDword(keyPath, "AllowSubFolders")` instead. Defer to a follow-up sweep (Phase 3 binding work touches the same script).
 - **OQ #9** *(opened by Opus Round 3 P3 review; defer-recommended)* — `workbook_save_as` doc-block says "Callers MUST treat the session as poisoned after restore failure" but the restore failure path silently discards the error (`let _ = invoke_put(...)`). The caller has no programmatic signal to detect poisoning. Either (a) remove the MUST and rely on subsequent operations failing organically, or (b) add a poisoning tracking field to `ExcelSession` and surface it via a `is_poisoned()` query. Defer to Phase 4 (when concrete caller patterns clarify the cost/benefit of (b)).
+- **OQ #10** *(opened by Phase 3 Round 2 review; defer to Phase 4)* — typed-envelope structured error fields for the napi shim. Currently `VbaBridgeError::Display` produces flat prose strings like `"ComCallFailed: HRESULT=0x800ac472 at CodeModule.AddFromString"` and the Phase 4 TS layer must regex-extract HRESULT / context. napi-rs exposes `Error::new(Status, reason)` with a separate `Status` field that could carry structured data, OR a `code` JSON field could be added to the typed-error mapping. Phase 4 typed envelope design absorbs the trade-off; v1 prefix parsing is sufficient for the demo path.
+- **OQ #11** *(opened by Phase 3 Round 2 review; defer to Phase 4)* — `excelSessionIsAlive` napi export use case. Phase 3 ships it for completeness (the binding may need a non-throwing existence check before issuing a cleanup) but Phase 4 has not yet specified a consumer. If Phase 4 confirms it is unused, either (a) remove it pre-v1.5.0, or (b) keep as a defensive surface for future tools. Lean: keep — pre-Phase-4 removal would force a re-publish if Phase 4 then needs it.
 
 ---
 
@@ -524,3 +534,13 @@ Author: Claude (Sonnet) reflecting Opus Round 1 on Phase 2e PR.
 - **§3.6 signature alignment** — Round 1 / 2 listed `SaveFormat` enum, `WorkbookHandle` type, `excel_close(s: ExcelSession, save: bool)` consuming session. Phase 2 implementation consolidated around `ExcelSession::ActiveWorkbook` (no `WorkbookHandle`), renamed enum to `XlFileFormat` (Excel COM type-library parity), changed close to borrowing `&ExcelSession` (closes workbook, not session). §3.6 prose updated to document each implementation choice with rationale; signature table now matches Phase 2 / Phase 2e crate surface
 - **§7 R9** added — "`DisplayAlerts = false` leaked past `workbook_save_as`" — structurally eliminated by the save-restore guard inside `workbook_save_as` (preserves the prior `DisplayAlerts` value, sets `false` for the SaveAs window, restores on exit including error paths)
 - **§8 OQ #7** added — whether Phase 4 should expose `set_display_alerts` as a public MCP tool action. Lean: only the internal guard in v1 (avoids re-introducing the R9 leak at MCP envelope layer)
+
+### 2026-05-12 — Implementation update (Phase 3 Round 2 reflecting Opus Round 1)
+
+Author: Claude (Sonnet) reflecting Opus Round 1 on Phase 3 PR.
+
+- **§4.3 acceptance fixed** — Round 1 referenced a `cargo build --bin generate-types` that never existed; replaced with the actual `check:native-types` drift gate. Also corrected the function count from "8 + checkAccessVbom" (=9) to "11 functions" with explicit itemization of the 8 §3.6 wrappers + 3 session-lifecycle helpers (`excelSessionSpawn` / `excelSessionClose` / `excelSessionIsAlive`). Lifecycle helpers are NOT in §3.6 because `ExcelSession` cannot cross the napi FFI boundary by value
+- **§4.4 binding-level codes table added** — Round 2 introduced 3 new typed-error codes that live in the napi shim (`src/vba_bridge.rs`), not in the `engine_vba_bridge::errors` enum: `SessionNotFound`, `SessionIdExhausted`, `VbaUnsupportedFileFormat`. They are listed in a sub-table alongside the 8 crate-level codes so Phase 4's `_errors.ts` SUGGESTS catalog has the full set
+- **§6 acceptance** — typed-error count updated "8 new typed errors" → "8 crate-level + 3 binding-level = 11 typed errors"
+- **§8 OQ #10 / OQ #11 added** — Phase 4 carry-overs persisted in docs per CLAUDE.md §9 (commit-message-only deferral was insufficient)
+- **`src/vba_bridge.rs` `NEXT_ID` race-free** — Round 2's `load+fetch_add` check-then-act window replaced with `fetch_update` CAS loop. Even if Phase 4 introduces `AsyncTask` and removes the libuv-single-threaded property, the saturation check + increment are now a single atomic transition

--- a/index.d.ts
+++ b/index.d.ts
@@ -422,3 +422,76 @@ export interface NativeDirtyRectsResult {
  * `(frame_index, count)`; empty result when the pipeline has no rect
  * yet, the slot is poisoned, or no rect for the requested monitor. */
 export declare function viewGetDirtyRects(monitorIndex: number): NativeDirtyRectsResult
+
+// ─── VBA Extensibility bridge (ADR-015 Phase 3) ──────────────────────────────
+//
+// napi-rs binding for `engine-vba-bridge::excel::*`. Session lifecycle
+// is handled via integer handle IDs stored in a process-global
+// `Mutex<HashMap<u32, Arc<ExcelSession>>>` inside `src/vba_bridge.rs`.
+// Phase 4 wraps these into the single MCP tool surface `excel` (per
+// ADR-015 §4.4) with a Zod discriminated union on `action`.
+
+export interface ExcelAccessVbomStatus {
+  trusted: boolean
+  lockedByPolicy: boolean
+  /** One of `"hklm-policy"` (HKLM dictates the value), `"hkcu"` (HKLM
+   * unset, HKCU is 1), or `"default"` (neither set). */
+  scope: string
+}
+
+/** Spawn an STA worker + create `Excel.Application`. Returns an integer
+ * session ID for subsequent calls. The caller MUST call
+ * `excelSessionClose(id)` when done; relying on GC will eventually
+ * clean up but leaves Excel.exe running in the meantime. */
+export declare function excelSessionSpawn(): number
+
+/** Close the session: removes from the registry, joins the STA worker
+ * thread, releases the IDispatch pointer + Excel.Application. Idempotent. */
+export declare function excelSessionClose(sessionId: number): void
+
+/** True if the session ID is still in the registry (not yet closed). */
+export declare function excelSessionIsAlive(sessionId: number): boolean
+
+/** Set `Application.Visible`. */
+export declare function excelSetVisible(sessionId: number, visible: boolean): void
+
+/** Set `Application.DisplayAlerts`. The Phase 2e demo path does NOT need
+ * to call this — `excelWorkbookSaveAs` manages it internally via a
+ * save-restore guard (ADR-015 §7 R9). Exposed for manual control. */
+export declare function excelSetDisplayAlerts(sessionId: number, enabled: boolean): void
+
+/** Create a fresh blank workbook on the active session. */
+export declare function excelWorkbookAddNew(sessionId: number): void
+
+/** Save the active workbook. `fileFormat` is the numeric `XlFileFormat`
+ * value; v1 supports `52` (xlOpenXMLWorkbookMacroEnabled / `.xlsm`) only —
+ * passing other values throws `VbaUnsupportedArgumentType`. Internally
+ * manages `DisplayAlerts` via a save-restore guard. */
+export declare function excelWorkbookSaveAs(
+  sessionId: number,
+  path: string,
+  fileFormat: number,
+): void
+
+/** Close the active workbook. Does not close `Excel.Application` —
+ * use `excelSessionClose` for that. */
+export declare function excelWorkbookClose(sessionId: number, saveChanges: boolean): void
+
+/** Add a VBA module to the active workbook + write source into it.
+ * Requires `AccessVBOM = 1` (HKCU or HKLM); otherwise throws
+ * `VbaAccessNotTrusted`. */
+export declare function excelVbaModuleAdd(
+  sessionId: number,
+  moduleName: string,
+  code: string,
+): void
+
+/** Run a previously-added macro by name. Calls `Application.Run`.
+ * Requires the workbook to be anchored in a Trusted Location (see
+ * ADR-015 §3.6 / Phase 2e); otherwise throws `VbaMacroExecutionFailed`
+ * with HRESULT `0x800a03ec`. */
+export declare function excelMacroRun(sessionId: number, macroName: string): void
+
+/** Read HKCU / HKLM `AccessVBOM` state without modifying the registry.
+ * Used by the Phase 4 MCP tool's `check_access_vbom` action. */
+export declare function excelCheckAccessVbom(): ExcelAccessVbomStatus

--- a/index.js
+++ b/index.js
@@ -125,4 +125,19 @@ export const viewGetFocusedWithWallclock = nativeBinding.viewGetFocusedWithWallc
 // ─── L3 perception dirty_rects_aggregate view (S2 D2-C) ──────────────────────
 export const viewGetDirtyRects          = nativeBinding.viewGetDirtyRects;
 
+// ─── VBA Extensibility bridge (ADR-015 Phase 3) ──────────────────────────────
+// Session-handle based bindings around engine-vba-bridge::excel. Phase 4
+// wraps these into the single `excel` MCP tool action dispatcher.
+export const excelSessionSpawn          = nativeBinding.excelSessionSpawn;
+export const excelSessionClose          = nativeBinding.excelSessionClose;
+export const excelSessionIsAlive        = nativeBinding.excelSessionIsAlive;
+export const excelSetVisible            = nativeBinding.excelSetVisible;
+export const excelSetDisplayAlerts      = nativeBinding.excelSetDisplayAlerts;
+export const excelWorkbookAddNew        = nativeBinding.excelWorkbookAddNew;
+export const excelWorkbookSaveAs        = nativeBinding.excelWorkbookSaveAs;
+export const excelWorkbookClose         = nativeBinding.excelWorkbookClose;
+export const excelVbaModuleAdd          = nativeBinding.excelVbaModuleAdd;
+export const excelMacroRun              = nativeBinding.excelMacroRun;
+export const excelCheckAccessVbom       = nativeBinding.excelCheckAccessVbom;
+
 export default nativeBinding;

--- a/src/engine/native-engine.ts
+++ b/src/engine/native-engine.ts
@@ -47,6 +47,7 @@ import type {
   NativeFocusedElementWithWallclock,
   NativeLeaseTokenSummary,
   NativeDirtyRectsResult,
+  NativeExcelAccessVbomStatus,
 } from "./native-types.js";
 
 export type * from "./native-types.js";
@@ -380,6 +381,53 @@ export const nativeViewFocus: NativeViewFocus | null =
     ? (nativeBinding as unknown as NativeViewFocus)
     : null;
 
+// ─── VBA Extensibility bridge (ADR-015 Phase 3) ──────────────────────────────
+//
+// napi-rs binding around `engine-vba-bridge`. Session-handle based (integer
+// IDs). Phase 4 wraps these into the single `excel` MCP tool surface.
+//
+// Methods are optional so a pre-Phase-3 addon build cleanly falls back to
+// null; the Phase 4 TS wrapper throws `VbaBridgeUnavailable` rather than
+// silently proceeding when the addon doesn't expose this surface.
+export interface NativeExcel {
+  // Session lifecycle
+  excelSessionSpawn?(): number;
+  excelSessionClose?(sessionId: number): void;
+  excelSessionIsAlive?(sessionId: number): boolean;
+
+  // Application property setters
+  excelSetVisible?(sessionId: number, visible: boolean): void;
+  excelSetDisplayAlerts?(sessionId: number, enabled: boolean): void;
+
+  // Workbook lifecycle
+  excelWorkbookAddNew?(sessionId: number): void;
+  excelWorkbookSaveAs?(
+    sessionId: number,
+    path: string,
+    fileFormat: number,
+  ): void;
+  excelWorkbookClose?(sessionId: number, saveChanges: boolean): void;
+
+  // VBA authoring + execution
+  excelVbaModuleAdd?(
+    sessionId: number,
+    moduleName: string,
+    code: string,
+  ): void;
+  excelMacroRun?(sessionId: number, macroName: string): void;
+
+  // Registry inspection (read-only)
+  excelCheckAccessVbom?(): NativeExcelAccessVbomStatus;
+}
+
+// Probe key: `excelSessionSpawn` is the entry point for any Excel work —
+// if the addon exposes it, the rest of the surface is also expected to
+// be present (they all live in the same Rust module `vba_bridge.rs`).
+export const nativeExcel: NativeExcel | null =
+  nativeBinding && typeof nativeBinding.excelSessionSpawn === "function"
+    ? (nativeBinding as unknown as NativeExcel)
+    : null;
+
 if (nativeEngine) {
   console.error("[native-engine] Rust image-diff engine loaded (SSE2 SIMD)");
 }
@@ -394,4 +442,7 @@ if (nativeWin32) {
 }
 if (nativeL1) {
   console.error("[native-engine] Rust L1 capture loaded (ADR-007 P5a)");
+}
+if (nativeExcel) {
+  console.error("[native-engine] Rust VBA bridge loaded (ADR-015 Phase 3)");
 }

--- a/src/engine/native-types.ts
+++ b/src/engine/native-types.ts
@@ -502,3 +502,22 @@ export interface NativeLeaseTokenSummary {
   targetGeneration: string
   evidenceDigestPrefix8: string
 }
+
+// ── ADR-015 Phase 3: VBA Extensibility bridge ────────────────────────────────
+//
+// Mirror types for the napi-rs binding in `src/vba_bridge.rs`. Session
+// lifecycle uses integer handle IDs; the TS layer in Phase 4 will wrap
+// these into the single `excel` MCP tool action dispatcher.
+
+/** Read-only HKCU / HKLM `AccessVBOM` registry inspection result.
+ * Returned by `excelCheckAccessVbom`. Mirrors
+ * `engine_vba_bridge::registry::AccessVbomStatus` with `scope` as a
+ * String (napi cannot marshal `&'static str` for an object field). */
+export interface NativeExcelAccessVbomStatus {
+  /** Effective trust state. `true` when either HKCU is 1 or HKLM forces 1. */
+  trusted: boolean
+  /** `true` only when HKLM is set to 0 (group policy forces denial). */
+  lockedByPolicy: boolean
+  /** `"hklm-policy"` (HKLM dictates), `"hkcu"` (HKLM unset, HKCU is 1), or `"default"` (neither set). */
+  scope: string
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,12 @@ mod l1_capture;
 // See `src/l3_bridge/mod.rs` for the rationale on direction-of-dep.
 #[cfg(windows)]
 mod l3_bridge;
+// ADR-015 Phase 3: VBA Extensibility bridge napi binding (Windows only).
+// Thin shim around `engine-vba-bridge::excel::*` that manages session
+// handle IDs and maps `VbaBridgeError` to napi typed errors. See
+// `src/vba_bridge.rs` for the full design rationale.
+#[cfg(windows)]
+mod vba_bridge;
 
 // Visual GPU Phase 4 backend (ADR-005). The module always compiles so that
 // `detect_capability()` can report `backend_built=false` cleanly when the

--- a/src/vba_bridge.rs
+++ b/src/vba_bridge.rs
@@ -1,0 +1,314 @@
+//! napi-rs binding for the VBA Extensibility bridge (ADR-015 Phase 3).
+//!
+//! Exposes the `engine-vba-bridge` crate's IDispatch-based `Excel.Application`
+//! wrapper to TypeScript via napi-rs. Each public function is a thin
+//! `#[napi]` shim that:
+//!
+//! 1. Wraps the body in `napi_safe_call` (panic → typed napi::Error so the
+//!    libuv main thread does not crash).
+//! 2. Looks up the `ExcelSession` by an integer handle ID (held in
+//!    [`SESSIONS`] — a `Mutex<HashMap>` keyed by u32 IDs).
+//! 3. Calls the corresponding `engine_vba_bridge::excel::*` function.
+//! 4. Maps `VbaBridgeError` to `napi::Error::from_reason` with the error
+//!    code as a prefix (e.g. `"VbaAccessNotTrusted: HKCU AccessVBOM is 0; run scripts/enable-access-vbom.mjs"`),
+//!    which the TS layer parses to produce typed `_errors.ts` envelopes.
+//!
+//! ## Session handle management
+//!
+//! `ExcelSession` cannot cross the napi-rs FFI boundary by value because
+//! it owns COM-affine resources (the STA worker thread + IDispatch
+//! pointer must be released on the apartment thread, not on V8's main).
+//! Instead, the binding stores sessions in a process-global `Mutex<HashMap<u32, Arc<ExcelSession>>>`
+//! and returns the u32 ID to JS. The TS wrapper (Phase 4) treats the ID
+//! as an opaque token that flows back into subsequent calls.
+//!
+//! On `excel_session_close`, the binding removes the entry from the map,
+//! which drops the last `Arc<ExcelSession>` strong reference, which
+//! invokes `ExcelSession::drop`, which joins the STA worker thread (the
+//! worker handles `drop(app) + CoUninitialize` on the apartment thread).
+//! See `crates/engine-vba-bridge/src/apartment.rs` for the teardown
+//! invariants.
+//!
+//! ## Threading semantics
+//!
+//! All `#[napi]` functions in this module run **synchronously on the
+//! libuv main thread**. They are NOT wrapped in `AsyncTask` because:
+//!
+//! 1. `ExcelSession::with_app` already dispatches the actual COM work
+//!    onto the STA worker thread internally via a `crossbeam-channel`.
+//!    The main-thread call only blocks on `recv()` waiting for the
+//!    worker's reply.
+//! 2. Excel COM operations in the demo path are short (< 100ms typical)
+//!    and the MCP server processes one request at a time. Blocking
+//!    libuv briefly is acceptable; the next request is only enqueued
+//!    after the current one completes.
+//!
+//! If Phase 4 / future profiling shows blocking issues (e.g. long-running
+//! macros), individual functions can be migrated to `AsyncTask` without
+//! breaking the public napi API.
+
+#![cfg(windows)]
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use napi::bindgen_prelude::*;
+use napi_derive::napi;
+
+use engine_vba_bridge::errors::{VbaBridgeError, VbaBridgeResult};
+use engine_vba_bridge::{apartment, excel, registry};
+
+use crate::win32::safety::napi_safe_call;
+
+/// Process-global session registry. Sessions are inserted by
+/// [`excel_session_spawn`] and removed by [`excel_session_close`].
+/// Operations look up the session by ID, clone the `Arc`, drop the
+/// lock, then call the wrapped method — so multiple sessions can
+/// proceed in parallel.
+///
+/// `Arc<ExcelSession>` (not just `ExcelSession`) so we can drop the
+/// outer `Mutex` lock before doing the actual COM call. The Arc count
+/// is always 1 (only the HashMap owns it) until a call clones for the
+/// duration of its work; after the clone goes out of scope, the count
+/// returns to 1.
+static SESSIONS: OnceLock<Mutex<HashMap<u32, Arc<apartment::ExcelSession>>>> = OnceLock::new();
+
+/// Monotonic ID allocator. Never reuses an ID even after `close` so a
+/// caller holding a stale ID gets a clean "session not found" error
+/// rather than silently hitting a different session.
+static NEXT_ID: AtomicU32 = AtomicU32::new(1);
+
+fn sessions() -> &'static Mutex<HashMap<u32, Arc<apartment::ExcelSession>>> {
+    SESSIONS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Resolve a session ID to its `Arc<ExcelSession>`, cloning the Arc so
+/// the caller can drop the registry lock before the COM call.
+fn get_session(id: u32) -> Result<Arc<apartment::ExcelSession>> {
+    let map = sessions().lock().map_err(|_| {
+        Error::from_reason("vba_bridge: session registry mutex poisoned")
+    })?;
+    map.get(&id).cloned().ok_or_else(|| {
+        Error::from_reason(format!(
+            "VbaBridgeError::SessionNotFound: no Excel session with id={id} \
+             (already closed or never opened)"
+        ))
+    })
+}
+
+/// Convert an `engine_vba_bridge::VbaBridgeError` into a `napi::Error`.
+/// The message prefix is the PascalCase error code so the TS layer
+/// can pattern-match on it to populate `_errors.ts` envelopes.
+fn to_napi_err(e: VbaBridgeError) -> Error {
+    // The Display impl already prefixes with the code (`Self::VbaAccessNotTrusted => write!(f, "VbaAccessNotTrusted: ...")`)
+    // so we just stringify.
+    Error::from_reason(e.to_string())
+}
+
+/// Helper: turn a `VbaBridgeResult<T>` into a `napi::Result<T>`.
+fn map_bridge<T>(r: VbaBridgeResult<T>) -> Result<T> {
+    r.map_err(to_napi_err)
+}
+
+// ─── Session lifecycle ───────────────────────────────────────────────
+
+/// Spawn a new Excel STA worker + create `Excel.Application` on it.
+/// Returns an integer session ID that subsequent `excel_*` calls use
+/// to address the session. The caller MUST call [`excel_session_close`]
+/// when done to release the COM resources; relying on GC will
+/// eventually clean up but leaves Excel.exe running in the meantime.
+#[napi]
+pub fn excel_session_spawn() -> Result<u32> {
+    napi_safe_call("excel_session_spawn", || {
+        let session = map_bridge(apartment::ExcelSession::spawn())?;
+        let id = NEXT_ID.fetch_add(1, Ordering::SeqCst);
+        let mut map = sessions().lock().map_err(|_| {
+            Error::from_reason("vba_bridge: session registry mutex poisoned")
+        })?;
+        map.insert(id, Arc::new(session));
+        Ok(id)
+    })
+}
+
+/// Close an Excel session, releasing the STA worker thread + IDispatch
+/// + Excel.Application. Idempotent: closing an unknown / already-closed
+/// ID returns Ok with no effect (matches the `try_take_session` semantic
+/// the TS layer expects).
+#[napi]
+pub fn excel_session_close(session_id: u32) -> Result<()> {
+    napi_safe_call("excel_session_close", || {
+        let removed = {
+            let mut map = sessions().lock().map_err(|_| {
+                Error::from_reason("vba_bridge: session registry mutex poisoned")
+            })?;
+            map.remove(&session_id)
+        };
+        // Drop the Arc outside the lock so the `ExcelSession::drop`
+        // (which joins the STA worker thread, briefly blocking) does
+        // not hold the registry lock while waiting for COM teardown.
+        drop(removed);
+        Ok(())
+    })
+}
+
+/// Returns true if the given session ID exists in the registry. Useful
+/// for the TS layer to verify a session hasn't been collected before
+/// issuing further operations.
+#[napi]
+pub fn excel_session_is_alive(session_id: u32) -> Result<bool> {
+    napi_safe_call("excel_session_is_alive", || {
+        let map = sessions().lock().map_err(|_| {
+            Error::from_reason("vba_bridge: session registry mutex poisoned")
+        })?;
+        Ok(map.contains_key(&session_id))
+    })
+}
+
+// ─── Application property setters ────────────────────────────────────
+
+/// Set `Application.Visible`.
+#[napi]
+pub fn excel_set_visible(session_id: u32, visible: bool) -> Result<()> {
+    napi_safe_call("excel_set_visible", || {
+        let session = get_session(session_id)?;
+        map_bridge(excel::set_visible(&session, visible))
+    })
+}
+
+/// Set `Application.DisplayAlerts`.
+///
+/// The Phase 2e demo path does NOT need to call this directly because
+/// [`excel_workbook_save_as`] manages it internally via a save-restore
+/// guard (see ADR-015 §7 R9). Exposed here for callers who want
+/// manual control (Phase 4 may or may not surface this as an MCP
+/// action — see ADR-015 §8 OQ #7).
+#[napi]
+pub fn excel_set_display_alerts(session_id: u32, enabled: bool) -> Result<()> {
+    napi_safe_call("excel_set_display_alerts", || {
+        let session = get_session(session_id)?;
+        map_bridge(excel::set_display_alerts(&session, enabled))
+    })
+}
+
+// ─── Workbook lifecycle ──────────────────────────────────────────────
+
+/// Add a new blank workbook on the active session. Equivalent to
+/// `Application.Workbooks.Add()`. The new workbook becomes
+/// `ActiveWorkbook` immediately.
+#[napi]
+pub fn excel_workbook_add_new(session_id: u32) -> Result<()> {
+    napi_safe_call("excel_workbook_add_new", || {
+        let session = get_session(session_id)?;
+        map_bridge(excel::workbook_add_new(&session))
+    })
+}
+
+/// Save the active workbook to a file path using the given XlFileFormat
+/// numeric value. The only format supported in v1 is
+/// `OpenXmlWorkbookMacroEnabled = 52` (`.xlsm`); passing any other
+/// numeric value is accepted by Excel COM but silently drops VBA on
+/// disk for non-macro formats — Phase 4 will validate at the TS layer.
+///
+/// Internally manages `DisplayAlerts` via a save-restore guard (ADR-015
+/// §7 R9), so callers do not need to suppress alerts manually.
+#[napi]
+pub fn excel_workbook_save_as(
+    session_id: u32,
+    path: String,
+    file_format: i32,
+) -> Result<()> {
+    napi_safe_call("excel_workbook_save_as", || {
+        let session = get_session(session_id)?;
+        // The Rust enum is `#[repr(i32)]` so a runtime numeric match
+        // is straightforward. We deliberately do NOT add a "default"
+        // arm — unknown formats return a typed error so the TS layer
+        // can map to `VbaUnsupportedArgumentType` cleanly.
+        let format = match file_format {
+            52 => excel::XlFileFormat::OpenXmlWorkbookMacroEnabled,
+            other => {
+                return Err(Error::from_reason(format!(
+                    "VbaUnsupportedArgumentType: file_format={other} not supported in v1. \
+                     The only supported value is 52 (xlOpenXMLWorkbookMacroEnabled, .xlsm)."
+                )));
+            }
+        };
+        map_bridge(excel::workbook_save_as(&session, path, format))
+    })
+}
+
+/// Close the active workbook. `save_changes` maps directly to the
+/// `SaveChanges` argument of `Workbook.Close`. Does not close the
+/// Excel application — use [`excel_session_close`] for that.
+#[napi]
+pub fn excel_workbook_close(session_id: u32, save_changes: bool) -> Result<()> {
+    napi_safe_call("excel_workbook_close", || {
+        let session = get_session(session_id)?;
+        map_bridge(excel::workbook_close(&session, save_changes))
+    })
+}
+
+// ─── VBA authoring + execution ───────────────────────────────────────
+
+/// Add a VBA module to the active workbook and write source into it.
+/// Internally walks `Application.ActiveWorkbook.VBProject.VBComponents.Add(1)`
+/// (`vbext_ct_StdModule`) → `<NewComponent>.CodeModule.AddFromString(code)`.
+///
+/// Requires `AccessVBOM = 1` (HKCU or HKLM). Otherwise the VBProject
+/// access raises COM error `0x800AC472` which is surfaced as
+/// `VbaAccessNotTrusted`.
+#[napi]
+pub fn excel_vba_module_add(
+    session_id: u32,
+    module_name: String,
+    code: String,
+) -> Result<()> {
+    napi_safe_call("excel_vba_module_add", || {
+        let session = get_session(session_id)?;
+        map_bridge(excel::vba_module_add(&session, module_name, code))
+    })
+}
+
+/// Run a previously-added macro by name. Calls `Application.Run(macro_name)`.
+///
+/// **Trust Center note (ADR-015 §3.6)**: macros on an in-memory unsaved
+/// workbook cannot be run regardless of `VBAWarnings` — Excel returns
+/// HRESULT `0x800a03ec`. Phase 2e adds [`excel_workbook_save_as`] +
+/// the managed Trusted Location so callers can anchor the workbook
+/// before invoking `macro_run`.
+#[napi]
+pub fn excel_macro_run(session_id: u32, macro_name: String) -> Result<()> {
+    napi_safe_call("excel_macro_run", || {
+        let session = get_session(session_id)?;
+        map_bridge(excel::macro_run(&session, macro_name))
+    })
+}
+
+// ─── AccessVBOM registry inspection ──────────────────────────────────
+
+/// Mirror of `engine_vba_bridge::registry::AccessVbomStatus` for the
+/// napi-rs serialiser. `scope` is mapped to a String so napi-rs can
+/// marshal it; the Rust source uses a `&'static str` for zero-alloc.
+#[napi(object)]
+pub struct ExcelAccessVbomStatus {
+    pub trusted: bool,
+    pub locked_by_policy: bool,
+    pub scope: String,
+}
+
+/// Read the current HKCU / HKLM `AccessVBOM` state without modifying
+/// the registry. Used by the Phase 4 MCP tool's `check_access_vbom`
+/// action and by any caller that wants to provide a remediation
+/// suggestion (run `scripts/enable-access-vbom.mjs`) without first
+/// trying a real COM call.
+#[napi]
+pub fn excel_check_access_vbom() -> Result<ExcelAccessVbomStatus> {
+    napi_safe_call("excel_check_access_vbom", || {
+        let status = map_bridge(registry::check())?;
+        Ok(ExcelAccessVbomStatus {
+            trusted: status.trusted,
+            locked_by_policy: status.locked_by_policy,
+            scope: status.scope.to_string(),
+        })
+    })
+}

--- a/src/vba_bridge.rs
+++ b/src/vba_bridge.rs
@@ -75,16 +75,15 @@ use crate::win32::safety::napi_safe_call;
 static SESSIONS: OnceLock<Mutex<HashMap<u32, Arc<apartment::ExcelSession>>>> = OnceLock::new();
 
 /// Monotonic ID allocator. Reserved ID `0` is never issued so the
-/// initial fetch returns `1`.
+/// first CAS loop yields `1`.
 ///
-/// **Wraparound semantics** (Opus Round 1 P2-1): `AtomicU32::fetch_add`
-/// wraps without panic. At `2^32` spawns the counter would return `0`
-/// (the reserved sentinel), then `1` which could collide with a still-
-/// alive session. To prevent silent collision, [`excel_session_spawn`]
-/// fails with `SessionIdExhausted` once the counter reaches `u32::MAX`;
-/// restarting the MCP server resets it. At one spawn per second this
-/// is reachable after ~136 years, so practically a documentation /
-/// invariant-enforcement gesture rather than an operational concern.
+/// **Wraparound semantics** (Opus Round 1 P2-1 / Round 2 P2-NEW1):
+/// [`excel_session_spawn`] uses [`AtomicU32::fetch_update`] with a CAS
+/// loop that refuses to advance past `u32::MAX`, surfacing
+/// `SessionIdExhausted` instead. This is structurally race-free even
+/// under concurrent callers (Phase 4 may introduce `AsyncTask` and
+/// remove the libuv-single-threaded property earlier rounds relied
+/// on). Practically unreachable (~136 years at 1 spawn/sec).
 static NEXT_ID: AtomicU32 = AtomicU32::new(1);
 
 fn sessions() -> &'static Mutex<HashMap<u32, Arc<apartment::ExcelSession>>> {
@@ -138,26 +137,51 @@ fn map_bridge<T>(r: VbaBridgeResult<T>) -> Result<T> {
 /// when done to release the COM resources; relying on GC will
 /// eventually clean up but leaves Excel.exe running in the meantime.
 ///
-/// **Exhaustion safety** (Opus Round 1 P2-1): returns `SessionIdExhausted`
-/// when the u32 monotonic counter saturates at `u32::MAX`. Restart the
-/// MCP server to reset. Practically unreachable but pins the
-/// "never-reuse" invariant the surrounding comments promise.
+/// **Exhaustion safety** (Opus Round 1 P2-1 / Round 2 P2-NEW1): the
+/// ID allocation uses [`AtomicU32::fetch_update`] with a CAS loop so
+/// the saturation check and the increment are a single atomic
+/// transition — no check-then-act race window even if multiple
+/// threads ever call `excel_session_spawn` concurrently. When the
+/// counter reaches `u32::MAX`, `fetch_update` returns `Err` and the
+/// shim surfaces `SessionIdExhausted` rather than wrapping to `0`
+/// (reserved sentinel) or colliding with a still-alive ID. Practically
+/// unreachable (136 years at 1 spawn/sec) but pins the "never-reuse"
+/// invariant structurally regardless of the napi caller's threading
+/// model — Phase 4 may introduce `AsyncTask`, removing the libuv-
+/// single-threaded assumption that earlier rounds relied on.
 #[napi]
 pub fn excel_session_spawn() -> Result<u32> {
     napi_safe_call("excel_session_spawn", || {
-        // Check BEFORE spawning Excel so we don't leak a session
-        // immediately. The check is on the next ID we'd issue, not the
-        // one being returned: if `NEXT_ID` is already at MAX, the next
-        // fetch_add wraps to 0 (reserved sentinel) and then to 1
-        // (potential collision), so we refuse to issue further IDs.
-        if NEXT_ID.load(Ordering::SeqCst) == u32::MAX {
-            return Err(Error::from_reason(
-                "SessionIdExhausted: the u32 monotonic session counter has saturated \
-                 at 2^32 spawns. Restart the MCP server to reset.",
-            ));
-        }
-        let session = map_bridge(apartment::ExcelSession::spawn())?;
-        let id = NEXT_ID.fetch_add(1, Ordering::SeqCst);
+        // Allocate the ID FIRST via a race-free CAS loop. If
+        // saturation triggers, we never start Excel — preventing the
+        // "spawn succeeded but ID assignment failed" leak window.
+        let id = NEXT_ID
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |current| {
+                if current == u32::MAX {
+                    None // signal saturation; fetch_update returns Err
+                } else {
+                    Some(current + 1)
+                }
+            })
+            .map_err(|_| {
+                Error::from_reason(
+                    "SessionIdExhausted: the u32 monotonic session counter has saturated \
+                     at 2^32 spawns. Restart the MCP server to reset.",
+                )
+            })?;
+
+        // Spawn Excel only after we hold a guaranteed-unique ID.
+        let session = match map_bridge(apartment::ExcelSession::spawn()) {
+            Ok(s) => s,
+            Err(e) => {
+                // ID was allocated but the spawn failed — the slot
+                // for `id` is permanently skipped. This is fine
+                // (monotonic semantics allow gaps) and prevents
+                // the ID from being reused by a later spawn.
+                return Err(e);
+            }
+        };
+
         let mut map = sessions().lock().map_err(|_| {
             Error::from_reason("vba_bridge: session registry mutex poisoned")
         })?;

--- a/src/vba_bridge.rs
+++ b/src/vba_bridge.rs
@@ -74,9 +74,17 @@ use crate::win32::safety::napi_safe_call;
 /// returns to 1.
 static SESSIONS: OnceLock<Mutex<HashMap<u32, Arc<apartment::ExcelSession>>>> = OnceLock::new();
 
-/// Monotonic ID allocator. Never reuses an ID even after `close` so a
-/// caller holding a stale ID gets a clean "session not found" error
-/// rather than silently hitting a different session.
+/// Monotonic ID allocator. Reserved ID `0` is never issued so the
+/// initial fetch returns `1`.
+///
+/// **Wraparound semantics** (Opus Round 1 P2-1): `AtomicU32::fetch_add`
+/// wraps without panic. At `2^32` spawns the counter would return `0`
+/// (the reserved sentinel), then `1` which could collide with a still-
+/// alive session. To prevent silent collision, [`excel_session_spawn`]
+/// fails with `SessionIdExhausted` once the counter reaches `u32::MAX`;
+/// restarting the MCP server resets it. At one spawn per second this
+/// is reachable after ~136 years, so practically a documentation /
+/// invariant-enforcement gesture rather than an operational concern.
 static NEXT_ID: AtomicU32 = AtomicU32::new(1);
 
 fn sessions() -> &'static Mutex<HashMap<u32, Arc<apartment::ExcelSession>>> {
@@ -85,13 +93,24 @@ fn sessions() -> &'static Mutex<HashMap<u32, Arc<apartment::ExcelSession>>> {
 
 /// Resolve a session ID to its `Arc<ExcelSession>`, cloning the Arc so
 /// the caller can drop the registry lock before the COM call.
+///
+/// Error message uses the bare `SessionNotFound:` prefix (Opus Round 1
+/// P2-3 — earlier `VbaBridgeError::SessionNotFound:` double prefix was
+/// inconsistent with the bare-PascalCase convention used by every other
+/// error path via `VbaBridgeError::Display`). Phase 4's TS parser
+/// pattern-matches `e.message.startsWith("SessionNotFound:")` so the
+/// prefix must be the bare PascalCase code, NOT the full Rust path.
+/// `SessionNotFound` is a napi-binding-level error (no Rust variant in
+/// `engine_vba_bridge::errors`) because the crate is session-handle-
+/// agnostic; Phase 4 catalogues it in `_errors.ts` SUGGESTS alongside
+/// the crate-level `VbaBridgeError` codes.
 fn get_session(id: u32) -> Result<Arc<apartment::ExcelSession>> {
     let map = sessions().lock().map_err(|_| {
         Error::from_reason("vba_bridge: session registry mutex poisoned")
     })?;
     map.get(&id).cloned().ok_or_else(|| {
         Error::from_reason(format!(
-            "VbaBridgeError::SessionNotFound: no Excel session with id={id} \
+            "SessionNotFound: no Excel session with id={id} \
              (already closed or never opened)"
         ))
     })
@@ -118,9 +137,25 @@ fn map_bridge<T>(r: VbaBridgeResult<T>) -> Result<T> {
 /// to address the session. The caller MUST call [`excel_session_close`]
 /// when done to release the COM resources; relying on GC will
 /// eventually clean up but leaves Excel.exe running in the meantime.
+///
+/// **Exhaustion safety** (Opus Round 1 P2-1): returns `SessionIdExhausted`
+/// when the u32 monotonic counter saturates at `u32::MAX`. Restart the
+/// MCP server to reset. Practically unreachable but pins the
+/// "never-reuse" invariant the surrounding comments promise.
 #[napi]
 pub fn excel_session_spawn() -> Result<u32> {
     napi_safe_call("excel_session_spawn", || {
+        // Check BEFORE spawning Excel so we don't leak a session
+        // immediately. The check is on the next ID we'd issue, not the
+        // one being returned: if `NEXT_ID` is already at MAX, the next
+        // fetch_add wraps to 0 (reserved sentinel) and then to 1
+        // (potential collision), so we refuse to issue further IDs.
+        if NEXT_ID.load(Ordering::SeqCst) == u32::MAX {
+            return Err(Error::from_reason(
+                "SessionIdExhausted: the u32 monotonic session counter has saturated \
+                 at 2^32 spawns. Restart the MCP server to reset.",
+            ));
+        }
         let session = map_bridge(apartment::ExcelSession::spawn())?;
         let id = NEXT_ID.fetch_add(1, Ordering::SeqCst);
         let mut map = sessions().lock().map_err(|_| {
@@ -135,6 +170,17 @@ pub fn excel_session_spawn() -> Result<u32> {
 /// + Excel.Application. Idempotent: closing an unknown / already-closed
 /// ID returns Ok with no effect (matches the `try_take_session` semantic
 /// the TS layer expects).
+///
+/// **Concurrent-call semantics** (Opus Round 1 P3-2): when another
+/// thread holds an `Arc<ExcelSession>` clone (mid-call via
+/// [`get_session`]), `drop(removed)` here only decrements the Arc
+/// strong count. The actual `ExcelSession::drop` (which joins the
+/// STA worker thread) runs when the last in-flight call completes
+/// and releases its clone. This is intentional — concurrent in-flight
+/// calls are NOT truncated by a close. The registry slot is freed
+/// immediately so the ID becomes "not found" on subsequent lookups
+/// (matching the user's mental model that close completes
+/// instantly).
 #[napi]
 pub fn excel_session_close(session_id: u32) -> Result<()> {
     napi_safe_call("excel_session_close", || {
@@ -144,9 +190,10 @@ pub fn excel_session_close(session_id: u32) -> Result<()> {
             })?;
             map.remove(&session_id)
         };
-        // Drop the Arc outside the lock so the `ExcelSession::drop`
-        // (which joins the STA worker thread, briefly blocking) does
-        // not hold the registry lock while waiting for COM teardown.
+        // Drop the Arc outside the lock so any STA-worker-thread join
+        // triggered by the final-Arc drop does not hold the registry
+        // lock. See the per-strong-count comment above for what
+        // actually happens at this drop site.
         drop(removed);
         Ok(())
     })
@@ -223,12 +270,29 @@ pub fn excel_workbook_save_as(
         // The Rust enum is `#[repr(i32)]` so a runtime numeric match
         // is straightforward. We deliberately do NOT add a "default"
         // arm — unknown formats return a typed error so the TS layer
-        // can map to `VbaUnsupportedArgumentType` cleanly.
+        // can map to a dedicated `VbaUnsupportedFileFormat` typed code.
+        //
+        // **Why a dedicated code (not `VbaUnsupportedArgumentType`)**
+        // (Opus Round 1 P2-4): `VbaUnsupportedArgumentType` is reserved
+        // for the VARIANT bridge's JSON-type rejection (`errors.rs:65`
+        // documents this) — an object/array passed where v1 only
+        // supports null/boolean/number/string. File-format mismatch is
+        // a distinct concept (the bridge supports VARIANT-side .xlsm
+        // but rejects other Excel file formats in v1). Phase 4 catalogs
+        // both in `_errors.ts` SUGGESTS separately so the remediation
+        // text can be specific (file_format → "use 52"; argument_type
+        // → "serialize into a worksheet cell").
+        //
+        // `VbaUnsupportedFileFormat` is a napi-binding-level error
+        // (lives in this shim, not in `engine_vba_bridge::errors`)
+        // because the crate's `excel::workbook_save_as` accepts an
+        // `XlFileFormat` enum — the runtime validation of caller-
+        // supplied integers happens here.
         let format = match file_format {
             52 => excel::XlFileFormat::OpenXmlWorkbookMacroEnabled,
             other => {
                 return Err(Error::from_reason(format!(
-                    "VbaUnsupportedArgumentType: file_format={other} not supported in v1. \
+                    "VbaUnsupportedFileFormat: file_format={other} not supported in v1. \
                      The only supported value is 52 (xlOpenXMLWorkbookMacroEnabled, .xlsm)."
                 )));
             }
@@ -276,6 +340,15 @@ pub fn excel_vba_module_add(
 /// HRESULT `0x800a03ec`. Phase 2e adds [`excel_workbook_save_as`] +
 /// the managed Trusted Location so callers can anchor the workbook
 /// before invoking `macro_run`.
+///
+/// **TODO (Phase 4 reconsideration)**: this function is synchronous —
+/// the libuv main thread blocks for the full macro duration. User-
+/// authored VBA macros can run arbitrarily long; a long macro freezes
+/// the Node event loop including MCP stdin reads. If Phase 4 caller
+/// patterns expose this hazard, migrate to `AsyncTask` (matches the
+/// UIA-side pattern in `lib.rs`). The migration is non-breaking
+/// because the napi return type changes from `Result<()>` to
+/// `Promise<void>` which the TS layer already awaits anyway.
 #[napi]
 pub fn excel_macro_run(session_id: u32, macro_name: String) -> Result<()> {
     napi_safe_call("excel_macro_run", || {


### PR DESCRIPTION
## Summary

Exposes the Phase 2e `engine-vba-bridge` Rust crate to TypeScript via napi-rs. New `src/vba_bridge.rs` module + 11 `#[napi]` exports + matching TS interface.

- **Rust binding**: `src/vba_bridge.rs` — `Mutex<HashMap<u32, Arc<ExcelSession>>>` keyed by integer handle IDs; each napi function wraps `engine_vba_bridge::excel::*` calls with `napi_safe_call` panic containment + typed error mapping
- **TS surface**: `NativeExcel` interface in `native-engine.ts`, `NativeExcelAccessVbomStatus` in `native-types.ts`
- **napi-rs declarations**: 11 entries in `index.d.ts` + matching re-exports in `index.js`

## Why (ADR-015 §4.3 acceptance)

> `engine-vba-bridge` exports surfaced through the existing napi build, TypeScript types added to `src/engine/native-types.ts`, standard `check:native-types` / `check:stub-catalog` CI checks green

This PR implements that acceptance exactly. Phase 4 wraps these 11 functions into the single `excel` MCP tool surface (per ADR-015 §4.4).

## Threading semantics

All 11 napi functions are SYNC (not AsyncTask). The actual COM work happens on the STA worker thread internally via `ExcelSession::with_app`; the napi-main-thread call only blocks on the channel `recv()`. Excel COM operations in the demo path are short (<100ms typical). If profiling later shows blocking issues, individual functions can migrate to AsyncTask without breaking the public napi API. Module doc-block (`src/vba_bridge.rs:35-46`) explains the rationale.

## Session lifecycle

Handles are u32 IDs allocated from a monotonic counter — never reused so a stale ID gets a clean `"VbaBridgeError::SessionNotFound: no Excel session with id=N"` error rather than silently hitting a different session. The Phase 4 TS wrapper treats the ID as an opaque token.

`excelSessionClose` removes the entry from the registry; dropping the last `Arc<ExcelSession>` reference invokes `ExcelSession::drop`, which joins the STA worker thread (the worker performs `drop(app) + CoUninitialize` on the apartment thread before exiting).

## Verification

- [x] `cargo check --lib`: OK (12 pre-existing warnings unrelated to Phase 3)
- [x] `cargo test -p engine-vba-bridge`: 16/16 PASS
- [x] `npm run check:native-types`: OK — 62 Rust exports all declared in `index.d.ts` (51 pre-existing + 11 new)
- [x] `npm run check:napi-safe`: OK — all 11 new sync exports wrap `napi_safe_call`
- [x] `npm run check:stub-catalog`: regenerates with no diff (Phase 3 adds no MCP tool — that's Phase 4)
- [x] `npm run build` (tsc): OK
- [x] `npm run test:unit`: 2856/2865 pass; 4 pre-existing failures on main (terminal.ts naming + scroll epsilon) confirmed unrelated by `git checkout main && npm run test:unit -- <files>`

Local napi `.node` build skipped: dev machine's default rustup toolchain is `x86_64-pc-windows-gnu` (libnode.a needed; out of scope per `scripts/build-rs.mjs`). CI (windows-latest MSVC) builds the actual `.node` artifact.

## Review focus

Per CLAUDE.md §3.3 Step 0 this is production code so both Opus + Codex are required.

**Opus axis** (architecture / lifecycle / docs integrity):
- Session-handle pattern via `Mutex<HashMap<u32, Arc<ExcelSession>>>` — is the `Arc::clone` outside the lock + drop-inside-or-outside semantics correct for the close path?
- Sync vs AsyncTask choice rationale (module doc-block) — appropriate for the demo path?
- Error mapping: `VbaBridgeError::Display` → `napi::Error::from_reason` with PascalCase code prefix. Will the Phase 4 TS parser need anything stronger (typed envelopes vs string-prefix parse)?
- ADR-015 §4.3 acceptance checkboxes all satisfied?

**Codex axis** (API contract / runtime path):
- `excelWorkbookSaveAs` `fileFormat` numeric validation: only `52` allowed in v1. Should this be a string discriminator instead of a raw int? (Trade-off: int matches Excel COM exactly; string would be friendlier from TS but adds a mapping layer in the napi shim.)
- `excelSessionClose` idempotency: closing an unknown ID returns Ok with no effect. Is this the right semantic, or should it throw `SessionNotFound`?
- Handle ID overflow: u32 monotonic; after 4B spawns wraps to 0 which is technically a never-issued ID. In practice impossible — but is the "never reuse" claim sound at the type level?
- `ExcelAccessVbomStatus.scope: String` field naming — should `lockedByPolicy` follow camelCase in the napi serialise (the Rust source uses `locked_by_policy` with serde rename via `#[serde(rename_all = "camelCase")]`, but napi-rs `#[napi(object)]` does its own camelCase mapping)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)