### PR TITLE
fix(keyboard): tighten rawKeyboard return type + pin sequence sentinel placement (PR #270 P3 carry-over)

### DIFF
--- a/src/engine/nutjs.ts
+++ b/src/engine/nutjs.ts
@@ -123,13 +123,16 @@ export function withKeyboardLock<T>(fn: () => Promise<T>): Promise<T> {
  * variant, so call it OUTSIDE the lock (e.g. from a sequence handler's
  * `catch` block that sits outside `withKeyboardLock`).
  */
-// Note: libnut's pressKey/releaseKey actually return Promise<KeyboardClass>
-// (fluent chainable). Callers in sequence handler discard the return; typing
-// as Promise<unknown> avoids forcing an awkward .then(()=>void) wrap while
-// preserving the variadic key signature.
+// Note: libnut's pressKey/releaseKey return Promise<KeyboardClass> (fluent
+// chainable). All known callers in the sequence handler `await` and discard
+// the return, so collapse it to Promise<void> at the boundary — keeps the
+// type discipline tight without forcing every caller to `await ... .then(()
+// => undefined)` themselves (Opus PR #270 P3-4).
 export const rawKeyboard = {
-  pressKeyDown: _rawKeyboard.pressKey.bind(_rawKeyboard) as (...keys: Key[]) => Promise<unknown>,
-  pressKeyUp: _rawKeyboard.releaseKey.bind(_rawKeyboard) as (...keys: Key[]) => Promise<unknown>,
+  pressKeyDown: (...keys: Key[]): Promise<void> =>
+    _rawKeyboard.pressKey(...keys).then(() => undefined),
+  pressKeyUp: (...keys: Key[]): Promise<void> =>
+    _rawKeyboard.releaseKey(...keys).then(() => undefined),
 };
 
 /**

--- a/src/tools/keyboard.ts
+++ b/src/tools/keyboard.ts
@@ -2001,6 +2001,13 @@ export const keyboardSequenceHandler = async ({
             }
           }
           // Sentinel: full sequence completed without throwing.
+          //
+          // IMPORTANT: this MUST stay as the last statement inside the
+          // withKeyboardLock callback. Any logic added below it that throws
+          // would set failedIndex=-1 just before, leaving the outer catch
+          // with no step index to attach — the catch then rethrows past the
+          // failWith branch and the LLM loses completedSteps/remaining.
+          // (Opus PR #270 round 2 P3-6.)
           failedIndex = -1;
         });
       } catch (loopErr) {


### PR DESCRIPTION
## Summary

Two cosmetic carry-overs from PR #270 Opus review rounds 1 and 2. Both are P3 nits that were deferred at merge time.

### P3-4 (round 1) — `rawKeyboard` return type

`rawKeyboard.pressKeyDown` / `pressKeyUp` in `src/engine/nutjs.ts` previously cast libnut's fluent `Promise<KeyboardClass>` return to `Promise<unknown>` to dodge a `.then(() => undefined)` wrap at the boundary. Every call site (`src/tools/keyboard.ts:1986,1993` and `tests/unit/keyboard-input-serialization.test.ts:173-176`) already does `await rawKeyboard.x(...)` and discards the value, so push the unwrap into the wrapper instead of leaking the unused-Promise type to callers. Tightens to `Promise<void>` without any behavior change.

### P3-6 (round 2) — `failedIndex` reset sentinel placement

`failedIndex = -1` at the bottom of the sequence loop in `keyboard:sequence` (`src/tools/keyboard.ts:2004`) is the "completed without throw" sentinel. If a future maintainer adds any logic between that line and the closing of the `withKeyboardLock` callback that can throw, `failedIndex` is already -1 by the time the outer catch sees the error, so the `failWith` branch is skipped and the LLM loses `completedSteps` / `remaining` context.

Pin the invariant with an explicit comment so the trap is visible at the site itself instead of only in the review thread.

## What was NOT done

The other PR #270 P3 ideas (B1 effectiveWindowTitle SSOT alignment, B3 N=1 sequence verifyDelivery lift, C2 partial-step idempotency hint) are deliberately left out:

- B1 needs a deeper decision about whether `effectiveWindowTitle` or the caller-supplied `windowTitle` is the SSOT for error context — too much for a P3 PR.
- B3 changes verifyDelivery contract for a corner case and deserves an issue + design pass.
- C2 (warnings.warnings.push("PartialStepReleased: step i")) is an LLM-UX improvement that should be paired with a corresponding test pinning the hint shape.

All three will be filed as follow-up issues separately.

## Verification

```
npx vitest run tests/unit/keyboard-input-serialization.test.ts tests/unit/keyboard-guard-evaluation.test.ts tests/unit/keyboard-method-resolution.test.ts tests/unit/keyboard-leash-guard.test.ts
# Test Files  4 passed (4)
# Tests  58 passed (58)
```

`npm run build` (tsc) clean. `npm run check:stub-catalog` clean (no description changes).

## Test plan

- [x] keyboard test suite passes (58/58)
- [x] `npm run build` (tsc) passes
- [x] `npm run check:stub-catalog` clean
- [ ] Codex P1 = 0 on PR
- [ ] Opus P1 / P2 = 0 on PR (per CLAUDE.md merge gate)