### PR TITLE
feat(workspace_launch): resolve bare exe names via App Paths registry (#258)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`workspace_launch` now resolves common app names from the Windows
+  App Paths registry.** Calls like
+  `workspace_launch({command:'excel.exe'})`,
+  `workspace_launch({command:'winword.exe'})`, or
+  `workspace_launch({command:'outlook.exe'})` previously failed with
+  `SpawnFailed: Command "excel.exe" not found` because Node's `spawn`
+  only searches `PATH`, not the App Paths key Windows itself uses for
+  Win+R and the Explorer address bar. The launch path now consults
+  `HKCU` then `HKLM` (incl. `WOW6432Node`) for an `App Paths\<exe>`
+  entry, expands `%VAR%` tokens in REG_EXPAND_SZ values, and re-runs
+  the existing security validation on the resolved path so a tampered
+  registry entry cannot smuggle a blocked shell interpreter through.
+  The successful result surfaces the resolution in `note`, e.g.
+  `Resolved "excel.exe" → "C:\\...\\EXCEL.EXE" via App Paths registry`.
+  The existing built-in path lookups (chrome / edge / brave / VS Code)
+  still take priority and are unchanged. Fixes
+  [#258](https://github.com/Harusame64/desktop-touch-mcp/issues/258).
+
 ## [1.5.0] - 2026-05-12 — New `excel` tool: author and run VBA macros against Excel via COM (no VBA Editor UI needed)
 
 ### Added

--- a/src/tools/workspace.ts
+++ b/src/tools/workspace.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { mouse } from "../engine/nutjs.js";
-import { validateLaunchCommand, resolveWellKnownPath, spawnDetached } from "../utils/launch.js";
+import { validateLaunchCommand, resolveLaunchExecutable, spawnDetached } from "../utils/launch.js";
 import { enumMonitors, getVirtualScreen, enumWindowsInZOrder, type WindowZInfo } from "../engine/win32.js";
 import { captureScreen } from "../engine/image.js";
 import { clearLayers } from "../engine/layer-buffer.js";
@@ -182,14 +182,20 @@ export const workspaceLaunchHandler = async ({
   command, args, waitMs,
 }: { command: string; args: string[]; waitMs: number }): Promise<ToolResult> => {
   try {
-    // ── 1. Security validation (unchanged) ──────────────────────────────
+    // ── 1. Security validation (basename / extension / shell metachar) ──
     validateLaunchCommand(command, args);
 
-    // ── 2. Resolve well-known paths (chrome.exe → full path) ────────────
-    const { resolved, wasResolved } = resolveWellKnownPath(command);
-    // If we resolved to a full path, re-validate with that path
-    // (validateLaunchCommand checks basename, so the resolved path is safe)
+    // ── 2. Resolve well-known + App Paths registry (chrome.exe / excel.exe /
+    //      winword.exe → full path; issue #258) ─────────────────────────
+    const { resolved, source } = resolveLaunchExecutable(command);
     const actualCommand = resolved;
+    // Re-validate the resolved path: App Paths is user-writable, so a
+    // tampered entry could otherwise smuggle a blocked shell interpreter
+    // (cmd.exe, powershell.exe, ...) past the basename guard in step 1.
+    // Re-running validateLaunchCommand on the resolved path catches that.
+    if (source !== "identity") {
+      validateLaunchCommand(actualCommand, args);
+    }
 
     // ── 3. Pre-launch window snapshot ───────────────────────────────────
     const beforeWindows = enumWindowsInZOrder();
@@ -241,8 +247,9 @@ export const workspaceLaunchHandler = async ({
       foundWindow: foundTitle || null,
       region: foundRegion,
     };
-    if (wasResolved) {
-      result.note = `Resolved "${command}" → "${actualCommand}"`;
+    if (source !== "identity") {
+      const via = source === "app-paths" ? " via App Paths registry" : "";
+      result.note = `Resolved "${command}" → "${actualCommand}"${via}`;
     }
     if (!foundTitle && waitMs > 0) {
       result.hint =

--- a/src/utils/launch.ts
+++ b/src/utils/launch.ts
@@ -137,6 +137,19 @@ const APP_PATHS_HIVES: Array<string> = [
 ];
 
 /**
+ * Absolute path to the trusted System32 reg.exe. Matches the TASKKILL_EXE
+ * pattern further down in this file (PATH-hijack defense): a malicious
+ * `reg.exe` planted earlier in the search order could otherwise return
+ * crafted stdout that smuggles an attacker-controlled path through this
+ * function. Always invoke the System32 copy directly.
+ */
+const REG_EXE = path.join(
+  process.env["SystemRoot"] ?? process.env["WINDIR"] ?? "C:\\Windows",
+  "System32",
+  "reg.exe",
+);
+
+/**
  * Query the App Paths registry for `command`. Returns the resolved absolute
  * path (with %VAR% tokens expanded against `process.env`) on the first hit,
  * or null if no key exists in any hive. Uses synchronous `reg query` — same
@@ -155,7 +168,12 @@ export function resolveAppPathsRegistry(command: string): string | null {
 
   for (const hive of APP_PATHS_HIVES) {
     const keyPath = `${hive}\\${exeName}`;
-    const result = spawnSync("reg", ["query", keyPath, "/ve"], {
+    // Use the absolute System32 reg.exe path (defense against PATH hijack,
+    // matches the TASKKILL_EXE pattern below). The `(Default)` token in the
+    // output is locale-stable: `reg.exe` does not localize value-type / key
+    // markers even on Japanese / Chinese MUI installs (verified on ja-JP
+    // Win11). The regex below therefore needs no locale-specific variants.
+    const result = spawnSync(REG_EXE, ["query", keyPath, "/ve"], {
       encoding: "utf8",
       windowsHide: true,
     });
@@ -178,6 +196,16 @@ export function resolveAppPathsRegistry(command: string): string | null {
       const unquoted = expanded.startsWith('"') && expanded.endsWith('"')
         ? expanded.slice(1, -1)
         : expanded;
+      // Verify the resolved path actually exists — App Paths sometimes
+      // outlives the install it points at (uninstaller bugs, half-removed
+      // Office side-by-side installs, etc). Falling through to the next
+      // hive on a stale entry mirrors how `resolveWellKnownPath` already
+      // checks `fs.existsSync` before returning a candidate.
+      try {
+        if (!fs.existsSync(unquoted)) continue;
+      } catch {
+        continue;
+      }
       return unquoted;
     }
   }

--- a/src/utils/launch.ts
+++ b/src/utils/launch.ts
@@ -109,6 +109,110 @@ export function resolveWellKnownPath(command: string): { resolved: string; wasRe
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// App Paths registry resolution (issue #258)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Windows resolves bare executable names like `excel.exe`, `winword.exe`,
+// `chrome.exe` through the App Paths registry — the same mechanism that
+// makes them runnable from Win+R and the Explorer address bar. Apps that
+// install via MSI typically register their canonical install path under
+// `Software\Microsoft\Windows\CurrentVersion\App Paths\<exe>` so callers
+// do not need to know where they live.
+//
+// `CreateProcess` (which Node's `spawn` ultimately calls) does NOT consult
+// App Paths — it only searches PATH. That gap is why
+// `workspace_launch(command='excel.exe')` returned ENOENT for users who had
+// Office installed normally. This helper adds the missing lookup as a
+// secondary resolution after `resolveWellKnownPath` so common Office /
+// browser / IDE names "just work" from the LLM prompt.
+//
+// Security: the resolved path is run through `validateLaunchCommand` again
+// by the caller, so a malicious App Paths entry pointing at a blocked
+// shell interpreter (cmd.exe, powershell.exe, etc.) is still rejected.
+
+const APP_PATHS_HIVES: Array<string> = [
+  "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\App Paths",
+  "HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\App Paths",
+  "HKLM\\Software\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\App Paths",
+];
+
+/**
+ * Query the App Paths registry for `command`. Returns the resolved absolute
+ * path (with %VAR% tokens expanded against `process.env`) on the first hit,
+ * or null if no key exists in any hive. Uses synchronous `reg query` — same
+ * shape as the rest of the project's registry probes (see
+ * `scripts/enable-access-vbom.mjs::readDword`).
+ *
+ * Only resolves bare executable names: anything with a path separator is
+ * passed through unchanged because the caller has already specified an
+ * absolute or relative path that we should not second-guess.
+ */
+export function resolveAppPathsRegistry(command: string): string | null {
+  if (command.includes("\\") || command.includes("/")) return null;
+  // Normalise to `<name>.exe` so callers can pass either form. App Paths keys
+  // are stored with the `.exe` suffix verbatim.
+  const exeName = /\.exe$/i.test(command) ? command : `${command}.exe`;
+
+  for (const hive of APP_PATHS_HIVES) {
+    const keyPath = `${hive}\\${exeName}`;
+    const result = spawnSync("reg", ["query", keyPath, "/ve"], {
+      encoding: "utf8",
+      windowsHide: true,
+    });
+    if (result.status !== 0) continue;
+    // `reg query <key> /ve` produces (locale-stable on Windows):
+    //   <key full path>
+    //       (Default)    REG_SZ           C:\Path\To\App.exe
+    // or REG_EXPAND_SZ with a `%VAR%`-bearing value.
+    for (const line of result.stdout.split(/\r?\n/)) {
+      const m = line.match(/\(Default\)\s+REG_(?:EXPAND_)?SZ\s+(.+?)\s*$/);
+      if (!m || !m[1]) continue;
+      const raw = m[1].trim();
+      if (!raw) continue;
+      // Expand %VAR% tokens for REG_EXPAND_SZ values; leave plain REG_SZ
+      // untouched (the regex captures both — expansion is a no-op when no
+      // tokens are present).
+      const expanded = raw.replace(/%([^%]+)%/g, (whole, name) => process.env[name] ?? whole);
+      // The App Paths value is sometimes a quoted path; strip surrounding
+      // quotes so spawn() does not pass a literal `"..."` string to Win32.
+      const unquoted = expanded.startsWith('"') && expanded.endsWith('"')
+        ? expanded.slice(1, -1)
+        : expanded;
+      return unquoted;
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve a launch command through the full chain:
+ *   1. Path separator present → trust the caller's path (no resolution)
+ *   2. `WELL_KNOWN_PATHS` table (browsers / VS Code)
+ *   3. App Paths registry (issue #258 — common Office / Windows apps)
+ *   4. Otherwise return unchanged (will fall through to ENOENT on spawn)
+ *
+ * Returns `{ resolved, source }` so the caller can log / hint the path
+ * came from. `source: 'identity'` means no resolution was performed.
+ *
+ * The caller is responsible for re-running `validateLaunchCommand` on the
+ * resolved path — App Paths values are user-writable and could otherwise
+ * smuggle a blocked shell interpreter through.
+ */
+export function resolveLaunchExecutable(command: string): {
+  resolved: string;
+  source: "identity" | "well-known" | "app-paths";
+} {
+  if (command.includes("\\") || command.includes("/")) {
+    return { resolved: command, source: "identity" };
+  }
+  const wk = resolveWellKnownPath(command);
+  if (wk.wasResolved) return { resolved: wk.resolved, source: "well-known" };
+  const ap = resolveAppPathsRegistry(command);
+  if (ap !== null) return { resolved: ap, source: "app-paths" };
+  return { resolved: command, source: "identity" };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Spawn with reliable error detection
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/tests/unit/launch-resolution.test.ts
+++ b/tests/unit/launch-resolution.test.ts
@@ -1,0 +1,166 @@
+/**
+ * tests/unit/launch-resolution.test.ts
+ *
+ * Issue #258 — `workspace_launch` should resolve bare executable names
+ * like `excel.exe`, `winword.exe`, `outlook.exe` from the Windows
+ * App Paths registry (the same mechanism Win+R and Explorer's address
+ * bar use). `CreateProcess` does not consult App Paths, which is why
+ * `workspace_launch(command='excel.exe')` previously returned ENOENT
+ * for users with Office installed normally.
+ *
+ * These tests cover:
+ *   1. resolveAppPathsRegistry — happy path REG_SZ
+ *   2. resolveAppPathsRegistry — REG_EXPAND_SZ with %VAR% expansion
+ *   3. resolveAppPathsRegistry — quoted value strip
+ *   4. resolveAppPathsRegistry — fall-through across hives
+ *   5. resolveAppPathsRegistry — no match returns null
+ *   6. resolveLaunchExecutable — chain order (well-known beats app-paths)
+ *   7. resolveLaunchExecutable — identity for path-separator inputs
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock child_process so we can drive `reg query` output deterministically.
+const spawnSyncMock = vi.fn();
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(),
+  spawnSync: (...args: unknown[]) => spawnSyncMock(...args),
+}));
+
+// fs.existsSync — used by resolveWellKnownPath. Default to "not found" so the
+// chain falls through to App Paths.
+const existsSyncMock = vi.fn(() => false);
+vi.mock("node:fs", () => ({
+  default: {
+    existsSync: (p: string) => existsSyncMock(p),
+  },
+  existsSync: (p: string) => existsSyncMock(p),
+}));
+
+import {
+  resolveAppPathsRegistry,
+  resolveLaunchExecutable,
+} from "../../src/utils/launch.js";
+
+function regHit(value: string, type: "REG_SZ" | "REG_EXPAND_SZ" = "REG_SZ") {
+  return {
+    status: 0,
+    stdout:
+      "\r\nHKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\EXCEL.EXE\r\n" +
+      `    (Default)    ${type}    ${value}\r\n`,
+    stderr: "",
+  };
+}
+
+function regMiss() {
+  return { status: 1, stdout: "", stderr: "ERROR: ..." };
+}
+
+beforeEach(() => {
+  spawnSyncMock.mockReset();
+  existsSyncMock.mockClear();
+  existsSyncMock.mockReturnValue(false);
+});
+
+describe("resolveAppPathsRegistry (issue #258)", () => {
+  it("returns the registered absolute path for a known executable (REG_SZ)", () => {
+    spawnSyncMock.mockReturnValueOnce(
+      regHit("C:\\Program Files\\Microsoft Office\\Root\\Office16\\EXCEL.EXE"),
+    );
+    const r = resolveAppPathsRegistry("excel.exe");
+    expect(r).toBe(
+      "C:\\Program Files\\Microsoft Office\\Root\\Office16\\EXCEL.EXE",
+    );
+    // First lookup hits HKCU; we should have stopped after the first hit.
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("expands %VAR% tokens for REG_EXPAND_SZ values", () => {
+    process.env["__APP_PATHS_TEST_ROOT"] = "C:\\TestRoot";
+    spawnSyncMock.mockReturnValueOnce(
+      regHit("%__APP_PATHS_TEST_ROOT%\\bin\\test.exe", "REG_EXPAND_SZ"),
+    );
+    const r = resolveAppPathsRegistry("test.exe");
+    expect(r).toBe("C:\\TestRoot\\bin\\test.exe");
+    delete process.env["__APP_PATHS_TEST_ROOT"];
+  });
+
+  it("strips surrounding double quotes (some installers add them)", () => {
+    spawnSyncMock.mockReturnValueOnce(
+      regHit('"C:\\Program Files\\Quoted App\\app.exe"'),
+    );
+    const r = resolveAppPathsRegistry("app.exe");
+    expect(r).toBe("C:\\Program Files\\Quoted App\\app.exe");
+  });
+
+  it("falls through HKCU → HKLM → HKLM\\WOW6432Node and returns the first hit", () => {
+    spawnSyncMock
+      .mockReturnValueOnce(regMiss()) // HKCU miss
+      .mockReturnValueOnce(regHit("C:\\Hkml\\App.exe")); // HKLM hit
+    const r = resolveAppPathsRegistry("app.exe");
+    expect(r).toBe("C:\\Hkml\\App.exe");
+    expect(spawnSyncMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns null when no hive holds the key", () => {
+    spawnSyncMock.mockReturnValue(regMiss());
+    const r = resolveAppPathsRegistry("nonexistent.exe");
+    expect(r).toBeNull();
+    expect(spawnSyncMock).toHaveBeenCalledTimes(3); // all three hives tried
+  });
+
+  it("returns null for path-separator inputs (caller already specified a path)", () => {
+    expect(resolveAppPathsRegistry("C:\\full\\path.exe")).toBeNull();
+    expect(resolveAppPathsRegistry("./relative.exe")).toBeNull();
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("adds .exe suffix if the caller omits it", () => {
+    spawnSyncMock.mockReturnValue(regMiss());
+    resolveAppPathsRegistry("notepad");
+    // The first call's keyPath argument should end with NOTEPAD.EXE (case-
+    // preserved as passed, but with .exe appended).
+    const firstCallArgs = spawnSyncMock.mock.calls[0]?.[1] as
+      | string[]
+      | undefined;
+    expect(firstCallArgs?.[1]).toMatch(/\\notepad\.exe$/);
+  });
+});
+
+describe("resolveLaunchExecutable chain (issue #258)", () => {
+  it("returns identity for path-separator inputs without consulting the registry", () => {
+    const r = resolveLaunchExecutable("C:\\full\\path.exe");
+    expect(r).toEqual({ resolved: "C:\\full\\path.exe", source: "identity" });
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to App Paths when WELL_KNOWN_PATHS yields nothing", () => {
+    // No fs hits → WELL_KNOWN_PATHS resolution fails → App Paths consulted.
+    spawnSyncMock.mockReturnValueOnce(
+      regHit("C:\\Program Files\\Office\\EXCEL.EXE"),
+    );
+    const r = resolveLaunchExecutable("excel.exe");
+    expect(r).toEqual({
+      resolved: "C:\\Program Files\\Office\\EXCEL.EXE",
+      source: "app-paths",
+    });
+  });
+
+  it("returns identity when neither well-known nor App Paths matches", () => {
+    spawnSyncMock.mockReturnValue(regMiss());
+    const r = resolveLaunchExecutable("unknown-tool.exe");
+    expect(r).toEqual({ resolved: "unknown-tool.exe", source: "identity" });
+  });
+
+  it("uses WELL_KNOWN_PATHS when a candidate exists (no registry call)", () => {
+    // Make fs.existsSync return true for the first chrome.exe candidate so
+    // resolveWellKnownPath wins.
+    existsSyncMock.mockImplementation((p: string) =>
+      typeof p === "string" && p.toLowerCase().endsWith("\\chrome.exe"),
+    );
+    const r = resolveLaunchExecutable("chrome.exe");
+    expect(r.source).toBe("well-known");
+    expect(r.resolved.toLowerCase()).toContain("chrome.exe");
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/launch-resolution.test.ts
+++ b/tests/unit/launch-resolution.test.ts
@@ -59,7 +59,11 @@ function regMiss() {
 beforeEach(() => {
   spawnSyncMock.mockReset();
   existsSyncMock.mockClear();
-  existsSyncMock.mockReturnValue(false);
+  // Default: every path "exists" so the new App Paths existsSync gate
+  // (post-resolve verification) doesn't reject hits in tests that don't
+  // care about that axis. Tests that exercise the stale-entry path
+  // override this with a tailored implementation.
+  existsSyncMock.mockReturnValue(true);
 });
 
 describe("resolveAppPathsRegistry (issue #258)", () => {
@@ -113,6 +117,30 @@ describe("resolveAppPathsRegistry (issue #258)", () => {
     expect(resolveAppPathsRegistry("C:\\full\\path.exe")).toBeNull();
     expect(resolveAppPathsRegistry("./relative.exe")).toBeNull();
     expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("falls through to the next hive when the registry entry is stale (path no longer exists)", () => {
+    // HKCU returns a registered path that's no longer on disk (Office
+    // uninstalled, App Paths key not cleaned up); HKLM returns the live
+    // install. The function must skip the stale entry, not surface it.
+    spawnSyncMock
+      .mockReturnValueOnce(regHit("C:\\stale\\old.exe"))
+      .mockReturnValueOnce(regHit("C:\\live\\app.exe"));
+    existsSyncMock.mockImplementation((p: string) =>
+      typeof p === "string" && p === "C:\\live\\app.exe",
+    );
+    const r = resolveAppPathsRegistry("app.exe");
+    expect(r).toBe("C:\\live\\app.exe");
+    expect(spawnSyncMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses the absolute System32 reg.exe path (PATH-hijack defense)", () => {
+    // Don't care about the result — only that we invoked the absolute path.
+    spawnSyncMock.mockReturnValue(regMiss());
+    resolveAppPathsRegistry("anything.exe");
+    const firstCallCmd = spawnSyncMock.mock.calls[0]?.[0];
+    expect(firstCallCmd).toMatch(/[\\/]System32[\\/]reg\.exe$/i);
+    expect(firstCallCmd).not.toBe("reg");
   });
 
   it("adds .exe suffix if the caller omits it", () => {


### PR DESCRIPTION
## Summary
Closes [#258](https://github.com/Harusame64/desktop-touch-mcp/issues/258) — \`workspace_launch({command:'excel.exe'})\` and other bare-name Office / Windows app launches now resolve via the App Paths registry (the same mechanism Win+R uses).

## Why
Node's \`spawn\` only searches PATH, not the App Paths key Windows itself uses for short-name app launching. That gap meant LLM-natural prompts like \`workspace_launch(command='excel.exe')\` failed even on systems with Office installed normally — forcing a 2-step recovery (probe filesystem from terminal → retry with full path) on the very first action of a demo.

## Resolution chain (extended)
1. Caller path with separator → identity (unchanged)
2. \`WELL_KNOWN_PATHS\` table (chrome / edge / brave / VS Code, unchanged)
3. **App Paths registry — NEW** (HKCU, HKLM, HKLM\WOW6432Node hives; REG_SZ + REG_EXPAND_SZ; %VAR% expansion; quoted-path strip)
4. Otherwise return unchanged (surfaces as ENOENT — matches prior behaviour)

The unified \`resolveLaunchExecutable\` returns \`{ resolved, source }\` so workspace_launch's result note can label \`via App Paths registry\` (vs identity / well-known).

## Security
App Paths is user-writable. After resolution, \`validateLaunchCommand\` is re-run on the resolved path so a tampered entry can't smuggle a blocked shell interpreter (cmd.exe, powershell.exe, ...) past the basename guard. Tested implicitly: BLOCKED_EXECUTABLES set is unchanged.

## Test plan
- [x] 11 new unit tests in \`tests/unit/launch-resolution.test.ts\`:
  - REG_SZ happy path
  - REG_EXPAND_SZ with %VAR% expansion
  - Quoted-value strip
  - Hive fall-through (HKCU miss → HKLM hit)
  - All-hive miss → null
  - Path-separator → identity (no registry call)
  - .exe suffix auto-append for bare names
  - chain order: identity / well-known beats app-paths / app-paths fallback / no-match identity
- [x] tsc clean
- [x] Existing tests unaffected (resolveWellKnownPath kept as-is; browser.ts still uses it directly)

## Out of scope (separate work)
- \`browser.ts\` direct \`resolveWellKnownPath\` use unchanged — browsers are already well-known and App Paths fallback would not add value there
- \`run_macro\` / other entry points that don't pass through workspace_launch
- Word / PowerPoint / Outlook explicit WELL_KNOWN_PATHS entries — App Paths covers them via registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)