### PR TITLE
fix(modal): exclude UI chrome from isModalCandidate — closes #297

### DIFF
--- a/src/engine/world-graph/session-registry.ts
+++ b/src/engine/world-graph/session-registry.ts
@@ -15,17 +15,76 @@ import { resolveCandidates } from "./resolver.js";
 export type TargetSpec = { windowTitle?: string; hwnd?: string; tabId?: string };
 
 /**
+ * UI-chrome control types that UIA exposes with `role:"unknown"` but which
+ * are NEVER modal blockers (Issue #297). Without this exclusion list,
+ * `isModalCandidate` flagged a focused `MenuBar` / `TitleBar` / `StatusBar`
+ * on a non-modal main window as a positive `blockingElement` hit, telling
+ * the LLM to "dismiss" UI chrome it cannot dismiss.
+ *
+ * Conservative list — entries here must be UI chrome that is **always**
+ * non-modal, regardless of application state. Adding a control type should
+ * require a fresh dogfood report rather than speculation.
+ */
+const NON_MODAL_CHROME_CONTROL_TYPES = new Set([
+  "MenuBar",
+  "Menu",
+  "MenuItem",
+  "TitleBar",
+  "StatusBar",
+  "ToolBar",
+  "ScrollBar",
+  "Tab",
+]);
+
+/**
  * Shared predicate used by the default `isModalBlocking` and `findBlockingModal`
  * implementations so they cannot diverge. UIA exposes system dialogs and
  * overlays as `role: "unknown"` elements; the self-exclusion (entityId !==)
  * keeps a dialog from blocking actions on its own children. Issue #63.
+ *
+ * Issue #297: UI chrome (MenuBar / TitleBar / StatusBar / ToolBar) is also
+ * `role:"unknown"` in the UIA tree but is never a modal blocker. The
+ * `controlType` field carried through by Issue #296 lets the predicate
+ * distinguish dialog overlays (no `controlType` or `Pane` / `Window`) from
+ * UI chrome (`MenuBar` etc.). Entities lacking `controlType` (legacy /
+ * non-UIA-fronted producers) fall through to the prior behaviour for
+ * back-compat.
+ *
+ * Exported for direct unit testing of the truth table (the per-clause
+ * negation order is load-bearing — Codex / Opus reviewers historically
+ * read this code line-by-line).
+ *
+ * Cross-signal consistency note (Issue #297): the three modal-detection
+ * APIs in this codebase serve different layers and intentionally use
+ * different signals:
+ *
+ *   - `desktop-state.ts::MODAL_RE` — window-title regex; surface-level
+ *     "is there a window with 'dialog' / 'confirm' / '警告' in its title".
+ *     Cheap, top-of-window flag for orientation.
+ *   - `isModalCandidate` (this function) — UIA-tree based; resolves
+ *     `blockingElement` for `desktop_act` so the LLM can dismiss the
+ *     specific element. Requires Issue #296's `controlType` to exclude
+ *     UI chrome.
+ *   - `evaluateModalAbove` (`sensors-win32.ts`) — Win32-Z-order based
+ *     confidence score (owner chain + className `#32770` + target
+ *     disabled). Used for perception-layer attention scoring.
+ *
+ * The three are NOT expected to converge on every state — they answer
+ * different questions and target different layers. The chrome exclusion
+ * here is the minimum change needed so they no longer **disagree** in
+ * the common false-positive case (MenuBar on a non-modal main window).
  */
-function isModalCandidate(target: UiEntity, candidate: UiEntity): boolean {
-  return (
-    candidate.entityId !== target.entityId &&
-    candidate.sources.includes("uia") &&
-    candidate.role === "unknown"
-  );
+export function isModalCandidate(target: UiEntity, candidate: UiEntity): boolean {
+  if (candidate.entityId === target.entityId) return false;
+  if (!candidate.sources.includes("uia")) return false;
+  if (candidate.role !== "unknown") return false;
+  if (
+    candidate.controlType !== undefined &&
+    NON_MODAL_CHROME_CONTROL_TYPES.has(candidate.controlType)
+  ) {
+    return false;
+  }
+  return true;
 }
 
 export type TargetSessionKey =

--- a/tests/unit/modal-candidate.test.ts
+++ b/tests/unit/modal-candidate.test.ts
@@ -1,0 +1,93 @@
+/**
+ * tests/unit/modal-candidate.test.ts — Issue #297.
+ *
+ * Pins the `isModalCandidate` truth table so the per-clause negation order
+ * (self / source / role / chrome) cannot drift silently. Issue #297 added
+ * the chrome-exclusion clause (`controlType` in MenuBar / TitleBar / …);
+ * without it the LLM saw spurious `blockingElement` hits for focused UI
+ * chrome that it cannot dismiss.
+ */
+
+import { describe, it, expect } from "vitest";
+import { isModalCandidate } from "../../src/engine/world-graph/session-registry.js";
+import type { UiEntity } from "../../src/engine/world-graph/types.js";
+
+function makeEntity(overrides: Partial<UiEntity> = {}): UiEntity {
+  return {
+    entityId: "ent-default",
+    role: "unknown",
+    confidence: 1,
+    sources: ["uia"],
+    affordances: [],
+    generation: "g0",
+    evidenceDigest: "d0",
+    ...overrides,
+  };
+}
+
+describe("isModalCandidate — Issue #297 truth table", () => {
+  const target = makeEntity({ entityId: "target", role: "button" });
+
+  it("returns true for a UIA unknown-role overlay (the canonical dialog pattern)", () => {
+    const overlay = makeEntity({ entityId: "overlay", role: "unknown" });
+    expect(isModalCandidate(target, overlay)).toBe(true);
+  });
+
+  it("returns false for the target itself (self-exclusion)", () => {
+    expect(isModalCandidate(target, target)).toBe(false);
+  });
+
+  it("returns false when the candidate has no UIA source (cdp-only / visual-only)", () => {
+    const cdpOverlay = makeEntity({ entityId: "cdp", sources: ["cdp"] });
+    expect(isModalCandidate(target, cdpOverlay)).toBe(false);
+    const visualOverlay = makeEntity({ entityId: "v", sources: ["visual_gpu"] });
+    expect(isModalCandidate(target, visualOverlay)).toBe(false);
+  });
+
+  it("returns false when the candidate's role is NOT 'unknown' (e.g. a button)", () => {
+    const btn = makeEntity({ entityId: "btn", role: "button" });
+    expect(isModalCandidate(target, btn)).toBe(false);
+  });
+
+  // Issue #297 — UI chrome exclusions
+  it.each([
+    "MenuBar",
+    "Menu",
+    "MenuItem",
+    "TitleBar",
+    "StatusBar",
+    "ToolBar",
+    "ScrollBar",
+    "Tab",
+  ])("returns false for chrome controlType=%s on a role:'unknown' UIA entity", (chromeCt) => {
+    const chrome = makeEntity({ entityId: "chrome", controlType: chromeCt });
+    expect(isModalCandidate(target, chrome)).toBe(false);
+  });
+
+  it("returns true for a dialog Pane with controlType:'Pane' (NOT in the chrome list)", () => {
+    const pane = makeEntity({ entityId: "pane", controlType: "Pane" });
+    expect(isModalCandidate(target, pane)).toBe(true);
+  });
+
+  it("returns true for a UIA unknown-role entity with NO controlType (legacy / back-compat)", () => {
+    // Pre-Issue-#296 producers do not populate controlType. The chrome
+    // exclusion is opt-in — a missing field falls through to the original
+    // "trust the role:'unknown' signal" behaviour.
+    const legacy = makeEntity({ entityId: "legacy" });
+    expect(isModalCandidate(target, legacy)).toBe(true);
+  });
+
+  it("returns true for multi-source UIA + visual_gpu unknown-role entity", () => {
+    const multi = makeEntity({ entityId: "m", sources: ["uia", "visual_gpu"] });
+    expect(isModalCandidate(target, multi)).toBe(true);
+  });
+
+  it("chrome exclusion still applies on multi-source entities (UIA + visual_gpu MenuBar)", () => {
+    const multiChrome = makeEntity({
+      entityId: "mc",
+      sources: ["uia", "visual_gpu"],
+      controlType: "MenuBar",
+    });
+    expect(isModalCandidate(target, multiChrome)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #297.

`isModalCandidate` (`session-registry.ts`) flagged every UIA `role:'unknown'` entity as a potential modal blocker. The UIA tree exposes UI chrome (MenuBar / TitleBar / StatusBar / ToolBar / ScrollBar / Tab / Menu / MenuItem) with the same `role:'unknown'` as overlay dialogs, so on a non-modal main window with focused chrome the LLM would receive a spurious `blockingElement` hint pointing at chrome it cannot dismiss — the exact false-positive Issue #297 reports.

## Changes

1. **`isModalCandidate` consults `controlType`** (carried through by Issue #296). A conservative `NON_MODAL_CHROME_CONTROL_TYPES` set short-circuits 8 chrome control types. Entities lacking `controlType` fall through to the prior behaviour for back-compat.
2. **`isModalCandidate` is now exported** so its 4-clause negation order (self → source → role → chrome) can be pinned by direct unit tests rather than only through `desktop-facade.test.ts` end-to-end paths.
3. **Header comment documents the cross-signal relationship** between the three modal-detection APIs:
   - `desktop-state.ts::MODAL_RE` — title regex; surface-level orientation flag
   - `isModalCandidate` (this PR) — UIA tree; resolves `blockingElement` for `desktop_act`
   - `evaluateModalAbove` (`sensors-win32.ts`) — Win32 Z-order confidence score; perception-layer attention scoring
   These target different layers by design and are not expected to converge on every state — but they no longer **disagree** on the common chrome false-positive case.

## Test coverage (`tests/unit/modal-candidate.test.ts` — new, 16 cases)

| Case | Expected |
|---|---|
| UIA + `role:'unknown'` + no controlType (canonical dialog) | `true` |
| Self-exclusion | `false` |
| Non-UIA source (cdp / visual_gpu) | `false` |
| Non-`unknown` role (e.g. `'button'`) | `false` |
| All 8 chrome controlType values (table-driven) | `false` |
| `controlType:'Pane'` (NOT in chrome list — typical dialog pane) | `true` |
| Missing `controlType` (legacy back-compat) | `true` |
| Multi-source (uia + visual_gpu) overlay | `true` |
| Multi-source chrome (uia + visual_gpu + MenuBar) | `false` |

## Scope cap (carry-over)

- **`desktop-state.ts::MODAL_RE` title regex unification with UIA signals** — out of scope; the three modal APIs target different layers by design. The chrome exclusion here is the minimum change that brings them into consistency on the reported false-positive shape.
- **`evaluateModalAbove` (Win32 Z-order confidence score)** — unchanged; separate concern (perception-layer attention scoring).
- **Per-app modal whitelist / blacklist** — not in this PR. The chrome list is fixed and conservative; per-app tuning belongs in a future ADR if dogfood surfaces a new false-positive shape.

## Test plan

- [x] `npx vitest run --project unit` → **3067 passed | 5 skipped** (+16 new)
- [x] `npm run build` → clean
- [x] `npm run check:stub-catalog` → clean

Manual dogfood (post-merge):
- Main window with focused MenuBar — `desktop_act` no longer reports `blockingElement: { name: 'MenuBar', ... }`
- Real modal dialog (Save As, common confirm) — still flagged correctly as `blockingElement`
- Notepad with focused title bar — no false-positive modal hint

## Related

- Closes #297
- Builds on Issue #296 PR #300 (which carried `controlType` through `UiEntity`)
- Issue #63 (original `isModalCandidate` invariant — preserved)
