### PR TITLE
feat(adr-018-phase-2a): flatten discriminatedUnion tool schemas — fix tools/list empty properties

### DIFF
--- a/scripts/generate-stub-tool-catalog.mjs
+++ b/scripts/generate-stub-tool-catalog.mjs
@@ -769,10 +769,126 @@ function parseDiscriminatedUnionSchema(rawExpr) {
   return { type: 'object', oneOf };
 }
 
+// Shared `include?: string[]` field definition — injected by both the
+// `withEnvelopeIncludeForUnion` recursion and the ADR-018 Phase 2a
+// `flattenUnionToObjectSchema` recursion below.
+const STUB_INCLUDE_FIELD_DEF = {
+  type: 'array',
+  items: { type: 'string' },
+  description:
+    "Optional response-shape opt-in. " +
+    "`['envelope']` returns the self-documenting envelope " +
+    "(`_version` / `data` / `as_of` / `confidence`). " +
+    "`['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). " +
+    "Default behaviour is raw shape (compat with existing clients).",
+};
+
+// ADR-018 Phase 2a — extract the discriminator field name from a raw
+// `z.discriminatedUnion("action", [...])` expression (its first arg).
+function extractDiscriminatorName(unionRawExpr) {
+  const raw = unionRawExpr.trim();
+  const m = /^z\s*\.\s*discriminatedUnion\s*\(/.exec(raw);
+  if (!m) return undefined;
+  const argsEnd = scanBalanced(raw, m[0].length, '(', ')');
+  const args = splitTopLevelArgs(raw.slice(m[0].length, argsEnd - 1));
+  if (args.length < 1) return undefined;
+  try { return String(evalExpr(args[0])); } catch { return undefined; }
+}
+
+// ADR-018 Phase 2a — static flatten of a discriminatedUnion `{ oneOf: [...] }`
+// (the output of `parseDiscriminatedUnionSchema`) into a single flat object.
+// Mirrors `src/tools/_envelope.ts::flattenUnionToObjectSchema` for the
+// cross-platform stub catalog: the discriminator becomes a required `enum` of
+// every variant's literal; every other field is optional; same-named `enum`
+// collisions merge their value sets; other collisions keep the first variant's
+// shape (the stub catalog is for non-Windows tool DISCOVERY — runtime
+// `parseActionArgsOrFail` does the real strict per-action validation).
+function flattenOneOfToObject(unionSchema, discriminatorKey) {
+  const mergedProps = {};
+  const literals = [];
+  for (const variant of unionSchema.oneOf) {
+    if (!variant || !variant.properties) continue;
+    for (const [key, prop] of Object.entries(variant.properties)) {
+      if (key === discriminatorKey) {
+        // parseZObjectVariant renders the discriminator as `{ const: <lit> }`.
+        if (prop && typeof prop === 'object' && 'const' in prop) {
+          if (!literals.includes(prop.const)) literals.push(prop.const);
+        }
+        continue;
+      }
+      if (!(key in mergedProps)) {
+        mergedProps[key] = prop;
+      } else {
+        const existing = mergedProps[key];
+        if (Array.isArray(existing?.enum) && Array.isArray(prop?.enum)) {
+          mergedProps[key] = {
+            ...existing,
+            enum: [...new Set([...existing.enum, ...prop.enum])],
+          };
+        }
+        // else: keep the first variant's shape (discovery stub — acceptable).
+      }
+    }
+  }
+  const properties = {
+    [discriminatorKey]: {
+      type: 'string',
+      enum: literals,
+      description:
+        `Action selector — one of: ${literals.join(', ')}. ` +
+        'Per-action required fields are enforced at call time (see the tool ' +
+        "description); this flat schema lists every action's fields as optional.",
+    },
+    ...mergedProps,
+  };
+  return {
+    type: 'object',
+    properties,
+    required: [discriminatorKey],
+    additionalProperties: false,
+  };
+}
+
 function parseSchema(src, schemaName) {
   if (!schemaName) return { type: 'object', properties: {}, additionalProperties: false };
   let expr = findConstExpression(src, schemaName);
   if (!expr) return { type: 'object', properties: {}, additionalProperties: true };
+
+  // ADR-018 Phase 2a — `flattenUnionToObjectSchema(<identifier>)`: the 7
+  // multi-action tools register a FLAT wire schema produced by
+  // `flattenUnionToObjectSchema(<tool>UnionWithInclude)`, where
+  // `<tool>UnionWithInclude = withEnvelopeIncludeForUnion(<bareUnion>)`.
+  // The generator cannot run that function call, so resolve the chain
+  // statically: flatten(...) → withEnvelopeIncludeForUnion(...) →
+  // z.discriminatedUnion(...), parse the variants, inject `include` into each
+  // (mirroring the runtime helper's input), then flatten to one flat object.
+  const flattenWrapperMatch = expr.trim().match(
+    /^flattenUnionToObjectSchema\s*\(\s*([A-Za-z_$][\w$]*)\s*\)\s*;?\s*$/,
+  );
+  if (flattenWrapperMatch) {
+    const uwiName = flattenWrapperMatch[1];
+    const uwiExpr = (findConstExpression(src, uwiName) ?? '').trim();
+    const uwiMatch = uwiExpr.match(
+      /^withEnvelopeIncludeForUnion\s*\(\s*([A-Za-z_$][\w$]*)\s*\)\s*;?\s*$/,
+    );
+    if (uwiMatch) {
+      const bareExpr = (findConstExpression(src, uwiMatch[1]) ?? '').trim();
+      const discriminator = extractDiscriminatorName(bareExpr);
+      const unionSchema = parseDiscriminatedUnionSchema(bareExpr);
+      if (unionSchema && Array.isArray(unionSchema.oneOf) && discriminator) {
+        // The runtime `flattenUnionToObjectSchema` input is the
+        // include-injected union — inject `include` into each variant first,
+        // so it lands as one of the flat object's optional fields.
+        for (const variant of unionSchema.oneOf) {
+          if (variant && variant.properties) {
+            variant.properties.include = STUB_INCLUDE_FIELD_DEF;
+          }
+        }
+        return flattenOneOfToObject(unionSchema, discriminator);
+      }
+    }
+    return { type: 'object', properties: {}, additionalProperties: true };
+  }
 
   // PR #112 Round 1 P1 follow-up: when a schema is wrapped via the
   // L5 envelope helper `withEnvelopeIncludeSchema(baseShape)`, recurse

--- a/src/stub-tool-catalog.ts
+++ b/src/stub-tool-catalog.ts
@@ -80,149 +80,79 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
     "description": "Purpose: Inspect or operate on a browser tab via 3 actions: 'js' (evaluate JS), 'dom' (get HTML), 'appState' (extract SSR-injected SPA state).\nDetails: action='js' — Run a JS expression. withPerception:true wraps in {ok, result, post}. action='dom' — Return outerHTML of selector (or document.body), truncated to maxLength. action='appState' — Scan Next/Nuxt/Remix/Apollo/GitHub/Redux SSR injected JSON; pass selectors to override defaults.\nPrefer: Use action='appState' BEFORE 'dom' or 'js' on SPAs where rendered HTML is sparse — single CDP call. Use 'dom' when 'appState' is empty and you need page structure. Use 'js' as the escape hatch for arbitrary scripting.\nCaveats: DOM nodes cannot be returned from action='js' directly (circular refs are serialized safely). React/Vue/Svelte controlled inputs cannot be set via element.value — use keyboard(action='type') / browser_fill instead. readyState is strictly checked; guard blocks if page is still loading. Typed errors: code:'BrowserNotConnected' on CDP disconnect (re-attach via browser_open); code:'AutoGuardBlocked' when the auto-guard refuses (e.g. page still loading) — the error message preserves the guard's 1-sentence recommended next step (most often wait_until({condition:'ready_state'}) or browser_eval readyState polling, then retry).\nExamples:\n  browser_eval({action:'js', expression:'document.title'}) → page title\n  browser_eval({action:'dom', selector:'#main', maxLength:5000}) → outerHTML\n  browser_eval({action:'appState'}) → default SPA state probes",
     "inputSchema": {
       "type": "object",
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "action": {
-              "const": "js"
-            },
-            "expression": {
-              "description": "JavaScript expression to evaluate. The server automatically wraps snippets in an async IIFE to avoid repeated const/let collisions. For multi-statement snippets, use an explicit final return value. Declarations (const/let/var) are scoped per snippet — use window.* / globalThis.* for persistence.",
-              "type": "string"
-            },
-            "withPerception": {
-              "description": "When true, return structured JSON {ok, result, post} with post.perception attached. Default false preserves raw-text return.",
-              "type": "boolean",
-              "default": false
-            },
-            "lensId": {
-              "description": "Optional perception lens ID. Guards (target.identityStable) are evaluated before eval.",
-              "type": "string"
-            },
-            "tabId": {
-              "type": "string",
-              "description": "Tab ID from browser_open. Omit to use the first page tab."
-            },
-            "port": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 65535,
-              "default": 9222,
-              "description": "Chrome/Edge CDP remote debugging port."
-            },
-            "includeContext": {
-              "type": "boolean",
-              "default": true,
-              "description": "When true, append activeTab and readyState context to the response."
-            },
-            "include": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "action",
-            "expression"
-          ]
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "js",
+            "dom",
+            "appState"
+          ],
+          "description": "Action selector — one of: js, dom, appState. Per-action required fields are enforced at call time (see the tool description); this flat schema lists every action's fields as optional."
         },
-        {
-          "type": "object",
-          "properties": {
-            "action": {
-              "const": "dom"
-            },
-            "selector": {
-              "description": "CSS selector for root element. Omit for document.body.",
-              "type": "string"
-            },
-            "maxLength": {
-              "description": "Max characters of HTML to return (default 10000).",
-              "type": "integer",
-              "default": 10000,
-              "minimum": 100,
-              "maximum": 100000
-            },
-            "tabId": {
-              "type": "string",
-              "description": "Tab ID from browser_open. Omit to use the first page tab."
-            },
-            "port": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 65535,
-              "default": 9222,
-              "description": "Chrome/Edge CDP remote debugging port."
-            },
-            "includeContext": {
-              "type": "boolean",
-              "default": true,
-              "description": "When true, append activeTab and readyState context to the response."
-            },
-            "include": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "action"
-          ]
+        "expression": {
+          "description": "JavaScript expression to evaluate. The server automatically wraps snippets in an async IIFE to avoid repeated const/let collisions. For multi-statement snippets, use an explicit final return value. Declarations (const/let/var) are scoped per snippet — use window.* / globalThis.* for persistence.",
+          "type": "string"
         },
-        {
-          "type": "object",
-          "properties": {
-            "action": {
-              "const": "appState"
-            },
-            "selectors": {
-              "description": "Custom probe selectors. Omit to use the default SPA framework set (__NEXT_DATA__ / __NUXT_DATA__ / __REMIX_CONTEXT__ / __APOLLO_STATE__ / window:__INITIAL_STATE__ etc.). Window globals must be prefixed with 'window:'.",
-              "type": "array"
-            },
-            "maxBytes": {
-              "description": "Max bytes per individual payload (default 4000). Larger payloads are truncated.",
-              "type": "integer",
-              "default": 4000,
-              "minimum": 256,
-              "maximum": 64000
-            },
-            "tabId": {
-              "type": "string",
-              "description": "Tab ID from browser_open. Omit to use the first page tab."
-            },
-            "port": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 65535,
-              "default": 9222,
-              "description": "Chrome/Edge CDP remote debugging port."
-            },
-            "includeContext": {
-              "type": "boolean",
-              "default": true,
-              "description": "When true, append activeTab and readyState context to the response."
-            },
-            "include": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
-            }
+        "withPerception": {
+          "description": "When true, return structured JSON {ok, result, post} with post.perception attached. Default false preserves raw-text return.",
+          "type": "boolean",
+          "default": false
+        },
+        "lensId": {
+          "description": "Optional perception lens ID. Guards (target.identityStable) are evaluated before eval.",
+          "type": "string"
+        },
+        "tabId": {
+          "type": "string",
+          "description": "Tab ID from browser_open. Omit to use the first page tab."
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "default": 9222,
+          "description": "Chrome/Edge CDP remote debugging port."
+        },
+        "includeContext": {
+          "type": "boolean",
+          "default": true,
+          "description": "When true, append activeTab and readyState context to the response."
+        },
+        "include": {
+          "type": "array",
+          "items": {
+            "type": "string"
           },
-          "additionalProperties": false,
-          "required": [
-            "action"
-          ]
+          "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
+        },
+        "selector": {
+          "description": "CSS selector for root element. Omit for document.body.",
+          "type": "string"
+        },
+        "maxLength": {
+          "description": "Max characters of HTML to return (default 10000).",
+          "type": "integer",
+          "default": 10000,
+          "minimum": 100,
+          "maximum": 100000
+        },
+        "selectors": {
+          "description": "Custom probe selectors. Omit to use the default SPA framework set (__NEXT_DATA__ / __NUXT_DATA__ / __REMIX_CONTEXT__ / __APOLLO_STATE__ / window:__INITIAL_STATE__ etc.). Window globals must be prefixed with 'window:'.",
+          "type": "array"
+        },
+        "maxBytes": {
+          "description": "Max bytes per individual payload (default 4000). Larger payloads are truncated.",
+          "type": "integer",
+          "default": 4000,
+          "minimum": 256,
+          "maximum": 64000
         }
-      ]
+      },
+      "required": [
+        "action"
+      ],
+      "additionalProperties": false
     }
   },
   {
@@ -698,52 +628,32 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
     "description": "Read or write the Windows clipboard. action='read' returns current text content (empty string if non-text). action='write' replaces clipboard with given text and verifies delivery via Get-Clipboard -Raw read-back, comparing the bytes (UTF-16LE) for exact equality. Caveats: Non-text clipboard payloads (images, files) return empty string on read. Overwrites existing clipboard content on write. action='write' delivery-verification failure returns code:'ClipboardWriteNotDelivered' — typical causes: a third-party clipboard manager intercepts SetClipboardData, DLP / endpoint protection blocks the payload, RDP / Citrix clipboard transcoding strips the text, or another process clears the clipboard between Set and the read-back. Recovery: retry the write, or fall back to keyboard(action='type', use_clipboard=false) for short text. Examples: clipboard({action:'write', text:'hello'}) → write+verify; clipboard({action:'read'}) → returns current text.",
     "inputSchema": {
       "type": "object",
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "action": {
-              "const": "read"
-            },
-            "include": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "action"
-          ]
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "read",
+            "write"
+          ],
+          "description": "Action selector — one of: read, write. Per-action required fields are enforced at call time (see the tool description); this flat schema lists every action's fields as optional."
         },
-        {
-          "type": "object",
-          "properties": {
-            "action": {
-              "const": "write"
-            },
-            "text": {
-              "description": "Text to place on the clipboard",
-              "type": "string",
-              "maxLength": 100000
-            },
-            "include": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
-            }
+        "include": {
+          "type": "array",
+          "items": {
+            "type": "string"
           },
-          "additionalProperties": false,
-          "required": [
-            "action",
-            "text"
-          ]
+          "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
+        },
+        "text": {
+          "description": "Text to place on the clipboard",
+          "type": "string",
+          "maxLength": 100000
         }
-      ]
+      },
+      "required": [
+        "action"
+      ],
+      "additionalProperties": false
     }
   },
   {
@@ -847,283 +757,145 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
     "description": "Purpose: Send keyboard input to a window: 'type' for text, 'press' for key combos, 'sequence' for atomic multi-step chords.\nDetails: action='type' inserts text (auto-clipboard for non-ASCII / IME-safe). action='press' sends key combos like 'ctrl+c'/'alt+tab'. action='sequence' runs ordered steps in one keyboard lock — use for Alt+letter, letter mnemonic chains where intermediate tool calls would close the menu. Pass windowTitle to auto-focus and auto-guard (identity, foreground, modal) before input. Omitting windowTitle acts on the active window (unguarded).\nPrefer: Use windowTitle to auto-focus before injection. Set lensId for perception guards. Use desktop_act({action:'setValue'}) for UIA ValuePattern text fields.\nCaveats: win+r/win+x/win+s/win+l blocked. action='type' does not handle CJK IME composition — use use_clipboard=true or desktop_act({action:'setValue'}). Non-ASCII text (CJK / emoji / diacritics / smart-quote-class punctuation) auto-clipboards to prevent silent-drop and Chrome accelerator hijack; pass forceKeystrokes:true to disable. Background (PostMessage/WM_CHAR) auto-engages for terminal-class windows (Windows Terminal / cmd / PowerShell); DTM_BG_AUTO=1 enables globally. Foreground non-terminal type runs a per-chunk leash; user focus-steal mid-stream aborts with FocusLostDuringType + context.typed/remaining; pass abortOnFocusLoss:false to disable. BG type verifies WM_CHAR via UIA TextPattern read-back; mismatch returns BackgroundInputNotDelivered (see SUGGESTS for false-positive notes). BG press read-back is scoped to terminal-class + enter/tab/arrow; other combos return verifyDelivery:'unverifiable', failure returns BackgroundKeyNotDelivered. action='sequence' is FG-only (BG/foreground_flash schema-rejected); emits verifyDelivery:'focus_only'; mid-loop focus theft returns MenuFocusLostMidSequence + context.remaining: Step[]. Win11 FG refusal returns ForegroundRestricted — terminal-class targets auto-engage BG; non-terminal switch to desktop_act / click_element.\nExamples:\n  keyboard({action:'type', text:'hello', windowTitle:'Notepad'}) → text injected (guarded)\n  keyboard({action:'type', text:'hello'}) → text injected (unguarded)\n  keyboard({action:'press', keys:'ctrl+c'}) → copy\n  keyboard({action:'press', keys:'escape', windowTitle:'Dialog'}) → dismiss dialog\n  keyboard({action:'sequence', steps:[{keys:'alt+i', gapMs:100},{keys:'m'}], windowTitle:'Microsoft Visual Basic'}) → Insert > Module (atomic)",
     "inputSchema": {
       "type": "object",
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "action": {
-              "const": "type"
-            },
-            "text": {
-              "description": "The text to type (max 10,000 characters)",
-              "type": "string",
-              "maxLength": 10000
-            },
-            "method": {
-              "type": "string",
-              "enum": [
-                "auto",
-                "background",
-                "foreground"
-              ],
-              "default": "auto",
-              "description": "Input method. background = WM_CHAR PostMessage (no focus change); foreground = SendInput (current default); auto = pick automatically."
-            },
-            "narrate": {
-              "type": "string",
-              "enum": [
-                "minimal",
-                "rich"
-              ],
-              "default": "minimal",
-              "description": "Narration level. rich includes UIA or browser state diff when supported."
-            },
-            "use_clipboard": {
-              "description": "If true, copy text to clipboard and paste with Ctrl+V instead of simulating keystrokes. Use this when typing URLs, paths, or ASCII text into apps with Japanese IME active — prevents IME from converting characters. Default false.",
-              "type": "boolean",
-              "default": false
-            },
-            "replaceAll": {
-              "description": "When true, send Ctrl+A to select all existing text before typing. Equivalent to Ctrl+A → keyboard(action='type') in one call (requires field already focused). Default false.",
-              "type": "boolean",
-              "default": false
-            },
-            "forceKeystrokes": {
-              "description": "When true, always use keystroke mode even if text contains non-ASCII content (CJK, emoji, diacritics, em-dash, smart quotes, etc.) that would normally trigger auto-clipboard. Default false — auto-clipboard is enabled.",
-              "type": "boolean",
-              "default": false
-            },
-            "windowTitle": {
-              "type": "string",
-              "description": "Partial title of the window that should receive keyboard input."
-            },
-            "hwnd": {
-              "type": "string",
-              "description": "Direct window handle ID (takes precedence over windowTitle). Obtain from get_windows response (hwnd field). String type to avoid 64-bit precision issues."
-            },
-            "forceFocus": {
-              "type": "boolean",
-              "description": "Bypass Windows foreground-stealing protection before focusing."
-            },
-            "trackFocus": {
-              "type": "boolean",
-              "default": true,
-              "description": "Detect if focus was stolen after the action."
-            },
-            "settleMs": {
-              "type": "integer",
-              "minimum": 0,
-              "maximum": 2000,
-              "default": 300,
-              "description": "Milliseconds to wait before checking post-action state."
-            },
-            "lensId": {
-              "description": "Optional perception lens ID. Guards (safe.keyboardTarget) are evaluated before typing, and a perception envelope is attached to post.perception on success.",
-              "type": "string"
-            },
-            "fixId": {
-              "description": "Approve a pending suggestedFix (one-shot, 15s TTL). Pass the fixId returned by a previous failed keyboard(action='type') to re-attempt with guard-validated args.",
-              "type": "string"
-            },
-            "abortOnFocusLoss": {
-              "description": "Focus Leash Phase B: when true, the foreground keystroke send is split into chunks (default 8 chars; override via DTM_LEASH_CHUNK_SIZE env) and the target window's foreground state is verified between chunks. If the user grabs focus mid-stream, the call aborts and returns FocusLostDuringType with context.typed (chars delivered to target) and context.remaining (unsent tail) so the caller can re-focus and retry the unsent portion. Default: true when windowTitle is provided, false otherwise. Has no effect on the clipboard path (atomic Ctrl+V) or the BG (WM_CHAR) path (HWND-targeted, foreground-independent).",
-              "type": "boolean"
-            },
-            "forceImeOff": {
-              "description": "Issue #245 系統②: when true, query the target window's IME open-status via Imm32 before typing; if ON, switch OFF for the duration of this call and restore the prior state in `finally`. Prevents silent romaji conversion when the user's Japanese IME is active but the LLM is typing ASCII commands. Requires `windowTitle` or `hwnd` (otherwise no target to query). Default false — existing use_clipboard auto-promotion still handles non-ASCII symbols transparently. No-op when the addon predates the IMM bridge (call proceeds with whatever IME state is in effect).",
-              "type": "boolean",
-              "default": false
-            },
-            "include": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "action",
-            "text"
-          ]
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "type",
+            "press",
+            "sequence"
+          ],
+          "description": "Action selector — one of: type, press, sequence. Per-action required fields are enforced at call time (see the tool description); this flat schema lists every action's fields as optional."
         },
-        {
-          "type": "object",
-          "properties": {
-            "action": {
-              "const": "press"
-            },
-            "keys": {
-              "description": "Key combo string, e.g. 'ctrl+c', 'alt+tab', 'enter', 'ctrl+shift+s'. Note: win+r, win+x, win+s, win+l are blocked for security.",
-              "type": "string",
-              "maxLength": 100
-            },
-            "method": {
-              "type": "string",
-              "enum": [
-                "auto",
-                "background",
-                "foreground"
-              ],
-              "default": "auto",
-              "description": "Input method. background = WM_CHAR PostMessage (no focus change); foreground = SendInput (current default); auto = pick automatically."
-            },
-            "narrate": {
-              "type": "string",
-              "enum": [
-                "minimal",
-                "rich"
-              ],
-              "default": "minimal",
-              "description": "Narration level. rich includes UIA or browser state diff when supported."
-            },
-            "windowTitle": {
-              "type": "string",
-              "description": "Partial title of the window that should receive keyboard input."
-            },
-            "hwnd": {
-              "type": "string",
-              "description": "Direct window handle ID (takes precedence over windowTitle). Obtain from get_windows response (hwnd field). String type to avoid 64-bit precision issues."
-            },
-            "forceFocus": {
-              "type": "boolean",
-              "description": "Bypass Windows foreground-stealing protection before focusing."
-            },
-            "trackFocus": {
-              "type": "boolean",
-              "default": true,
-              "description": "Detect if focus was stolen after the action."
-            },
-            "settleMs": {
-              "type": "integer",
-              "minimum": 0,
-              "maximum": 2000,
-              "default": 300,
-              "description": "Milliseconds to wait before checking post-action state."
-            },
-            "lensId": {
-              "description": "Optional perception lens ID. Guards (safe.keyboardTarget) are evaluated before the key press.",
-              "type": "string"
-            },
-            "include": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "action",
-            "keys"
-          ]
+        "text": {
+          "description": "The text to type (max 10,000 characters)",
+          "type": "string",
+          "maxLength": 10000
         },
-        {
-          "type": "object",
-          "properties": {
-            "action": {
-              "const": "sequence"
-            },
-            "steps": {
-              "description": "Ordered list of key-press steps. Min 1, max 16. Total duration must not exceed 5000ms (excludes settleMs and focus acquisition). N=1 is allowed but inherits the sequence verification contract (hints.verifyDelivery.status='focus_only'); if you want the stricter keyboard:press contract, call keyboard({action:'press', keys}) directly (issue #278, matrix doc §3.1).",
-              "type": "array",
-              "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                  "keys": {
-                    "description": "Key combo for this step (e.g. 'alt+i' then 'm'). Same syntax as keyboard(action='press'). Blocked combos (win+r, win+x, win+s, win+l) are rejected per-step.",
-                    "type": "string",
-                    "maxLength": 100
-                  },
-                  "holdMs": {
-                    "description": "Hold time within this step (key-down → wait holdMs → key-up). Default 0 = tap. Use a positive value when the target requires a long press (rare for menu nav; useful for some games / accessibility apps).",
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 500
-                  },
-                  "gapMs": {
-                    "description": "Wait between this step's release and the next step's press. Default 80ms — chosen to give Windows menu pump time to register the previous mnemonic before the next letter. The last step's gapMs is ignored.",
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 2000
-                  }
-                },
-                "required": [
-                  "keys"
-                ]
-              },
-              "minItems": 1,
-              "maxItems": 16
-            },
-            "method": {
-              "description": "Sequence is foreground-only by design — Alt-menu mnemonics need real SendInput. Omit, or pass 'foreground'. method:'background' / 'foreground_flash' are rejected at schema parse time (typed codes BackgroundNotApplicableToSequence / ForegroundFlashNotApplicableToSequence document the rationale for LLMs).",
-              "const": "foreground",
-              "type": "string"
-            },
-            "narrate": {
-              "type": "string",
-              "enum": [
-                "minimal",
-                "rich"
-              ],
-              "default": "minimal",
-              "description": "Narration level. rich includes UIA or browser state diff when supported."
-            },
-            "windowTitle": {
-              "type": "string",
-              "description": "Partial title of the window that should receive keyboard input."
-            },
-            "hwnd": {
-              "type": "string",
-              "description": "Direct window handle ID (takes precedence over windowTitle). Obtain from get_windows response (hwnd field). String type to avoid 64-bit precision issues."
-            },
-            "forceFocus": {
-              "type": "boolean",
-              "description": "Bypass Windows foreground-stealing protection before focusing."
-            },
-            "trackFocus": {
-              "type": "boolean",
-              "default": true,
-              "description": "Detect if focus was stolen after the action."
-            },
-            "settleMs": {
-              "type": "integer",
-              "minimum": 0,
-              "maximum": 2000,
-              "default": 300,
-              "description": "Milliseconds to wait before checking post-action state."
-            },
-            "lensId": {
-              "description": "Optional perception lens ID. Guards (safe.keyboardTarget) are evaluated once before the first step.",
-              "type": "string"
-            },
-            "fixId": {
-              "description": "Approve a pending suggestedFix (one-shot, 15s TTL). Only meaningful for GUARD-pre-loop rejections (e.g. unsafe.keyboardTarget). Mid-loop MenuFocusLostMidSequence does NOT issue fixIds — recover by re-calling with context.remaining.",
-              "type": "string"
-            },
-            "forceImeOff": {
-              "description": "Issue #245 系統②: query the target's IME open-status before the first step; if ON, switch OFF for the whole sequence and restore in finally. Prevents Alt-mnemonic hijack when 日本語 IME is active (the OS routes Alt+letter to IME composition instead of the menu). Requires windowTitle or hwnd. Default false.",
-              "type": "boolean",
-              "default": false
-            },
-            "include": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
-            }
+        "method": {
+          "type": "string",
+          "enum": [
+            "auto",
+            "background",
+            "foreground"
+          ],
+          "default": "auto",
+          "description": "Input method. background = WM_CHAR PostMessage (no focus change); foreground = SendInput (current default); auto = pick automatically."
+        },
+        "narrate": {
+          "type": "string",
+          "enum": [
+            "minimal",
+            "rich"
+          ],
+          "default": "minimal",
+          "description": "Narration level. rich includes UIA or browser state diff when supported."
+        },
+        "use_clipboard": {
+          "description": "If true, copy text to clipboard and paste with Ctrl+V instead of simulating keystrokes. Use this when typing URLs, paths, or ASCII text into apps with Japanese IME active — prevents IME from converting characters. Default false.",
+          "type": "boolean",
+          "default": false
+        },
+        "replaceAll": {
+          "description": "When true, send Ctrl+A to select all existing text before typing. Equivalent to Ctrl+A → keyboard(action='type') in one call (requires field already focused). Default false.",
+          "type": "boolean",
+          "default": false
+        },
+        "forceKeystrokes": {
+          "description": "When true, always use keystroke mode even if text contains non-ASCII content (CJK, emoji, diacritics, em-dash, smart quotes, etc.) that would normally trigger auto-clipboard. Default false — auto-clipboard is enabled.",
+          "type": "boolean",
+          "default": false
+        },
+        "windowTitle": {
+          "type": "string",
+          "description": "Partial title of the window that should receive keyboard input."
+        },
+        "hwnd": {
+          "type": "string",
+          "description": "Direct window handle ID (takes precedence over windowTitle). Obtain from get_windows response (hwnd field). String type to avoid 64-bit precision issues."
+        },
+        "forceFocus": {
+          "type": "boolean",
+          "description": "Bypass Windows foreground-stealing protection before focusing."
+        },
+        "trackFocus": {
+          "type": "boolean",
+          "default": true,
+          "description": "Detect if focus was stolen after the action."
+        },
+        "settleMs": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 2000,
+          "default": 300,
+          "description": "Milliseconds to wait before checking post-action state."
+        },
+        "lensId": {
+          "description": "Optional perception lens ID. Guards (safe.keyboardTarget) are evaluated before typing, and a perception envelope is attached to post.perception on success.",
+          "type": "string"
+        },
+        "fixId": {
+          "description": "Approve a pending suggestedFix (one-shot, 15s TTL). Pass the fixId returned by a previous failed keyboard(action='type') to re-attempt with guard-validated args.",
+          "type": "string"
+        },
+        "abortOnFocusLoss": {
+          "description": "Focus Leash Phase B: when true, the foreground keystroke send is split into chunks (default 8 chars; override via DTM_LEASH_CHUNK_SIZE env) and the target window's foreground state is verified between chunks. If the user grabs focus mid-stream, the call aborts and returns FocusLostDuringType with context.typed (chars delivered to target) and context.remaining (unsent tail) so the caller can re-focus and retry the unsent portion. Default: true when windowTitle is provided, false otherwise. Has no effect on the clipboard path (atomic Ctrl+V) or the BG (WM_CHAR) path (HWND-targeted, foreground-independent).",
+          "type": "boolean"
+        },
+        "forceImeOff": {
+          "description": "Issue #245 系統②: when true, query the target window's IME open-status via Imm32 before typing; if ON, switch OFF for the duration of this call and restore the prior state in `finally`. Prevents silent romaji conversion when the user's Japanese IME is active but the LLM is typing ASCII commands. Requires `windowTitle` or `hwnd` (otherwise no target to query). Default false — existing use_clipboard auto-promotion still handles non-ASCII symbols transparently. No-op when the addon predates the IMM bridge (call proceeds with whatever IME state is in effect).",
+          "type": "boolean",
+          "default": false
+        },
+        "include": {
+          "type": "array",
+          "items": {
+            "type": "string"
           },
-          "additionalProperties": false,
-          "required": [
-            "action",
-            "steps"
-          ]
+          "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
+        },
+        "keys": {
+          "description": "Key combo string, e.g. 'ctrl+c', 'alt+tab', 'enter', 'ctrl+shift+s'. Note: win+r, win+x, win+s, win+l are blocked for security.",
+          "type": "string",
+          "maxLength": 100
+        },
+        "steps": {
+          "description": "Ordered list of key-press steps. Min 1, max 16. Total duration must not exceed 5000ms (excludes settleMs and focus acquisition). N=1 is allowed but inherits the sequence verification contract (hints.verifyDelivery.status='focus_only'); if you want the stricter keyboard:press contract, call keyboard({action:'press', keys}) directly (issue #278, matrix doc §3.1).",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "keys": {
+                "description": "Key combo for this step (e.g. 'alt+i' then 'm'). Same syntax as keyboard(action='press'). Blocked combos (win+r, win+x, win+s, win+l) are rejected per-step.",
+                "type": "string",
+                "maxLength": 100
+              },
+              "holdMs": {
+                "description": "Hold time within this step (key-down → wait holdMs → key-up). Default 0 = tap. Use a positive value when the target requires a long press (rare for menu nav; useful for some games / accessibility apps).",
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 500
+              },
+              "gapMs": {
+                "description": "Wait between this step's release and the next step's press. Default 80ms — chosen to give Windows menu pump time to register the previous mnemonic before the next letter. The last step's gapMs is ignored.",
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 2000
+              }
+            },
+            "required": [
+              "keys"
+            ]
+          },
+          "minItems": 1,
+          "maxItems": 16
         }
-      ]
+      },
+      "required": [
+        "action"
+      ],
+      "additionalProperties": false
     }
   },
   {
@@ -1569,347 +1341,216 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
     "description": "Purpose: Scroll a window or page. 5 strategies via action: 'raw' (wheel notches), 'to_element' (UIA name/automationId or CSS selector), 'smart' (auto-detect target with multi-strategy fallback), 'capture' (full-page stitched image), 'read' (scroll+OCR+dedupe → stitched text).\nDetails: action='raw': send raw mouse-wheel notches at (x,y) or current cursor, optional window focus. action='to_element': scroll a named element into viewport (UIA or CDP). action='smart': handles nested scroll layers, virtualised lists, sticky-header occlusion. action='capture': stitches full-page images (caps at ~700KB raw); sizeReduced=true means downscaled. action='read': scrolls page-by-page, OCRs each viewport, deduplicates overlapping lines, returns stitched text; language auto-detected from OS locale if omitted.\nPrefer: Use action='to_element' or action='smart' for click target out-of-viewport recovery (entity_outside_viewport). Use action='capture' for reading long pages as images. Use action='read' for extracting text from long native-app documents (PDF readers, text editors, terminals) where copy-paste is unavailable. For simple scroll without target, use action='raw'.\nCaveats: action='capture' returns stitched image — pixels do NOT match screen coords when sizeReduced=true, use for reading only, not mouse_click. action='smart' CDP path requires browser_open. action='to_element' native path requires element to implement UIA ScrollItemPattern. action='read' uses OCR (imperfect accuracy) and requires the window to be visible; for browser pages prefer browser_eval or browser_overview for accurate DOM text. action='raw' typed errors: code:'ScrollNotDelivered' on silent drop (overlay / non-scrollable / UIPI low-IL); already-at-boundary is success via pre/post-percent disambiguation. hints.verifyDelivery.{channel,reason} per ADR-018 §2.6 (Phase 1b: Tier 1 UIA dispatch for HWNDs exposing ScrollPattern; other apps use legacy SendInput). action='smart' typed errors: code:'OverflowHiddenAncestor' (retry with expandHidden:true), code:'VirtualScrollExhausted' (provide virtualIndex).\nExamples:\n  scroll({action:'raw', direction:'down', amount:5, windowTitle:'Chrome'})\n  scroll({action:'to_element', name:'OK', windowTitle:'Dialog'})\n  scroll({action:'smart', target:'#create-release-btn'})\n  scroll({action:'capture', windowTitle:'Chrome', maxScrolls:10})\n  scroll({action:'read', windowTitle:'Acrobat', maxPages:15}) // OCR + dedupe long PDF",
     "inputSchema": {
       "type": "object",
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "action": {
-              "const": "raw"
-            },
-            "direction": {
-              "description": "Scroll direction",
-              "type": "string",
-              "enum": [
-                "up",
-                "down",
-                "left",
-                "right"
-              ]
-            },
-            "amount": {
-              "description": "Number of scroll steps (default 3)",
-              "type": "integer",
-              "default": 3
-            },
-            "x": {
-              "description": "X coordinate to scroll at (moves cursor there first)",
-              "type": "number"
-            },
-            "y": {
-              "description": "Y coordinate to scroll at",
-              "type": "number"
-            },
-            "speed": {
-              "description": "Cursor movement speed in px/sec (0=teleport, omit=default)",
-              "type": "number"
-            },
-            "homing": {
-              "description": "Apply window-movement homing correction to (x,y) before scrolling. Default true.",
-              "type": "boolean",
-              "default": true
-            },
-            "windowTitle": {
-              "description": "Partial window title. When provided, the server focuses this window first.",
-              "type": "string"
-            },
-            "hwnd": {
-              "description": "Direct window handle ID (takes precedence over windowTitle).",
-              "type": "string"
-            },
-            "include": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "action",
-            "direction"
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "raw",
+            "to_element",
+            "smart",
+            "capture",
+            "read"
+          ],
+          "description": "Action selector — one of: raw, to_element, smart, capture, read. Per-action required fields are enforced at call time (see the tool description); this flat schema lists every action's fields as optional."
+        },
+        "direction": {
+          "description": "Scroll direction",
+          "type": "string",
+          "enum": [
+            "up",
+            "down",
+            "left",
+            "right",
+            "into-view"
           ]
         },
-        {
-          "type": "object",
-          "properties": {
-            "action": {
-              "const": "to_element"
-            },
-            "name": {
-              "description": "Partial name/label of the element (UIA name match). Use for native app elements. At least one of name or selector must be provided.",
-              "type": "string"
-            },
-            "selector": {
-              "description": "CSS selector for the element (Chrome/Edge only). At least one of name or selector must be provided.",
-              "type": "string"
-            },
-            "windowTitle": {
-              "description": "Partial window title (required for native path when name is used)",
-              "type": "string"
-            },
-            "block": {
-              "description": "Vertical alignment after scroll — start/center/end/nearest (Chrome path only, default: center)",
-              "type": "string",
-              "enum": [
-                "start",
-                "center",
-                "end",
-                "nearest"
-              ],
-              "default": "center"
-            },
-            "tabId": {
-              "description": "Tab ID (Chrome path only). Omit for first page tab.",
-              "type": "string"
-            },
-            "port": {
-              "description": "CDP port for Chrome path (default 9222)",
-              "type": "integer",
-              "default": 9222,
-              "minimum": 1,
-              "maximum": 65535
-            },
-            "include": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
-            }
+        "amount": {
+          "description": "Number of scroll steps (default 3)",
+          "type": "integer",
+          "default": 3
+        },
+        "x": {
+          "description": "X coordinate to scroll at (moves cursor there first)",
+          "type": "number"
+        },
+        "y": {
+          "description": "Y coordinate to scroll at",
+          "type": "number"
+        },
+        "speed": {
+          "description": "Cursor movement speed in px/sec (0=teleport, omit=default)",
+          "type": "number"
+        },
+        "homing": {
+          "description": "Apply window-movement homing correction to (x,y) before scrolling. Default true.",
+          "type": "boolean",
+          "default": true
+        },
+        "windowTitle": {
+          "description": "Partial window title. When provided, the server focuses this window first.",
+          "type": "string"
+        },
+        "hwnd": {
+          "description": "Direct window handle ID (takes precedence over windowTitle).",
+          "type": "string"
+        },
+        "include": {
+          "type": "array",
+          "items": {
+            "type": "string"
           },
-          "additionalProperties": false,
-          "required": [
-            "action"
+          "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
+        },
+        "name": {
+          "description": "Partial name/label of the element (UIA name match). Use for native app elements. At least one of name or selector must be provided.",
+          "type": "string"
+        },
+        "selector": {
+          "description": "CSS selector for the element (Chrome/Edge only). At least one of name or selector must be provided.",
+          "type": "string"
+        },
+        "block": {
+          "description": "Vertical alignment after scroll — start/center/end/nearest (Chrome path only, default: center)",
+          "type": "string",
+          "enum": [
+            "start",
+            "center",
+            "end",
+            "nearest"
+          ],
+          "default": "center"
+        },
+        "tabId": {
+          "description": "Tab ID (Chrome path only). Omit for first page tab.",
+          "type": "string"
+        },
+        "port": {
+          "description": "CDP port for Chrome path (default 9222)",
+          "type": "integer",
+          "default": 9222,
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "target": {
+          "description": "CSS selector (Chrome/Edge) or partial UIA name (native apps). For CDP path, must be a valid CSS selector (starts with #, ., tag, or [ ). For UIA path, a partial name match against element Name property.",
+          "type": "string"
+        },
+        "strategy": {
+          "description": "auto (default): try CDP → UIA → image in order. cdp: Chrome/Edge only. uia: native Windows UIA. image: image + Win32 binary-search.",
+          "type": "string",
+          "enum": [
+            "auto",
+            "cdp",
+            "uia",
+            "image"
+          ],
+          "default": "auto"
+        },
+        "inline": {
+          "description": "Vertical alignment after scroll (CDP path). Default: center.",
+          "type": "string",
+          "enum": [
+            "start",
+            "center",
+            "end",
+            "nearest"
+          ],
+          "default": "center"
+        },
+        "maxDepth": {
+          "description": "Max number of ancestor scroll containers to walk. Default 3.",
+          "type": "integer",
+          "default": 3,
+          "minimum": 1,
+          "maximum": 10
+        },
+        "retryCount": {
+          "description": "Max scroll attempts (image path binary-search). Default 3, cap 4.",
+          "type": "integer",
+          "default": 3,
+          "minimum": 1,
+          "maximum": 4
+        },
+        "verifyWithHash": {
+          "description": "Verify scroll effectiveness via perceptual hash comparison. Automatically enabled for image path.",
+          "type": "boolean",
+          "default": false
+        },
+        "virtualIndex": {
+          "description": "Target row index in a virtualised list (0-based). Enables direct TanStack/data-index seeking.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "virtualTotal": {
+          "description": "Total row count in a virtualised list. Required when virtualIndex is set.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "expandHidden": {
+          "description": "Temporarily set overflow:hidden ancestors to overflow:auto to unlock scroll. Mutates live CSS.",
+          "type": "boolean",
+          "default": false
+        },
+        "hint": {
+          "description": "Scroll direction hint for binary-search (image path). Seeds lo/hi bounds to reduce attempts.",
+          "type": "string",
+          "enum": [
+            "above",
+            "below",
+            "left",
+            "right"
           ]
         },
-        {
-          "type": "object",
-          "properties": {
-            "action": {
-              "const": "smart"
-            },
-            "target": {
-              "description": "CSS selector (Chrome/Edge) or partial UIA name (native apps). For CDP path, must be a valid CSS selector (starts with #, ., tag, or [ ). For UIA path, a partial name match against element Name property.",
-              "type": "string"
-            },
-            "windowTitle": {
-              "description": "Partial window title. Required for UIA and image paths. For CDP path, optional.",
-              "type": "string"
-            },
-            "tabId": {
-              "description": "CDP tab ID (Chrome path only). Omit for first page tab.",
-              "type": "string"
-            },
-            "port": {
-              "description": "CDP port (default 9222)",
-              "type": "integer",
-              "default": 9222,
-              "minimum": 1,
-              "maximum": 65535
-            },
-            "strategy": {
-              "description": "auto (default): try CDP → UIA → image in order. cdp: Chrome/Edge only. uia: native Windows UIA. image: image + Win32 binary-search.",
-              "type": "string",
-              "enum": [
-                "auto",
-                "cdp",
-                "uia",
-                "image"
-              ],
-              "default": "auto"
-            },
-            "direction": {
-              "description": "Scroll direction. into-view: scroll until target element is visible (default). Other values scroll unconditionally.",
-              "type": "string",
-              "enum": [
-                "into-view",
-                "up",
-                "down",
-                "left",
-                "right"
-              ],
-              "default": "into-view"
-            },
-            "inline": {
-              "description": "Vertical alignment after scroll (CDP path). Default: center.",
-              "type": "string",
-              "enum": [
-                "start",
-                "center",
-                "end",
-                "nearest"
-              ],
-              "default": "center"
-            },
-            "maxDepth": {
-              "description": "Max number of ancestor scroll containers to walk. Default 3.",
-              "type": "integer",
-              "default": 3,
-              "minimum": 1,
-              "maximum": 10
-            },
-            "retryCount": {
-              "description": "Max scroll attempts (image path binary-search). Default 3, cap 4.",
-              "type": "integer",
-              "default": 3,
-              "minimum": 1,
-              "maximum": 4
-            },
-            "verifyWithHash": {
-              "description": "Verify scroll effectiveness via perceptual hash comparison. Automatically enabled for image path.",
-              "type": "boolean",
-              "default": false
-            },
-            "virtualIndex": {
-              "description": "Target row index in a virtualised list (0-based). Enables direct TanStack/data-index seeking.",
-              "type": "integer",
-              "minimum": 0
-            },
-            "virtualTotal": {
-              "description": "Total row count in a virtualised list. Required when virtualIndex is set.",
-              "type": "integer",
-              "minimum": 1
-            },
-            "expandHidden": {
-              "description": "Temporarily set overflow:hidden ancestors to overflow:auto to unlock scroll. Mutates live CSS.",
-              "type": "boolean",
-              "default": false
-            },
-            "hint": {
-              "description": "Scroll direction hint for binary-search (image path). Seeds lo/hi bounds to reduce attempts.",
-              "type": "string",
-              "enum": [
-                "above",
-                "below",
-                "left",
-                "right"
-              ]
-            },
-            "include": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "action",
-            "target"
-          ]
+        "maxScrolls": {
+          "description": "Maximum scroll iterations before stopping (default 10, max 30)",
+          "type": "integer",
+          "default": 10,
+          "minimum": 1,
+          "maximum": 30
         },
-        {
-          "type": "object",
-          "properties": {
-            "action": {
-              "const": "capture"
-            },
-            "windowTitle": {
-              "description": "Partial title of the window to capture (case-insensitive match)",
-              "type": "string"
-            },
-            "direction": {
-              "description": "Scroll direction: 'down' (vertical, uses Page Down key) or 'right' (horizontal, uses mouse scroll). Default 'down'.",
-              "type": "string",
-              "enum": [
-                "down",
-                "right"
-              ],
-              "default": "down"
-            },
-            "maxScrolls": {
-              "description": "Maximum scroll iterations before stopping (default 10, max 30)",
-              "type": "integer",
-              "default": 10,
-              "minimum": 1,
-              "maximum": 30
-            },
-            "scrollDelayMs": {
-              "description": "Milliseconds to wait after each scroll for rendering to settle (default 400). Increase for slow/animated pages.",
-              "type": "integer",
-              "default": 400,
-              "minimum": 100,
-              "maximum": 3000
-            },
-            "maxWidth": {
-              "description": "Max size of the short edge of the final image (default 1280). For 'down': caps the image width; height is unconstrained. For 'right': caps the image height; width is unconstrained.",
-              "type": "integer",
-              "default": 1280
-            },
-            "include": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "action",
-            "windowTitle"
-          ]
+        "scrollDelayMs": {
+          "description": "Milliseconds to wait after each scroll for rendering to settle (default 400). Increase for slow/animated pages.",
+          "type": "integer",
+          "default": 400,
+          "minimum": 100,
+          "maximum": 3000
         },
-        {
-          "type": "object",
-          "properties": {
-            "action": {
-              "const": "read"
-            },
-            "windowTitle": {
-              "description": "Partial window title to focus and OCR (case-insensitive match).",
-              "type": "string"
-            },
-            "maxPages": {
-              "description": "Maximum number of scroll steps / OCR pages (default 20, max 50).",
-              "type": "integer",
-              "default": 20,
-              "minimum": 1,
-              "maximum": 50
-            },
-            "scrollKey": {
-              "description": "Key sent to scroll one page. PageDown (default): full-page scroll for most apps. Space: web/PDF readers. ArrowDown: line-by-line slow scroll.",
-              "type": "string",
-              "enum": [
-                "PageDown",
-                "Space",
-                "ArrowDown"
-              ],
-              "default": "PageDown"
-            },
-            "scrollDelayMs": {
-              "description": "Milliseconds to wait after each scroll for rendering to settle (default 400).",
-              "type": "integer",
-              "default": 400,
-              "minimum": 100,
-              "maximum": 3000
-            },
-            "stopWhenNoChange": {
-              "description": "Stop automatically when two consecutive pages yield no new lines after deduplication (page-end detection). Default true.",
-              "type": "boolean",
-              "default": true
-            },
-            "language": {
-              "description": "OCR language code (e.g. 'ja', 'en', 'zh'). Omit to auto-detect from Windows system locale via Intl.DateTimeFormat().resolvedOptions().locale. Default: auto.",
-              "type": "string"
-            },
-            "include": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "action",
-            "windowTitle"
-          ]
+        "maxWidth": {
+          "description": "Max size of the short edge of the final image (default 1280). For 'down': caps the image width; height is unconstrained. For 'right': caps the image height; width is unconstrained.",
+          "type": "integer",
+          "default": 1280
+        },
+        "maxPages": {
+          "description": "Maximum number of scroll steps / OCR pages (default 20, max 50).",
+          "type": "integer",
+          "default": 20,
+          "minimum": 1,
+          "maximum": 50
+        },
+        "scrollKey": {
+          "description": "Key sent to scroll one page. PageDown (default): full-page scroll for most apps. Space: web/PDF readers. ArrowDown: line-by-line slow scroll.",
+          "type": "string",
+          "enum": [
+            "PageDown",
+            "Space",
+            "ArrowDown"
+          ],
+          "default": "PageDown"
+        },
+        "stopWhenNoChange": {
+          "description": "Stop automatically when two consecutive pages yield no new lines after deduplication (page-end detection). Default true.",
+          "type": "boolean",
+          "default": true
+        },
+        "language": {
+          "description": "OCR language code (e.g. 'ja', 'en', 'zh'). Omit to auto-detect from Windows system locale via Intl.DateTimeFormat().resolvedOptions().locale. Default: auto.",
+          "type": "string"
         }
-      ]
+      },
+      "required": [
+        "action"
+      ],
+      "additionalProperties": false
     }
   },
   {
@@ -1934,99 +1575,61 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
     "description": "Purpose: Interact with a terminal window: read output, send input, or run+wait+read in one call. action='read' / action='send' absorb the formerly-standalone read/send tools (Phase 4).\nDetails: action='run' is the recommended high-level workflow: send command → wait until quiet/pattern/timeout → read output. The command text is passed as `input` (the legacy parameter name `command` is also accepted as a deprecated alias — see issue #245). Returns completion={reason, elapsedMs} first-class plus outputIntegrity:'ok'|'baseline_lost' so callers can detect when scrollback could not be anchored to the pre-send buffer. action='read' reads current text via UIA TextPattern (falls back to OCR); use sinceMarker for incremental diff. action='send' sends a command with focus management.\nPrefer: action='run' for command execution + result. For long-running commands (test runners, builds, deploys) use until:{mode:'pattern', pattern:'<final marker>'} — the default quiet mode is tuned for short interactive commands and may complete prematurely on multi-second silent gaps mid-run. Use action='read'/'send' for fine-grained control or when you need to interleave other actions.\nCaveats: Do not screenshot the terminal — action='read' is cheaper and structured. action='run' supports completion reasons: quiet | pattern_matched | timeout | window_closed | window_not_found | send_failed (send rejected on a live window — see warnings for the underlying error code). When outputIntegrity:'baseline_lost' is returned, output is forced to '' and readError.code='BaselineMarkerLost' is set: rerun with until:{mode:'pattern',...} or longer timeoutMs. action='run' may also emit warnings prefixed FileLockCollision: when output reveals an EBUSY/Windows-lock/EAGAIN-EDEADLK file collision (e.g. shell '>' redirect colliding with the script's own writer — issue #236). Default quietMs=1500 (issue #196); long silences require pattern mode. preferClipboard=true (send default) overwrites clipboard. Hidden-input prompts emit verifyDelivery.unverifiable (reason:'hidden_input_prompt') — use method:'foreground'. action='read' typed errors: TerminalWindowNotFound, TerminalTextPatternUnavailable (force source:'ocr'); stale sinceMarker → hints.terminalMarker.previousMatched:false on ok:true (omit sinceMarker). FG-path Win11 foreground refusal returns code:'ForegroundRestricted' — switch to method:'background' or DTM_BG_AUTO=1. BG path auto-engages only when (a) the target window class is `ConsoleWindowClass` (conhost: cmd / PowerShell / pwsh classic hosts) OR (b) env DTM_BG_AUTO=1 is set globally. Windows Terminal (`CASCADIA_HOSTING_WINDOW_CLASS`) is intentionally EXCLUDED from auto-engage (issue #173): WT runs on WinUI/XAML and silently drops WM_CHAR posted to its HWND, so the FG path is used by default — pass sendOptions:{method:'background'} only if you have verified your WT build accepts BG input.\nExamples:\n  terminal({action:'run', windowTitle:'PowerShell', input:'npm test', until:{mode:'pattern', pattern:'Test Files'}}) → recommended for test runners; matches when vitest summary appears\n  terminal({action:'run', windowTitle:'pwsh', input:'ls'}) → quiet 1500ms wait, returns output (short interactive)\n  terminal({action:'run', windowTitle:'pwsh', command:'ls'}) → identical to the above; `command` is a deprecated alias of `input` (issue #245)\n  terminal({action:'read', windowTitle:'PowerShell', sinceMarker:'...'}) → incremental diff using the read action\n  terminal({action:'send', windowTitle:'PowerShell', input:'echo hello'}) → sends text + Enter using the send action",
     "inputSchema": {
       "type": "object",
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "action": {
-              "const": "read"
-            },
-            "include": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "action"
-          ]
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "read",
+            "send",
+            "run"
+          ],
+          "description": "Action selector — one of: read, send, run. Per-action required fields are enforced at call time (see the tool description); this flat schema lists every action's fields as optional."
         },
-        {
-          "type": "object",
-          "properties": {
-            "action": {
-              "const": "send"
-            },
-            "include": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
-            }
+        "include": {
+          "type": "array",
+          "items": {
+            "type": "string"
           },
-          "additionalProperties": false,
-          "required": [
-            "action"
-          ]
+          "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
         },
-        {
-          "type": "object",
-          "properties": {
-            "action": {
-              "const": "run"
-            },
-            "windowTitle": {
-              "description": "Partial title of the terminal window (e.g. 'PowerShell', 'pwsh', 'WindowsTerminal').",
-              "type": "string",
-              "maxLength": 200
-            },
-            "input": {
-              "description": "Command to send (Enter is appended automatically). Either `input` or its deprecated alias `command` is required.",
-              "type": "string",
-              "maxLength": 10000
-            },
-            "command": {
-              "description": "[Deprecated alias of `input`] Accepted for callers that mis-remember the parameter name; new code should use `input`. If both are set, `input` wins.",
-              "type": "string",
-              "maxLength": 10000
-            },
-            "until": {
-              "type": "object"
-            },
-            "timeoutMs": {
-              "description": "Hard timeout in ms (default 30s)",
-              "type": "integer",
-              "default": 30000,
-              "minimum": 500,
-              "maximum": 600000
-            },
-            "sendOptions": {
-              "description": "Extra options forwarded to terminal send (method, chunkSize, etc.)",
-              "type": "object"
-            },
-            "readOptions": {
-              "description": "Extra options forwarded to terminal read (lines, source, ocrLanguage, etc.)",
-              "type": "object"
-            },
-            "include": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "action",
-            "windowTitle"
-          ]
+        "windowTitle": {
+          "description": "Partial title of the terminal window (e.g. 'PowerShell', 'pwsh', 'WindowsTerminal').",
+          "type": "string",
+          "maxLength": 200
+        },
+        "input": {
+          "description": "Command to send (Enter is appended automatically). Either `input` or its deprecated alias `command` is required.",
+          "type": "string",
+          "maxLength": 10000
+        },
+        "command": {
+          "description": "[Deprecated alias of `input`] Accepted for callers that mis-remember the parameter name; new code should use `input`. If both are set, `input` wins.",
+          "type": "string",
+          "maxLength": 10000
+        },
+        "until": {
+          "type": "object"
+        },
+        "timeoutMs": {
+          "description": "Hard timeout in ms (default 30s)",
+          "type": "integer",
+          "default": 30000,
+          "minimum": 500,
+          "maximum": 600000
+        },
+        "sendOptions": {
+          "description": "Extra options forwarded to terminal send (method, chunkSize, etc.)",
+          "type": "object"
+        },
+        "readOptions": {
+          "description": "Extra options forwarded to terminal read (lines, source, ocrLanguage, etc.)",
+          "type": "object"
         }
-      ]
+      },
+      "required": [
+        "action"
+      ],
+      "additionalProperties": false
     }
   },
   {
@@ -2086,123 +1689,75 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
     "description": "Purpose: Decorate a window: pin (always-on-top), unpin, or dock (move + resize + optional pin).\nDetails: action='pin' makes window always-on-top until unpin/duration_ms. action='unpin' removes always-on-top. action='dock' positions to corner with width/height (default 480×360 bottom-right) and optionally pins. Minimized windows are automatically restored before docking.\nPrefer: Use action='dock' for terminal/CLI window auto-positioning at session start. Use action='pin' alone when you only need always-on-top without moving or resizing.\nCaveats: Pin survives minimize/restore; explicit action='unpin' needed to release. Dock fails on elevated processes. Dock overrides any existing Win+Arrow snap arrangement.\nExamples:\n  window_dock({action:'dock', title:'PowerShell', corner:'bottom-right', width:480, height:360})\n  window_dock({action:'pin', title:'Settings', duration_ms:5000})\n  window_dock({action:'unpin', title:'Settings'})",
     "inputSchema": {
       "type": "object",
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "action": {
-              "const": "pin"
-            },
-            "title": {
-              "description": "Partial window title (case-insensitive)",
-              "type": "string"
-            },
-            "duration_ms": {
-              "description": "Auto-unpin after this many ms (0–60000). Omit to pin indefinitely.",
-              "type": "integer",
-              "minimum": 0,
-              "maximum": 60000
-            },
-            "include": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "action",
-            "title"
-          ]
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "pin",
+            "unpin",
+            "dock"
+          ],
+          "description": "Action selector — one of: pin, unpin, dock. Per-action required fields are enforced at call time (see the tool description); this flat schema lists every action's fields as optional."
         },
-        {
-          "type": "object",
-          "properties": {
-            "action": {
-              "const": "unpin"
-            },
-            "title": {
-              "description": "Partial window title (case-insensitive)",
-              "type": "string"
-            },
-            "include": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "action",
-            "title"
-          ]
+        "title": {
+          "description": "Partial window title (case-insensitive)",
+          "type": "string"
         },
-        {
-          "type": "object",
-          "properties": {
-            "action": {
-              "const": "dock"
-            },
-            "title": {
-              "description": "Partial window title to dock (case-insensitive). Matches the first visible window containing this text. Example: 'Claude Code', 'メモ帳'.",
-              "type": "string"
-            },
-            "corner": {
-              "description": "Screen corner to snap the window to. Default 'bottom-right'.",
-              "type": "string",
-              "enum": [
-                "top-left",
-                "top-right",
-                "bottom-left",
-                "bottom-right"
-              ],
-              "default": "bottom-right"
-            },
-            "width": {
-              "description": "Window width in pixels after docking. Default 480.",
-              "type": "integer",
-              "default": 480
-            },
-            "height": {
-              "description": "Window height in pixels after docking. Default 360.",
-              "type": "integer",
-              "default": 360
-            },
-            "pin": {
-              "description": "If true, set always-on-top so the docked window stays visible on top of other windows. Use window_dock(action='unpin') to remove the topmost flag later. Default true.",
-              "type": "boolean",
-              "default": true
-            },
-            "monitorId": {
-              "description": "Monitor to dock on (from desktop_state({includeScreen:true})). Omit for primary monitor.",
-              "type": "integer",
-              "minimum": 0
-            },
-            "margin": {
-              "description": "Pixel padding between the window and the screen edge. Default 8.",
-              "type": "integer",
-              "default": 8,
-              "minimum": 0
-            },
-            "include": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
-            }
+        "duration_ms": {
+          "description": "Auto-unpin after this many ms (0–60000). Omit to pin indefinitely.",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 60000
+        },
+        "include": {
+          "type": "array",
+          "items": {
+            "type": "string"
           },
-          "additionalProperties": false,
-          "required": [
-            "action",
-            "title"
-          ]
+          "description": "Optional response-shape opt-in. `['envelope']` returns the self-documenting envelope (`_version` / `data` / `as_of` / `confidence`). `['raw']` forces raw shape (overrides DESKTOP_TOUCH_ENVELOPE=1 server default). Default behaviour is raw shape (compat with existing clients)."
+        },
+        "corner": {
+          "description": "Screen corner to snap the window to. Default 'bottom-right'.",
+          "type": "string",
+          "enum": [
+            "top-left",
+            "top-right",
+            "bottom-left",
+            "bottom-right"
+          ],
+          "default": "bottom-right"
+        },
+        "width": {
+          "description": "Window width in pixels after docking. Default 480.",
+          "type": "integer",
+          "default": 480
+        },
+        "height": {
+          "description": "Window height in pixels after docking. Default 360.",
+          "type": "integer",
+          "default": 360
+        },
+        "pin": {
+          "description": "If true, set always-on-top so the docked window stays visible on top of other windows. Use window_dock(action='unpin') to remove the topmost flag later. Default true.",
+          "type": "boolean",
+          "default": true
+        },
+        "monitorId": {
+          "description": "Monitor to dock on (from desktop_state({includeScreen:true})). Omit for primary monitor.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "margin": {
+          "description": "Pixel padding between the window and the screen edge. Default 8.",
+          "type": "integer",
+          "default": 8,
+          "minimum": 0
         }
-      ]
+      },
+      "required": [
+        "action"
+      ],
+      "additionalProperties": false
     }
   },
   {

--- a/src/tools/_envelope.ts
+++ b/src/tools/_envelope.ts
@@ -607,8 +607,12 @@ function mergeFlatField(schemas: z.ZodTypeAny[]): z.ZodTypeAny {
     const base = stripFieldWrappers(schema);
     let sig: string;
     try {
-      // Colliding keys are simple types (string / number / enum / literal /
-      // bool) — `z.toJSONSchema` is a safe structural signature here.
+      // `z.toJSONSchema` is the structural signature. In practice colliding
+      // keys across the 7 tools are simple types (string / number / enum /
+      // literal / bool) which serialize cleanly; the `catch` below is the real
+      // guarantee — a field `z.toJSONSchema` cannot serialize (e.g. a future
+      // shared `z.preprocess` field) is simply treated as a distinct shape and
+      // falls through to the `z.union` widening, which is still correct.
       const js = z.toJSONSchema(base) as Record<string, unknown>;
       delete js.$schema;
       delete js.description; // structural identity ignores description text

--- a/src/tools/_envelope.ts
+++ b/src/tools/_envelope.ts
@@ -116,7 +116,8 @@ import {
   _setSingleSessionPinForTest,
   _resetSingleSessionPinForTest,
 } from "./_session-context.js";
-import { getSuggestsForCode } from "./_errors.js";
+import { getSuggestsForCode, failArgs } from "./_errors.js";
+import type { ToolResult } from "./_types.js";
 import {
   uiPatternStore,
   parseMemoryRedactMode,
@@ -498,6 +499,201 @@ export function withEnvelopeIncludeForUnion(union: any): any {
   }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return z.discriminatedUnion(discriminator, newOptions as any);
+}
+
+// ─── ADR-018 Phase 2a — discriminatedUnion flatten + strict re-parse ─────────
+
+/**
+ * ADR-018 Phase 2a §2.5.2 — flatten a `z.discriminatedUnion` into a single flat
+ * `z.object` for use as a tool's `registerTool` `inputSchema` (the WIRE schema).
+ *
+ * The MCP SDK's `normalizeObjectSchema` returns `undefined` for a top-level
+ * union → `tools/list` falls back to empty `properties`. A flat `z.object` is
+ * recognized and produces real `properties`. Top-level `oneOf` is NOT an
+ * option — the Anthropic API rejects it (HTTP 400, "not planned").
+ *
+ * **Input** is the `withEnvelopeIncludeForUnion(...)`-injected union (so every
+ * variant carries `include`). Pass that SAME value to `parseActionArgsOrFail`.
+ *
+ * The flat schema is intentionally LOOSE: the discriminator becomes a required
+ * `z.enum` of all variant literals; every other field becomes `.optional()`.
+ * It is NOT the validation gate — `parseActionArgsOrFail` (below), called
+ * inside each `*DispatchHandler`, re-parses against the real union and is the
+ * strict per-action gate. A field appearing in multiple variants with
+ * structurally-different schemas is widened: all-`z.enum` collisions merge to
+ * one `z.enum` of the value union; otherwise to a `z.union` (renders as a
+ * property-level `anyOf` — accepted by the Anthropic API; only *top-level*
+ * `oneOf`/`anyOf` is rejected).
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function flattenUnionToObjectSchema(union: any): z.ZodObject<z.ZodRawShape> {
+  const discriminator = (union._def?.discriminator ?? union.discriminator) as
+    | string
+    | undefined;
+  if (typeof discriminator !== "string" || discriminator.length === 0) {
+    throw new Error(
+      "flattenUnionToObjectSchema: failed to resolve discriminator field from input union " +
+        "(checked union._def.discriminator and union.discriminator). Zod major-version drift?",
+    );
+  }
+  const variants = union.options as readonly z.ZodObject<z.ZodRawShape>[];
+  const literals = new Set<string>();
+  const fieldVariants = new Map<string, z.ZodTypeAny[]>();
+  for (const variant of variants) {
+    // zod 4.3.6: a `.refine()`-wrapped variant is still a `ZodObject` —
+    // `.shape` is directly accessible, no unwrap needed (verified).
+    const shape = variant.shape as Record<string, z.ZodTypeAny>;
+    for (const [key, fieldSchema] of Object.entries(shape)) {
+      if (key === discriminator) {
+        // zod 4: a literal field's `_def.values` is the array of literal values.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const fdef = (fieldSchema as any)._def;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const values = (fdef?.values as unknown[] | undefined) ?? [(fieldSchema as any).value];
+        for (const v of values) {
+          if (v !== undefined && v !== null) literals.add(String(v));
+        }
+        continue;
+      }
+      const list = fieldVariants.get(key) ?? [];
+      list.push(fieldSchema);
+      fieldVariants.set(key, list);
+    }
+  }
+  const literalList = [...literals];
+  if (literalList.length === 0) {
+    throw new Error(
+      `flattenUnionToObjectSchema: no discriminator literal values found for "${discriminator}".`,
+    );
+  }
+  const mergedShape: Record<string, z.ZodTypeAny> = {
+    [discriminator]: z
+      .enum(literalList as [string, ...string[]])
+      .describe(
+        `Action selector — one of: ${literalList.join(", ")}. ` +
+          "Per-action required fields are enforced at call time (see the tool description); " +
+          "this flat schema lists every action's fields as optional.",
+      ),
+  };
+  for (const [key, schemas] of fieldVariants) {
+    mergedShape[key] = mergeFlatField(schemas);
+  }
+  return z.object(mergedShape);
+}
+
+/** Strip outer ZodOptional / ZodDefault / ZodNullable wrappers to the base. */
+function stripFieldWrappers(schema: z.ZodTypeAny): z.ZodTypeAny {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let cur: any = schema;
+  for (let guard = 0; guard < 12; guard++) {
+    const t = cur?._def?.type;
+    if (t !== "optional" && t !== "default" && t !== "nullable") break;
+    const inner = cur._def.innerType;
+    if (!inner || inner === cur) break;
+    cur = inner;
+  }
+  return cur as z.ZodTypeAny;
+}
+
+/**
+ * Merge the per-variant schemas for one field name into a single optional
+ * schema for the flat wire object. Structurally-identical variants (ignoring
+ * description text) collapse to one; genuinely-different ones widen — all-enum
+ * collisions to one `z.enum` of the value union, otherwise to a `z.union`.
+ */
+function mergeFlatField(schemas: z.ZodTypeAny[]): z.ZodTypeAny {
+  const uniqueBySig = new Map<string, z.ZodTypeAny>();
+  schemas.forEach((schema, i) => {
+    const base = stripFieldWrappers(schema);
+    let sig: string;
+    try {
+      // Colliding keys are simple types (string / number / enum / literal /
+      // bool) — `z.toJSONSchema` is a safe structural signature here.
+      const js = z.toJSONSchema(base) as Record<string, unknown>;
+      delete js.$schema;
+      delete js.description; // structural identity ignores description text
+      sig = JSON.stringify(js);
+    } catch {
+      sig = `__unserializable_${i}__`; // treat as a distinct shape
+    }
+    if (!uniqueBySig.has(sig)) uniqueBySig.set(sig, base);
+  });
+  const bases = [...uniqueBySig.values()];
+  if (bases.length === 1) return bases[0].optional();
+  // All-`z.enum` collision → merge to one `z.enum` of the value union. Carry
+  // over the first variant's description (the per-variant `.describe()` is
+  // otherwise lost; per-action specifics live in the tool's Caveats block).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const asEnum = (b: any): string[] | null =>
+    b?._def?.type === "enum" && Array.isArray(b.options) ? (b.options as string[]) : null;
+  const enumValueSets = bases.map(asEnum);
+  if (enumValueSets.every((v) => v !== null)) {
+    const merged = [...new Set(enumValueSets.flat() as string[])];
+    let mergedEnum = z.enum(merged as [string, ...string[]]);
+    const firstDesc = bases.find((b) => typeof b.description === "string")?.description;
+    if (firstDesc) mergedEnum = mergedEnum.describe(firstDesc);
+    return mergedEnum.optional();
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return z.union(bases as [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]).optional();
+}
+
+/**
+ * ADR-018 Phase 2a §2.5.2 — discriminated result of `parseActionArgsOrFail`.
+ * Explicit wrapper (NOT `T | ToolResult`): `ToolResult` and a parsed union
+ * value share no safe top-level discriminant and no `isToolResult` predicate
+ * exists, so callers narrow on `.ok`.
+ */
+export type ParsedOrFail<T> =
+  | { ok: true; value: T }
+  | { ok: false; result: ToolResult };
+
+/**
+ * ADR-018 Phase 2a §2.5.2 — the strict per-action validation gate that the
+ * flat wire schema (`flattenUnionToObjectSchema`) deliberately does NOT
+ * provide. Each of the 7 flattened tools' `*DispatchHandler` calls this as its
+ * first statement, before the `switch (action)`:
+ *
+ * ```ts
+ * const parsed = parseActionArgsOrFail(scrollUnionWithInclude, args, "scroll");
+ * if (!parsed.ok) return parsed.result;
+ * switch (parsed.value.action) { ... }
+ * ```
+ *
+ * `unionWithInclude` MUST be the `withEnvelopeIncludeForUnion(...)`-injected
+ * union — NOT the bare `scrollSchema`. The bare union has no `include` field,
+ * so `.parse()` against it would strip `include`. The include-injected union
+ * carries `include` AND every `.refine()` / `z.literal()` / per-action
+ * `required` constraint (`withEnvelopeIncludeForUnion` only `.extend()`s).
+ *
+ * On failure: returns `{ ok: false, result }` where `result` is built via
+ * `failArgs` (the dedicated `code:"InvalidArgs"` path — NOT `failWith`, which
+ * would mislabel a per-action schema violation as a generic tool error). It
+ * does NOT throw — the `ToolResult` flows out through the handler's normal
+ * return path (the `makeCommitWrapper` / `withRichNarration` wrappers have
+ * already seen the raw `args`).
+ */
+export function parseActionArgsOrFail<T>(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  unionWithInclude: any,
+  args: unknown,
+  toolName: string,
+): ParsedOrFail<T> {
+  const parsed = unionWithInclude.safeParse(args);
+  if (parsed.success) {
+    return { ok: true, value: parsed.data as T };
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const rawIssues = (parsed.error?.issues ?? []) as Array<any>;
+  const issues = rawIssues.map((iss) => ({
+    path: Array.isArray(iss.path) ? iss.path.join(".") : String(iss.path ?? ""),
+    message: String(iss.message ?? "invalid"),
+  }));
+  const first = issues[0];
+  const summary = first
+    ? `${first.message}${first.path ? ` (at "${first.path}")` : ""}`
+    : "invalid arguments";
+  return { ok: false, result: failArgs(summary, toolName, { issues }) };
 }
 
 /** Shared description for `include` field across raw-shape and discriminatedUnion injection. */

--- a/src/tools/_envelope.ts
+++ b/src/tools/_envelope.ts
@@ -600,6 +600,23 @@ function stripFieldWrappers(schema: z.ZodTypeAny): z.ZodTypeAny {
  * schema for the flat wire object. Structurally-identical variants (ignoring
  * description text) collapse to one; genuinely-different ones widen — all-enum
  * collisions to one `z.enum` of the value union, otherwise to a `z.union`.
+ *
+ * Each merged field is `.optional()` — **not** `.catch(undefined)`. A `.catch`
+ * was considered (Codex PR #290 Round 2 P2: make the wire schema tolerate a
+ * wrong-typed off-action field the way `z.discriminatedUnion` strips an
+ * off-variant key) and **rejected** (Opus adjudication): `.catch` would
+ * silently *drop* a malformed value, and for a field whose real-union schema
+ * carries a `.default()` (`terminal`'s `until` =
+ * `z.preprocess(...).default({mode:"quiet"})`) the subsequent
+ * `parseActionArgsOrFail` re-parse would then substitute that default — a
+ * malformed polling spec runs as quiet-mode with **no error surfaced**
+ * (issue #196 regression). A wrong-typed off-action field being rejected with
+ * a typed `InvalidArgs` error is the contract working, not a silent failure;
+ * the discriminatedUnion's key-strip tolerance was a Zod mechanic, not a
+ * designed contract. NOTE: `stripFieldWrappers` strips `optional`/`default`/
+ * `nullable` but **not** `preprocess` — a preprocess-wrapped field keeps its
+ * inner `.default()` reachable through the union re-parse, which is why
+ * `.catch` here would be actively harmful. Do not reintroduce it.
  */
 function mergeFlatField(schemas: z.ZodTypeAny[]): z.ZodTypeAny {
   const uniqueBySig = new Map<string, z.ZodTypeAny>();

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -23,7 +23,7 @@ import { getCdpPort } from "../utils/desktop-config.js";
 import { fail } from "./_types.js";
 import { setBrowserSearchHook } from "./wait-until.js";
 import { narrateParam, withRichNarration } from "./_narration.js";
-import { makeCommitWrapper, makeQueryWrapper, withEnvelopeIncludeSchema, withEnvelopeIncludeForUnion, genericQueryCausedByProjector, defaultQuerySessionId } from "./_envelope.js";
+import { makeCommitWrapper, makeQueryWrapper, withEnvelopeIncludeSchema, withEnvelopeIncludeForUnion, flattenUnionToObjectSchema, parseActionArgsOrFail, genericQueryCausedByProjector, defaultQuerySessionId } from "./_envelope.js";
 import type { RichBlock } from "../engine/uia-diff.js";
 import { evaluatePreToolGuards, buildEnvelopeFor } from "../engine/perception/registry.js";
 import { runActionGuard, isAutoGuardEnabled, validateAndPrepareFix, consumeFix } from "./_action-guard.js";
@@ -2389,13 +2389,21 @@ export const browserEvalSchema = z.discriminatedUnion("action", [
 export type BrowserEvalArgs = z.infer<typeof browserEvalSchema>;
 
 export const browserEvalHandler = async (args: BrowserEvalArgs): Promise<ToolResult> => {
-  switch (args.action) {
+  // ADR-018 Phase 2a — strict per-action gate (§2.5.2). The registered wire
+  // schema is the flat `flattenUnionToObjectSchema` output; re-parse against
+  // the real (include-injected) union here. Scope fence: this touches ONLY the
+  // `browser_eval` union — the flat-object browser tools in this file are not
+  // affected.
+  const parsed = parseActionArgsOrFail<BrowserEvalArgs>(browserEvalUnionWithInclude, args, "browser_eval");
+  if (!parsed.ok) return parsed.result;
+  const a = parsed.value;
+  switch (a.action) {
     case "js":
-      return browserEvalJsHandler(args);
+      return browserEvalJsHandler(a);
     case "dom":
-      return browserGetDomHandler(args);
+      return browserGetDomHandler(a);
     case "appState":
-      return browserGetAppStateHandler(args);
+      return browserGetAppStateHandler(a);
   }
 };
 
@@ -2537,7 +2545,11 @@ export const browserFormRegistrationHandler = makeCommitWrapper(
  * terminal の discriminatedUnion 3b family 同型 (windowTitleKey 省略 —
  * browser CDP tab; pre-expansion `withPostState` 直 wrap を置換)。
  */
-export const browserEvalRegistrationSchema = withEnvelopeIncludeForUnion(browserEvalSchema);
+// ADR-018 Phase 2a — `browserEvalUnionWithInclude` (include-injected union)
+// feeds BOTH the flat wire schema AND the in-handler `parseActionArgsOrFail`
+// gate. Scope fence: only the `browser_eval` union is flattened here.
+const browserEvalUnionWithInclude = withEnvelopeIncludeForUnion(browserEvalSchema);
+export const browserEvalRegistrationSchema = flattenUnionToObjectSchema(browserEvalUnionWithInclude);
 
 export const browserEvalRegistrationHandler = makeCommitWrapper(
   withRichNarration(

--- a/src/tools/clipboard.ts
+++ b/src/tools/clipboard.ts
@@ -6,7 +6,12 @@ import { ok } from "./_types.js";
 import type { ToolResult } from "./_types.js";
 import { failWith } from "./_errors.js";
 import { withRichNarration } from "./_narration.js";
-import { makeCommitWrapper, withEnvelopeIncludeForUnion } from "./_envelope.js";
+import {
+  makeCommitWrapper,
+  withEnvelopeIncludeForUnion,
+  flattenUnionToObjectSchema,
+  parseActionArgsOrFail,
+} from "./_envelope.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -140,8 +145,14 @@ export const clipboardSchema = z.discriminatedUnion("action", [
 export type ClipboardArgs = z.infer<typeof clipboardSchema>;
 
 export const clipboardHandler = async (args: ClipboardArgs): Promise<import("./_types.js").ToolResult> => {
-  if (args.action === "read") return clipboardReadHandler();
-  return clipboardWriteHandler(args);
+  // ADR-018 Phase 2a — strict per-action gate. The registered wire schema is
+  // the flat `flattenUnionToObjectSchema` output; re-parse against the real
+  // (include-injected) union so per-action constraints are still enforced.
+  const parsed = parseActionArgsOrFail<ClipboardArgs>(clipboardUnionWithInclude, args, "clipboard");
+  if (!parsed.ok) return parsed.result;
+  const a = parsed.value;
+  if (a.action === "read") return clipboardReadHandler();
+  return clipboardWriteHandler(a);
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -177,7 +188,11 @@ export const clipboardHandler = async (args: ClipboardArgs): Promise<import("./_
  * (expansion-pr-guard.yml + check-expansion-disjoint.mjs)、handler internal
  * logic + Zod schema + 戻り値 shape 不変 (ADR-010 §1.5)。
  */
-export const clipboardRegistrationSchema = withEnvelopeIncludeForUnion(clipboardSchema);
+// ADR-018 Phase 2a — `clipboardUnionWithInclude` (include-injected union) feeds
+// BOTH the flat wire schema (`registerTool` inputSchema) AND the in-handler
+// `parseActionArgsOrFail` strict gate. Do not pass the bare `clipboardSchema`.
+const clipboardUnionWithInclude = withEnvelopeIncludeForUnion(clipboardSchema);
+export const clipboardRegistrationSchema = flattenUnionToObjectSchema(clipboardUnionWithInclude);
 
 export const clipboardRegistrationHandler = makeCommitWrapper(
   withRichNarration(
@@ -199,6 +214,6 @@ export function registerClipboardTools(server: McpServer): void {
       description: "Read or write the Windows clipboard. action='read' returns current text content (empty string if non-text). action='write' replaces clipboard with given text and verifies delivery via Get-Clipboard -Raw read-back, comparing the bytes (UTF-16LE) for exact equality. Caveats: Non-text clipboard payloads (images, files) return empty string on read. Overwrites existing clipboard content on write. action='write' delivery-verification failure returns code:'ClipboardWriteNotDelivered' — typical causes: a third-party clipboard manager intercepts SetClipboardData, DLP / endpoint protection blocks the payload, RDP / Citrix clipboard transcoding strips the text, or another process clears the clipboard between Set and the read-back. Recovery: retry the write, or fall back to keyboard(action='type', use_clipboard=false) for short text. Examples: clipboard({action:'write', text:'hello'}) → write+verify; clipboard({action:'read'}) → returns current text.",
       inputSchema: clipboardRegistrationSchema,
     },
-    clipboardRegistrationHandler as typeof clipboardHandler
+    clipboardRegistrationHandler as (args: Record<string, unknown>) => Promise<ToolResult>
   );
 }

--- a/src/tools/excel.ts
+++ b/src/tools/excel.ts
@@ -6,7 +6,12 @@ import { ok, buildDesc } from "./_types.js";
 import type { ToolResult } from "./_types.js";
 import { failWith } from "./_errors.js";
 import { withRichNarration } from "./_narration.js";
-import { makeCommitWrapper, withEnvelopeIncludeForUnion } from "./_envelope.js";
+import {
+  makeCommitWrapper,
+  withEnvelopeIncludeForUnion,
+  flattenUnionToObjectSchema,
+  parseActionArgsOrFail,
+} from "./_envelope.js";
 import { nativeExcel } from "../engine/native-engine.js";
 import type { NativeExcelAccessVbomStatus } from "../engine/native-types.js";
 
@@ -272,9 +277,15 @@ async function handleCheckAccessVbom(): Promise<ToolResult> {
 }
 
 export const excelHandler = async (args: ExcelArgs): Promise<ToolResult> => {
-  switch (args.action) {
+  // ADR-018 Phase 2a — strict per-action gate (see §2.5.2). The registered wire
+  // schema is the flat `flattenUnionToObjectSchema` output; re-parse against the
+  // real (include-injected) union here.
+  const parsed = parseActionArgsOrFail<ExcelArgs>(excelUnionWithInclude, args, "excel");
+  if (!parsed.ok) return parsed.result;
+  const a = parsed.value;
+  switch (a.action) {
     case "run_vba":
-      return handleRunVba(args);
+      return handleRunVba(a);
     case "check_access_vbom":
       return handleCheckAccessVbom();
   }
@@ -298,7 +309,10 @@ export const excelHandler = async (args: ExcelArgs): Promise<ToolResult> => {
  * shares the same wrapped instance (PR #112 shared registration handler
  * pattern, strip risk prevention).
  */
-export const excelRegistrationSchema = withEnvelopeIncludeForUnion(excelSchema);
+// ADR-018 Phase 2a — `excelUnionWithInclude` (include-injected union) feeds BOTH
+// the flat wire schema AND the in-handler `parseActionArgsOrFail` strict gate.
+const excelUnionWithInclude = withEnvelopeIncludeForUnion(excelSchema);
+export const excelRegistrationSchema = flattenUnionToObjectSchema(excelUnionWithInclude);
 
 export const excelRegistrationHandler = makeCommitWrapper(
   withRichNarration(
@@ -345,6 +359,6 @@ export function registerExcelTools(server: McpServer): void {
       }),
       inputSchema: excelRegistrationSchema,
     },
-    excelRegistrationHandler as typeof excelHandler
+    excelRegistrationHandler as (args: Record<string, unknown>) => Promise<ToolResult>
   );
 }

--- a/src/tools/keyboard.ts
+++ b/src/tools/keyboard.ts
@@ -30,7 +30,12 @@ import { detectFocusLoss, checkForegroundOnce } from "./_focus.js";
 import { evaluatePreToolGuards, buildEnvelopeFor } from "../engine/perception/registry.js";
 import { runActionGuard, isAutoGuardEnabled, validateAndPrepareFix, consumeFix } from "./_action-guard.js";
 import { resolveWindowTarget } from "./_resolve-window.js";
-import { makeCommitWrapper, withEnvelopeIncludeForUnion } from "./_envelope.js";
+import {
+  makeCommitWrapper,
+  withEnvelopeIncludeForUnion,
+  flattenUnionToObjectSchema,
+  parseActionArgsOrFail,
+} from "./_envelope.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -2290,13 +2295,20 @@ export const keyboardSchema = z.discriminatedUnion("action", [
 export type KeyboardArgs = z.infer<typeof keyboardSchema>;
 
 export const keyboardHandler = async (args: KeyboardArgs): Promise<import("./_types.js").ToolResult> => {
-  if (args.action === "type") {
-    return keyboardTypeHandler(args);
+  // ADR-018 Phase 2a — strict per-action gate (§2.5.2). The registered wire
+  // schema is the flat `flattenUnionToObjectSchema` output; re-parse against
+  // the real (include-injected) union so per-action constraints — incl. the
+  // `sequence` variant's `method: z.literal("foreground")` — still apply.
+  const parsed = parseActionArgsOrFail<KeyboardArgs>(keyboardUnionWithInclude, args, "keyboard");
+  if (!parsed.ok) return parsed.result;
+  const a = parsed.value;
+  if (a.action === "type") {
+    return keyboardTypeHandler(a);
   }
-  if (args.action === "sequence") {
-    return keyboardSequenceHandler(args);
+  if (a.action === "sequence") {
+    return keyboardSequenceHandler(a);
   }
-  return keyboardPressHandler(args);
+  return keyboardPressHandler(a);
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -2340,7 +2352,10 @@ export const keyboardHandler = async (args: KeyboardArgs): Promise<import("./_ty
  * (Codex PR #123 P2 + PR #112 P1-1 同型 risk pattern, discriminatedUnion
  * 系の延長線).
  */
-export const keyboardRegistrationSchema = withEnvelopeIncludeForUnion(keyboardSchema);
+// ADR-018 Phase 2a — `keyboardUnionWithInclude` (include-injected union) feeds
+// BOTH the flat wire schema AND the in-handler `parseActionArgsOrFail` gate.
+const keyboardUnionWithInclude = withEnvelopeIncludeForUnion(keyboardSchema);
+export const keyboardRegistrationSchema = flattenUnionToObjectSchema(keyboardUnionWithInclude);
 
 export const keyboardRegistrationHandler = makeCommitWrapper(
   withRichNarration(
@@ -2374,6 +2389,6 @@ export function registerKeyboardTools(server: McpServer): void {
       }),
       inputSchema: keyboardRegistrationSchema,
     },
-    keyboardRegistrationHandler as typeof keyboardHandler,
+    keyboardRegistrationHandler as (args: Record<string, unknown>) => Promise<import("./_types.js").ToolResult>,
   );
 }

--- a/src/tools/scroll.ts
+++ b/src/tools/scroll.ts
@@ -5,7 +5,12 @@ import type { ToolResult } from "./_types.js";
 import { coercedBoolean } from "./_coerce.js";
 import { getCdpPort } from "../utils/desktop-config.js";
 import { withRichNarration } from "./_narration.js";
-import { makeCommitWrapper, withEnvelopeIncludeForUnion } from "./_envelope.js";
+import {
+  makeCommitWrapper,
+  withEnvelopeIncludeForUnion,
+  flattenUnionToObjectSchema,
+  parseActionArgsOrFail,
+} from "./_envelope.js";
 
 // Internal handlers imported from existing files (retained as internal exports)
 import { scrollHandler as rawScrollHandler } from "./mouse.js";
@@ -186,17 +191,23 @@ export const scrollSchema = z.discriminatedUnion("action", [
 export type ScrollArgs = z.infer<typeof scrollSchema>;
 
 export const scrollDispatchHandler = async (args: ScrollArgs): Promise<ToolResult> => {
-  switch (args.action) {
+  // ADR-018 Phase 2a — strict per-action gate (§2.5.2). The registered wire
+  // schema is the flat `flattenUnionToObjectSchema` output; re-parse against
+  // the real (include-injected) union so per-action constraints still apply.
+  const parsed = parseActionArgsOrFail<ScrollArgs>(scrollUnionWithInclude, args, "scroll");
+  if (!parsed.ok) return parsed.result;
+  const a = parsed.value;
+  switch (a.action) {
     case "raw":
-      return rawScrollHandler(args);
+      return rawScrollHandler(a);
     case "to_element":
-      return scrollToElementHandler(args);
+      return scrollToElementHandler(a);
     case "smart":
-      return smartScrollHandler(args);
+      return smartScrollHandler(a);
     case "capture":
-      return scrollCaptureHandler(args);
+      return scrollCaptureHandler(a);
     case "read":
-      return scrollReadHandler(args);
+      return scrollReadHandler(a);
   }
 };
 
@@ -226,7 +237,11 @@ export const scrollDispatchHandler = async (args: ScrollArgs): Promise<ToolResul
  * (expansion-pr-guard.yml + check-expansion-disjoint.mjs)、handler internal
  * logic + Zod schema + 戻り値 shape 不変 (ADR-010 §1.5)。
  */
-export const scrollRegistrationSchema = withEnvelopeIncludeForUnion(scrollSchema);
+// ADR-018 Phase 2a — `scrollUnionWithInclude` (include-injected union) feeds
+// BOTH the flat wire schema (`registerTool` inputSchema) AND the in-handler
+// `parseActionArgsOrFail` strict gate. Do not pass the bare `scrollSchema`.
+const scrollUnionWithInclude = withEnvelopeIncludeForUnion(scrollSchema);
+export const scrollRegistrationSchema = flattenUnionToObjectSchema(scrollUnionWithInclude);
 
 export const scrollRegistrationHandler = makeCommitWrapper(
   withRichNarration(

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -37,7 +37,12 @@ import { parseKeys } from "../utils/key-map.js";
 import { typeViaClipboard } from "./keyboard.js";
 import { setTerminalReadHook } from "./wait-until.js";
 import { withRichNarration } from "./_narration.js";
-import { makeCommitWrapper, withEnvelopeIncludeForUnion } from "./_envelope.js";
+import {
+  makeCommitWrapper,
+  withEnvelopeIncludeForUnion,
+  flattenUnionToObjectSchema,
+  parseActionArgsOrFail,
+} from "./_envelope.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Schemas
@@ -1680,20 +1685,28 @@ export const terminalSchema = z.discriminatedUnion("action", [
 export type TerminalArgs = z.infer<typeof terminalSchema>;
 
 export const terminalDispatchHandler = async (args: TerminalArgs): Promise<ToolResult> => {
-  switch (args.action) {
-    case "read": return terminalReadHandler(args);
-    case "send": return terminalSendHandler(args);
+  // ADR-018 Phase 2a — strict per-action gate (§2.5.2). The registered wire
+  // schema is the flat `flattenUnionToObjectSchema` output; re-parse against
+  // the real (include-injected) union so the `run` variant's
+  // `.refine(input || command)` and the nested `until` union still apply.
+  const parsed = parseActionArgsOrFail<TerminalArgs>(terminalUnionWithInclude, args, "terminal");
+  if (!parsed.ok) return parsed.result;
+  const a = parsed.value;
+  switch (a.action) {
+    case "read": return terminalReadHandler(a);
+    case "send": return terminalSendHandler(a);
     case "run": {
       // Issue #245 系統③: `command` is a deprecated alias of `input` for LLMs
       // that mis-remember the parameter name. Resolve to `input` here so the
       // handler signature stays `input: string`.
-      const resolvedInput = typeof args.input === "string" ? args.input : args.command;
+      const resolvedInput = typeof a.input === "string" ? a.input : a.command;
       if (typeof resolvedInput !== "string") {
-        // Should be unreachable thanks to the schema-level refine, but guard
-        // anyway so TS can narrow `resolvedInput` to `string`.
+        // Unreachable: `parseActionArgsOrFail` above re-parsed `terminalSchema`,
+        // whose `run` variant `.refine(input || command)` already rejected this
+        // case as a typed InvalidArgs error. Kept so TS narrows `resolvedInput`.
         throw new Error("terminal(action='run'): neither `input` nor `command` provided");
       }
-      return terminalRunHandler({ ...args, input: resolvedInput });
+      return terminalRunHandler({ ...a, input: resolvedInput });
     }
   }
 };
@@ -1731,7 +1744,14 @@ export { TERMINAL_PROCESS_RE };
  * `macro.ts`) shares the same wrapped instance (PR #112 shared
  * registration handler pattern, strip risk prevention).
  */
-export const terminalRegistrationSchema = withEnvelopeIncludeForUnion(terminalSchema);
+// ADR-018 Phase 2a — `terminalUnionWithInclude` (include-injected union) feeds
+// BOTH the flat wire schema AND the in-handler `parseActionArgsOrFail` gate.
+// The flatten reads each variant's `.shape` directly — terminal's `run` variant
+// is `.refine()`-wrapped but in zod 4.3.6 that is still a `ZodObject`, so no
+// unwrap is needed; the nested `until` discriminatedUnion is left intact and
+// renders as a property-level `anyOf` (accepted by the Anthropic API).
+const terminalUnionWithInclude = withEnvelopeIncludeForUnion(terminalSchema);
+export const terminalRegistrationSchema = flattenUnionToObjectSchema(terminalUnionWithInclude);
 
 export const terminalRegistrationHandler = makeCommitWrapper(
   withRichNarration(

--- a/src/tools/window-dock.ts
+++ b/src/tools/window-dock.ts
@@ -5,7 +5,12 @@ import type { ToolResult } from "./_types.js";
 import { pinWindowHandler, unpinWindowHandler } from "./pin.js";
 import { dockWindowHandler } from "./dock.js";
 import { withRichNarration } from "./_narration.js";
-import { makeCommitWrapper, withEnvelopeIncludeForUnion } from "./_envelope.js";
+import {
+  makeCommitWrapper,
+  withEnvelopeIncludeForUnion,
+  flattenUnionToObjectSchema,
+  parseActionArgsOrFail,
+} from "./_envelope.js";
 import { coercedBoolean } from "./_coerce.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -52,10 +57,16 @@ export const windowDockSchema = z.discriminatedUnion("action", [
 export type WindowDockArgs = z.infer<typeof windowDockSchema>;
 
 export const windowDockHandler = async (args: WindowDockArgs): Promise<ToolResult> => {
-  switch (args.action) {
-    case "pin": return pinWindowHandler(args);
-    case "unpin": return unpinWindowHandler(args);
-    case "dock": return dockWindowHandler(args);
+  // ADR-018 Phase 2a — strict per-action gate (§2.5.2). Registered wire schema
+  // is the flat `flattenUnionToObjectSchema` output; re-parse against the real
+  // (include-injected) union here.
+  const parsed = parseActionArgsOrFail<WindowDockArgs>(windowDockUnionWithInclude, args, "window_dock");
+  if (!parsed.ok) return parsed.result;
+  const a = parsed.value;
+  switch (a.action) {
+    case "pin": return pinWindowHandler(a);
+    case "unpin": return unpinWindowHandler(a);
+    case "dock": return dockWindowHandler(a);
   }
 };
 
@@ -82,7 +93,10 @@ export const windowDockHandler = async (args: WindowDockArgs): Promise<ToolResul
  * `macro.ts`) shares the same wrapped instance (PR #112 shared
  * registration handler pattern, strip risk prevention).
  */
-export const windowDockRegistrationSchema = withEnvelopeIncludeForUnion(windowDockSchema);
+// ADR-018 Phase 2a — `windowDockUnionWithInclude` (include-injected union) feeds
+// BOTH the flat wire schema AND the in-handler `parseActionArgsOrFail` gate.
+const windowDockUnionWithInclude = withEnvelopeIncludeForUnion(windowDockSchema);
+export const windowDockRegistrationSchema = flattenUnionToObjectSchema(windowDockUnionWithInclude);
 
 export const windowDockRegistrationHandler = makeCommitWrapper(
   withRichNarration(
@@ -114,6 +128,6 @@ export function registerWindowDockTools(server: McpServer): void {
       }),
       inputSchema: windowDockRegistrationSchema,
     },
-    windowDockRegistrationHandler as typeof windowDockHandler
+    windowDockRegistrationHandler as (args: Record<string, unknown>) => Promise<ToolResult>
   );
 }

--- a/tests/integration/tools-list-schema.test.ts
+++ b/tests/integration/tools-list-schema.test.ts
@@ -8,10 +8,22 @@
  *      regression surface is a top-level `z.discriminatedUnion` slipping past
  *      `flattenUnionToObjectSchema`; this guard catches any future slip on ANY
  *      tool, not just the 7 known ones.
- *   2. NO registered tool's top-level `inputSchema` has `oneOf`/`anyOf`/`allOf`
- *      — the Anthropic API rejects those (HTTP 400).
+ *   2. NO registered tool's *top-level* `inputSchema` has `oneOf`/`anyOf`/
+ *      `allOf` — the Anthropic API rejects those (HTTP 400). (Property-level
+ *      `oneOf`/`anyOf` — e.g. `terminal.until` — is fine and expected.)
  *   3. The 7 flattened tools each expose non-empty `properties` including the
  *      `action` discriminator enumerated as a flat `z.enum`.
+ *   4. `terminal.until` (a nested `z.discriminatedUnion`) renders as a
+ *      *property-level* `oneOf` — intact, not stripped (ADR-018 §3 G2a #6).
+ *
+ * **Gating**: `describe.skipIf(process.platform !== "win32")`. This is a
+ * default-running regression gate on Windows (the dev + MCP-server platform);
+ * it is platform-gated rather than env-gated (`RUN_OCR_GOLDEN`-style) precisely
+ * BECAUSE it must run by default to function as a gate. The `beforeAll` below
+ * dynamically imports the full Windows tool surface (native input bindings via
+ * `nutjs`, etc.) — those imports only run inside the (Windows-only) describe,
+ * so a Linux / minimal CI environment skips cleanly instead of failing at
+ * module load (Codex PR #290 Round 1 P1).
  */
 
 import { describe, it, expect, beforeAll } from "vitest";
@@ -33,89 +45,108 @@ interface ListedTool {
   inputSchema?: any;
 }
 
-let tools: ListedTool[] = [];
+describe.skipIf(process.platform !== "win32")(
+  "ADR-018 Phase 2a — tools/list inputSchema CI gate",
+  () => {
+    let tools: ListedTool[] = [];
 
-beforeAll(async () => {
-  const s = new McpServer({ name: "tools-list-schema-test", version: "0" });
+    beforeAll(async () => {
+      const s = new McpServer({ name: "tools-list-schema-test", version: "0" });
 
-  // Mirror server-windows.ts::createMcpServer registration list (the failsafe
-  // wrapper + tray + transport are not needed for a tools/list dump).
-  const regs: Array<[string, string]> = [
-    ["../../src/tools/screenshot.js", "registerScreenshotTools"],
-    ["../../src/tools/mouse.js", "registerMouseTools"],
-    ["../../src/tools/keyboard.js", "registerKeyboardTools"],
-    ["../../src/tools/window.js", "registerWindowTools"],
-    ["../../src/tools/ui-elements.js", "registerUiElementTools"],
-    ["../../src/tools/workspace.js", "registerWorkspaceTools"],
-    ["../../src/tools/macro.js", "registerMacroTools"],
-    ["../../src/tools/scroll.js", "registerScrollTools"],
-    ["../../src/tools/browser.js", "registerBrowserTools"],
-    ["../../src/tools/window-dock.js", "registerWindowDockTools"],
-    ["../../src/tools/wait-until.js", "registerWaitUntilTool"],
-    ["../../src/tools/desktop-state.js", "registerDesktopStateTools"],
-    ["../../src/tools/terminal.js", "registerTerminalTools"],
-    ["../../src/tools/events.js", "registerEventTools"],
-    ["../../src/tools/clipboard.js", "registerClipboardTools"],
-    ["../../src/tools/notification.js", "registerNotificationTools"],
-    ["../../src/tools/excel.js", "registerExcelTools"],
-    ["../../src/tools/perception.js", "registerPerceptionTools"],
-    ["../../src/tools/server-status.js", "registerServerStatusTool"],
-  ];
-  for (const [path, fn] of regs) {
-    const mod = await import(path);
-    (mod as Record<string, (srv: McpServer) => void>)[fn](s);
-  }
-  // Anti-Fukuwarai v2 (desktop_discover / desktop_act) — default-on, optional.
-  try {
-    const v2 = await import("../../src/tools/desktop-register.js");
-    (v2 as { registerDesktopTools: (srv: McpServer) => void }).registerDesktopTools(s);
-  } catch {
-    /* v2 module optional in some envs */
-  }
+      // Mirror server-windows.ts::createMcpServer registration list (the
+      // failsafe wrapper + tray + transport are not needed for a tools/list dump).
+      const regs: Array<[string, string]> = [
+        ["../../src/tools/screenshot.js", "registerScreenshotTools"],
+        ["../../src/tools/mouse.js", "registerMouseTools"],
+        ["../../src/tools/keyboard.js", "registerKeyboardTools"],
+        ["../../src/tools/window.js", "registerWindowTools"],
+        ["../../src/tools/ui-elements.js", "registerUiElementTools"],
+        ["../../src/tools/workspace.js", "registerWorkspaceTools"],
+        ["../../src/tools/macro.js", "registerMacroTools"],
+        ["../../src/tools/scroll.js", "registerScrollTools"],
+        ["../../src/tools/browser.js", "registerBrowserTools"],
+        ["../../src/tools/window-dock.js", "registerWindowDockTools"],
+        ["../../src/tools/wait-until.js", "registerWaitUntilTool"],
+        ["../../src/tools/desktop-state.js", "registerDesktopStateTools"],
+        ["../../src/tools/terminal.js", "registerTerminalTools"],
+        ["../../src/tools/events.js", "registerEventTools"],
+        ["../../src/tools/clipboard.js", "registerClipboardTools"],
+        ["../../src/tools/notification.js", "registerNotificationTools"],
+        ["../../src/tools/excel.js", "registerExcelTools"],
+        ["../../src/tools/perception.js", "registerPerceptionTools"],
+        ["../../src/tools/server-status.js", "registerServerStatusTool"],
+      ];
+      for (const [path, fn] of regs) {
+        const mod = await import(path);
+        (mod as Record<string, (srv: McpServer) => void>)[fn](s);
+      }
+      // Anti-Fukuwarai v2 (desktop_discover / desktop_act) — default-on, optional.
+      try {
+        const v2 = await import("../../src/tools/desktop-register.js");
+        (v2 as { registerDesktopTools: (srv: McpServer) => void }).registerDesktopTools(s);
+      } catch {
+        /* v2 module optional in some envs */
+      }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const handler = (s.server as any)._requestHandlers.get("tools/list");
-  const res = await handler(
-    { method: "tools/list", params: {} },
-    { signal: new AbortController().signal },
-  );
-  tools = res.tools as ListedTool[];
-});
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const handler = (s.server as any)._requestHandlers.get("tools/list");
+      const res = await handler(
+        { method: "tools/list", params: {} },
+        { signal: new AbortController().signal },
+      );
+      tools = res.tools as ListedTool[];
+    });
 
-describe("ADR-018 Phase 2a — tools/list inputSchema CI gate", () => {
-  it("registers the full public tool surface", () => {
-    expect(tools.length).toBeGreaterThanOrEqual(20);
-  });
+    it("registers the full public tool surface", () => {
+      // The server registers ~29 tools (26 stub catalog + 2 v2 + V1 fallbacks
+      // vary by env). 28 is a tight lower bound that still catches a
+      // registration regression dropping a tool family.
+      expect(tools.length).toBeGreaterThanOrEqual(28);
+    });
 
-  it("NO registered tool has empty `properties` (server-wide top-level-union regression guard)", () => {
-    const empty = tools
-      .filter((t) => Object.keys(t.inputSchema?.properties ?? {}).length === 0)
-      .map((t) => t.name);
-    expect(empty).toEqual([]);
-  });
+    it("NO registered tool has empty `properties` (server-wide top-level-union regression guard)", () => {
+      const empty = tools
+        .filter((t) => Object.keys(t.inputSchema?.properties ?? {}).length === 0)
+        .map((t) => t.name);
+      expect(empty).toEqual([]);
+    });
 
-  it("NO registered tool has a top-level oneOf/anyOf/allOf (Anthropic API rejects those)", () => {
-    const bad = tools
-      .filter(
-        (t) =>
-          t.inputSchema?.oneOf !== undefined ||
-          t.inputSchema?.anyOf !== undefined ||
-          t.inputSchema?.allOf !== undefined,
-      )
-      .map((t) => t.name);
-    expect(bad).toEqual([]);
-  });
+    it("NO registered tool has a TOP-LEVEL oneOf/anyOf/allOf (Anthropic API rejects those)", () => {
+      const bad = tools
+        .filter(
+          (t) =>
+            t.inputSchema?.oneOf !== undefined ||
+            t.inputSchema?.anyOf !== undefined ||
+            t.inputSchema?.allOf !== undefined,
+        )
+        .map((t) => t.name);
+      expect(bad).toEqual([]);
+    });
 
-  it("each of the 7 flattened tools exposes non-empty `properties` with an `action` enum", () => {
-    for (const name of FLATTENED_TOOLS) {
-      const tool = tools.find((t) => t.name === name);
-      expect(tool, `tool "${name}" should be registered`).toBeDefined();
-      const props = (tool!.inputSchema?.properties ?? {}) as Record<string, unknown>;
-      expect(Object.keys(props).length, `${name}: non-empty properties`).toBeGreaterThan(0);
-      const action = props.action as { enum?: unknown[] } | undefined;
-      expect(action, `${name}.action present`).toBeDefined();
-      expect(Array.isArray(action!.enum), `${name}.action is an enum`).toBe(true);
-      expect(action!.enum!.length, `${name}.action enum non-empty`).toBeGreaterThan(0);
-    }
-  });
-});
+    it("each of the 7 flattened tools exposes non-empty `properties` with an `action` enum", () => {
+      for (const name of FLATTENED_TOOLS) {
+        const tool = tools.find((t) => t.name === name);
+        expect(tool, `tool "${name}" should be registered`).toBeDefined();
+        const props = (tool!.inputSchema?.properties ?? {}) as Record<string, unknown>;
+        expect(Object.keys(props).length, `${name}: non-empty properties`).toBeGreaterThan(0);
+        const action = props.action as { enum?: unknown[] } | undefined;
+        expect(action, `${name}.action present`).toBeDefined();
+        expect(Array.isArray(action!.enum), `${name}.action is an enum`).toBe(true);
+        expect(action!.enum!.length, `${name}.action enum non-empty`).toBeGreaterThan(0);
+      }
+    });
+
+    it("terminal.until — a nested z.discriminatedUnion — renders as a PROPERTY-LEVEL oneOf, intact (ADR-018 §3 G2a #6)", () => {
+      const terminal = tools.find((t) => t.name === "terminal");
+      expect(terminal).toBeDefined();
+      const until = terminal!.inputSchema?.properties?.until;
+      expect(until, "terminal.until is present, not stripped").toBeDefined();
+      // The nested `z.discriminatedUnion("mode", ...)` renders as a
+      // property-level `oneOf` (each branch carries its `mode` discriminator
+      // const). Property-level oneOf is accepted by the Anthropic API — only
+      // *top-level* oneOf is rejected (asserted separately above).
+      expect(Array.isArray(until.oneOf), "terminal.until.oneOf is an array").toBe(true);
+      expect(until.oneOf.length, "terminal.until.oneOf has the mode branches").toBeGreaterThanOrEqual(2);
+    });
+  },
+);

--- a/tests/integration/tools-list-schema.test.ts
+++ b/tests/integration/tools-list-schema.test.ts
@@ -1,0 +1,121 @@
+/**
+ * ADR-018 Phase 2a — integration CI gate for the MCP `tools/list` inputSchema.
+ *
+ * Registers every public tool on a real `McpServer` (mirroring
+ * `server-windows.ts::createMcpServer`'s registration list) and dumps
+ * `tools/list`, then asserts:
+ *   1. NO registered tool has an empty `properties` — the empty-`properties`
+ *      regression surface is a top-level `z.discriminatedUnion` slipping past
+ *      `flattenUnionToObjectSchema`; this guard catches any future slip on ANY
+ *      tool, not just the 7 known ones.
+ *   2. NO registered tool's top-level `inputSchema` has `oneOf`/`anyOf`/`allOf`
+ *      — the Anthropic API rejects those (HTTP 400).
+ *   3. The 7 flattened tools each expose non-empty `properties` including the
+ *      `action` discriminator enumerated as a flat `z.enum`.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+const FLATTENED_TOOLS = [
+  "scroll",
+  "keyboard",
+  "excel",
+  "browser_eval",
+  "window_dock",
+  "terminal",
+  "clipboard",
+] as const;
+
+interface ListedTool {
+  name: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  inputSchema?: any;
+}
+
+let tools: ListedTool[] = [];
+
+beforeAll(async () => {
+  const s = new McpServer({ name: "tools-list-schema-test", version: "0" });
+
+  // Mirror server-windows.ts::createMcpServer registration list (the failsafe
+  // wrapper + tray + transport are not needed for a tools/list dump).
+  const regs: Array<[string, string]> = [
+    ["../../src/tools/screenshot.js", "registerScreenshotTools"],
+    ["../../src/tools/mouse.js", "registerMouseTools"],
+    ["../../src/tools/keyboard.js", "registerKeyboardTools"],
+    ["../../src/tools/window.js", "registerWindowTools"],
+    ["../../src/tools/ui-elements.js", "registerUiElementTools"],
+    ["../../src/tools/workspace.js", "registerWorkspaceTools"],
+    ["../../src/tools/macro.js", "registerMacroTools"],
+    ["../../src/tools/scroll.js", "registerScrollTools"],
+    ["../../src/tools/browser.js", "registerBrowserTools"],
+    ["../../src/tools/window-dock.js", "registerWindowDockTools"],
+    ["../../src/tools/wait-until.js", "registerWaitUntilTool"],
+    ["../../src/tools/desktop-state.js", "registerDesktopStateTools"],
+    ["../../src/tools/terminal.js", "registerTerminalTools"],
+    ["../../src/tools/events.js", "registerEventTools"],
+    ["../../src/tools/clipboard.js", "registerClipboardTools"],
+    ["../../src/tools/notification.js", "registerNotificationTools"],
+    ["../../src/tools/excel.js", "registerExcelTools"],
+    ["../../src/tools/perception.js", "registerPerceptionTools"],
+    ["../../src/tools/server-status.js", "registerServerStatusTool"],
+  ];
+  for (const [path, fn] of regs) {
+    const mod = await import(path);
+    (mod as Record<string, (srv: McpServer) => void>)[fn](s);
+  }
+  // Anti-Fukuwarai v2 (desktop_discover / desktop_act) — default-on, optional.
+  try {
+    const v2 = await import("../../src/tools/desktop-register.js");
+    (v2 as { registerDesktopTools: (srv: McpServer) => void }).registerDesktopTools(s);
+  } catch {
+    /* v2 module optional in some envs */
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const handler = (s.server as any)._requestHandlers.get("tools/list");
+  const res = await handler(
+    { method: "tools/list", params: {} },
+    { signal: new AbortController().signal },
+  );
+  tools = res.tools as ListedTool[];
+});
+
+describe("ADR-018 Phase 2a — tools/list inputSchema CI gate", () => {
+  it("registers the full public tool surface", () => {
+    expect(tools.length).toBeGreaterThanOrEqual(20);
+  });
+
+  it("NO registered tool has empty `properties` (server-wide top-level-union regression guard)", () => {
+    const empty = tools
+      .filter((t) => Object.keys(t.inputSchema?.properties ?? {}).length === 0)
+      .map((t) => t.name);
+    expect(empty).toEqual([]);
+  });
+
+  it("NO registered tool has a top-level oneOf/anyOf/allOf (Anthropic API rejects those)", () => {
+    const bad = tools
+      .filter(
+        (t) =>
+          t.inputSchema?.oneOf !== undefined ||
+          t.inputSchema?.anyOf !== undefined ||
+          t.inputSchema?.allOf !== undefined,
+      )
+      .map((t) => t.name);
+    expect(bad).toEqual([]);
+  });
+
+  it("each of the 7 flattened tools exposes non-empty `properties` with an `action` enum", () => {
+    for (const name of FLATTENED_TOOLS) {
+      const tool = tools.find((t) => t.name === name);
+      expect(tool, `tool "${name}" should be registered`).toBeDefined();
+      const props = (tool!.inputSchema?.properties ?? {}) as Record<string, unknown>;
+      expect(Object.keys(props).length, `${name}: non-empty properties`).toBeGreaterThan(0);
+      const action = props.action as { enum?: unknown[] } | undefined;
+      expect(action, `${name}.action present`).toBeDefined();
+      expect(Array.isArray(action!.enum), `${name}.action is an enum`).toBe(true);
+      expect(action!.enum!.length, `${name}.action enum non-empty`).toBeGreaterThan(0);
+    }
+  });
+});

--- a/tests/unit/flatten-union-schema.test.ts
+++ b/tests/unit/flatten-union-schema.test.ts
@@ -1,0 +1,165 @@
+/**
+ * ADR-018 Phase 2a — unit tests for `flattenUnionToObjectSchema` and
+ * `parseActionArgsOrFail` (`src/tools/_envelope.ts` §2.5.2).
+ *
+ * Contract pinned:
+ *   1. `flattenUnionToObjectSchema(unionWithInclude)` → a flat top-level
+ *      `z.object` (no top-level oneOf/anyOf — the Anthropic API rejects those),
+ *      `action` becomes a required `z.enum`, every other field optional,
+ *      the `include` envelope field is carried through, collisions widen.
+ *   2. The flat wire schema is strictly LOOSER than the include-injected union
+ *      — it never rejects an input the union accepts.
+ *   3. `parseActionArgsOrFail` re-parses against the include-injected union
+ *      (the strict gate the flat wire schema deliberately drops): valid →
+ *      `{ ok: true, value }`, invalid → `{ ok: false, result }` with a typed
+ *      `InvalidArgs` error; it never throws; `include` survives.
+ */
+
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import {
+  flattenUnionToObjectSchema,
+  parseActionArgsOrFail,
+  withEnvelopeIncludeForUnion,
+} from "../../src/tools/_envelope.js";
+
+// Synthetic discriminated union exercising every collision class:
+//  - `windowTitle`: same structural shape across variants (string, only the
+//    description differs) → collapses to one optional field
+//  - `direction`: different `z.enum`s per variant → all-enum merge to the
+//    value union (one `z.enum`)
+//  - `count`: `number` in one variant, `string` in another → `z.union`
+//    fallback → property-level `anyOf`
+//  - `onlyA` / `onlyB`: single-variant fields → optional passthrough
+const synthBare = z.discriminatedUnion("action", [
+  z.object({
+    action: z.literal("a"),
+    windowTitle: z.string().describe("win title"),
+    direction: z.enum(["up", "down"]),
+    count: z.number(),
+    onlyA: z.boolean(),
+  }),
+  z.object({
+    action: z.literal("b"),
+    windowTitle: z.string().describe("win title (b variant)"),
+    direction: z.enum(["down", "left"]),
+    count: z.string(),
+    onlyB: z.string().optional(),
+  }),
+]);
+const synthUnionWithInclude = withEnvelopeIncludeForUnion(synthBare);
+
+function failureOf(result: { content: Array<{ text?: string }> }): {
+  ok: false;
+  code: string;
+  error: string;
+  context?: { issues?: unknown[] };
+} {
+  return JSON.parse(result.content[0]?.text ?? "{}");
+}
+
+describe("ADR-018 Phase 2a — flattenUnionToObjectSchema", () => {
+  const flat = flattenUnionToObjectSchema(synthUnionWithInclude);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const js = z.toJSONSchema(flat) as any;
+
+  it("produces a flat top-level object — no oneOf/anyOf/allOf at the root", () => {
+    expect(js.type).toBe("object");
+    expect(js.oneOf).toBeUndefined();
+    expect(js.anyOf).toBeUndefined();
+    expect(js.allOf).toBeUndefined();
+  });
+
+  it("the discriminator becomes a required z.enum of all variant literals", () => {
+    expect([...js.properties.action.enum].sort()).toEqual(["a", "b"]);
+    expect(js.required).toEqual(["action"]);
+  });
+
+  it("carries the `include` envelope field through, optional (load-bearing)", () => {
+    expect(js.properties.include).toBeDefined();
+    expect(js.required).not.toContain("include");
+  });
+
+  it("same-structure collision (windowTitle) collapses to ONE optional field", () => {
+    expect(js.properties.windowTitle.type).toBe("string");
+    expect(js.properties.windowTitle.anyOf).toBeUndefined();
+    expect(js.required).not.toContain("windowTitle");
+  });
+
+  it("all-enum collision (direction) merges to one z.enum of the value union", () => {
+    expect([...js.properties.direction.enum].sort()).toEqual(["down", "left", "up"]);
+    expect(js.properties.direction.anyOf).toBeUndefined();
+  });
+
+  it("mixed-type collision (count) widens to a property-level anyOf", () => {
+    expect(js.properties.count.anyOf).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const types = js.properties.count.anyOf.map((b: any) => b.type).sort();
+    expect(types).toEqual(["number", "string"]);
+  });
+
+  it("single-variant fields pass through as optional", () => {
+    expect(js.properties.onlyA.type).toBe("boolean");
+    expect(js.properties.onlyB.type).toBe("string");
+    expect(js.required).not.toContain("onlyA");
+    expect(js.required).not.toContain("onlyB");
+  });
+
+  it("the flat wire schema is strictly LOOSER than the include-injected union — accepts every input the union accepts", () => {
+    const validInputs: Record<string, unknown>[] = [
+      { action: "a", windowTitle: "x", direction: "up", count: 1, onlyA: true },
+      { action: "b", windowTitle: "y", direction: "left", count: "n", onlyB: "z" },
+      { action: "a", windowTitle: "x", direction: "down", count: 0, onlyA: false, include: ["envelope"] },
+    ];
+    for (const input of validInputs) {
+      expect(synthUnionWithInclude.safeParse(input).success, `union: ${JSON.stringify(input)}`).toBe(true);
+      expect(flat.safeParse(input).success, `flat: ${JSON.stringify(input)}`).toBe(true);
+    }
+  });
+});
+
+describe("ADR-018 Phase 2a — parseActionArgsOrFail", () => {
+  it("valid input → { ok: true, value } with the discriminator narrowed", () => {
+    const r = parseActionArgsOrFail<z.infer<typeof synthBare>>(
+      synthUnionWithInclude,
+      { action: "a", windowTitle: "x", direction: "up", count: 1, onlyA: true },
+      "synth",
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.action).toBe("a");
+  });
+
+  it("per-action-invalid input (the flat wire schema would accept it) → { ok: false } with code InvalidArgs", () => {
+    // `onlyA` is required by the real `a` variant but the flat wire schema has
+    // it optional — this is exactly the gap `parseActionArgsOrFail` closes.
+    const badForUnion = { action: "a", windowTitle: "x", direction: "up", count: 1 };
+    const flat = flattenUnionToObjectSchema(synthUnionWithInclude);
+    expect(flat.safeParse(badForUnion).success, "flat wire schema is loose").toBe(true);
+
+    const r = parseActionArgsOrFail(synthUnionWithInclude, badForUnion, "synth");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      const failure = failureOf(r.result);
+      expect(failure.code).toBe("InvalidArgs");
+      expect(failure.error).toContain("synth");
+      expect(Array.isArray(failure.context?.issues)).toBe(true);
+    }
+  });
+
+  it("preserves the `include` field on the parsed value (no strip)", () => {
+    const r = parseActionArgsOrFail<z.infer<typeof synthUnionWithInclude>>(
+      synthUnionWithInclude,
+      { action: "a", windowTitle: "x", direction: "up", count: 1, onlyA: true, include: ["envelope"] },
+      "synth",
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) expect((r.value as { include?: unknown }).include).toEqual(["envelope"]);
+  });
+
+  it("never throws — returns a typed-error ToolResult on a bad discriminator", () => {
+    expect(() => parseActionArgsOrFail(synthUnionWithInclude, { action: "nonexistent" }, "synth")).not.toThrow();
+    const r = parseActionArgsOrFail(synthUnionWithInclude, { action: "nonexistent" }, "synth");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(failureOf(r.result).code).toBe("InvalidArgs");
+  });
+});

--- a/tests/unit/flatten-union-schema.test.ts
+++ b/tests/unit/flatten-union-schema.test.ts
@@ -105,7 +105,13 @@ describe("ADR-018 Phase 2a — flattenUnionToObjectSchema", () => {
     expect(js.required).not.toContain("onlyB");
   });
 
-  it("the flat wire schema is strictly LOOSER than the include-injected union — accepts every input the union accepts", () => {
+  it("the flat wire schema accepts every VALID input the include-injected union accepts (never rejects a valid call)", () => {
+    // The flat wire schema's looseness contract is: a *valid* call — one that
+    // the real union accepts — must also pass the wire schema. (It is NOT a
+    // claim that the wire schema swallows *invalid* input: a wrong-typed
+    // off-action field IS rejected, with a typed error — that is the contract
+    // working, not a regression. `.catch(undefined)` was considered for that
+    // case and rejected; see the `mergeFlatField` doc comment.)
     const validInputs: Record<string, unknown>[] = [
       { action: "a", windowTitle: "x", direction: "up", count: 1, onlyA: true },
       { action: "b", windowTitle: "y", direction: "left", count: "n", onlyB: "z" },

--- a/tests/unit/keyboard-input-serialization.test.ts
+++ b/tests/unit/keyboard-input-serialization.test.ts
@@ -246,20 +246,26 @@ describe("keyboard(action='sequence') — issue #257 contract pins", () => {
     }).toThrow(/win\+r|shell|allowed/i);
   });
 
-  // ── Pin 4: stub-catalog emits sequence variant with per-item shape ──────────
-  it("stub-tool-catalog includes the sequence variant with full items shape", () => {
+  // ── Pin 4: stub-catalog (flat, Phase 2a) still surfaces the sequence steps.items shape ──
+  it("stub-tool-catalog keyboard is a FLAT schema that still surfaces the sequence steps.items shape", () => {
+    // ADR-018 Phase 2a: `keyboard` registers a FLAT `z.object` wire schema
+    // (`flattenUnionToObjectSchema`), not a top-level `oneOf`. The per-step
+    // contract of the `sequence` action's `steps` array must still survive
+    // regen — if the generator dropped the `z.array(z.object(...))` recursion,
+    // Linux stub callers would lose all per-step contract info.
     const kb = STUB_TOOL_CATALOG.find((t) => t.name === "keyboard");
     expect(kb).toBeDefined();
-    const variants = kb!.inputSchema.oneOf;
-    expect(Array.isArray(variants)).toBe(true);
-    const seq = variants!.find(
-      (v) => (v.properties?.action as { const?: unknown })?.const === "sequence",
-    );
-    expect(seq).toBeDefined();
+    const schema = kb!.inputSchema as {
+      oneOf?: unknown;
+      properties?: Record<string, unknown>;
+    };
+    expect(schema.oneOf, "Phase 2a: flat object, no top-level oneOf").toBeUndefined();
+    const action = schema.properties!.action as { enum?: string[] };
+    expect(action.enum).toContain("sequence");
 
-    // The steps array must surface its inner item shape; if regen drops the
-    // recursion, Linux stub callers lose all per-step contract info.
-    const steps = seq!.properties!.steps as {
+    // `steps` (a `sequence`-only field) is merged into the flat `properties`
+    // map — still carrying its inner `z.array(z.object(...))` item shape.
+    const steps = schema.properties!.steps as {
       type?: string;
       items?: { properties?: Record<string, unknown>; required?: string[]; additionalProperties?: boolean };
     };
@@ -272,15 +278,26 @@ describe("keyboard(action='sequence') — issue #257 contract pins", () => {
     });
     expect(steps.items!.required).toContain("keys");
     expect(steps.items!.additionalProperties).toBe(false);
+  });
 
-    // Variant-level required must list steps (regression pin for the
-    // optional-scan-scope fix in generate-stub-tool-catalog.mjs).
-    expect(seq!.required).toContain("action");
-    expect(seq!.required).toContain("steps");
-
-    // method literal "foreground" const should evaluate, not stay as undefined.
-    const method = seq!.properties!.method as { const?: unknown };
-    expect(method.const).toBe("foreground");
+  // ── Pin 4b: per-action contract moved to the real union (re-parsed in-handler) ──
+  it("the real keyboardSchema union still pins the sequence variant's per-action contract", () => {
+    // The flat wire schema is intentionally loose (all fields optional, `method`
+    // widened to the union of every variant's enum) — the strict per-action
+    // contract moved to the real `keyboardSchema` union, re-parsed in-handler
+    // by `parseActionArgsOrFail`. Pin it here against the bare union
+    // (unchanged by Phase 2a).
+    expect(
+      keyboardSchema.safeParse({ action: "sequence" }).success,
+      "sequence without steps must be rejected by the real union",
+    ).toBe(false);
+    expect(
+      keyboardSchema.safeParse({ action: "sequence", steps: [{ keys: "alt+i" }] }).success,
+      "sequence with valid steps is accepted",
+    ).toBe(true);
+    expect(
+      keyboardSchema.safeParse({ action: "sequence", steps: [{ keys: "m" }], method: "foreground" }).success,
+    ).toBe(true);
   });
 
   // ── Pin 5: context.remaining is directly re-invocable via the same schema ──

--- a/tests/unit/tool-naming-phase3.test.ts
+++ b/tests/unit/tool-naming-phase3.test.ts
@@ -245,57 +245,38 @@ describe("Phase 3 — stub-tool-catalog drops absorbed/privatized 4 names", () =
     expect(entry!.description).toMatch(/launch/);
   });
 
-  // Codex PR #40 P2: stub catalog must preserve action-specific fields for
-  // discriminatedUnion dispatchers. Previous generator emitted only
-  // {action: string, additionalProperties: true} which dropped fields like
-  // expression/selector/maxLength, breaking cross-platform tool discovery.
-  it("browser_eval inputSchema is a oneOf with all 3 actions (js/dom/appState)", () => {
+  // ADR-018 Phase 2a: the 7 multi-action dispatchers register a FLAT
+  // `z.object` wire schema (`flattenUnionToObjectSchema`) instead of a
+  // top-level `oneOf` — `oneOf` at the top level is rejected by the Anthropic
+  // API (HTTP 400), and the SDK emitted empty `properties` for a top-level
+  // `z.discriminatedUnion`. The stub catalog mirrors that: `action` is a flat
+  // `enum` of every variant literal, and every action's fields are merged
+  // into the one `properties` map (all optional — runtime
+  // `parseActionArgsOrFail` is the strict per-action gate). The assertions
+  // below pin the new flat contract AND that every action-specific field is
+  // still reachable for cross-platform tool discovery.
+  it("browser_eval inputSchema is a FLAT object with the action enum (js/dom/appState), no top-level oneOf", () => {
     const entry = STUB_TOOL_CATALOG.find((e) => e.name === "browser_eval");
     expect(entry).toBeDefined();
-    const schema = entry!.inputSchema as { oneOf?: Array<{ properties?: Record<string, { const?: string }> }> };
-    expect(schema.oneOf).toBeDefined();
-    expect(schema.oneOf!.length).toBe(3);
-    const actions = schema.oneOf!.map((v) => v.properties?.action?.const).sort();
-    expect(actions).toEqual(["appState", "dom", "js"]);
+    const schema = entry!.inputSchema as {
+      oneOf?: unknown;
+      properties?: Record<string, { enum?: string[] }>;
+    };
+    expect(schema.oneOf, "Phase 2a: no top-level oneOf").toBeUndefined();
+    expect(schema.properties?.action?.enum?.slice().sort()).toEqual(["appState", "dom", "js"]);
   });
 
-  it("browser_eval js variant exposes the expression field", () => {
+  it("browser_eval flat schema exposes every action's fields (js: expression / dom: selector,maxLength / appState: selectors,maxBytes)", () => {
     const entry = STUB_TOOL_CATALOG.find((e) => e.name === "browser_eval");
-    const schema = entry!.inputSchema as {
-      oneOf: Array<{ properties: Record<string, unknown>; required?: string[] }>;
-    };
-    const jsVariant = schema.oneOf.find(
-      (v) => (v.properties.action as { const?: string })?.const === "js",
-    );
-    expect(jsVariant).toBeDefined();
-    expect(jsVariant!.properties.expression).toBeDefined();
-    expect(jsVariant!.required).toContain("expression");
-  });
-
-  it("browser_eval dom variant exposes selector and maxLength fields", () => {
-    const entry = STUB_TOOL_CATALOG.find((e) => e.name === "browser_eval");
-    const schema = entry!.inputSchema as {
-      oneOf: Array<{ properties: Record<string, unknown> }>;
-    };
-    const domVariant = schema.oneOf.find(
-      (v) => (v.properties.action as { const?: string })?.const === "dom",
-    );
-    expect(domVariant).toBeDefined();
-    expect(domVariant!.properties.selector).toBeDefined();
-    expect(domVariant!.properties.maxLength).toBeDefined();
-  });
-
-  it("browser_eval appState variant exposes selectors and maxBytes fields", () => {
-    const entry = STUB_TOOL_CATALOG.find((e) => e.name === "browser_eval");
-    const schema = entry!.inputSchema as {
-      oneOf: Array<{ properties: Record<string, unknown> }>;
-    };
-    const appStateVariant = schema.oneOf.find(
-      (v) => (v.properties.action as { const?: string })?.const === "appState",
-    );
-    expect(appStateVariant).toBeDefined();
-    expect(appStateVariant!.properties.selectors).toBeDefined();
-    expect(appStateVariant!.properties.maxBytes).toBeDefined();
+    const props = (entry!.inputSchema as { properties?: Record<string, unknown> }).properties ?? {};
+    // js
+    expect(props.expression).toBeDefined();
+    // dom
+    expect(props.selector).toBeDefined();
+    expect(props.maxLength).toBeDefined();
+    // appState
+    expect(props.selectors).toBeDefined();
+    expect(props.maxBytes).toBeDefined();
   });
 
   // Cover all six dispatchers (Phase 2 carry-over plus Phase 3 browser_eval).
@@ -308,19 +289,20 @@ describe("Phase 3 — stub-tool-catalog drops absorbed/privatized 4 names", () =
     ["terminal", ["read", "run", "send"]],
     ["browser_eval", ["appState", "dom", "js"]],
   ])(
-    "%s dispatcher has oneOf with action const values: %p",
+    "%s dispatcher is a flat object with an `action` enum: %p (ADR-018 Phase 2a)",
     (toolName, expectedActions) => {
       const entry = STUB_TOOL_CATALOG.find((e) => e.name === toolName);
       expect(entry, `${toolName} catalog entry`).toBeDefined();
       const schema = entry!.inputSchema as {
-        oneOf?: Array<{ properties?: Record<string, { const?: string }> }>;
+        oneOf?: unknown;
+        properties?: Record<string, { enum?: string[] }>;
       };
-      expect(schema.oneOf, `${toolName} should use oneOf, not opaque stub`).toBeDefined();
-      const actions = schema
-        .oneOf!.map((v) => v.properties?.action?.const)
+      expect(schema.oneOf, `${toolName}: Phase 2a uses a flat object, no top-level oneOf`).toBeUndefined();
+      const actions = (schema.properties?.action?.enum ?? [])
         .filter((a): a is string => typeof a === "string")
+        .slice()
         .sort();
-      expect(actions).toEqual(expectedActions);
+      expect(actions, `${toolName}.action enum`).toEqual(expectedActions);
     },
   );
 });


### PR DESCRIPTION
## Summary
ADR-018 Phase 2a per `docs/adr-018-phase-2a-subplan.md`. Fixes the MCP `tools/list` empty-`properties` bug for **7 tools** (`scroll` / `keyboard` / `excel` / `browser_eval` / `window_dock` / `terminal` / `clipboard`) — all registered a top-level `z.discriminatedUnion`, which the SDK's `normalizeObjectSchema` returns `undefined` for, so `tools/list` emitted `inputSchema: { type:'object', properties:{} }`.

- **`flattenUnionToObjectSchema(unionWithInclude)`** (`_envelope.ts`) → a flat `z.object` WIRE schema (discriminator → required `z.enum`; every other field optional; `include` carried through; collisions widened — all-enum → one `z.enum` of the value union, mixed-type → `z.union` → property-level `anyOf`). The SDK recognizes a flat object → emits real `properties`. Top-level `oneOf` is **not** used — the Anthropic API rejects it (HTTP 400).
- **`parseActionArgsOrFail(unionWithInclude, args, toolName)`** (`_envelope.ts`) → the strict per-action gate the flat wire schema drops. Re-parses against the `withEnvelopeIncludeForUnion`-injected union (carries every `.refine()`/`z.literal()` **and** `include` — the bare union would strip `include`). Returns `{ ok:true,value } | { ok:false,result }`; failure built via `failArgs` (`code:"InvalidArgs"`); never throws.
- All 7 tools: `registerTool` `inputSchema` → `flattenUnionToObjectSchema(...)`; each `*DispatchHandler` calls `parseActionArgsOrFail` as its first statement. Bare `z.discriminatedUnion` definitions unchanged. `macro.ts` needs no edit (references `*RegistrationSchema` by name → now flat; `run_macro` shares the same wrapped `*DispatchHandler`).
- Tests: `flatten-union-schema.test.ts` (12 — collision classes, looser-than-union, typed-error rejection, `include` preservation) + `tools-list-schema.test.ts` (server-wide: no empty `properties`, no top-level `oneOf`; 7 flattened tools expose `action` enum).

## Test plan
- [ ] Opus review — verify the wire-schema/strict-gate split, the `unionWithInclude` reuse, per-tool wiring, no scope creep
- [ ] Codex review — schema/API-contract axis
- tsc clean; new tests 12/12 + 4/4; full vitest 3264 pass — 4 failures are pre-existing/flaky (replay-backend + process-tree pass on isolated re-run; foreground-flash-verification fails identically without these changes, stash-confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)