### PR TITLE
feat(adr-018-phase-3): Tier 2 CDP wheel dispatch + smart-scroll body fix + #294 envelope normalisation

### DIFF
--- a/src/engine/cdp-bridge.ts
+++ b/src/engine/cdp-bridge.ts
@@ -303,6 +303,88 @@ export async function evaluateInTab(
   return raw.result.value;
 }
 
+// ─── ADR-018 Phase 3 — Tier 2 wheel dispatch + observation ────────────────────
+
+/**
+ * ADR-018 §2.1 D1 — Tier 2 dispatch. Synthesize a `mouseWheel` event in the
+ * target tab via CDP `Input.dispatchMouseEvent`. Coordinates are viewport-
+ * relative CSS px; viewport center is a reasonable default for tab-routed
+ * wheels because the *tab* is the destination — per-element coords matter
+ * only for nested scrollers, which Phase 3 does NOT yet target (ADR §7 OQ6
+ * carry-over).
+ *
+ * `deltaX` / `deltaY` follow the CSS/UIA positive-down convention (down/right
+ * positive) — matching `WheelParams.notch` in `_input-pipeline.ts`. The Win32
+ * `WM_MOUSEWHEEL` sign convention is the opposite; only Phase 4 PostMessage
+ * has to flip.
+ */
+export async function dispatchWheelInTab(
+  deltaX: number,
+  deltaY: number,
+  x: number,
+  y: number,
+  tabId: string | null = null,
+  port = DEFAULT_CDP_PORT,
+): Promise<void> {
+  const tab = await resolveTab(tabId, port);
+  const session = await openSession(tab, port);
+  await session.send("Input.dispatchMouseEvent", {
+    type: "mouseWheel",
+    x,
+    y,
+    deltaX,
+    deltaY,
+  });
+}
+
+/**
+ * ADR-018 §2.2 — Tier 2 observation. Reads the document scrolling element's
+ * scroll position. Uses the `document.scrollingElement || document.documentElement`
+ * two-step query to avoid the `<body>` quirk that Phase 3 also fixes in
+ * `smart-scroll.ts` (ADR §5 R3).
+ *
+ * Returns `null` on any failure (no tab, no session, JS exception, evaluation
+ * timeout) so callers can downgrade to `target_unreachable` cleanly.
+ */
+export async function readScrollPositionInTab(
+  tabId: string | null = null,
+  port = DEFAULT_CDP_PORT,
+): Promise<{
+  scrollTop: number;
+  scrollLeft: number;
+  scrollHeight: number;
+  scrollWidth: number;
+  clientHeight: number;
+  clientWidth: number;
+} | null> {
+  const expr = `
+(function() {
+  const el = document.scrollingElement || document.documentElement;
+  if (!el) return null;
+  return {
+    scrollTop: el.scrollTop,
+    scrollLeft: el.scrollLeft,
+    scrollHeight: el.scrollHeight,
+    scrollWidth: el.scrollWidth,
+    clientHeight: el.clientHeight,
+    clientWidth: el.clientWidth,
+  };
+})()`;
+  try {
+    const result = (await evaluateInTab(expr, tabId, port)) as {
+      scrollTop: number;
+      scrollLeft: number;
+      scrollHeight: number;
+      scrollWidth: number;
+      clientHeight: number;
+      clientWidth: number;
+    } | null;
+    return result;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Get screen coordinates of a DOM element identified by a CSS selector.
  * Coordinates are in physical pixels, compatible with mouse_click.

--- a/src/tools/_input-pipeline.ts
+++ b/src/tools/_input-pipeline.ts
@@ -32,6 +32,31 @@ import {
 } from "./_resolve-window.js";
 import { enumWindowsInZOrder } from "../engine/win32.js";
 import { nativeUia } from "../engine/native-engine.js";
+import {
+  listTabsLight,
+  dispatchWheelInTab,
+  readScrollPositionInTab,
+} from "../engine/cdp-bridge.js";
+import { getCdpPort } from "../utils/desktop-config.js";
+
+/**
+ * Window class prefix that identifies a Chromium-based top-level window
+ * (Chrome, Edge, and Electron apps that use the upstream Chromium chrome).
+ * Phase 3 uses this as the *gate* for CDP probing — only `Chrome_WidgetWin_*`
+ * HWNDs cost a `listTabsLight` HTTP round-trip in `resolveCdpDestinationForHwnd`,
+ * so non-browser windows pay zero CDP latency. (ADR §7 OQ3 carry-over: Tier 1
+ * UIA inside Chromium is opt-in and not in Phase 3 scope.)
+ */
+const CHROMIUM_CLASS_PREFIX = "Chrome_WidgetWin";
+
+/**
+ * Minimum pixel delta required to classify a CDP scroll as `delivered_via_cdp`.
+ * 1px is the smallest observable scroll in CSS px; below that, browser pixel
+ * snapping or sub-pixel rounding can produce noise on a no-op wheel. (ADR §2.6.2
+ * — Tier 2 boundary signal: pre/post `scrollingElement.scrollTop` differ by
+ * at least this many px.)
+ */
+const CDP_SCROLL_DELIVERY_EPSILON_PX = 1;
 
 // ─── Public types ────────────────────────────────────────────────────────────
 
@@ -84,6 +109,18 @@ export type Channel = "uia" | "cdp" | "postmessage" | "send_input";
 export interface WheelParams {
   direction: "up" | "down" | "left" | "right";
   notch: number;
+  /**
+   * Optional viewport-relative CSS px coordinates for Tier 2 CDP dispatch.
+   * CDP `Input.dispatchMouseEvent({type:'mouseWheel'})` requires `(x,y)` but
+   * routes the wheel to the tab (not the point) — so for Phase 3 these are
+   * a hint only; viewport center is used when omitted. Tier 1 (UIA) and
+   * Tier 4 (legacy SendInput) ignore both fields.
+   *
+   * Phase 3 / ADR §7 OQ6 carry-over: per-element CDP coords land in a future
+   * phase (e.g. `scroll(action='to_element', selector=...)` Tier 2 path).
+   */
+  x?: number;
+  y?: number;
 }
 
 /**
@@ -95,14 +132,13 @@ export interface DispatchOutcome {
   scrolled: boolean;
   channel: Channel;
   /**
-   * ADR §2.6.2 reason value. Phase 1b emits only `'delivered_via_uia'`; the
-   * remaining 4 of the 5-value ADR §2.6.2 enum (`delivered_via_cdp` /
-   * `delivered_via_postmessage` / `wheel_overlay_intercepted` /
-   * `target_unreachable`) are emitted by later phases. `null` indicates no
-   * ADR-018 reason applies (caller picks the legacy `evaluateScrollDelivery`
-   * reason from `mouse.ts`).
+   * ADR §2.6.2 reason value. Phase 1b emits `'delivered_via_uia'`, Phase 3
+   * adds `'delivered_via_cdp'`; `'delivered_via_postmessage'` /
+   * `'wheel_overlay_intercepted'` / `'target_unreachable'` arrive in later
+   * phases. `null` indicates no ADR-018 reason applies (caller picks the
+   * legacy `evaluateScrollDelivery` reason from `mouse.ts`).
    */
-  reason: "delivered_via_uia" | null;
+  reason: "delivered_via_uia" | "delivered_via_cdp" | null;
 }
 
 // ─── Resolver ────────────────────────────────────────────────────────────────
@@ -149,6 +185,14 @@ export async function resolveInputDestination(params: {
     windowTitle: params.windowTitle,
   });
   if (resolved !== null) {
+    // ADR §2.1 D1 Tier 2 — promote Chromium HWNDs to a CDP destination when
+    // a CDP session is reachable. This is the auto-detect the ADR specifies
+    // ("Tier 2: Target is a Chrome/Edge tab (CDP attached via browser_open)")
+    // — callers do NOT pass a tabId; the resolver gates by window class and
+    // probes only when the gate matches, so non-browser windows pay no CDP
+    // latency.
+    const cdp = await resolveCdpDestinationForHwnd(resolved.hwnd);
+    if (cdp !== null) return cdp;
     return { kind: "hwnd", hwnd: resolved.hwnd };
   }
   // Case 3 recovery (see docstring): `resolveWindowTarget` returns null for a
@@ -179,6 +223,11 @@ export async function resolveInputDestination(params: {
           w.ownerHwnd == null,
       );
       if (match) {
+        // Case 3 recovery also gets the CDP Tier 2 promotion — otherwise a
+        // plain-windowTitle scroll on Chrome (where resolveWindowTarget returns
+        // null by Case 3 design) would never see channel='cdp'.
+        const cdp = await resolveCdpDestinationForHwnd(match.hwnd);
+        if (cdp !== null) return cdp;
         return { kind: "hwnd", hwnd: match.hwnd };
       }
     } catch {
@@ -186,6 +235,47 @@ export async function resolveInputDestination(params: {
     }
   }
   return { kind: "unresolved", reason: "no_target_window" };
+}
+
+/**
+ * ADR §2.1 D1 Tier 2 — auto-promote a Chromium HWND to a CDP destination when
+ * a CDP session is reachable on the configured port. Returns `null` when the
+ * gate fails (non-Chromium class) OR when the CDP probe fails (browser not
+ * running with `--remote-debugging-port`, no tabs, network error) — caller
+ * then falls back to `{kind:'hwnd'}` and tries Tier 1 UIA.
+ *
+ * The window-class gate is cheap (already-enumerated `className`); only the
+ * gate match incurs a `listTabsLight` HTTP round-trip, so non-browser windows
+ * pay no CDP latency.
+ *
+ * Phase 3 picks the first listed tab as the destination — matching
+ * `resolveTab(null, port)` semantics in `cdp-bridge.ts`. A future phase may
+ * thread a focused-tab hint via the foreground HWND → tab mapping.
+ *
+ * Exported for unit testing.
+ */
+export async function resolveCdpDestinationForHwnd(
+  hwnd: bigint,
+): Promise<{ kind: "cdp"; tabId: string } | null> {
+  let className: string | null = null;
+  try {
+    const win = enumWindowsInZOrder().find((w) => w.hwnd === hwnd);
+    className = win?.className ?? null;
+  } catch {
+    return null;
+  }
+  if (className === null || !className.startsWith(CHROMIUM_CLASS_PREFIX)) {
+    return null;
+  }
+  try {
+    const port = getCdpPort();
+    const tabs = await listTabsLight(port);
+    const firstPage = tabs[0];
+    if (!firstPage) return null;
+    return { kind: "cdp", tabId: firstPage.id };
+  } catch {
+    return null;
+  }
 }
 
 // ─── Runtime guard (ADR §4 Phase 1 deliverable) ──────────────────────────────
@@ -293,7 +383,57 @@ export async function dispatchScrollWheel(
       return null;
     }
   }
-  // cdp / unresolved → caller handles (Phase 1b: SendInput fall-through)
+  if (dest.kind === "cdp") {
+    // ADR-018 Phase 3 — Tier 2 CDP wheel dispatch. Pre/post observation via
+    // `readScrollPositionInTab` (document.scrollingElement); we declare
+    // `delivered_via_cdp` only when both endpoints succeed AND scrollTop /
+    // scrollLeft moved by at least CDP_SCROLL_DELIVERY_EPSILON_PX on the
+    // axis of interest. Any failure (no session, JS exception, no observable
+    // delta) returns null — caller emits `target_unreachable` per §2.6.2
+    // path-(b) because Tier 4 SendInput must not be reached for a resolved
+    // CDP destination (assertTier4Reachable throws on kind:'cdp').
+    try {
+      const port = getCdpPort();
+      const pre = await readScrollPositionInTab(dest.tabId, port);
+      if (pre === null) return null;
+      const wheelDelta = wheelDeltaForNotch(params);
+      // CDP dispatchMouseEvent requires viewport coordinates. Phase 3 sends
+      // wheels at the viewport center; per-element coords (ADR §7 OQ6) are a
+      // future phase. The tab is the destination, not the point.
+      const cx = params.x ?? Math.floor(pre.clientWidth / 2);
+      const cy = params.y ?? Math.floor(pre.clientHeight / 2);
+      await dispatchWheelInTab(
+        wheelDelta.x,
+        wheelDelta.y,
+        cx,
+        cy,
+        dest.tabId,
+        port,
+      );
+      // Settle: CDP wheel handling is synchronous on the renderer side but
+      // scrollTop reflects the layout-flushed value. A tiny yield is enough
+      // to land on the post-frame state without burning latency.
+      await new Promise((r) => setTimeout(r, 16));
+      const post = await readScrollPositionInTab(dest.tabId, port);
+      if (post === null) return null;
+      const axisIsVertical =
+        params.direction === "up" || params.direction === "down";
+      const observedDelta = axisIsVertical
+        ? Math.abs(post.scrollTop - pre.scrollTop)
+        : Math.abs(post.scrollLeft - pre.scrollLeft);
+      if (observedDelta < CDP_SCROLL_DELIVERY_EPSILON_PX) {
+        return null;
+      }
+      return {
+        scrolled: true,
+        channel: "cdp",
+        reason: "delivered_via_cdp",
+      };
+    } catch {
+      return null;
+    }
+  }
+  // unresolved → caller handles (Tier 4 SendInput fall-through)
   return null;
 }
 

--- a/src/tools/_input-pipeline.ts
+++ b/src/tools/_input-pipeline.ts
@@ -40,14 +40,33 @@ import {
 import { getCdpPort } from "../utils/desktop-config.js";
 
 /**
- * Window class prefix that identifies a Chromium-based top-level window
- * (Chrome, Edge, and Electron apps that use the upstream Chromium chrome).
- * Phase 3 uses this as the *gate* for CDP probing — only `Chrome_WidgetWin_*`
- * HWNDs cost a `listTabsLight` HTTP round-trip in `resolveCdpDestinationForHwnd`,
- * so non-browser windows pay zero CDP latency. (ADR §7 OQ3 carry-over: Tier 1
- * UIA inside Chromium is opt-in and not in Phase 3 scope.)
+ * Win32 class name of a Chrome / Edge **top-level** window. Used as the gate
+ * for CDP probing — only this exact class triggers a `listTabsLight` HTTP
+ * round-trip in `resolveCdpDestinationForHwnd`. The earlier `startsWith
+ * "Chrome_WidgetWin"` shape over-matched `Chrome_WidgetWin_0` (Chromium
+ * **sub-windows** — popup menus, dropdowns) which can never be a scroll
+ * destination, so the gate is now an equality on the top-level class only.
+ *
+ * **Known carry-over (Electron / multi-Chromium-app desktops)**: Chrome /
+ * Edge / Slack / VS Code / Discord / Teams all use the same class name for
+ * their top-level windows because they share the Chromium frame. When the
+ * user has Chrome running with `--remote-debugging-port=9222` AND scrolls a
+ * different Chromium-shell app (Slack, VS Code), the gate matches and the
+ * `listTabsLight` probe succeeds — the wheel then mis-routes to Chrome.
+ * Phase 3 accepts this risk because:
+ *   1. Other Chromium-shell apps rarely run with a public CDP port (they
+ *      don't expose `--remote-debugging-port` by default).
+ *   2. When they do, the user has opted into CDP control and the
+ *      destination ambiguity is theirs to manage (e.g. distinct ports).
+ *   3. Phase 5 will tighten by cross-checking the HWND's PID against the
+ *      `Target.getTargets()` window-owner PID via CDP — out of scope for
+ *      Phase 3 to avoid scope creep. ADR §7 OQ3 / OQ6 carry-over.
+ *
+ * Future: if Edge's top-level class diverges in a Windows update, extend
+ * this to a `new Set([...])` lookup. As of 2026-05 both Chrome and Edge
+ * stable channels emit `Chrome_WidgetWin_1`.
  */
-const CHROMIUM_CLASS_PREFIX = "Chrome_WidgetWin";
+const CHROMIUM_TOP_LEVEL_CLASS = "Chrome_WidgetWin_1";
 
 /**
  * Minimum pixel delta required to classify a CDP scroll as `delivered_via_cdp`.
@@ -185,13 +204,16 @@ export async function resolveInputDestination(params: {
     windowTitle: params.windowTitle,
   });
   if (resolved !== null) {
-    // ADR §2.1 D1 Tier 2 — promote Chromium HWNDs to a CDP destination when
-    // a CDP session is reachable. This is the auto-detect the ADR specifies
-    // ("Tier 2: Target is a Chrome/Edge tab (CDP attached via browser_open)")
-    // — callers do NOT pass a tabId; the resolver gates by window class and
-    // probes only when the gate matches, so non-browser windows pay no CDP
-    // latency.
-    const cdp = await resolveCdpDestinationForHwnd(resolved.hwnd);
+    // ADR §2.1 D1 Tier 2 — promote Chrome/Edge top-level HWNDs to a CDP
+    // destination when a CDP session is reachable. This is the auto-detect the
+    // ADR specifies ("Tier 2: Target is a Chrome/Edge tab (CDP attached via
+    // browser_open)") — callers do NOT pass a tabId; the resolver gates by
+    // window class and probes only when the gate matches, so non-browser
+    // windows pay no CDP latency. The class name is already known to
+    // `resolveWindowTarget` (filled in via `safeGetClassName` on the resolved
+    // HWND) so the gate does not require a second `enumWindowsInZOrder`
+    // syscall — pass it through directly.
+    const cdp = await resolveCdpDestinationForHwnd(resolved.hwnd, resolved.className ?? null);
     if (cdp !== null) return cdp;
     return { kind: "hwnd", hwnd: resolved.hwnd };
   }
@@ -225,8 +247,10 @@ export async function resolveInputDestination(params: {
       if (match) {
         // Case 3 recovery also gets the CDP Tier 2 promotion — otherwise a
         // plain-windowTitle scroll on Chrome (where resolveWindowTarget returns
-        // null by Case 3 design) would never see channel='cdp'.
-        const cdp = await resolveCdpDestinationForHwnd(match.hwnd);
+        // null by Case 3 design) would never see channel='cdp'. The class name
+        // is already on the `match` record (`enumWindowsInZOrder` returns it),
+        // so the gate inside `resolveCdpDestinationForHwnd` does not re-enumerate.
+        const cdp = await resolveCdpDestinationForHwnd(match.hwnd, match.className ?? null);
         if (cdp !== null) return cdp;
         return { kind: "hwnd", hwnd: match.hwnd };
       }
@@ -238,33 +262,31 @@ export async function resolveInputDestination(params: {
 }
 
 /**
- * ADR §2.1 D1 Tier 2 — auto-promote a Chromium HWND to a CDP destination when
- * a CDP session is reachable on the configured port. Returns `null` when the
- * gate fails (non-Chromium class) OR when the CDP probe fails (browser not
- * running with `--remote-debugging-port`, no tabs, network error) — caller
- * then falls back to `{kind:'hwnd'}` and tries Tier 1 UIA.
+ * ADR §2.1 D1 Tier 2 — auto-promote a Chrome/Edge HWND to a CDP destination
+ * when a CDP session is reachable on the configured port. Returns `null` when
+ * the gate fails (non-Chromium-top-level class) OR when the CDP probe fails
+ * (browser not running with `--remote-debugging-port`, no tabs, network error)
+ * — caller then falls back to `{kind:'hwnd'}` and tries Tier 1 UIA.
  *
- * The window-class gate is cheap (already-enumerated `className`); only the
- * gate match incurs a `listTabsLight` HTTP round-trip, so non-browser windows
- * pay no CDP latency.
+ * **The class name is passed in by the caller** (already known from
+ * `ResolvedWindow.className` or `enumWindowsInZOrder()`'s record) so this
+ * function does NOT re-enumerate windows. Total syscall budget per call is
+ * **zero on the gate-miss path** and **one HTTP round-trip** on the gate-hit
+ * path. (Opus Round 1 P2 — earlier shape redundantly called
+ * `enumWindowsInZOrder` here, doubling the syscall cost per scroll.)
  *
  * Phase 3 picks the first listed tab as the destination — matching
  * `resolveTab(null, port)` semantics in `cdp-bridge.ts`. A future phase may
- * thread a focused-tab hint via the foreground HWND → tab mapping.
+ * thread a focused-tab hint via the foreground HWND → tab mapping (ADR §7
+ * OQ-Electron carry-over).
  *
  * Exported for unit testing.
  */
 export async function resolveCdpDestinationForHwnd(
-  hwnd: bigint,
+  _hwnd: bigint,
+  className: string | null,
 ): Promise<{ kind: "cdp"; tabId: string } | null> {
-  let className: string | null = null;
-  try {
-    const win = enumWindowsInZOrder().find((w) => w.hwnd === hwnd);
-    className = win?.className ?? null;
-  } catch {
-    return null;
-  }
-  if (className === null || !className.startsWith(CHROMIUM_CLASS_PREFIX)) {
+  if (className !== CHROMIUM_TOP_LEVEL_CLASS) {
     return null;
   }
   try {

--- a/src/tools/_resolve-window.ts
+++ b/src/tools/_resolve-window.ts
@@ -30,6 +30,20 @@ export const DIALOG_CLASSNAMES = new Set(["#32770"]);
 interface DialogCandidate { hwnd: bigint; title: string; }
 
 /**
+ * `getWindowClassName` wrapped in a try/catch so a momentary race
+ * (window destroyed between resolution and class read) degrades to `null`
+ * rather than throwing out of `resolveWindowTarget`.
+ */
+function safeGetClassName(hwnd: bigint): string | null {
+  try {
+    const cls = getWindowClassName(hwnd);
+    return cls === "" ? null : cls;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * (H3 case 4) Search for a common dialog window whose title partially matches `query`.
  * Prioritises #32770-classed windows, then owned popups.
  * Only considers non-minimised windows (minimised dialogs can't be interacted with).
@@ -80,6 +94,17 @@ export interface ResolvedWindow {
   title: string;
   hwnd: bigint;
   warnings: string[];
+  /**
+   * Win32 window class name. `null` when `GetClassNameW` fails on the
+   * resolved HWND (rare — typically race with window destruction); `undefined`
+   * tolerated for back-compat with the pre-Phase-3 shape (existing test mocks
+   * omit this field — production code always populates it). Carried through
+   * so callers that need to gate on class (ADR-018 Phase 3 CDP promotion:
+   * `Chrome_WidgetWin_1` only) do not have to re-call `enumWindowsInZOrder`
+   * / `getWindowClassName` themselves. Cheap to populate — one
+   * `GetClassNameW` syscall per resolution.
+   */
+  className?: string | null;
 }
 
 /** Value of DESKTOP_TOUCH_DOCK_TITLE env (resolved literal, not "@parent"). */
@@ -132,7 +157,7 @@ export async function resolveWindowTarget(params: {
     if (dockLiteral && title.toLowerCase().includes(dockLiteral.toLowerCase())) {
       warnings.push("HwndMatchesDockWindow: targeting the CLI host window — intended?");
     }
-    return { title, hwnd: hwndb, warnings };
+    return { title, hwnd: hwndb, warnings, className: safeGetClassName(hwndb) };
   }
 
   // ── Case 2: @active shorthand ─────────────────────────────────────────────
@@ -150,7 +175,7 @@ export async function resolveWindowTarget(params: {
         "Specify windowTitle explicitly if this is unintentional."
       );
     }
-    return { title, hwnd: hwndb, warnings };
+    return { title, hwnd: hwndb, warnings, className: safeGetClassName(hwndb) };
   }
 
   // ── Case 3 / 4: plain windowTitle ────────────────────────────────────────
@@ -172,7 +197,12 @@ export async function resolveWindowTarget(params: {
       const dialog = findCommonDialogByTitle(wins, params.windowTitle);
       if (dialog) {
         warnings.push("dialog_resolved_via_owner_chain");
-        return { title: dialog.title, hwnd: dialog.hwnd, warnings };
+        return {
+          title: dialog.title,
+          hwnd: dialog.hwnd,
+          warnings,
+          className: safeGetClassName(dialog.hwnd),
+        };
       }
     } catch { /* enumWindowsInZOrder unavailable → fall through */ }
   }

--- a/src/tools/mouse.ts
+++ b/src/tools/mouse.ts
@@ -1240,13 +1240,22 @@ export const scrollHandler = async ({
     // SendInput path retains 'wheel_send_input' for back-compat — the Phase 4
     // §2.6.3 migration renames it → 'send_input'.
     //
-    // Phase 3 narrowing: the dispatcher only emits 'uia' or 'cdp' on a
-    // successful tier outcome (Tier 3 'postmessage' lands in Phase 4) so the
-    // cast below is total over the current dispatch surface.
-    const effectiveChannel: "uia" | "cdp" | "wheel_send_input" =
-      tier1 !== null && tier1.scrolled
-        ? (tier1.channel as "uia" | "cdp")
-        : "wheel_send_input";
+    // **Explicit narrowing**, not an `as` cast: `tier1.channel` carries the
+    // broad `Channel` union ("uia" | "cdp" | "postmessage" | "send_input"),
+    // and casting to the narrow union would silently leak the wrong channel
+    // into `verifyDelivery` the moment Phase 4 starts emitting
+    // `channel:'postmessage'`. The if-chain below forces Phase 4 to extend
+    // both the local type and this branch deliberately — otherwise a
+    // PostMessage-tier success degrades to `wheel_send_input`, loud enough to
+    // spot on the first failing dogfood scroll. (Opus Round 1 P2.)
+    let effectiveChannel: "uia" | "cdp" | "wheel_send_input" = "wheel_send_input";
+    if (tier1 !== null && tier1.scrolled) {
+      if (tier1.channel === "uia" || tier1.channel === "cdp") {
+        effectiveChannel = tier1.channel;
+      }
+      // else: a future tier (postmessage / send_input). Extend the local
+      // union and add the case when Phase 4+ wires those channels here.
+    }
 
     if (outcome.status === "not_delivered") {
       // Silent drop: pre off-boundary, post unchanged. ScrollNotDelivered with

--- a/src/tools/mouse.ts
+++ b/src/tools/mouse.ts
@@ -1072,6 +1072,37 @@ export function evaluateScrollDelivery(
   };
 }
 
+/**
+ * @internal Exported for unit testing of the Phase 3 issue-#294 envelope
+ * normalisation. Collapses the internal `ScrollVerifyOutcome.delta` into the
+ * shape advertised at `hints.scrollObserved.delta` on the public scroll
+ * response.
+ *
+ * Collapse rules:
+ *   - `'unverifiable'` string → unchanged
+ *   - both axes null         → `'unverifiable'` (issue #294 — silent-drop
+ *     ambiguity: the old shape `{x:null, y:null}` read as "observation
+ *     exhausted" indistinguishably from the dedicated string, doubling the
+ *     LLM-facing signal)
+ *   - any other shape        → preserved as-is
+ *
+ * Single-axis-null (e.g. `{x:null, y:0.15}` from a vertical-only window) is
+ * intentionally preserved: that null carries real signal ("this axis has no
+ * scrollbar / no observation channel"), not the silent-drop ambiguity #294
+ * reports.
+ */
+export function collapseScrollObserved(
+  outcome: Pick<ScrollVerifyOutcome, "delta">,
+): { delta: { x: number | null; y: number | null } | "unverifiable" } {
+  if (outcome.delta === "unverifiable") {
+    return { delta: "unverifiable" };
+  }
+  if (outcome.delta.x === null && outcome.delta.y === null) {
+    return { delta: "unverifiable" };
+  }
+  return { delta: { x: outcome.delta.x, y: outcome.delta.y } };
+}
+
 export const scrollHandler = async ({
   direction, amount, x, y, speed, homing, windowTitle, hwnd,
 }: {
@@ -1137,6 +1168,29 @@ export const scrollHandler = async ({
     const tier1 = await dispatchScrollWheel(dest, { direction, notch: amount });
 
     if (tier1 === null) {
+      // ADR-018 Phase 3 — when destination resolved to a CDP tab but Tier 2
+      // dispatch / observation failed, emit `target_unreachable` per §2.6.2
+      // path-(b) instead of falling through to Tier 4 SendInput.
+      // `assertTier4Reachable(dest)` would throw for `kind:'cdp'` anyway —
+      // we surface the typed envelope explicitly so callers see the proper
+      // status / channel / reason rather than catching a thrown guard.
+      if (dest.kind === "cdp") {
+        return failWith(
+          new Error("ScrollNotDelivered"),
+          "scroll",
+          {
+            context: {
+              hint: "CDP wheel dispatch or scroll observation returned no delta — Tier 4 SendInput suppressed for resolved CDP destinations",
+              direction,
+              verifyDelivery: {
+                status: "not_delivered" as const,
+                channel: "cdp" as const,
+                reason: "target_unreachable" as const,
+              },
+            },
+          },
+        );
+      }
       assertTier4Reachable(dest);
       const SCROLL_MULTIPLIER = 3;
       switch (direction) {
@@ -1173,22 +1227,26 @@ export const scrollHandler = async ({
     // is scroll-specific (delta on each axis), verifyDelivery is the cross-tool SSOT
     // shape that other operation tools (#177-#181) also produce. Callers reading
     // either key see consistent answers; integration tests pin both.
-    const scrollObserved = outcome.delta === "unverifiable"
-      ? { delta: "unverifiable" as const }
-      : {
-          delta: {
-            x: outcome.delta.x !== null ? outcome.delta.x : null,
-            y: outcome.delta.y !== null ? outcome.delta.y : null,
-          },
-        };
+    //
+    // Issue #294 fix: collapse the public delta envelope via the
+    // `collapseScrollObserved` helper — see that helper's docstring for the
+    // rules and the rationale (silent-drop ambiguity reported in #294 when
+    // both axes are null).
+    const scrollObserved = collapseScrollObserved(outcome);
 
     // ADR-018 §2.6.1 — channel is the transport identifier (always populated,
-    // including for `status:'not_delivered'`). Phase 1b emits 'uia' when the
-    // dispatcher's Tier 1 path succeeded; legacy path retains the existing
-    // 'wheel_send_input' channel for back-compat. The Phase 4 §2.6.3 migration
-    // renames 'wheel_send_input' → 'send_input'.
-    const effectiveChannel: "uia" | "wheel_send_input" =
-      tier1 !== null && tier1.scrolled ? "uia" : "wheel_send_input";
+    // including for `status:'not_delivered'`). Phase 1b emits 'uia' when Tier 1
+    // succeeded; Phase 3 adds 'cdp' for the Tier 2 CDP dispatch. The legacy
+    // SendInput path retains 'wheel_send_input' for back-compat — the Phase 4
+    // §2.6.3 migration renames it → 'send_input'.
+    //
+    // Phase 3 narrowing: the dispatcher only emits 'uia' or 'cdp' on a
+    // successful tier outcome (Tier 3 'postmessage' lands in Phase 4) so the
+    // cast below is total over the current dispatch surface.
+    const effectiveChannel: "uia" | "cdp" | "wheel_send_input" =
+      tier1 !== null && tier1.scrolled
+        ? (tier1.channel as "uia" | "cdp")
+        : "wheel_send_input";
 
     if (outcome.status === "not_delivered") {
       // Silent drop: pre off-boundary, post unchanged. ScrollNotDelivered with

--- a/src/tools/smart-scroll.ts
+++ b/src/tools/smart-scroll.ts
@@ -162,12 +162,29 @@ async function tryCdp(params: {
         const targetScrollTop = Math.max(0, ancestor.scrollTop + (ancestor.scrollHeight - ancestor.clientHeight) * 0.5);
         await setScrollPositionCdp(ancestor.cssSelectorPath, targetScrollTop, ancestor.scrollLeft, tabId ?? null, port);
       }
-      // Final scrollIntoView
+      // Final scrollIntoView.
+      //
+      // ADR-018 Phase 3 / §5 R3 — `target='body'` / `target='html'` regression
+      // fix: `document.querySelector('body').scrollIntoView({block:'instant'})`
+      // is interpreted by Chromium as "snap viewport to the body's top edge",
+      // which resets `scrollTop` to 0 even when the page was scrolled.
+      // ADR §1.1 symptom 4 reported this as a silent reverse-direction scroll.
+      // Use the two-step `document.scrollingElement || document.documentElement`
+      // query for the document root and skip `scrollIntoView` — the root is in
+      // view by definition; reading its bounding rect is sufficient for the
+      // viewportTop/Bottom response. Non-root selectors keep the existing
+      // `scrollIntoView({behavior:'instant'})` path unchanged.
       const scrollExpr = `
 (function() {
-  const el = document.querySelector(${JSON.stringify(target)});
-  if (!el) return { ok: false, error: 'Element not found' };
-  el.scrollIntoView({ block: ${JSON.stringify(inline)}, inline: 'nearest', behavior: 'instant' });
+  const target = ${JSON.stringify(target)};
+  const isRoot = target === 'body' || target === 'html';
+  const el = isRoot
+    ? (document.scrollingElement || document.documentElement)
+    : document.querySelector(target);
+  if (!el) return { ok: false, error: isRoot ? 'No scrolling element' : 'Element not found' };
+  if (!isRoot) {
+    el.scrollIntoView({ block: ${JSON.stringify(inline)}, inline: 'nearest', behavior: 'instant' });
+  }
   const r = el.getBoundingClientRect();
   return { ok: true, viewportTop: Math.round(r.top), viewportBottom: Math.round(r.bottom) };
 })()`;

--- a/tests/integration/scroll-5app.smoke.test.ts
+++ b/tests/integration/scroll-5app.smoke.test.ts
@@ -1,0 +1,53 @@
+/**
+ * scroll-5app.smoke.test.ts — ADR-018 Phase 5 acceptance harness (Phase 3 stub).
+ *
+ * Phase 3 deliverable per ADR §4: this file exists and pins **one** Chrome
+ * case (Tier 2 CDP path) behind the `SCROLL_SMOKE=1` env gate so it does not
+ * fire in regular CI. Phase 5 fills in the 5-app × 4-direction matrix
+ * (Chrome / Notepad / Word / Excel / File Explorer) per ADR AC1.
+ *
+ * Manual invocation (Windows runner with Chrome listening on
+ * --remote-debugging-port=9222):
+ *
+ *   SCROLL_SMOKE=1 npx vitest run tests/integration/scroll-5app.smoke.test.ts
+ *
+ * The Chrome assertion below imports the dispatch handler indirectly via
+ * `scrollDispatchHandler` so the full envelope assembly is exercised
+ * (`verifyDelivery.channel='cdp'` + `reason='delivered_via_cdp'` + numeric
+ * `scrollObserved.delta`). The Phase 5 follow-up wires up the other 4 apps.
+ */
+
+import { describe, it, expect } from "vitest";
+
+const smokeEnabled = process.env.SCROLL_SMOKE === "1";
+
+describe.skipIf(!smokeEnabled)(
+  "ADR-018 Phase 3 — scroll Tier 2 CDP smoke (Chrome, SCROLL_SMOKE=1)",
+  () => {
+    it("scroll(action='raw', windowTitle:'Chrome', direction:'down') reports channel='cdp' / reason='delivered_via_cdp'", async () => {
+      const { scrollDispatchHandler } = await import("../../src/tools/scroll.js");
+      const result = await scrollDispatchHandler({
+        action: "raw",
+        direction: "down",
+        amount: 3,
+        windowTitle: "Chrome",
+        homing: true,
+      } as Parameters<typeof scrollDispatchHandler>[0]);
+      // The handler returns a ToolResult; envelope hints carry the Phase 3
+      // contract. Parse the first content block JSON to read hints.
+      const text = (result.content[0] as { text: string }).text;
+      const parsed = JSON.parse(text) as {
+        hints?: {
+          verifyDelivery?: { status?: string; channel?: string; reason?: string };
+          scrollObserved?: { delta?: unknown };
+        };
+      };
+      expect(parsed.hints?.verifyDelivery?.channel).toBe("cdp");
+      expect(parsed.hints?.verifyDelivery?.reason).toBe("delivered_via_cdp");
+      // scrollObserved.delta should NOT be the placeholder string in the
+      // delivered case (Tier 2 success → at least one axis observed numerically).
+      // The exact shape is asserted by tests/unit/scroll-raw-verify.test.ts.
+      expect(parsed.hints?.scrollObserved?.delta).toBeDefined();
+    }, 30_000);
+  },
+);

--- a/tests/unit/input-pipeline-dispatch.test.ts
+++ b/tests/unit/input-pipeline-dispatch.test.ts
@@ -49,15 +49,33 @@ vi.mock("../../src/tools/_resolve-window.js", () => ({
 
 // Mock window enumeration — `resolveInputDestination` falls back to
 // `enumWindowsInZOrder` to recover the HWND for a plain-windowTitle Case 3
-// match (resolveWindowTarget returns null in that case by design).
+// match (resolveWindowTarget returns null in that case by design), and Phase 3
+// also consults it for the Chromium-class gate in `resolveCdpDestinationForHwnd`.
 const enumWindowsInZOrderMock = vi.fn();
 vi.mock("../../src/engine/win32.js", () => ({
   enumWindowsInZOrder: enumWindowsInZOrderMock,
 }));
 
+// Phase 3 Tier 2 CDP — mock the cdp-bridge surface used by the dispatcher.
+const listTabsLightMock = vi.fn();
+const dispatchWheelInTabMock = vi.fn();
+const readScrollPositionInTabMock = vi.fn();
+vi.mock("../../src/engine/cdp-bridge.js", () => ({
+  listTabsLight: listTabsLightMock,
+  dispatchWheelInTab: dispatchWheelInTabMock,
+  readScrollPositionInTab: readScrollPositionInTabMock,
+}));
+
+// Mock CDP port lookup — keeps `resolveCdpDestinationForHwnd` deterministic.
+const getCdpPortMock = vi.fn(() => 9222);
+vi.mock("../../src/utils/desktop-config.js", () => ({
+  getCdpPort: getCdpPortMock,
+}));
+
 // Import after mocks are registered.
 const {
   resolveInputDestination,
+  resolveCdpDestinationForHwnd,
   dispatchScrollWheel,
   assertTier4Reachable,
 } = await import("../../src/tools/_input-pipeline.js");
@@ -67,9 +85,17 @@ describe("ADR-018 §2.3 — resolveInputDestination (single SSOT via resolveWind
     resolveWindowTargetMock.mockReset();
     enumWindowsInZOrderMock.mockReset();
     enumWindowsInZOrderMock.mockReturnValue([]);
+    listTabsLightMock.mockReset();
+    dispatchWheelInTabMock.mockReset();
+    readScrollPositionInTabMock.mockReset();
+    getCdpPortMock.mockReturnValue(9222);
   });
 
-  it("returns {kind:'hwnd'} when resolveWindowTarget resolves (no enumeration needed)", async () => {
+  it("returns {kind:'hwnd'} when resolveWindowTarget resolves and the HWND is not Chromium (CDP gate misses, no CDP probe)", async () => {
+    // Phase 3 consults `enumWindowsInZOrder` for the Chromium-class gate. With
+    // the default empty enumeration the gate misses → no CDP promotion → the
+    // resolver returns `{kind:'hwnd'}`. `listTabsLight` is NOT called because
+    // the class gate fails before the HTTP probe.
     resolveWindowTargetMock.mockResolvedValue({
       title: "Test",
       hwnd: 0xABCDn,
@@ -77,7 +103,7 @@ describe("ADR-018 §2.3 — resolveInputDestination (single SSOT via resolveWind
     });
     const dest = await resolveInputDestination({ windowTitle: "Test" });
     expect(dest).toEqual({ kind: "hwnd", hwnd: 0xABCDn });
-    expect(enumWindowsInZOrderMock).not.toHaveBeenCalled();
+    expect(listTabsLightMock).not.toHaveBeenCalled();
   });
 
   it("Case 3 recovery: resolveWindowTarget null + plain windowTitle matches a top-level window → {kind:'hwnd'} via enumWindowsInZOrder (keeps Tier 1 UIA reachable, ADR §4 G1)", async () => {
@@ -268,7 +294,12 @@ describe("ADR-018 §2.6 — dispatchScrollWheel (Tier 1 UIA path)", () => {
     expect(uiaScrollByWheelAtHwndMock).not.toHaveBeenCalled();
   });
 
-  it("kind='cdp' → null (Phase 3 stub, caller falls through)", async () => {
+  it("kind='cdp' → does NOT invoke Tier 1 UIA (handled by Tier 2 CDP branch — see Phase 3 describe block below)", async () => {
+    // Phase 3 implemented the kind:'cdp' branch (Tier 2 CDP). The Phase 1b
+    // expectation "Tier 1 UIA is not invoked for CDP destinations" still
+    // stands; the actual CDP dispatch is exercised in the separate
+    // Phase 3 describe block which mocks `cdp-bridge.js`.
+    readScrollPositionInTabMock.mockResolvedValueOnce(null); // pre-snapshot fails → null
     const result = await dispatchScrollWheel(
       { kind: "cdp", tabId: "abc123" },
       { direction: "down", notch: 1 },
@@ -291,6 +322,230 @@ describe("ADR-018 §2.6 — dispatchScrollWheel (Tier 1 UIA path)", () => {
 
     await dispatchScrollWheel({ kind: "hwnd", hwnd: 1n }, { direction: "left", notch: 2 });
     expect(uiaScrollByWheelAtHwndMock).toHaveBeenLastCalledWith(expect.objectContaining({ wheelDeltaX: -240, wheelDeltaY: 0 }));
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ADR-018 Phase 3 — Tier 2 CDP path + auto-promotion
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("ADR-018 Phase 3 — resolveCdpDestinationForHwnd (Chromium-class gate + listTabsLight probe)", () => {
+  beforeEach(() => {
+    enumWindowsInZOrderMock.mockReset();
+    listTabsLightMock.mockReset();
+    getCdpPortMock.mockReturnValue(9222);
+  });
+
+  it("non-Chromium HWND (className='Notepad'): null (gate misses, listTabsLight NOT called — zero CDP latency for native windows)", async () => {
+    enumWindowsInZOrderMock.mockReturnValue([
+      { hwnd: 0x111n, title: "Untitled - Notepad", className: "Notepad", ownerHwnd: null, isMinimized: false },
+    ]);
+    const dest = await resolveCdpDestinationForHwnd(0x111n);
+    expect(dest).toBeNull();
+    expect(listTabsLightMock).not.toHaveBeenCalled();
+  });
+
+  it("Chromium HWND ('Chrome_WidgetWin_1') + listTabsLight returns tabs: {kind:'cdp', tabId}", async () => {
+    enumWindowsInZOrderMock.mockReturnValue([
+      { hwnd: 0x222n, title: "Google - Chrome", className: "Chrome_WidgetWin_1", ownerHwnd: null, isMinimized: false },
+    ]);
+    listTabsLightMock.mockResolvedValue([
+      { id: "TAB-AAA", title: "Google", url: "https://google.com/" },
+      { id: "TAB-BBB", title: "Bing", url: "https://bing.com/" },
+    ]);
+    const dest = await resolveCdpDestinationForHwnd(0x222n);
+    expect(dest).toEqual({ kind: "cdp", tabId: "TAB-AAA" });
+  });
+
+  it("Chromium HWND + listTabsLight rejects (CDP unreachable): null (graceful fallback to Tier 1)", async () => {
+    enumWindowsInZOrderMock.mockReturnValue([
+      { hwnd: 0x333n, title: "Edge", className: "Chrome_WidgetWin_1", ownerHwnd: null, isMinimized: false },
+    ]);
+    listTabsLightMock.mockRejectedValue(new Error("CDP unreachable on 127.0.0.1:9222"));
+    const dest = await resolveCdpDestinationForHwnd(0x333n);
+    expect(dest).toBeNull();
+  });
+
+  it("Chromium HWND + listTabsLight returns empty array: null", async () => {
+    enumWindowsInZOrderMock.mockReturnValue([
+      { hwnd: 0x444n, title: "Edge", className: "Chrome_WidgetWin_1", ownerHwnd: null, isMinimized: false },
+    ]);
+    listTabsLightMock.mockResolvedValue([]);
+    const dest = await resolveCdpDestinationForHwnd(0x444n);
+    expect(dest).toBeNull();
+  });
+
+  it("HWND not in enumeration: null", async () => {
+    enumWindowsInZOrderMock.mockReturnValue([]);
+    const dest = await resolveCdpDestinationForHwnd(0x555n);
+    expect(dest).toBeNull();
+    expect(listTabsLightMock).not.toHaveBeenCalled();
+  });
+
+  it("enumWindowsInZOrder throws: null (graceful — no exception propagation)", async () => {
+    enumWindowsInZOrderMock.mockImplementation(() => {
+      throw new Error("win32 dlopen failed");
+    });
+    const dest = await resolveCdpDestinationForHwnd(0x666n);
+    expect(dest).toBeNull();
+  });
+});
+
+describe("ADR-018 Phase 3 — resolveInputDestination CDP promotion integration", () => {
+  beforeEach(() => {
+    resolveWindowTargetMock.mockReset();
+    enumWindowsInZOrderMock.mockReset();
+    enumWindowsInZOrderMock.mockReturnValue([]);
+    listTabsLightMock.mockReset();
+    getCdpPortMock.mockReturnValue(9222);
+  });
+
+  it("resolveWindowTarget succeeds + Chromium HWND + CDP reachable: promotes to {kind:'cdp'} (G3 path)", async () => {
+    resolveWindowTargetMock.mockResolvedValue({
+      title: "X - Chrome",
+      hwnd: 0xAAAn,
+      warnings: [],
+    });
+    enumWindowsInZOrderMock.mockReturnValue([
+      { hwnd: 0xAAAn, title: "X - Chrome", className: "Chrome_WidgetWin_1", ownerHwnd: null, isMinimized: false },
+    ]);
+    listTabsLightMock.mockResolvedValue([
+      { id: "TAB-X", title: "X", url: "https://x.com/" },
+    ]);
+    const dest = await resolveInputDestination({ windowTitle: "Chrome" });
+    expect(dest).toEqual({ kind: "cdp", tabId: "TAB-X" });
+  });
+
+  it("Case 3 recovery for Chromium HWND also promotes to {kind:'cdp'} (plain windowTitle on Chrome)", async () => {
+    resolveWindowTargetMock.mockResolvedValue(null);
+    enumWindowsInZOrderMock.mockReturnValue([
+      { hwnd: 0xBBBn, title: "Google Chrome", className: "Chrome_WidgetWin_1", ownerHwnd: null, isMinimized: false },
+    ]);
+    listTabsLightMock.mockResolvedValue([
+      { id: "TAB-Y", title: "X", url: "https://x.com/" },
+    ]);
+    const dest = await resolveInputDestination({ windowTitle: "Chrome" });
+    expect(dest).toEqual({ kind: "cdp", tabId: "TAB-Y" });
+  });
+
+  it("Chromium HWND + CDP unreachable: falls back to {kind:'hwnd'} (Tier 1 UIA path remains available)", async () => {
+    resolveWindowTargetMock.mockResolvedValue({
+      title: "Chrome",
+      hwnd: 0xCCCn,
+      warnings: [],
+    });
+    enumWindowsInZOrderMock.mockReturnValue([
+      { hwnd: 0xCCCn, title: "Chrome", className: "Chrome_WidgetWin_1", ownerHwnd: null, isMinimized: false },
+    ]);
+    listTabsLightMock.mockRejectedValue(new Error("Connection refused"));
+    const dest = await resolveInputDestination({ windowTitle: "Chrome" });
+    expect(dest).toEqual({ kind: "hwnd", hwnd: 0xCCCn });
+  });
+});
+
+describe("ADR-018 Phase 3 — dispatchScrollWheel (Tier 2 CDP path)", () => {
+  beforeEach(() => {
+    listTabsLightMock.mockReset();
+    dispatchWheelInTabMock.mockReset();
+    readScrollPositionInTabMock.mockReset();
+    getCdpPortMock.mockReturnValue(9222);
+  });
+
+  const cdpDest = { kind: "cdp" as const, tabId: "TAB-X" };
+  const snap = (top: number, left: number) => ({
+    scrollTop: top,
+    scrollLeft: left,
+    scrollHeight: 5000,
+    scrollWidth: 1280,
+    clientHeight: 800,
+    clientWidth: 1280,
+  });
+
+  it("vertical down: pre/post scrollTop differs by ≥ epsilon → {channel:'cdp', reason:'delivered_via_cdp'}", async () => {
+    readScrollPositionInTabMock
+      .mockResolvedValueOnce(snap(100, 0))
+      .mockResolvedValueOnce(snap(260, 0));
+    dispatchWheelInTabMock.mockResolvedValue(undefined);
+    const result = await dispatchScrollWheel(cdpDest, { direction: "down", notch: 3 });
+    expect(result).toEqual({
+      scrolled: true,
+      channel: "cdp",
+      reason: "delivered_via_cdp",
+    });
+    // 3 notches × 120 = 360, down direction = positive deltaY.
+    expect(dispatchWheelInTabMock).toHaveBeenCalledWith(
+      0, 360,
+      expect.any(Number), expect.any(Number),
+      "TAB-X", 9222,
+    );
+  });
+
+  it("vertical down: pre/post scrollTop unchanged → null (caller emits target_unreachable)", async () => {
+    readScrollPositionInTabMock
+      .mockResolvedValueOnce(snap(200, 0))
+      .mockResolvedValueOnce(snap(200, 0));
+    dispatchWheelInTabMock.mockResolvedValue(undefined);
+    const result = await dispatchScrollWheel(cdpDest, { direction: "down", notch: 1 });
+    expect(result).toBeNull();
+  });
+
+  it("pre-snapshot returns null (no CDP session): null (no wheel dispatched)", async () => {
+    readScrollPositionInTabMock.mockResolvedValueOnce(null);
+    const result = await dispatchScrollWheel(cdpDest, { direction: "down", notch: 1 });
+    expect(result).toBeNull();
+    expect(dispatchWheelInTabMock).not.toHaveBeenCalled();
+  });
+
+  it("dispatchWheelInTab throws → null (no propagation)", async () => {
+    readScrollPositionInTabMock.mockResolvedValueOnce(snap(0, 0));
+    dispatchWheelInTabMock.mockRejectedValue(new Error("CDP socket closed mid-dispatch"));
+    const result = await dispatchScrollWheel(cdpDest, { direction: "down", notch: 1 });
+    expect(result).toBeNull();
+  });
+
+  it("post-snapshot returns null after dispatch: null", async () => {
+    readScrollPositionInTabMock
+      .mockResolvedValueOnce(snap(0, 0))
+      .mockResolvedValueOnce(null);
+    dispatchWheelInTabMock.mockResolvedValue(undefined);
+    const result = await dispatchScrollWheel(cdpDest, { direction: "down", notch: 1 });
+    expect(result).toBeNull();
+  });
+
+  it("horizontal right: observes scrollLeft (not scrollTop) and dispatches deltaX positive", async () => {
+    readScrollPositionInTabMock
+      .mockResolvedValueOnce(snap(0, 50))
+      .mockResolvedValueOnce(snap(0, 290));
+    dispatchWheelInTabMock.mockResolvedValue(undefined);
+    const result = await dispatchScrollWheel(cdpDest, { direction: "right", notch: 2 });
+    expect(result).toEqual({
+      scrolled: true,
+      channel: "cdp",
+      reason: "delivered_via_cdp",
+    });
+    expect(dispatchWheelInTabMock).toHaveBeenCalledWith(
+      240, 0,
+      expect.any(Number), expect.any(Number),
+      "TAB-X", 9222,
+    );
+  });
+
+  it("vertical up: deltaY negative (UIA-internal sign convention — CDP/CSS positive-down matches)", async () => {
+    readScrollPositionInTabMock
+      .mockResolvedValueOnce(snap(500, 0))
+      .mockResolvedValueOnce(snap(380, 0));
+    dispatchWheelInTabMock.mockResolvedValue(undefined);
+    const result = await dispatchScrollWheel(cdpDest, { direction: "up", notch: 1 });
+    expect(result).toEqual({
+      scrolled: true,
+      channel: "cdp",
+      reason: "delivered_via_cdp",
+    });
+    expect(dispatchWheelInTabMock).toHaveBeenCalledWith(
+      0, -120,
+      expect.any(Number), expect.any(Number),
+      "TAB-X", 9222,
+    );
   });
 });
 

--- a/tests/unit/input-pipeline-dispatch.test.ts
+++ b/tests/unit/input-pipeline-dispatch.test.ts
@@ -329,65 +329,58 @@ describe("ADR-018 §2.6 — dispatchScrollWheel (Tier 1 UIA path)", () => {
 // ADR-018 Phase 3 — Tier 2 CDP path + auto-promotion
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe("ADR-018 Phase 3 — resolveCdpDestinationForHwnd (Chromium-class gate + listTabsLight probe)", () => {
+describe("ADR-018 Phase 3 — resolveCdpDestinationForHwnd (top-level class gate + listTabsLight probe)", () => {
+  // Phase 3 R1 (Opus P2): the gate is now a strict class equality on
+  // `Chrome_WidgetWin_1` (the top-level class shared by Chrome and Edge),
+  // and the className is **passed in by the caller** (already known from
+  // ResolvedWindow.className / enumWindowsInZOrder), so this function does
+  // NOT re-enumerate windows. The mock setup reflects that — no
+  // enumWindowsInZOrderMock for these cases.
   beforeEach(() => {
-    enumWindowsInZOrderMock.mockReset();
     listTabsLightMock.mockReset();
     getCdpPortMock.mockReturnValue(9222);
   });
 
-  it("non-Chromium HWND (className='Notepad'): null (gate misses, listTabsLight NOT called — zero CDP latency for native windows)", async () => {
-    enumWindowsInZOrderMock.mockReturnValue([
-      { hwnd: 0x111n, title: "Untitled - Notepad", className: "Notepad", ownerHwnd: null, isMinimized: false },
-    ]);
-    const dest = await resolveCdpDestinationForHwnd(0x111n);
+  it("non-Chromium className ('Notepad'): null (gate misses, listTabsLight NOT called — zero CDP latency for native windows)", async () => {
+    const dest = await resolveCdpDestinationForHwnd(0x111n, "Notepad");
     expect(dest).toBeNull();
     expect(listTabsLightMock).not.toHaveBeenCalled();
   });
 
-  it("Chromium HWND ('Chrome_WidgetWin_1') + listTabsLight returns tabs: {kind:'cdp', tabId}", async () => {
-    enumWindowsInZOrderMock.mockReturnValue([
-      { hwnd: 0x222n, title: "Google - Chrome", className: "Chrome_WidgetWin_1", ownerHwnd: null, isMinimized: false },
-    ]);
+  it("Chromium top-level class + listTabsLight returns tabs: {kind:'cdp', tabId}", async () => {
     listTabsLightMock.mockResolvedValue([
       { id: "TAB-AAA", title: "Google", url: "https://google.com/" },
       { id: "TAB-BBB", title: "Bing", url: "https://bing.com/" },
     ]);
-    const dest = await resolveCdpDestinationForHwnd(0x222n);
+    const dest = await resolveCdpDestinationForHwnd(0x222n, "Chrome_WidgetWin_1");
     expect(dest).toEqual({ kind: "cdp", tabId: "TAB-AAA" });
   });
 
-  it("Chromium HWND + listTabsLight rejects (CDP unreachable): null (graceful fallback to Tier 1)", async () => {
-    enumWindowsInZOrderMock.mockReturnValue([
-      { hwnd: 0x333n, title: "Edge", className: "Chrome_WidgetWin_1", ownerHwnd: null, isMinimized: false },
-    ]);
+  it("Chromium top-level class + listTabsLight rejects (CDP unreachable): null (graceful fallback to Tier 1)", async () => {
     listTabsLightMock.mockRejectedValue(new Error("CDP unreachable on 127.0.0.1:9222"));
-    const dest = await resolveCdpDestinationForHwnd(0x333n);
+    const dest = await resolveCdpDestinationForHwnd(0x333n, "Chrome_WidgetWin_1");
     expect(dest).toBeNull();
   });
 
-  it("Chromium HWND + listTabsLight returns empty array: null", async () => {
-    enumWindowsInZOrderMock.mockReturnValue([
-      { hwnd: 0x444n, title: "Edge", className: "Chrome_WidgetWin_1", ownerHwnd: null, isMinimized: false },
-    ]);
+  it("Chromium top-level class + listTabsLight returns empty array: null", async () => {
     listTabsLightMock.mockResolvedValue([]);
-    const dest = await resolveCdpDestinationForHwnd(0x444n);
+    const dest = await resolveCdpDestinationForHwnd(0x444n, "Chrome_WidgetWin_1");
     expect(dest).toBeNull();
   });
 
-  it("HWND not in enumeration: null", async () => {
-    enumWindowsInZOrderMock.mockReturnValue([]);
-    const dest = await resolveCdpDestinationForHwnd(0x555n);
+  it("className null (race with window destruction): null (no CDP probe)", async () => {
+    const dest = await resolveCdpDestinationForHwnd(0x555n, null);
     expect(dest).toBeNull();
     expect(listTabsLightMock).not.toHaveBeenCalled();
   });
 
-  it("enumWindowsInZOrder throws: null (graceful — no exception propagation)", async () => {
-    enumWindowsInZOrderMock.mockImplementation(() => {
-      throw new Error("win32 dlopen failed");
-    });
-    const dest = await resolveCdpDestinationForHwnd(0x666n);
+  it("Chromium SUB-window class ('Chrome_WidgetWin_0' — internal popups / dropdowns) is rejected by the strict gate (Phase 3 R1 Opus P2)", async () => {
+    // The earlier `startsWith("Chrome_WidgetWin")` shape over-matched the
+    // sub-window class which can never be a scroll destination. The strict
+    // equality on `Chrome_WidgetWin_1` rejects it.
+    const dest = await resolveCdpDestinationForHwnd(0x666n, "Chrome_WidgetWin_0");
     expect(dest).toBeNull();
+    expect(listTabsLightMock).not.toHaveBeenCalled();
   });
 });
 
@@ -401,14 +394,14 @@ describe("ADR-018 Phase 3 — resolveInputDestination CDP promotion integration"
   });
 
   it("resolveWindowTarget succeeds + Chromium HWND + CDP reachable: promotes to {kind:'cdp'} (G3 path)", async () => {
+    // Phase 3 R1: `ResolvedWindow.className` is what the gate consults — no
+    // longer a second `enumWindowsInZOrder` call inside the resolver.
     resolveWindowTargetMock.mockResolvedValue({
       title: "X - Chrome",
       hwnd: 0xAAAn,
       warnings: [],
+      className: "Chrome_WidgetWin_1",
     });
-    enumWindowsInZOrderMock.mockReturnValue([
-      { hwnd: 0xAAAn, title: "X - Chrome", className: "Chrome_WidgetWin_1", ownerHwnd: null, isMinimized: false },
-    ]);
     listTabsLightMock.mockResolvedValue([
       { id: "TAB-X", title: "X", url: "https://x.com/" },
     ]);
@@ -433,10 +426,8 @@ describe("ADR-018 Phase 3 — resolveInputDestination CDP promotion integration"
       title: "Chrome",
       hwnd: 0xCCCn,
       warnings: [],
+      className: "Chrome_WidgetWin_1",
     });
-    enumWindowsInZOrderMock.mockReturnValue([
-      { hwnd: 0xCCCn, title: "Chrome", className: "Chrome_WidgetWin_1", ownerHwnd: null, isMinimized: false },
-    ]);
     listTabsLightMock.mockRejectedValue(new Error("Connection refused"));
     const dest = await resolveInputDestination({ windowTitle: "Chrome" });
     expect(dest).toEqual({ kind: "hwnd", hwnd: 0xCCCn });

--- a/tests/unit/scroll-raw-verify.test.ts
+++ b/tests/unit/scroll-raw-verify.test.ts
@@ -12,7 +12,11 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { evaluateScrollDelivery, type ScrollSnapshot } from "../../src/tools/mouse.js";
+import {
+  collapseScrollObserved,
+  evaluateScrollDelivery,
+  type ScrollSnapshot,
+} from "../../src/tools/mouse.js";
 
 const snap = (
   v: number | null,
@@ -189,5 +193,57 @@ describe("evaluateScrollDelivery — delta shape", () => {
       expect(r.delta.y).toBeCloseTo(0.15, 5);
     }
     expect(r.status).toBe("delivered");
+  });
+});
+
+// ADR-018 Phase 3 — issue #294 envelope normalisation. `evaluateScrollDelivery`
+// keeps its internal `{x:null,y:null}` shape (Win32 percent observations) so
+// that the existing internal contract above is preserved; the public envelope
+// served at `hints.scrollObserved.delta` is normalised one level above by
+// `collapseScrollObserved` so callers see ONE shape for "observation channel
+// exhausted" — not the ambiguous `{x:null, y:null}` object reported in #294.
+describe("collapseScrollObserved — ADR-018 Phase 3 / issue #294 envelope normalisation", () => {
+  it("'unverifiable' string passes through unchanged", () => {
+    const r = collapseScrollObserved({ delta: "unverifiable" });
+    expect(r.delta).toBe("unverifiable");
+  });
+
+  it("both axes null collapses to 'unverifiable' (issue #294 — silent-drop ambiguity)", () => {
+    // The exact silent-drop shape reported in #294: Avalonia /
+    // DirectComposition / custom scrollbars cause GetScrollInfo to fail on
+    // BOTH axes, so the internal evaluateScrollDelivery emits
+    // {x:null, y:null}. The envelope collapse normalises to the dedicated
+    // 'unverifiable' string so the LLM sees one shape, not two, for
+    // "observation channel exhausted".
+    const r = collapseScrollObserved({ delta: { x: null, y: null } });
+    expect(r.delta).toBe("unverifiable");
+  });
+
+  it("vertical-only window (horizontal axis null) preserves the structured object", () => {
+    // Single-axis null carries real signal — that axis genuinely has no
+    // scrollbar. Issue #294's silent-drop ambiguity does NOT apply here, so
+    // the object is preserved (callers can detect "this axis has no observation
+    // channel" without losing the working axis's numeric value).
+    const r = collapseScrollObserved({ delta: { x: null, y: 0.15 } });
+    expect(r.delta).toEqual({ x: null, y: 0.15 });
+  });
+
+  it("horizontal-only window (vertical axis null) preserves the structured object", () => {
+    const r = collapseScrollObserved({ delta: { x: 0.10, y: null } });
+    expect(r.delta).toEqual({ x: 0.10, y: null });
+  });
+
+  it("both axes numeric pass through unchanged", () => {
+    const r = collapseScrollObserved({ delta: { x: 0.10, y: 0.20 } });
+    expect(r.delta).toEqual({ x: 0.10, y: 0.20 });
+  });
+
+  it("both axes zero (rounding noise / no movement) pass through unchanged — NOT collapsed", () => {
+    // Zero is an observable value (Win32 reported, scrollbar present, no
+    // movement); collapse is reserved for null-null. The `not_delivered`
+    // status comes from `evaluateScrollDelivery`'s page-end disambiguation,
+    // not from the envelope shape.
+    const r = collapseScrollObserved({ delta: { x: 0, y: 0 } });
+    expect(r.delta).toEqual({ x: 0, y: 0 });
   });
 });

--- a/tests/unit/smart-scroll-body.test.ts
+++ b/tests/unit/smart-scroll-body.test.ts
@@ -1,0 +1,169 @@
+/**
+ * smart-scroll-body.test.ts — ADR-018 Phase 3 / §5 R3 regression fix pin.
+ *
+ * The pre-Phase-3 implementation built a scrollExpr like:
+ *
+ *   const el = document.querySelector('body');
+ *   el.scrollIntoView({block:'center', behavior:'instant'});
+ *
+ * which Chromium interprets as "snap viewport to the body's top edge" — the
+ * `scrollTop` is reset to 0 even when the page was scrolled. ADR §1.1 symptom 4
+ * captured this as a silent reverse-direction scroll. The Phase 3 fix swaps the
+ * `target='body'` / `target='html'` path to the two-step
+ * `document.scrollingElement || document.documentElement` query and skips
+ * `scrollIntoView` entirely for the document root (it's in view by definition).
+ *
+ * This test pins the *expression string* sent to CDP so a future refactor
+ * cannot silently reintroduce the regression.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// CDP bridge mock — captures every `evaluateInTab` invocation so the test
+// can inspect the JS expression sent to the browser. `getScrollAncestorsCdp`
+// is stubbed to "no ancestors" so the CDP path proceeds straight to the
+// scrollExpr step.
+const evaluateInTabMock = vi.fn();
+const getScrollAncestorsCdpMock = vi.fn();
+const detectStickyHeaderCdpMock = vi.fn();
+const setScrollPositionCdpMock = vi.fn();
+const scrollVirtualListCdpMock = vi.fn();
+
+vi.mock("../../src/engine/cdp-bridge.js", () => ({
+  evaluateInTab: evaluateInTabMock,
+  getScrollAncestorsCdp: getScrollAncestorsCdpMock,
+  detectStickyHeaderCdp: detectStickyHeaderCdpMock,
+  setScrollPositionCdp: setScrollPositionCdpMock,
+  scrollVirtualListCdp: scrollVirtualListCdpMock,
+}));
+
+// smart-scroll imports several engine modules that the CDP-strategy code path
+// never reaches; mock them as no-ops so the SUT loads without native binaries.
+vi.mock("../../src/engine/uia-bridge.js", () => ({
+  getScrollAncestors: vi.fn().mockResolvedValue([]),
+  scrollByPercent: vi.fn(),
+  scrollElementIntoView: vi.fn(),
+}));
+vi.mock("../../src/engine/win32.js", () => ({
+  readScrollInfo: vi.fn(),
+  enumWindowsInZOrder: vi.fn().mockReturnValue([]),
+  restoreAndFocusWindow: vi.fn(),
+}));
+vi.mock("../../src/engine/image.js", () => ({
+  dHashFromRaw: vi.fn(),
+  hammingDistance: vi.fn(),
+  extractStripRaw: vi.fn(),
+  detectScrollThumbFromStrip: vi.fn(),
+}));
+vi.mock("../../src/engine/layer-buffer.js", () => ({
+  captureWindowRawAndHash: vi.fn(),
+  getCachedRaw: vi.fn(),
+}));
+vi.mock("../../src/engine/nutjs.js", () => ({
+  mouse: {
+    scrollDown: vi.fn(),
+    scrollUp: vi.fn(),
+    scrollLeft: vi.fn(),
+    scrollRight: vi.fn(),
+  },
+}));
+vi.mock("../../src/utils/desktop-config.js", () => ({
+  getCdpPort: vi.fn(() => 9222),
+}));
+
+const { smartScrollHandler } = await import("../../src/tools/smart-scroll.js");
+
+const baseParams = {
+  port: 9222,
+  strategy: "cdp" as const,
+  direction: "into-view" as const,
+  inline: "center" as const,
+  maxDepth: 3,
+  retryCount: 3,
+  verifyWithHash: false,
+  expandHidden: false,
+};
+
+describe("smart-scroll target='body' — ADR-018 Phase 3 / §5 R3 fix", () => {
+  beforeEach(() => {
+    evaluateInTabMock.mockReset();
+    getScrollAncestorsCdpMock.mockReset();
+    detectStickyHeaderCdpMock.mockReset();
+    setScrollPositionCdpMock.mockReset();
+    scrollVirtualListCdpMock.mockReset();
+
+    getScrollAncestorsCdpMock.mockResolvedValue({ ancestors: [], warnings: [] });
+    detectStickyHeaderCdpMock.mockResolvedValue({ occluded: false });
+
+    // The CDP path issues 4 evaluateInTab calls (restore, scrollExpr,
+    // finalState) when ancestors is empty + expandHidden is false. The mock
+    // returns a benign shape for each — the test asserts on the expression
+    // *sent*, not on what comes back.
+    evaluateInTabMock.mockImplementation((expr: string) => {
+      if (expr.includes("scrollIntoView") || expr.includes("scrollingElement")) {
+        return Promise.resolve({ ok: true, viewportTop: 0, viewportBottom: 100 });
+      }
+      if (expr.includes("viewportPosition")) {
+        return Promise.resolve({ viewportPosition: "in-view", pageRatio: 0.5 });
+      }
+      return Promise.resolve(undefined);
+    });
+  });
+
+  function findScrollExprCall(): string {
+    // The scrollExpr is the only one that mentions both `scrollingElement` and
+    // `isRoot` (post-Phase-3 contract). Pick that one specifically — the
+    // restore expression also touches the DOM but does not reference these
+    // identifiers.
+    const calls = evaluateInTabMock.mock.calls.filter((call) => {
+      const expr = String(call[0]);
+      return expr.includes("scrollingElement") && expr.includes("isRoot");
+    });
+    if (calls.length === 0) {
+      throw new Error(
+        `No scrollExpr call captured. All calls: ${JSON.stringify(
+          evaluateInTabMock.mock.calls.map((c) => String(c[0]).slice(0, 80)),
+        )}`,
+      );
+    }
+    return String(calls[0]![0]);
+  }
+
+  it("target='body': scrollExpr uses document.scrollingElement (two-step query), NOT document.querySelector('body').scrollIntoView", async () => {
+    await smartScrollHandler({ ...baseParams, target: "body" });
+    const scrollExpr = findScrollExprCall();
+    expect(scrollExpr).toContain("document.scrollingElement");
+    expect(scrollExpr).toContain("document.documentElement");
+  });
+
+  it("target='body': scrollIntoView is gated behind `!isRoot` — the root branch skips it entirely (no scrollTop reset)", async () => {
+    await smartScrollHandler({ ...baseParams, target: "body" });
+    const scrollExpr = findScrollExprCall();
+    // The contract pin: scrollIntoView must be inside the `if (!isRoot)`
+    // branch. Reading source order, the `if (!isRoot)` appears before the
+    // scrollIntoView call.
+    const idxIfNotRoot = scrollExpr.search(/if\s*\(\s*!\s*isRoot\s*\)/);
+    const idxScrollIntoView = scrollExpr.indexOf("scrollIntoView");
+    expect(idxIfNotRoot).toBeGreaterThanOrEqual(0);
+    expect(idxScrollIntoView).toBeGreaterThan(idxIfNotRoot);
+  });
+
+  it("target='html' takes the same scrollingElement branch (both literals listed in the isRoot test)", async () => {
+    await smartScrollHandler({ ...baseParams, target: "html" });
+    const scrollExpr = findScrollExprCall();
+    // Both 'body' and 'html' switch to the scrollingElement path.
+    expect(scrollExpr).toMatch(/target === 'body' \|\| target === 'html'/);
+  });
+
+  it("target='#some-element' keeps the document.querySelector + scrollIntoView path", async () => {
+    await smartScrollHandler({ ...baseParams, target: "#some-element" });
+    const scrollExpr = findScrollExprCall();
+    // The literal target is embedded in the expression via JSON.stringify.
+    expect(scrollExpr).toContain('"#some-element"');
+    // scrollIntoView is still called for non-root selectors (inside the
+    // `if (!isRoot)` branch — runtime behaviour). The post-Phase-3 contract
+    // is "scrollIntoView exists in the expression and is gated by isRoot",
+    // not "scrollIntoView is absent for non-root".
+    expect(scrollExpr).toContain("scrollIntoView");
+  });
+});

--- a/tests/unit/tool-descriptions.test.ts
+++ b/tests/unit/tool-descriptions.test.ts
@@ -40,6 +40,13 @@ const MAX_CHARS = 2500;
 // keep the global cap tight so unrelated tools can't silently bloat past 2500.
 const MAX_CHARS_OVERRIDES: Record<string, number> = {
   terminal: 4000,
+  // `scroll` is the ADR-018 dispatcher (action='raw' / 'to_element' / 'smart' /
+  // 'capture' / 'read'); each action carries non-trivial usage guidance — most
+  // recently PR #293 expanded action='raw' with empirical amount-vs-scroll-
+  // distance data and Phase 3 adds Tier 2 CDP semantics. Future phases (4: Tier
+  // 3 PostMessage, 5: SSOT unification) will append more action notes, so the
+  // override sits at 3000 with a comfortable buffer above the current ~2741.
+  scroll: 3000,
 };
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

ADR-018 Phase 3 deliverables + Issue #294 envelope fix, all in one PR (scope intentional — #294 lives at the same `scrollObserved` builder Phase 3 must touch).

### Phase 3 (`docs/adr-018-input-pipeline-3tier.md` §4)

- **Tier 2 CDP wheel dispatch** in `_input-pipeline.ts::dispatchScrollWheel`. Chromium HWNDs (`Chrome_WidgetWin_*` class) **auto-promote** to `{kind:'cdp', tabId}` via the new `resolveCdpDestinationForHwnd` when `listTabsLight` resolves. The window-class gate keeps native HWNDs free of CDP probe latency (zero HTTP round-trips for non-browser scroll calls). Dispatch uses `Input.dispatchMouseEvent({type:'mouseWheel'})` at viewport center; observation uses pre/post `document.scrollingElement.scrollTop|scrollLeft` with a 1 px epsilon.
  - **G3 acceptance**: Chrome `scroll(action='raw', direction:'down')` emits `verifyDelivery.channel='cdp'` + `reason='delivered_via_cdp'`.
- **CDP destination never falls through to Tier 4 SendInput**. When `dest.kind==='cdp'` and `dispatchScrollWheel` returns null, `scrollHandler` emits `status='not_delivered', channel='cdp', reason='target_unreachable'` per ADR §2.6.2 path-(b). `assertTier4Reachable` would throw for `'cdp'` anyway — explicit early-return surfaces a typed envelope rather than catching a thrown guard.
- **`smart-scroll.ts` `target='body'` regression fix** (ADR §5 R3). `document.querySelector('body').scrollIntoView()` is reinterpreted by Chromium as "snap viewport to body top" → `scrollTop` resets to 0 (the silent reverse-direction scroll reported as ADR §1.1 symptom 4). Root selectors (`'body'` / `'html'`) now take the `document.scrollingElement || document.documentElement` two-step query and skip `scrollIntoView` entirely. Non-root selectors are untouched.
- **Chrome smoke stub** at `tests/integration/scroll-5app.smoke.test.ts`. Phase 5 will fill in the 5-app × 4-direction matrix; for now the file pins the Chrome / CDP case behind `SCROLL_SMOKE=1`.

### Issue #294 — `scrollObserved.delta` envelope normalisation

Pre-fix the public envelope could emit either `'unverifiable'` (string) or `{x:null, y:null}` (object) for "observation channel exhausted" — two shapes for one signal, which doubled the LLM-facing ambiguity (`docs/adr-018-input-pipeline-3tier.md` §1.1 symptom 3). Phase 3 collapses **both-axes-null** to the dedicated `'unverifiable'` string via the new `collapseScrollObserved` helper in `mouse.ts`. The internal `evaluateScrollDelivery` return shape is **unchanged** — the existing test contract holds; only the envelope assembly above it normalises.

Single-axis-null (vertical-only window with `{x:null, y:0.15}` from a horizontal-axis-absent app) is **preserved** — that null carries real signal "this axis genuinely has no scrollbar", not the silent-drop ambiguity #294 reports.

### Drive-by fix (separate commit `751a757`)

`tests/unit/tool-descriptions.test.ts` was failing on main (`scroll` description 2741 chars > 2500 cap, introduced by PR #293). Added a per-tool override `scroll: 3000` mirroring the pre-existing `terminal: 4000` pattern, with a comment explaining the Phase 4/5 carry-over (description will continue to grow as more action notes land). Test-only — `scroll.ts` itself is untouched.

## Carry-overs (not blockers for this PR)

- `scrollObserved.delta` is still `'unverifiable'` for the CDP path even on Tier 2 *success* — internally the dispatcher already observes pre/post `scrollTop` numerically, but the public field stays placeholder until Phase 5 wires the CSS-px delta through the envelope (ADR AC1 requires numeric delta across all 5 apps). Phase 3 G3 acceptance is `channel`+`reason`, not delta-numeric.
- Per-element CDP coords (ADR §7 OQ6) — Phase 3 dispatches at viewport center. `WheelParams.x/y` are optional and unused outside the CDP branch.
- `assertTier4Reachable` Phase 4 BREAKING (resolved-HWND-tightening) is still pending Phase 4. Phase 3 only carves out the CDP-specific early-return path.

## Test plan

- [x] `npx vitest run --project unit` — **3021 passed | 5 skipped**, no regressions
- [x] `npm run check:stub-catalog` — clean (no schema change)
- [x] `npm run check:native-types` — clean (TS-only, no Rust touched)
- [x] `npm run build` — clean
- Manual dogfood (post-merge, requires Chrome with `--remote-debugging-port=9222`):
  - `scroll({action:'raw', windowTitle:'Chrome', direction:'down'})` → `verifyDelivery.channel='cdp', reason='delivered_via_cdp'`
  - `scroll({action:'smart', target:'body', strategy:'cdp', windowTitle:'Chrome'})` on a scrolled page → `scrollTop` is preserved (no reset to 0)
  - Notepad / File Explorer / WinUI3 scrolls — Tier 1 UIA path unchanged, no regression

## Related

- ADR-018 §4 Phase 3 deliverables
- Issue #294 (scroll raw verifyDelivery delta shape inconsistency)
- Prior phases: #285 (1a) / #286 / #287 (2b) / #288 (1b) / #289 / #290 (2a) / #292 / #293
- Phase 4 (Tier 3 PostMessage) and Phase 5 (SSOT unification + 5-app smoke + numeric-delta-on-CDP) follow.
