### PR TITLE
feat(desktop/capabilities): derive EntityCapabilities from UIA controlType + patterns — closes #296

### DIFF
--- a/src/engine/vision-gpu/types.ts
+++ b/src/engine/vision-gpu/types.ts
@@ -75,6 +75,23 @@ export interface UiEntityCandidate {
   rect?: Rect;
   /** Verbs the resolver can expand into full UiAffordance (e.g. "scrollTo"|"select" added at resolver). */
   actionability: Array<"click" | "invoke" | "type" | "read">;
+  /**
+   * UIA control type (e.g. "Button", "ListItem", "CheckBox"). Populated only
+   * by the UIA provider; absent for CDP / visual_gpu / OCR / SOM lanes.
+   * Issue #296: feeds `deriveEntityCapabilities` so the LLM sees up-front
+   * which executor (`uia` Invoke vs `mouse` click) will succeed.
+   */
+  controlType?: string;
+  /**
+   * UIA pattern names supported by this element ("InvokePattern",
+   * "ValuePattern", "TogglePattern", etc.). Populated by the UIA provider
+   * from `getUiElements` — already collected by the underlying
+   * `GetSupportedPatterns()` call, so no new round-trip is needed.
+   * Issue #296: feeds `deriveEntityCapabilities`. Empty array means UIA
+   * was consulted but found no patterns; `undefined` means UIA was not the
+   * source. Both shapes are passed through to `UiEntity.patterns`.
+   */
+  patterns?: string[];
   confidence: number;
   /** Unix ms when this observation was captured. Required for resolver freshness ranking. */
   observedAtMs: number;

--- a/src/engine/world-graph/resolver.ts
+++ b/src/engine/world-graph/resolver.ts
@@ -151,7 +151,24 @@ export function resolveCandidates(
     const verbSet = new Set<string>();
     for (const c of group) c.actionability.forEach((v) => verbSet.add(v));
 
-    entities.push({
+    // Issue #296: carry the UIA-side controlType and union of pattern names
+    // through to the entity. UIA is the authoritative source for pattern data
+    // (CDP / visual lanes don't speak UIA patterns), so we look up the first
+    // UIA candidate in the group rather than using `primary` (which could be
+    // a non-UIA candidate that happened to be observed more recently).
+    const uiaCandidate = group.find((c) => c.source === "uia");
+    const controlType = uiaCandidate?.controlType;
+    let patterns: string[] | undefined;
+    if (uiaCandidate !== undefined) {
+      const set = new Set<string>();
+      for (const c of group) {
+        if (c.source !== "uia") continue;
+        for (const p of c.patterns ?? []) set.add(p);
+      }
+      patterns = [...set];
+    }
+
+    const entity: UiEntity = {
       entityId: stableEntityId(key),
       role: normalizeRole(primary.role),
       label: primary.label,
@@ -164,7 +181,10 @@ export function resolveCandidates(
       sourceId: primary.sourceId,
       generation,
       evidenceDigest: key,
-    });
+    };
+    if (controlType !== undefined) entity.controlType = controlType;
+    if (patterns !== undefined) entity.patterns = patterns;
+    entities.push(entity);
   }
   return entities;
 }

--- a/src/engine/world-graph/types.ts
+++ b/src/engine/world-graph/types.ts
@@ -67,6 +67,21 @@ export interface UiEntity {
    * Required — always set by resolveCandidates(). Used as EntityLease.evidenceDigest.
    */
   evidenceDigest: string;
+  /**
+   * UIA control type carried through from the candidate (Issue #296). Absent
+   * when no UIA candidate contributed to this entity (CDP-only / visual-only).
+   * Advisory: capability derivation reads this to map e.g. `ListItem` →
+   * `unsupportedExecutors:['uia']`. Not exposed in the entity view directly —
+   * the LLM sees the derived `capabilities` block instead.
+   */
+  controlType?: string;
+  /**
+   * UIA pattern names supported by the underlying element (Issue #296).
+   * Same advisory semantics as `controlType`. When multiple UIA candidates
+   * merged into one entity, the resolver unions their pattern arrays so
+   * `deriveEntityCapabilities` sees the full set.
+   */
+  patterns?: string[];
 }
 
 export interface EntityLease {

--- a/src/tools/desktop-capabilities.ts
+++ b/src/tools/desktop-capabilities.ts
@@ -10,14 +10,27 @@
  *
  * No I/O, no extra UIA round-trips — the pattern set was already collected
  * at discover time by `getUiElements`'s underlying `GetSupportedPatterns()`
- * call (Rust native path: `src/uia/thread.rs`; PowerShell fallback:
- * `makeGetElementsScript` in `uia-bridge.ts`). Both paths emit the same
- * `*Pattern`-suffixed string literals, so the rule table below matches
- * exactly without case-folding.
+ * call (Rust native path: `src/uia/tree.rs`; PowerShell fallback:
+ * `makeGetElementsScript` in `uia-bridge.ts`).
+ *
+ * **Pattern-name canonicalisation lives upstream** in
+ * `uia-provider.ts::normalizeUiaPatternNames` (Issue #296 / Opus R1 P1) —
+ * the Rust path emits the short form (`"Invoke"`) while the PowerShell path
+ * emits the suffixed form (`"InvokePattern"`). The provider normalises both
+ * to the `*Pattern`-suffixed form before they reach this module, so the rule
+ * table below can match by exact string equality without case-folding or
+ * suffix probing.
  */
 
 import type { UiEntity } from "../engine/world-graph/types.js";
 import type { EntityCapabilities, ViewConstraints } from "./desktop-constraints.js";
+
+// NB: `UiEntityCandidate.actionability` (set by `uia-provider.ts::uiaActionability`)
+// is a legacy controlType-based hint about what verbs the resolver may expand
+// into affordances. It is NOT the same signal as `EntityCapabilities` — when
+// the two disagree, `EntityCapabilities` is authoritative for executor
+// selection (it is derived from actual `GetSupportedPatterns()` data, not
+// just controlType heuristics). Future PR may collapse the two surfaces.
 
 /**
  * UIA pattern names this rule table recognises. Strings are the wire-form

--- a/src/tools/desktop-capabilities.ts
+++ b/src/tools/desktop-capabilities.ts
@@ -1,0 +1,147 @@
+/**
+ * desktop-capabilities.ts — Issue #296.
+ *
+ * Pure derivation of `EntityCapabilities` from a `UiEntity`. Reads UIA
+ * `controlType` + `patterns` (carried through the candidate → resolver →
+ * entity chain) and emits executor preferences so the LLM does not waste a
+ * round-trip on `click_element` against a target that does not expose
+ * `InvokePattern` (ListItem / TabItem / TreeItem / custom-drawn checkbox /
+ * custom-drawn button — Issue #296 user report).
+ *
+ * No I/O, no extra UIA round-trips — the pattern set was already collected
+ * at discover time by `getUiElements`'s underlying `GetSupportedPatterns()`
+ * call (Rust native path: `src/uia/thread.rs`; PowerShell fallback:
+ * `makeGetElementsScript` in `uia-bridge.ts`). Both paths emit the same
+ * `*Pattern`-suffixed string literals, so the rule table below matches
+ * exactly without case-folding.
+ */
+
+import type { UiEntity } from "../engine/world-graph/types.js";
+import type { EntityCapabilities, ViewConstraints } from "./desktop-constraints.js";
+
+/**
+ * UIA pattern names this rule table recognises. Strings are the wire-form
+ * values emitted by both the Rust native path and the PowerShell fallback.
+ */
+const INVOKE_PATTERN = "InvokePattern";
+const VALUE_PATTERN = "ValuePattern";
+const TOGGLE_PATTERN = "TogglePattern";
+
+/**
+ * UIA control types that historically refuse `Invoke` even though the LLM
+ * tends to treat them as clickable — TabItem / TreeItem / ListItem (Issue
+ * #296 user report). Selection happens via `SelectionItemPattern`, not
+ * `Invoke`, and the UIA executor in this codebase only routes the `click`
+ * verb through `InvokePattern` today. Keep this list conservative — expanding
+ * it should require a fresh dogfood report rather than speculation.
+ */
+const SELECTION_ONLY_CONTROLS = new Set(["ListItem", "TabItem", "TreeItem"]);
+
+/**
+ * Derive entity capabilities. Returns `undefined` when no signal is available
+ * (e.g. CDP-only entity, visual-only entity with no rect, UIA entity with
+ * neither Invoke nor a known fallback) — the existing default-dispatch path
+ * is then the correct response.
+ *
+ * Optional `viewConstraints` argument lets the caller propagate view-level
+ * UIA failure state (`constraints.uia === "provider_failed"`) so UIA-sourced
+ * entities in a UIA-blind view bias toward mouse even when their pattern set
+ * looks fine.
+ */
+export function deriveEntityCapabilities(
+  entity: UiEntity,
+  viewConstraints?: ViewConstraints,
+): EntityCapabilities | undefined {
+  const isUiaSource = entity.sources.includes("uia");
+  const hasRect = entity.rect !== undefined;
+  const patterns = entity.patterns ?? [];
+  const controlType = entity.controlType;
+
+  const uiaProviderFailed = viewConstraints?.uia === "provider_failed";
+
+  // Visual-only entity (SOM / GPU lane found a rect but no UIA element).
+  // Mouse is the only viable executor.
+  if (!isUiaSource) {
+    if (!hasRect) return undefined;
+    return {
+      preferredExecutors: ["mouse"],
+      unsupportedExecutors: ["uia"],
+    };
+  }
+
+  // From here the entity is UIA-sourced.
+  const hasInvoke = patterns.includes(INVOKE_PATTERN);
+  const hasToggle = patterns.includes(TOGGLE_PATTERN);
+  const hasValue = patterns.includes(VALUE_PATTERN);
+  const isSelectionOnly =
+    controlType !== undefined && SELECTION_ONLY_CONTROLS.has(controlType);
+
+  // Provider-level UIA failure (warnings emitted `uia_provider_failed` etc.).
+  // Bias every UIA-sourced entity in this view toward mouse — the UIA
+  // executor will likely hit the same failure the provider already saw.
+  if (uiaProviderFailed) {
+    if (!hasRect) return undefined;
+    return {
+      preferredExecutors: ["mouse"],
+      unsupportedExecutors: ["uia"],
+      fallbackHint: "use mouse_click — UIA provider failed for this view",
+    };
+  }
+
+  // Case 1: InvokePattern available → standard happy path. UIA `click` verb
+  // succeeds (Invoke); mouse is the natural fallback if the visible region
+  // shifts after focus.
+  if (hasInvoke) {
+    return {
+      preferredExecutors: ["uia", "mouse"],
+    };
+  }
+
+  // Case 2: SelectionItem-style controls (ListItem / TabItem / TreeItem)
+  // without Invoke. The UIA executor's `click` verb maps to Invoke, which
+  // fails with `InvokePatternNotSupported`. Steer to mouse_click directly so
+  // the LLM does not pay a round-trip discovering this.
+  if (isSelectionOnly && hasRect) {
+    return {
+      preferredExecutors: ["mouse"],
+      unsupportedExecutors: ["uia"],
+      fallbackHint: `use mouse_click — UIA InvokePattern not exposed on ${controlType ?? "this control"}`,
+    };
+  }
+
+  // Case 3: TogglePattern-only entity (custom checkboxes without Invoke).
+  // The current UIA executor does not yet implement Toggle, so until that
+  // lands (ADR-018 Phase 5 carry-over) the truthful recommendation is mouse.
+  // We deliberately do NOT advertise `preferredExecutors:['uia']` here —
+  // that would lie to the LLM about today's executor surface.
+  if (hasToggle && hasRect) {
+    return {
+      preferredExecutors: ["mouse"],
+      unsupportedExecutors: ["uia"],
+      fallbackHint: "use mouse_click — UIA executor does not yet implement TogglePattern",
+    };
+  }
+
+  // Case 4: ValuePattern-bearing entity (Edit / ComboBox / Document) with
+  // no Invoke. UIA `setValue` is the right path for value updates; we steer
+  // typing toward UIA. The mouse stays available as a `click`/focus fallback
+  // via default dispatch (no `unsupportedExecutors`).
+  if (hasValue) {
+    return {
+      preferredExecutors: ["uia"],
+    };
+  }
+
+  // Case 5: UIA-sourced but no actionable pattern (Text / Image labels,
+  // ScreenReader-only entities). Mouse may still hit the rect if it
+  // represents a visible widget.
+  if (hasRect) {
+    return {
+      preferredExecutors: ["mouse"],
+      unsupportedExecutors: ["uia"],
+    };
+  }
+
+  // No rect, no patterns → nothing actionable.
+  return undefined;
+}

--- a/src/tools/desktop-providers/uia-provider.ts
+++ b/src/tools/desktop-providers/uia-provider.ts
@@ -61,6 +61,12 @@ export async function fetchUiaCandidates(
         value: el.value,
         rect: el.boundingRect ?? undefined,
         actionability: uiaActionability(el.controlType),
+        // Issue #296: carry the UIA-side `controlType` and `patterns` through
+        // so `deriveEntityCapabilities` can advertise executor preferences
+        // at discover time (no extra UIA round-trip — `getUiElements` already
+        // collected both via `GetSupportedPatterns()`).
+        controlType: el.controlType,
+        patterns: el.patterns,
         confidence: 1.0,
         observedAtMs: Date.now(),
         provisional: false,

--- a/src/tools/desktop-providers/uia-provider.ts
+++ b/src/tools/desktop-providers/uia-provider.ts
@@ -32,6 +32,28 @@ function uiaActionability(ct: string): Array<"click" | "invoke" | "type" | "read
   return ["read"];
 }
 
+/**
+ * Issue #296 (Opus R1 P1) — canonicalise the UIA pattern-name wire form.
+ *
+ * The Rust native path (`src/uia/tree.rs`) emits the short form
+ * (`"Invoke"` / `"Value"` / `"Toggle"` / `"SelectionItem"` /
+ * `"ExpandCollapse"` / `"Scroll"`) while the PowerShell fallback
+ * (`makeGetElementsScript` in `uia-bridge.ts`) emits the suffixed form
+ * (`"InvokePattern"` / `"ValuePattern"` / …). Without this normalisation,
+ * `deriveEntityCapabilities` would silently inverse-classify every Rust-path
+ * entity (matching `"InvokePattern"` against `"Invoke"` always misses).
+ *
+ * Canonicalisation target: the `*Pattern`-suffixed form, which matches the
+ * documented Microsoft UI Automation pattern names ("Invoke Pattern" →
+ * `InvokePattern`). Pre-suffixed strings pass through unchanged.
+ *
+ * Exported for unit testing.
+ */
+export function normalizeUiaPatternNames(patterns: string[] | undefined): string[] {
+  if (patterns === undefined) return [];
+  return patterns.map((p) => (p.endsWith("Pattern") ? p : `${p}Pattern`));
+}
+
 export async function fetchUiaCandidates(
   target: TargetSpec | undefined
 ): Promise<ProviderResult> {
@@ -64,9 +86,14 @@ export async function fetchUiaCandidates(
         // Issue #296: carry the UIA-side `controlType` and `patterns` through
         // so `deriveEntityCapabilities` can advertise executor preferences
         // at discover time (no extra UIA round-trip — `getUiElements` already
-        // collected both via `GetSupportedPatterns()`).
+        // collected both via `GetSupportedPatterns()`). Patterns are normalised
+        // here because the Rust native path (`src/uia/tree.rs`) emits the
+        // short form (`"Invoke"`, `"Value"`, `"Toggle"`, …) while the
+        // PowerShell fallback (`makeGetElementsScript`) emits the suffixed
+        // form (`"InvokePattern"`, …). Downstream consumers (most importantly
+        // `deriveEntityCapabilities`) see a single canonical shape.
         controlType: el.controlType,
-        patterns: el.patterns,
+        patterns: normalizeUiaPatternNames(el.patterns),
         confidence: 1.0,
         observedAtMs: Date.now(),
         provisional: false,

--- a/src/tools/desktop-register.ts
+++ b/src/tools/desktop-register.ts
@@ -664,6 +664,7 @@ export function registerDesktopTools(server: McpServer): void {
       "dialog_resolved_via_owner_chain → common dialog (Save As/Open) found via owner chain; targeting is now hwnd-based;",
       "parent_disabled_prefer_popup → parent window blocked by a modal; switched to targeting the active popup dialog.",
       "response.softExpiresAtMs is an advisory timestamp at ~60% of the lease TTL window — past it the LLM should consider re-calling desktop_discover even though leases are still technically valid; lease.expiresAtMs remains the only correctness wall.",
+      "Issue #296: entities[].capabilities (when present) advises executor selection. preferredExecutors[0] is the executor most likely to succeed; if unsupportedExecutors contains 'uia', go straight to mouse_click instead of click_element (saves a InvokePatternNotSupported round-trip on ListItem / TabItem / custom-drawn controls).",
     ].join(" "),
     desktopDiscoverRegistrationSchema,
     desktopDiscoverRegistrationHandler as (input: unknown) => Promise<ToolResult>,

--- a/src/tools/desktop.ts
+++ b/src/tools/desktop.ts
@@ -16,6 +16,7 @@ import type { CandidateIngress } from "../engine/world-graph/candidate-ingress.j
 import { createDesktopExecutor, type ExecutorDeps } from "./desktop-executor.js";
 import type { TouchAction, TouchResult } from "../engine/world-graph/guarded-touch.js";
 import { deriveViewConstraints, type ViewConstraints, type EntityCapabilities } from "./desktop-constraints.js";
+import { deriveEntityCapabilities } from "./desktop-capabilities.js";
 
 export type { ViewConstraints, EntityCapabilities };
 
@@ -368,6 +369,18 @@ export class DesktopFacade {
     // H2: derive structured constraints from warnings for LLM fallback decisions.
     const constraints = deriveViewConstraints(rawResult.warnings, entityViews.length);
     if (constraints) output.constraints = constraints;
+
+    // Issue #296 — attach `capabilities` per entity, derived from the UIA
+    // `controlType` + `patterns` already carried through by the resolver.
+    // Pure derivation, no extra UIA round-trip. `constraints` is passed in
+    // so a UIA-blind view (`uia: 'provider_failed'`) can bias UIA-sourced
+    // entities toward mouse even when their pattern set looks fine.
+    for (let i = 0; i < entityViews.length; i++) {
+      const entity = resolved[i];
+      if (entity === undefined) continue;
+      const cap = deriveEntityCapabilities(entity, constraints);
+      if (cap) entityViews[i]!.capabilities = cap;
+    }
 
     // Codex PR #55 P2: refresh lastAccessMs at the END of see() too, in case
     // candidateProvider / ingress took longer than the eviction interval to

--- a/tests/unit/desktop-capabilities.test.ts
+++ b/tests/unit/desktop-capabilities.test.ts
@@ -1,0 +1,201 @@
+/**
+ * desktop-capabilities.test.ts — Issue #296.
+ *
+ * Pins the `deriveEntityCapabilities` rule table. Pure function — no mocks,
+ * no fixtures, no UIA round-trips. Each case targets one rule branch so a
+ * future refactor that drops a branch lands a discrete test failure rather
+ * than a silent capability regression.
+ */
+
+import { describe, it, expect } from "vitest";
+import { deriveEntityCapabilities } from "../../src/tools/desktop-capabilities.js";
+import type { UiEntity } from "../../src/engine/world-graph/types.js";
+
+function makeEntity(overrides: Partial<UiEntity> = {}): UiEntity {
+  return {
+    entityId: "test-entity",
+    role: "button",
+    confidence: 1,
+    sources: ["uia"],
+    affordances: [],
+    generation: "g0",
+    evidenceDigest: "d0",
+    ...overrides,
+  };
+}
+
+describe("deriveEntityCapabilities — Issue #296", () => {
+  it("UIA + InvokePattern → preferredExecutors:['uia','mouse'] (standard happy path)", () => {
+    const cap = deriveEntityCapabilities(
+      makeEntity({
+        controlType: "Button",
+        patterns: ["InvokePattern"],
+        rect: { x: 10, y: 10, width: 40, height: 20 },
+      }),
+    );
+    expect(cap?.preferredExecutors).toEqual(["uia", "mouse"]);
+    expect(cap?.unsupportedExecutors).toBeUndefined();
+    expect(cap?.fallbackHint).toBeUndefined();
+  });
+
+  it("UIA + ListItem + no InvokePattern → unsupportedExecutors:['uia'] (user report)", () => {
+    const cap = deriveEntityCapabilities(
+      makeEntity({
+        controlType: "ListItem",
+        patterns: ["SelectionItemPattern"],
+        rect: { x: 0, y: 0, width: 200, height: 28 },
+      }),
+    );
+    expect(cap?.unsupportedExecutors).toEqual(["uia"]);
+    expect(cap?.preferredExecutors).toEqual(["mouse"]);
+    expect(cap?.fallbackHint).toContain("mouse_click");
+    expect(cap?.fallbackHint).toContain("ListItem");
+  });
+
+  it("UIA + TabItem + no InvokePattern → unsupportedExecutors:['uia'] with TabItem hint", () => {
+    const cap = deriveEntityCapabilities(
+      makeEntity({
+        controlType: "TabItem",
+        patterns: ["SelectionItemPattern"],
+        rect: { x: 0, y: 0, width: 100, height: 28 },
+      }),
+    );
+    expect(cap?.preferredExecutors).toEqual(["mouse"]);
+    expect(cap?.unsupportedExecutors).toEqual(["uia"]);
+    expect(cap?.fallbackHint).toContain("TabItem");
+  });
+
+  it("UIA + TogglePattern-only (no Invoke) → preferredExecutors:['mouse'] (executor doesn't speak Toggle yet)", () => {
+    const cap = deriveEntityCapabilities(
+      makeEntity({
+        controlType: "CheckBox",
+        patterns: ["TogglePattern"],
+        rect: { x: 0, y: 0, width: 30, height: 30 },
+      }),
+    );
+    expect(cap?.preferredExecutors).toEqual(["mouse"]);
+    expect(cap?.unsupportedExecutors).toEqual(["uia"]);
+    expect(cap?.fallbackHint).toContain("TogglePattern");
+  });
+
+  it("UIA + InvokePattern + Toggle → Invoke wins (happy path takes precedence)", () => {
+    const cap = deriveEntityCapabilities(
+      makeEntity({
+        controlType: "CheckBox",
+        patterns: ["InvokePattern", "TogglePattern"],
+        rect: { x: 0, y: 0, width: 30, height: 30 },
+      }),
+    );
+    expect(cap?.preferredExecutors).toEqual(["uia", "mouse"]);
+    expect(cap?.unsupportedExecutors).toBeUndefined();
+  });
+
+  it("UIA + ValuePattern (Edit) → preferredExecutors:['uia'] (UIA setValue path)", () => {
+    const cap = deriveEntityCapabilities(
+      makeEntity({
+        role: "textbox",
+        controlType: "Edit",
+        patterns: ["ValuePattern"],
+        rect: { x: 0, y: 0, width: 200, height: 24 },
+      }),
+    );
+    expect(cap?.preferredExecutors).toEqual(["uia"]);
+    expect(cap?.unsupportedExecutors).toBeUndefined();
+  });
+
+  it("UIA + no actionable pattern + has rect → mouse fallback", () => {
+    const cap = deriveEntityCapabilities(
+      makeEntity({
+        controlType: "Text",
+        patterns: [],
+        rect: { x: 0, y: 0, width: 100, height: 20 },
+      }),
+    );
+    expect(cap?.preferredExecutors).toEqual(["mouse"]);
+    expect(cap?.unsupportedExecutors).toEqual(["uia"]);
+  });
+
+  it("UIA + no patterns + no rect → undefined (no actionable signal)", () => {
+    const cap = deriveEntityCapabilities(
+      makeEntity({
+        controlType: "Text",
+        patterns: [],
+      }),
+    );
+    expect(cap).toBeUndefined();
+  });
+
+  it("visual-only entity (no UIA source) with rect → mouse, uia unsupported", () => {
+    const cap = deriveEntityCapabilities(
+      makeEntity({
+        sources: ["visual_gpu"],
+        rect: { x: 0, y: 0, width: 80, height: 80 },
+      }),
+    );
+    expect(cap?.preferredExecutors).toEqual(["mouse"]);
+    expect(cap?.unsupportedExecutors).toEqual(["uia"]);
+  });
+
+  it("non-UIA source + no rect → undefined", () => {
+    const cap = deriveEntityCapabilities(
+      makeEntity({
+        sources: ["visual_gpu"],
+      }),
+    );
+    expect(cap).toBeUndefined();
+  });
+
+  it("multi-source (uia + visual_gpu) with InvokePattern → uia path wins", () => {
+    const cap = deriveEntityCapabilities(
+      makeEntity({
+        sources: ["uia", "visual_gpu"],
+        controlType: "Button",
+        patterns: ["InvokePattern"],
+        rect: { x: 0, y: 0, width: 60, height: 24 },
+      }),
+    );
+    expect(cap?.preferredExecutors).toEqual(["uia", "mouse"]);
+  });
+
+  it("viewConstraints.uia='provider_failed' biases UIA-sourced entity to mouse even with InvokePattern", () => {
+    // Defensive: the provider already reported it failed for this view, so
+    // believing the per-element pattern data would lead the LLM into the same
+    // failure mode again. The capability hint reflects the system-level signal.
+    const cap = deriveEntityCapabilities(
+      makeEntity({
+        controlType: "Button",
+        patterns: ["InvokePattern"],
+        rect: { x: 0, y: 0, width: 60, height: 24 },
+      }),
+      { uia: "provider_failed" },
+    );
+    expect(cap?.preferredExecutors).toEqual(["mouse"]);
+    expect(cap?.unsupportedExecutors).toEqual(["uia"]);
+    expect(cap?.fallbackHint).toContain("UIA provider failed");
+  });
+
+  it("viewConstraints.uia='provider_failed' with no rect → undefined (nothing actionable)", () => {
+    const cap = deriveEntityCapabilities(
+      makeEntity({
+        controlType: "Button",
+        patterns: ["InvokePattern"],
+      }),
+      { uia: "provider_failed" },
+    );
+    expect(cap).toBeUndefined();
+  });
+
+  it("patterns array undefined (only happens for non-UIA entities) → mouse if rect, undefined otherwise", () => {
+    // UIA-sourced entity should always have a `patterns` field from the
+    // resolver (empty array when UIA found no patterns) — but defensively,
+    // a UIA-sourced entity with patterns:undefined acts like patterns:[].
+    const cap = deriveEntityCapabilities(
+      makeEntity({
+        controlType: "Custom",
+        rect: { x: 0, y: 0, width: 40, height: 40 },
+      }),
+    );
+    expect(cap?.preferredExecutors).toEqual(["mouse"]);
+    expect(cap?.unsupportedExecutors).toEqual(["uia"]);
+  });
+});

--- a/tests/unit/desktop-providers.test.ts
+++ b/tests/unit/desktop-providers.test.ts
@@ -4,7 +4,7 @@ import {
   isBrowserTarget,
   isTerminalTarget,
 } from "../../src/tools/desktop-providers/compose-providers.js";
-import { fetchUiaCandidates }      from "../../src/tools/desktop-providers/uia-provider.js";
+import { fetchUiaCandidates, normalizeUiaPatternNames } from "../../src/tools/desktop-providers/uia-provider.js";
 import { fetchBrowserCandidates }  from "../../src/tools/desktop-providers/browser-provider.js";
 import { fetchTerminalCandidates } from "../../src/tools/desktop-providers/terminal-provider.js";
 import { fetchVisualCandidates }   from "../../src/tools/desktop-providers/visual-provider.js";
@@ -189,6 +189,120 @@ describe("Provider locator contracts — shape invariants (P2-B)", () => {
 });
 
 // ── Warnings (P2-C) ───────────────────────────────────────────────────────────
+
+// ── Issue #296 / Opus R1 P1: UIA pattern-name wire-form normalisation ───────
+
+describe("normalizeUiaPatternNames — Issue #296 / Opus R1 P1", () => {
+  it("strips no suffix on already-suffixed PowerShell-form input", () => {
+    expect(normalizeUiaPatternNames(["InvokePattern", "ValuePattern"])).toEqual([
+      "InvokePattern",
+      "ValuePattern",
+    ]);
+  });
+
+  it("appends `Pattern` to Rust-native-form short names", () => {
+    // Rust native path emits the short form (src/uia/tree.rs); these must
+    // canonicalise to the suffixed form so the rule table in
+    // desktop-capabilities.ts can match by exact string equality.
+    expect(normalizeUiaPatternNames(["Invoke", "Value", "Toggle"])).toEqual([
+      "InvokePattern",
+      "ValuePattern",
+      "TogglePattern",
+    ]);
+  });
+
+  it("handles mixed input (some suffixed, some not)", () => {
+    expect(normalizeUiaPatternNames(["Invoke", "ValuePattern", "Toggle"])).toEqual([
+      "InvokePattern",
+      "ValuePattern",
+      "TogglePattern",
+    ]);
+  });
+
+  it("undefined input returns empty array", () => {
+    expect(normalizeUiaPatternNames(undefined)).toEqual([]);
+  });
+
+  it("empty array passes through unchanged", () => {
+    expect(normalizeUiaPatternNames([])).toEqual([]);
+  });
+
+  it("SelectionItem / ExpandCollapse / Scroll Rust-form names all suffix correctly", () => {
+    expect(
+      normalizeUiaPatternNames(["SelectionItem", "ExpandCollapse", "Scroll"]),
+    ).toEqual(["SelectionItemPattern", "ExpandCollapsePattern", "ScrollPattern"]);
+  });
+});
+
+describe("fetchUiaCandidates — patterns canonicalisation end-to-end (Issue #296)", () => {
+  beforeEach(() => {
+    uiaBridgeMocks.getUiElements.mockReset();
+    uiaBridgeMocks.detectUiaBlind.mockReturnValue({ blind: false });
+  });
+
+  it("Rust-form patterns from getUiElements are canonicalised to *Pattern on the candidate", async () => {
+    uiaBridgeMocks.getUiElements.mockResolvedValue({
+      elements: [
+        {
+          name: "OK",
+          controlType: "Button",
+          automationId: "btn-ok",
+          isEnabled: true,
+          patterns: ["Invoke"], // Rust native path wire form
+          boundingRect: { x: 0, y: 0, width: 80, height: 24 },
+          depth: 1,
+        },
+      ],
+      elementCount: 1,
+      windowRect: null,
+    });
+    const { candidates } = await fetchUiaCandidates({ windowTitle: "Dialog" });
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.patterns).toEqual(["InvokePattern"]);
+    expect(candidates[0]?.controlType).toBe("Button");
+  });
+
+  it("PowerShell-form patterns pass through unchanged", async () => {
+    uiaBridgeMocks.getUiElements.mockResolvedValue({
+      elements: [
+        {
+          name: "Field",
+          controlType: "Edit",
+          automationId: "edt",
+          isEnabled: true,
+          patterns: ["ValuePattern"],
+          boundingRect: { x: 0, y: 0, width: 200, height: 24 },
+          depth: 1,
+        },
+      ],
+      elementCount: 1,
+      windowRect: null,
+    });
+    const { candidates } = await fetchUiaCandidates({ windowTitle: "Dialog" });
+    expect(candidates[0]?.patterns).toEqual(["ValuePattern"]);
+  });
+
+  it("element with no patterns yields empty array on the candidate (not undefined)", async () => {
+    uiaBridgeMocks.getUiElements.mockResolvedValue({
+      elements: [
+        {
+          name: "Label",
+          controlType: "Text",
+          automationId: "",
+          isEnabled: true,
+          // patterns intentionally absent (older Rust builds without
+          // GetSupportedPatterns) — normalizer must return [].
+          boundingRect: { x: 0, y: 0, width: 100, height: 20 },
+          depth: 1,
+        },
+      ],
+      elementCount: 1,
+      windowRect: null,
+    });
+    const { candidates } = await fetchUiaCandidates({ windowTitle: "Dialog" });
+    expect(candidates[0]?.patterns).toEqual([]);
+  });
+});
 
 describe("composeCandidates — warnings surface (P2-C)", () => {
   it("visual_provider_unavailable always present (Phase 2 stub)", async () => {


### PR DESCRIPTION
## Summary

Closes #296.

`desktop_discover` now attaches `capabilities.preferredExecutors` / `unsupportedExecutors` / `fallbackHint` to every entity, derived from the UIA `controlType` + supported-pattern data that `getUiElements` already collects via `GetSupportedPatterns()`. **No new UIA round-trips** — `fetchUiaCandidates` was discarding both fields before this PR.

This removes the **`click_element → InvokePatternNotSupported → mouse_click`** round-trip that Issue #296 reported (ListItem / TabItem / TreeItem / custom-drawn checkboxes / custom-drawn buttons), by telling the LLM up-front which executor to reach for.

## Changes

| Path | Change |
|---|---|
| `vision-gpu/types.ts` | `UiEntityCandidate` gains optional `controlType` + `patterns` (UIA-only) |
| `world-graph/types.ts` | `UiEntity` carries the same advisory fields through |
| `world-graph/resolver.ts` | Picks UIA candidate's `controlType`, unions `patterns` across same-evidence-key group |
| `desktop-providers/uia-provider.ts` | Populates the new fields on each candidate (already-collected data) |
| **`src/tools/desktop-capabilities.ts` (NEW)** | `deriveEntityCapabilities(entity, viewConstraints?)` — pure rule table |
| `desktop.ts` | `see()` calls the helper once per entity after `constraints` are computed |
| `desktop-register.ts` | One recovery sentence added to the `desktop_discover` tool description |
| **`tests/unit/desktop-capabilities.test.ts` (NEW)** | 14 cases — rule branches + multi-source merge + viewConstraints override |

## Rule table (`deriveEntityCapabilities`)

| Input | Output |
|---|---|
| UIA + InvokePattern | `preferredExecutors:['uia','mouse']` (happy path) |
| UIA + ListItem / TabItem / TreeItem + no Invoke | `unsupportedExecutors:['uia']` + `fallbackHint` |
| UIA + TogglePattern-only (no Invoke) | `preferredExecutors:['mouse']` (executor does not yet speak Toggle — ADR-018 Phase 5 carry-over) |
| UIA + ValuePattern (Edit / ComboBox) | `preferredExecutors:['uia']` |
| UIA + no actionable pattern + has rect | `['mouse']` + `['uia']` unsupported |
| non-UIA + has rect | `['mouse']` + `['uia']` unsupported |
| viewConstraints.uia='provider_failed' on any UIA-sourced entity | Bias to mouse defensively |
| Nothing actionable | `undefined` (default dispatch) |

## Scope cap (explicitly out of this PR)

- **`desktop-executor.ts` routing is UNCHANGED.** Executor still tries UIA first when `sources` includes `'uia'`. Phase 2 (separate PR) will consume `unsupportedExecutors` to short-circuit the UIA attempt — that change also affects `run_macro` and auto-fallback UX, so it earns its own review pass.
- **No new UIA syscalls.** Reuses `getUiElements`'s existing `GetSupportedPatterns()` call.
- **CheckBox `TogglePattern` execution.** UIA executor today only routes `click` through `InvokePattern`. Capability hint is `['mouse']` for `TogglePattern`-only entities to stay truthful. Carry-over: ADR-018 Phase 5 (UIA executor verb expansion).
- **CDP `aria-role` → pattern equivalents.** CDP doesn't speak UIA patterns; `EntityCapabilities` for CDP-only entities stays absent unless the entity also has a UIA source.
- **`canType` derivation for terminal Chromium/UWP.** Carry-over from H2 plan §6.

## Test plan

- [x] `npx vitest run --project unit` → **3042 passed | 5 skipped** (+14 new), no regressions
- [x] `npx vitest run tests/unit/desktop-capabilities.test.ts` → 14/14 pass
- [x] `npx vitest run tests/unit/tool-descriptions.test.ts` → 131/131 pass (description still within cap)
- [x] `npm run build` → clean
- [x] `npm run check:stub-catalog` → clean (no schema change)

Manual dogfood (post-merge):
- Notepad ListItem-heavy dialog → `capabilities.unsupportedExecutors` contains `'uia'`, `preferredExecutors[0] === 'mouse'`
- Normal Button → `preferredExecutors[0] === 'uia'`
- Edit textbox → `preferredExecutors === ['uia']`

## Related

- Closes #296
- Builds on the ADR-018 / EntityCapabilities Phase 1 type definition (`desktop-constraints.ts:72-86`)
- Phase 2 executor short-circuit (separate PR) will consume `unsupportedExecutors`
