### PR TITLE
fix(_errors): classify arm + SUGGESTS for ForegroundFlashNotApplicableToKeyPress (#279)

### DIFF
--- a/src/tools/_errors.ts
+++ b/src/tools/_errors.ts
@@ -296,6 +296,16 @@ const SUGGESTS: Record<string, string[]> = {
     "Sequence is foreground-only. Use keyboard(action:'press') with method:'foreground_flash' for individual key combos that need the ADR-013 妥協 path.",
     "If you need to chord Alt-mnemonics in a terminal, split the sequence into per-step keyboard(action:'press') calls.",
   ],
+  // Issue #279: keyboard(action:'press') rejects method:'foreground_flash'
+  // because clipboard-paste cannot deliver a key combo (would require Ctrl+V
+  // to inject Ctrl+V — circular). ADR-013 Option E targets text injection
+  // (keyboard:type / terminal:send) only. Producer: keyboard.ts:1490.
+  ForegroundFlashNotApplicableToKeyPress: [
+    "method:'foreground_flash' is for text injection (keyboard:type / terminal:send) only — clipboard paste cannot carry a key combo.",
+    "For the key combo, call keyboard({action:'press', keys, method:'foreground', windowTitle}) instead (default FG SendInput).",
+    "If the target supports background injection (WM_KEYDOWN-class hosts), keyboard({action:'press', keys, method:'background', windowTitle}) also works.",
+    "If you actually wanted to paste text (not chord keys), switch to keyboard({action:'type', text, method:'foreground_flash', windowTitle}) or terminal({action:'send', input, method:'foreground_flash'}).",
+  ],
   BackgroundNotApplicableToSequence: [
     "Sequence does not support the background path — Alt-menu mnemonics require real SendInput which only the foreground path provides.",
     "Use foreground (default) and target via windowTitle/hwnd, or split into separate keyboard(action:'press') calls if BG delivery is essential.",
@@ -545,6 +555,13 @@ function classify(message: string): { code: string; suggest: string[] } {
   }
   if (m.includes("foregroundflashnotapplicabletosequence")) {
     return { code: "ForegroundFlashNotApplicableToSequence", suggest: SUGGESTS.ForegroundFlashNotApplicableToSequence };
+  }
+  // Issue #279: keyboard(action:'press') with method:'foreground_flash' early
+  // reject (keyboard.ts:1490). Placed AFTER Sequence so neither substring
+  // poaches the other — the codes share the "ForegroundFlashNotApplicableTo"
+  // prefix, but the suffixes (Sequence / KeyPress) are mutually exclusive.
+  if (m.includes("foregroundflashnotapplicabletokeypress")) {
+    return { code: "ForegroundFlashNotApplicableToKeyPress", suggest: SUGGESTS.ForegroundFlashNotApplicableToKeyPress };
   }
   if (m.includes("backgroundnotapplicabletosequence")) {
     return { code: "BackgroundNotApplicableToSequence", suggest: SUGGESTS.BackgroundNotApplicableToSequence };

--- a/tests/unit/foreground-flash-keypress-classify.test.ts
+++ b/tests/unit/foreground-flash-keypress-classify.test.ts
@@ -1,0 +1,68 @@
+/**
+ * foreground-flash-keypress-classify.test.ts — Issue #279 (A5).
+ *
+ * Pins the `ForegroundFlashNotApplicableToKeyPress` typed code added to
+ * `_errors.ts::classify()` + `SUGGESTS`. Before this fix, the e2e test
+ * (`tests/e2e/foreground-flash-verification.test.ts:215-228`) only passed
+ * because `keyboard.ts:1490` `failWith` injected an inline `suggest[]`; the
+ * classify() lookup itself fell into the generic "Unknown" tail and any
+ * future producer relying on classify() alone would surface an empty
+ * suggest array to the LLM.
+ *
+ * Follows the precedent of `phase7-f3-spawn-failed-typed-code.test.ts` for
+ * dedicated single-typed-code routing pins.
+ */
+
+import { describe, it, expect } from "vitest";
+import { failWith, getSuggestsForCode } from "../../src/tools/_errors.js";
+
+describe("Issue #279: ForegroundFlashNotApplicableToKeyPress typed code", () => {
+  it("classify routes the bare PascalCase message to its typed code", () => {
+    // Matches the production producer at keyboard.ts:1490 which throws
+    // `new Error("ForegroundFlashNotApplicableToKeyPress")`. No inline
+    // suggest passed → classify() must populate it.
+    const result = failWith(
+      new Error("ForegroundFlashNotApplicableToKeyPress"),
+      "keyboard:press",
+    );
+    const body = JSON.parse(result.content[0]!.text);
+    expect(body.ok).toBe(false);
+    expect(body.code).toBe("ForegroundFlashNotApplicableToKeyPress");
+    expect(Array.isArray(body.suggest)).toBe(true);
+    expect(body.suggest.length).toBeGreaterThan(0);
+  });
+
+  it("classify routes a prose-suffixed message to the same typed code", () => {
+    // Defensive variant: even if a future producer appends prose to the
+    // error message, the substring match in classify() should still route.
+    const result = failWith(
+      new Error("ForegroundFlashNotApplicableToKeyPress: clipboard paste cannot deliver a key combo"),
+      "keyboard:press",
+    );
+    const body = JSON.parse(result.content[0]!.text);
+    expect(body.code).toBe("ForegroundFlashNotApplicableToKeyPress");
+  });
+
+  it("SUGGESTS dictionary exposes ForegroundFlashNotApplicableToKeyPress via getSuggestsForCode()", () => {
+    const suggests = getSuggestsForCode("ForegroundFlashNotApplicableToKeyPress");
+    expect(suggests.length).toBeGreaterThan(0);
+    // Recovery hints must name a concrete recoverable call so the LLM can
+    // act without re-deriving the recipe. e2e test asserts the same shape
+    // via inline suggest; this guards the classify() fallback path.
+    const joined = suggests.join(" ");
+    expect(joined).toMatch(/keyboard:type|terminal:send/);
+    expect(joined).toMatch(/keyboard\(.*action:.*press.*method:.*foreground/);
+  });
+
+  it("Sequence variant is unaffected (no substring poaching between the pair)", () => {
+    // The two ForegroundFlashNotApplicableTo* codes share a long prefix but
+    // mutually-exclusive suffixes. Pin that adding the KeyPress arm did not
+    // regress the existing Sequence arm.
+    const result = failWith(
+      new Error("ForegroundFlashNotApplicableToSequence"),
+      "keyboard:sequence",
+    );
+    const body = JSON.parse(result.content[0]!.text);
+    expect(body.code).toBe("ForegroundFlashNotApplicableToSequence");
+  });
+});


### PR DESCRIPTION
## Summary

- `keyboard.ts:1490` throws `new Error("ForegroundFlashNotApplicableToKeyPress")` when `keyboard({action:'press', method:'foreground_flash'})` is rejected, but `_errors.ts` had only the **Sequence** sibling registered — classify() fell to the generic `ToolError` tail at `_errors.ts:651`
- The existing e2e at `tests/e2e/foreground-flash-verification.test.ts:215-228` was effectively **dependent on this fix** to pass its `r.code === "ForegroundFlashNotApplicableToKeyPress"` assertion: `failWith` (`_errors.ts:663-697`) derives `code` and `suggest` from `classify(message)` only, and the inline `suggest:[...]` at the producer site (`keyboard.ts:1493-1496`) is silently buried under `context.suggest` (not in `ROOT_HOISTED_KEYS`) — verified by reading `failWith` body. The e2e likely never ran cleanly between PR #240 and this PR; running it now against the fix passes (`1 passed | 11 skipped`).
- Adds the missing `SUGGESTS` entry, the matching `classify()` arm, and a dedicated unit pin file (precedent: `tests/unit/phase7-f3-spawn-failed-typed-code.test.ts`)

## Changes

- **`src/tools/_errors.ts`** — `SUGGESTS.ForegroundFlashNotApplicableToKeyPress` (4 concrete recovery paths covering `keyboard:press method:'foreground'|'background'` and the text-injection pivot via `keyboard:type` / `terminal:send`) + classify arm placed AFTER the Sequence arm. The codes share the `"foregroundflashnotapplicableto"` prefix but diverge at char 30 (`s` vs `k`), so neither poaches the other — ordering is stylistic.
- **`tests/unit/foreground-flash-keypress-classify.test.ts`** — 4 pins: bare PascalCase routing, prose-suffixed variant, SUGGESTS contract, Sequence-sibling no-regression.

## Issue #279 (b) — no-op vs. current trunk

The issue body's "two `validate_input` reason mismatches" claim is **a stale carryover from the pre-PR-270 audit**. Verified against current main:

- Rust `as_str()` (`src/win32/foreground_flash.rs:151-158`) — 8 snake_case reasons
- TS union `ForegroundFlashFailureReason` (`src/engine/bg-input.ts:307-317`) — 8 identical strings
- E2E asserts (`tests/e2e/foreground-flash-verification.test.ts:70, 92`) — `input_contains_newline` / `input_exceeds_paste_warning_threshold` both match the Rust SoT

`grep -rn validate_input` finds no other assertion sites. Resolved during PR #270 itself; this PR scopes to (a) only.

## Out-of-scope follow-up (separate issue worth filing)

Opus review surfaced a systemic dead-arg pattern at multiple `failWith` call sites in `src/tools/keyboard.ts` (e.g. lines 1490, 764-767, 804-807, 1018-1021, 1229-1232, 1242-1245) where `{ suggest: [...], context: {...} }` is passed as the 3rd arg, but `failWith` only hoists `ROOT_HOISTED_KEYS` (`_perceptionForPost`, `_richForPost`, `hints`) — so the inline `suggest` becomes `context.suggest` and any `context` key inside the arg becomes `context.context.x` (double-nesting). After this PR the LLM-facing root `suggest` is the SUGGESTS-dict array (a strict superset of the inline 2-hint array at keyboard.ts:1490, so no behavior regression), but the dead-arg pattern is worth cleaning up in a follow-up.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run test:unit` — 190 files / 2942 passed (incl. new 4 pins + existing `issue-211-classify-branch-producer-pin` recognizing `keyboard.ts:1490` as the producer for the new arm)
- [x] e2e single-test (`tests/e2e/foreground-flash-verification.test.ts -t "rejects with ForegroundFlashNotApplicableToKeyPress"`) — 1 passed (the assertion this PR unblocks)
- [x] `npm run check:stub-catalog` — no drift (description-only / no Zod schema touch)
- [x] No native (`build:rs`) / no `index.d.ts` change — TS-only PR
- [x] Opus review — P1 / P2 = 0
- [ ] Codex review — P1 → 0

Closes #279