### PR TITLE
fix(perception/attention): surface UIA cache stale via attention='stale' + uiaCache.stale flag — closes #295

### DIFF
--- a/src/engine/identity-tracker.ts
+++ b/src/engine/identity-tracker.ts
@@ -56,7 +56,21 @@ export interface CacheStateHints {
     invalidatedBy?: InvalidationReason | null;
     previousTarget?: { pid: number; processName: string };
   };
-  uiaCache?: { exists: boolean; ageMs?: number; expiresInMs?: number };
+  uiaCache?: {
+    exists: boolean;
+    ageMs?: number;
+    expiresInMs?: number;
+    /**
+     * Issue #295 — `true` when the UIA cache exists but has fully expired
+     * (`expiresInMs === 0`). The `hints.caches.uiaCache.expiresInMs` field
+     * already carries the same information, but `stale: true` is the
+     * dedicated flag callers (and the LLM) read to decide whether to upgrade
+     * `attention` to `'stale'`. Omitted (rather than set to `false`) when the
+     * cache is fresh — symmetric with how the rest of this block surfaces
+     * optional state.
+     */
+    stale?: boolean;
+  };
   windowLayout?: { ageMs: number; expiresInMs: number };
 }
 
@@ -175,6 +189,20 @@ export function dropHwnd(hwnd: bigint): void {
   lastByHwnd.delete(String(hwnd));
 }
 
+/**
+ * Issue #295 — returns `true` when the UIA cache for `hwnd` exists but has
+ * fully expired (`age >= UIA_CACHE_TTL`). Callers building tool responses
+ * should upgrade their `attention` to `'stale'` when this returns `true`, so
+ * the LLM does not act on `actionable[]` derived from a stale cache snapshot.
+ * Returns `false` when the cache does not exist for the HWND (no false
+ * positive — caller's existing fresh-fetch path is the correct one).
+ */
+export function isUiaCacheStale(hwnd: bigint): boolean {
+  const ts = getUiaCacheTimestamp(hwnd);
+  if (ts === null) return false;
+  return Date.now() - ts >= UIA_CACHE_TTL_EXPORTED_MS;
+}
+
 /** Reset all identity tracking (test helper / explicit clear). */
 export function clearIdentities(): void {
   lastByKey.clear();
@@ -209,10 +237,15 @@ export function buildCacheStateHints(
     const uiaTs = getUiaCacheTimestamp(hwnd);
     if (uiaTs !== null) {
       const ageMs = now - uiaTs;
+      const expiresInMs = Math.max(0, UIA_CACHE_TTL_EXPORTED_MS - ageMs);
       out.uiaCache = {
         exists: true,
         ageMs,
-        expiresInMs: Math.max(0, UIA_CACHE_TTL_EXPORTED_MS - ageMs),
+        expiresInMs,
+        // Issue #295 — explicit stale flag so callers don't have to
+        // re-derive it from `expiresInMs === 0`. Single-source contract:
+        // `stale === true` iff the cache is fully expired.
+        ...(expiresInMs === 0 ? { stale: true as const } : {}),
       };
     } else {
       out.uiaCache = { exists: false };

--- a/src/tools/desktop-state.ts
+++ b/src/tools/desktop-state.ts
@@ -25,6 +25,7 @@ import type {
 import { CHROMIUM_TITLE_RE } from "./workspace.js";
 import { getSlotSnapshot } from "../engine/perception/hot-target-cache.js";
 import type { AttentionState } from "../engine/perception/types.js";
+import { isUiaCacheStale } from "../engine/identity-tracker.js";
 import {
   makeQueryWrapper,
   withEnvelopeIncludeSchema,
@@ -528,6 +529,20 @@ export const desktopStateHandler = async (args: {
           // "ambiguous" → ok (conservative safe baseline)
           attention = "ok";
         }
+      }
+
+      // Issue #295 — UIA cache stale upgrade. When the cached UIA snapshot for
+      // this HWND has fully expired (`expiresInMs === 0`), the focused-element
+      // / actionable[] views built from it can be out of date. Upgrade
+      // `attention` to `'stale'` so the LLM does not act on the snapshot
+      // without re-fetching. We only upgrade FROM `'ok'` — other attention
+      // values already signal degradation and must not be downgraded.
+      if (attention === "ok") {
+        try {
+          if (isUiaCacheStale(fg.hwnd)) {
+            attention = "stale";
+          }
+        } catch { /* best effort — never block desktop_state on cache lookup */ }
       }
     }
 

--- a/tests/unit/identity-tracker.test.ts
+++ b/tests/unit/identity-tracker.test.ts
@@ -1,10 +1,16 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   observeTarget,
   clearIdentities,
   takeLastInvalidation,
   buildCacheStateHints,
+  isUiaCacheStale,
 } from "../../src/engine/identity-tracker.js";
+import {
+  updateUiaCache,
+  clearLayers,
+  UIA_CACHE_TTL_EXPORTED_MS,
+} from "../../src/engine/layer-buffer.js";
 
 describe("identity-tracker", () => {
   beforeEach(() => {
@@ -38,5 +44,85 @@ describe("identity-tracker", () => {
     expect(hints.diffBaseline?.exists).toBe(false);
     // uiaCache also absent for a fresh hwnd.
     expect(hints.uiaCache?.exists).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #295 — UIA cache stale detection
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("isUiaCacheStale — issue #295", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    clearLayers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    clearLayers();
+  });
+
+  it("returns false when no UIA cache exists for the HWND", () => {
+    expect(isUiaCacheStale(0xD00D0n)).toBe(false);
+  });
+
+  it("returns false when the UIA cache is fresh (age < TTL)", () => {
+    updateUiaCache(0xD00D1n, "<UIA tree>");
+    // Advance to half the TTL — well within the fresh window.
+    vi.setSystemTime(UIA_CACHE_TTL_EXPORTED_MS / 2);
+    expect(isUiaCacheStale(0xD00D1n)).toBe(false);
+  });
+
+  it("returns true when the UIA cache is fully expired (age >= TTL)", () => {
+    updateUiaCache(0xD00D2n, "<UIA tree>");
+    vi.setSystemTime(UIA_CACHE_TTL_EXPORTED_MS + 1);
+    expect(isUiaCacheStale(0xD00D2n)).toBe(true);
+  });
+
+  it("returns true at the exact TTL boundary (age === TTL)", () => {
+    updateUiaCache(0xD00D3n, "<UIA tree>");
+    vi.setSystemTime(UIA_CACHE_TTL_EXPORTED_MS);
+    // The contract is `expiresInMs === 0` ⇔ `stale === true`, so the boundary
+    // (age === TTL) is stale rather than fresh.
+    expect(isUiaCacheStale(0xD00D3n)).toBe(true);
+  });
+});
+
+describe("buildCacheStateHints — uiaCache.stale flag (issue #295)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    clearLayers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    clearLayers();
+  });
+
+  it("uiaCache.stale is true when expiresInMs === 0 (cache fully expired)", () => {
+    updateUiaCache(0xCAFE1n, "<UIA tree>");
+    vi.setSystemTime(UIA_CACHE_TTL_EXPORTED_MS + 100);
+    const hints = buildCacheStateHints(0xCAFE1n);
+    expect(hints.uiaCache?.exists).toBe(true);
+    expect(hints.uiaCache?.expiresInMs).toBe(0);
+    expect(hints.uiaCache?.stale).toBe(true);
+  });
+
+  it("uiaCache.stale is OMITTED (not false) when the cache is fresh — symmetric with rest of the block", () => {
+    updateUiaCache(0xCAFE2n, "<UIA tree>");
+    vi.setSystemTime(100); // very fresh
+    const hints = buildCacheStateHints(0xCAFE2n);
+    expect(hints.uiaCache?.exists).toBe(true);
+    expect(hints.uiaCache?.expiresInMs).toBeGreaterThan(0);
+    // Omitted, not `false` — keeps the on-wire shape minimal.
+    expect(hints.uiaCache?.stale).toBeUndefined();
+  });
+
+  it("uiaCache.stale is omitted when the cache does not exist (no false signal for a missing cache)", () => {
+    const hints = buildCacheStateHints(0xCAFE3n);
+    expect(hints.uiaCache?.exists).toBe(false);
+    expect(hints.uiaCache?.stale).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Closes #295.

`deriveAttention()` in the perception envelope only reads FluentStatus dirty/settling/stale and never sees the UIA cache TTL state. As a result `desktop_state` can return `attention='ok'` while emitting `actionable[]` / `focusedElement` views derived from a fully-expired UIA snapshot — the LLM then acts on stale entities with no recovery signal.

Issue body called this **silent failure / P2** and proposed two fixes; this PR ships **option B** (the low-invasion path):

### Changes

1. **`identity-tracker.ts`** — new `isUiaCacheStale(hwnd)` predicate
   - Returns `true` iff a UIA cache entry exists for the HWND AND `age >= UIA_CACHE_TTL`.
   - Returns `false` when the cache is absent — the caller's fresh-fetch path is the correct response, no false positive on a missing cache.

2. **`buildCacheStateHints`** — add explicit `uiaCache.stale: true` field
   - When `expiresInMs === 0`, the response carries `stale: true` alongside the existing `expiresInMs`/`ageMs`.
   - Omitted (not set to `false`) when fresh, symmetric with the rest of the block — keeps the on-wire shape minimal.
   - The dedicated flag is the single-source contract: callers and the LLM read `stale === true` rather than re-deriving from `expiresInMs === 0`.

3. **`desktop-state.ts`** — upgrade `attention` to `'stale'` when the focused HWND's UIA cache is fully expired
   - Only upgrades FROM `'ok'` so already-degraded signals (dirty / settling / identity_changed / guard_failed) are never downgraded.
   - Guarded with try/catch so cache-lookup failures (e.g. HWND torn down mid-call) don't block the state response.

### Test coverage (7 new cases, `tests/unit/identity-tracker.test.ts`)

- `isUiaCacheStale`: 4 cases — no-cache / fresh / fully-expired / exact TTL boundary
- `buildCacheStateHints.uiaCache.stale`: 3 cases — expired-true / fresh-omitted / no-cache-omitted
- Uses `vi.useFakeTimers()` + `updateUiaCache` to drive the TTL window deterministically — no real-time delays.

## Test plan

- [x] `npx vitest run --project unit` → 3028 passed | 5 skipped, no regressions (+7 new)
- [x] `npm run build` → clean
- [x] `npm run check:stub-catalog` → clean (no schema change)
- Manual dogfood (post-merge): after `actionable[]` cache crosses TTL, next `desktop_state` reports `attention:'stale'` instead of silently `'ok'`.

## Carry-overs (out of scope)

- The issue's option A — register the UIA cache as a fluent in `FluentStore` and let `sweepTTL` flow into `deriveAttention` directly — is structurally cleaner but touches the perception engine surface. Option B (this PR) ships the user-visible fix today; the perception-engine integration can land in a follow-up if FluentStore lifecycle ever needs to know about UIA cache state for other reasons.
- `desktop_discover` may benefit from the same upgrade. Out of scope here — separate review needed to confirm where `attention` is assembled in that handler.

## Related

- Closes #295
- Phase 3 PR #298 (independent — different files, no merge conflict).
