### PR TITLE
fix(test): update scroll epsilon-jitter test to match 1e-6 threshold

### DIFF
--- a/tests/unit/scroll-raw-verify.test.ts
+++ b/tests/unit/scroll-raw-verify.test.ts
@@ -93,8 +93,11 @@ describe("evaluateScrollDelivery — Win32 axis present", () => {
   });
 
   it("epsilon-level noise (rounding) → not_delivered when below epsilon", () => {
-    // 1e-5 of percent jitter must be treated as no-movement (epsilon eats it).
-    const r = evaluateScrollDelivery(snap(0.50000, 0.0), snap(0.50001, 0.0), "down");
+    // SCROLL_PERCENT_EPSILON in mouse.ts is 1e-6 (intentionally low so single-step
+    // scrolls in ~1M-position ranges register as movement — see Codex P1 fix in
+    // PR #191). Any jitter below 1e-6 must be eaten by the epsilon. Use 1e-7
+    // here so the test stays valid for the current threshold.
+    const r = evaluateScrollDelivery(snap(0.5, 0.0), snap(0.5 + 1e-7, 0.0), "down");
     expect(r.status).toBe("not_delivered");
   });
 });


### PR DESCRIPTION
## Summary

`tests/unit/scroll-raw-verify.test.ts` had one pre-existing failure on `main`:

```
× evaluateScrollDelivery — Win32 axis present > epsilon-level noise (rounding) → not_delivered when below epsilon
  AssertionError: expected 'delivered' to be 'not_delivered'
```

### Root cause — test drift, not implementation bug

The test was added in PR #191 alongside `evaluateScrollDelivery`, when `SCROLL_PERCENT_EPSILON` was 1e-3 (= 0.001). With that threshold, the test's 1e-5 jitter was correctly eaten by the epsilon.

Inside the same PR, a Codex P1 fixup lowered `SCROLL_PERCENT_EPSILON` to 1e-6 to prevent false-positive `ScrollNotDelivered` errors on long scroll ranges (lists with ~1M positions naturally produce per-step `pageRatio` deltas under 1e-3 — see `src/tools/mouse.ts:885-892`). The implementation was updated; the test was not. Result: 1e-5 jitter > 1e-6 epsilon, so the implementation now correctly classifies it as `delivered`, but the test still expects `not_delivered`.

The implementation reasoning is intentional and load-bearing — reverting epsilon would resurrect the regression PR #191 was built to prevent. The test is what needs to follow.

### Fix

- `tests/unit/scroll-raw-verify.test.ts:97` — change jitter from 1e-5 → 1e-7 so it's actually below the 1e-6 epsilon
- Update the inline comment to reference both the current threshold and the PR #191 Codex P1 rationale, so the next epsilon adjustment surfaces this test as a sibling that needs updating

### Verification

```
npx vitest run tests/unit/scroll-raw-verify.test.ts
# Test Files  1 passed (1)
# Tests  17 passed (17)
```

## Out of scope

- A1+A2 → already in flight (#271)
- A4 (`native-win32-panic-fuzz` `win32GetProcessIdentity` zero-identified) — environment-vs-bug triage pending
- B/C (PR #270 round-1/2 P3 nits)

## Test plan

- [x] `npx vitest run tests/unit/scroll-raw-verify.test.ts` passes (17/17)
- [x] `npm run build` (tsc) passes
- [ ] Codex P1 = 0 on PR
- [ ] Opus P1 / P2 = 0 on PR (per CLAUDE.md merge gate)