### PR TITLE
fix(test): sample whole process map in win32GetProcessIdentity gauntlet

### DIFF
--- a/tests/unit/native-win32-panic-fuzz.test.ts
+++ b/tests/unit/native-win32-panic-fuzz.test.ts
@@ -293,22 +293,32 @@ describe.skipIf(!nativeWin32)("ADR-007 P1: native win32 panic-safety", () => {
       },
     );
 
-    it("win32GetProcessIdentity stays consistent across 100 PIDs", () => {
+    it("win32GetProcessIdentity stays consistent across the whole process map", () => {
       const map = native.win32BuildProcessParentMap!();
-      // Sample 100 PIDs (or all of them if fewer).
-      const sample = map.slice(0, 100).map((e) => e.pid);
+      // Walk the entire snapshot rather than slice(0, 100). Toolhelp32 returns
+      // processes in a system-defined order whose first ~100 entries on a
+      // typical Windows box are protected session-0 services (Idle, System,
+      // Registry, smss, csrss, services, lsass, …) that PROCESS_QUERY_LIMITED
+      // _INFORMATION cannot open from a user-mode process. Sampling only the
+      // head therefore can legitimately yield 0/N identified, which masks the
+      // very regression this gauntlet is designed to catch.
+      //
+      // Looping over the full map keeps the test's original intent intact —
+      // a sizeof bug in PROCESSENTRY32W or a mangled OpenProcess handle would
+      // push identifiedCount toward zero — while making the sample robust to
+      // wherever the user-session processes happen to land in the snapshot.
       let identifiedCount = 0;
-      for (const pid of sample) {
-        const id = native.win32GetProcessIdentity!(pid);
-        expect(id.pid).toBe(pid);
+      for (const e of map) {
+        const id = native.win32GetProcessIdentity!(e.pid);
+        expect(id.pid).toBe(e.pid);
         expect(typeof id.processName).toBe("string");
         expect(typeof id.processStartTimeMs).toBe("number");
         if (id.processName.length > 0) identifiedCount++;
       }
-      // We expect to resolve a non-trivial fraction of process names.
-      // A regression that mangled the OpenProcess handle would push this
-      // toward zero, while a sizeof bug in PROCESSENTRY32W would feed
-      // garbage PIDs that would all fail to resolve.
+      // Any healthy Windows session contains at least a handful of user-mode
+      // processes (the test runner itself, its shell, the desktop shell, …).
+      // If zero processes in the entire snapshot resolved, OpenProcess or the
+      // surrounding identity path is genuinely broken.
       expect(identifiedCount).toBeGreaterThan(0);
     });
   });


### PR DESCRIPTION
## Summary

`tests/unit/native-win32-panic-fuzz.test.ts > ADR-007 P3 sizeof gauntlet > win32GetProcessIdentity stays consistent across 100 PIDs` has been red on `main`, asserting `identifiedCount > 0` but observing 0/100 identified on this machine (deterministic, 3/3 reruns).

### Root cause — sampling bias, not Rust regression

The sample (`map.slice(0, 100)`) was taken from the head of Toolhelp32Snapshot's iteration order. On any typical Windows box the head is occupied by **protected session-0 system processes** — Idle, System, Registry, smss, csrss, services, lsass, etc. — none of which can be opened by a user-mode caller even with `PROCESS_QUERY_LIMITED_INFORMATION` rights. So the sample is structurally biased toward 0 identifications regardless of the Rust implementation's correctness.

Debug walk on this PC (298 total processes):

| Slice | PID range | Identified |
|-------|-----------|------------|
| `[0..99]` (failing test sample) | 0 – 3432 | **0 / 100** |
| `[100..199]` | 8704 – 7548 | 38 / 100 |
| `[200..297]` | 24648 – 7216 | 90 / 98 |
| **Full map** | | **128 / 298 (43 %)** |

The Rust path (`win32_get_process_identity` in `src/win32/process.rs:125`) is fine — `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION) → QueryFullProcessImageNameW → GetProcessTimes`. The test's sampling strategy was the bug.

### Fix

Switch the sample to the **entire process map**. The gauntlet's stated intent — "a sizeof bug in PROCESSENTRY32W or a mangled OpenProcess handle would push identifiedCount toward zero" — is preserved, because:

- Any healthy Windows session contains at least a handful of user-mode processes (the test runner, its shell, the desktop shell, …).
- 0 identifications across the *whole* snapshot is a real regression signal.

~298 calls per test run; no measurable cost increase.

Updated the inline comment to spell out the session-0 ACL bias so future maintainers don't reintroduce a `slice(0, N)`-style head sample.

### Verification

```
npx vitest run tests/unit/native-win32-panic-fuzz.test.ts
# Test Files  1 passed (1)
# Tests  91 passed (91)
```

## Out of scope

- A1+A2 → #271
- A3 → #272
- B/C (PR #270 round-1/2 P3 nits) — next

## Test plan

- [x] `npx vitest run tests/unit/native-win32-panic-fuzz.test.ts` passes (91/91)
- [x] `npm run build` (tsc) passes (no source changes — test-only)
- [ ] Codex P1 = 0 on PR
- [ ] Opus P1 / P2 = 0 on PR (per CLAUDE.md merge gate)