### PR TITLE
fix(scripts): remove dead init for trustedLocationStatus (CodeQL #122)

### DIFF
--- a/scripts/enable-access-vbom.mjs
+++ b/scripts/enable-access-vbom.mjs
@@ -510,7 +510,7 @@ function main() {
 
   // Trusted Location status check (Phase 2e). Read-only; ensureTrustedLocation
   // is what writes.
-  let trustedLocationStatus = "unknown";
+  let trustedLocationStatus;
   let trustedLocationDir = null;
   try {
     trustedLocationDir = getDefaultTrustedDir();


### PR DESCRIPTION
## Summary
- `scripts/enable-access-vbom.mjs:513` had `let trustedLocationStatus = "unknown";`
- The try/catch immediately below always assigns (`"registered"` / `"missing"` on success, `"error: ..."` on catch)
- CodeQL alert #122 (`js/useless-assignment-to-local`) flagged the initial value as unused
- Drop the dead initializer; CodeQL alert will auto-close on merge

## Test plan
- [x] `node --check scripts/enable-access-vbom.mjs` passes
- [ ] CodeQL re-scan after merge dismisses alert #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)