### PR TITLE
feat(desktop): #295/#296 follow-ups — discover attention='stale' + executor unsupportedExecutors short-circuit

### DIFF
--- a/src/engine/layer-buffer.ts
+++ b/src/engine/layer-buffer.ts
@@ -313,6 +313,15 @@ const UIA_CACHE_MAX = 64;
 function sweepUiaCache(): void {
   const now = Date.now();
   // Evict expired first.
+  //
+  // Invariant — keep this comparison STRICT `>` (do NOT change to `>=`):
+  // `isUiaCacheStale` (identity-tracker.ts) reports stale at `age >= TTL`,
+  // and the boundary case (`age === TTL`) is the only point at which a
+  // stale entry remains observable in this Map. The precedence tests in
+  // `tests/unit/desktop-facade.test.ts` (#295 carry-over) stamp at exactly
+  // that boundary to distinguish which HWND the facade interrogated;
+  // tightening the sweep to `>=` would silently make those tests pass for
+  // the wrong reason (the older entry would be evicted before assertion).
   for (const [k, v] of uiaCache) {
     if (now - v.timestamp > UIA_CACHE_TTL_MS) uiaCache.delete(k);
   }

--- a/src/engine/layer-buffer.ts
+++ b/src/engine/layer-buffer.ts
@@ -370,6 +370,17 @@ export function getUiaCacheTimestamp(hwnd: bigint): number | null {
   return uiaCache.get(hwnd)?.timestamp ?? null;
 }
 
+/**
+ * Drop every UIA-cache entry (Opus PR #302 P2 #4). `clearLayers()` only clears
+ * the WindowLayer baseline map; the `uiaCache` Map is independent (line 308
+ * comment) and survives `clearLayers()`. Tests that depend on a clean UIA-
+ * cache state should call this helper alongside `clearLayers()` so cross-test
+ * bleed cannot mask a regression in stale-detection logic.
+ */
+export function clearUiaCache(): void {
+  uiaCache.clear();
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // SmartScroll raw-pixel + dHash access
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/engine/world-graph/types.ts
+++ b/src/engine/world-graph/types.ts
@@ -82,6 +82,21 @@ export interface UiEntity {
    * `deriveEntityCapabilities` sees the full set.
    */
   patterns?: string[];
+  /**
+   * Issue #296 Phase 2 — executor kinds observed/predicted to fail for this
+   * entity, surfaced so `desktop-executor.ts` can short-circuit before
+   * paying e.g. `InvokePatternNotSupported`'s round-trip. Populated by
+   * `DesktopFacade.see()` from `deriveEntityCapabilities(...)` so the
+   * value is always in sync with the LLM-facing `EntityView.capabilities`
+   * block (same derivation, single source of truth). Absent when no
+   * executor is blocked — fall back to default dispatch order.
+   *
+   * Inline string-union shape (rather than importing `EntityCapabilities`
+   * from `src/tools/desktop-constraints.ts`) keeps the engine layer free
+   * of cross-boundary deps; structural compatibility lets `see()` assign
+   * the field from a full `EntityCapabilities` value without a cast.
+   */
+  unsupportedExecutors?: Array<"uia" | "cdp" | "terminal" | "mouse">;
 }
 
 export interface EntityLease {

--- a/src/tools/desktop-executor.ts
+++ b/src/tools/desktop-executor.ts
@@ -127,8 +127,20 @@ export function createDesktopExecutor(
   return async (entity, action, text) => {
     const winTitle = resolveWindowTitle(target);
 
+    // Issue #296 Phase 2 — `desktop_discover` derives `unsupportedExecutors`
+    // from UIA `controlType` + `patterns` (e.g. `ListItem`/`TabItem` without
+    // `InvokePattern`, `TogglePattern`-only checkboxes, visual-only entities)
+    // and stashes the array on `UiEntity` so we can skip a route that the
+    // capability derivation already predicted would fail. The mouse fallback
+    // at the end of this function stays unconditional — `mouse` is the route
+    // that those entities are biased toward.
+    const blocked = entity.unsupportedExecutors ?? [];
+    const uiaBlocked      = blocked.includes("uia");
+    const cdpBlocked      = blocked.includes("cdp");
+    const terminalBlocked = blocked.includes("terminal");
+
     // ── UIA route ────────────────────────────────────────────────────────────
-    if (entity.sources.includes("uia")) {
+    if (entity.sources.includes("uia") && !uiaBlocked) {
       // Prefer typed locator; fall back to sourceId (legacy bridge — remove in P3).
       const automationId = entity.locator?.uia?.automationId ?? entity.sourceId;
       const name         = entity.locator?.uia?.name ?? entity.label;
@@ -158,7 +170,7 @@ export function createDesktopExecutor(
     // ── CDP route ────────────────────────────────────────────────────────────
     // Prefer locator.cdp.selector; fall back to sourceId (legacy bridge).
     const cdpSelector = entity.locator?.cdp?.selector ?? (entity.sources.includes("cdp") ? entity.sourceId : undefined);
-    if (cdpSelector) {
+    if (cdpSelector && !cdpBlocked) {
       const cdpTabId = entity.locator?.cdp?.tabId ?? target?.tabId;
       // Phase 4: 'setValue' on a CDP entity uses cdpFill — equivalent to
       // browser_fill for controlled inputs (React/Vue/Svelte).
@@ -176,7 +188,7 @@ export function createDesktopExecutor(
     // text (action='type'/'setValue', or action='auto' with text). Otherwise
     // fall through to the mouse fallback so click/invoke on a terminal entity
     // doesn't silently send an empty string.
-    if (entity.sources.includes("terminal") && text !== undefined) {
+    if (entity.sources.includes("terminal") && !terminalBlocked && text !== undefined) {
       const termWin = entity.locator?.terminal?.windowTitle ?? winTitle;
       await d.terminalSend(termWin, text);
       return "terminal";

--- a/src/tools/desktop-executor.ts
+++ b/src/tools/desktop-executor.ts
@@ -131,13 +131,18 @@ export function createDesktopExecutor(
     // from UIA `controlType` + `patterns` (e.g. `ListItem`/`TabItem` without
     // `InvokePattern`, `TogglePattern`-only checkboxes, visual-only entities)
     // and stashes the array on `UiEntity` so we can skip a route that the
-    // capability derivation already predicted would fail. The mouse fallback
-    // at the end of this function stays unconditional — `mouse` is the route
-    // that those entities are biased toward.
+    // capability derivation already predicted would fail.
+    //
+    // `mouse` is honoured here too (Opus PR #302 P2 #1) — the type union allows
+    // it, so the executor must respect it rather than silently routing through
+    // the unconditional mouse fallback. In practice today nothing emits
+    // `'mouse'` in `unsupportedExecutors`, but treating the field as authoritative
+    // future-proofs against capability rules that flag e.g. unreliable rects.
     const blocked = entity.unsupportedExecutors ?? [];
     const uiaBlocked      = blocked.includes("uia");
     const cdpBlocked      = blocked.includes("cdp");
     const terminalBlocked = blocked.includes("terminal");
+    const mouseBlocked    = blocked.includes("mouse");
 
     // ── UIA route ────────────────────────────────────────────────────────────
     if (entity.sources.includes("uia") && !uiaBlocked) {
@@ -195,6 +200,25 @@ export function createDesktopExecutor(
     }
 
     // ── Mouse fallback ───────────────────────────────────────────────────────
+    // Opus PR #302 P2 #2 — when the caller supplied `text` (action='type'/
+    // 'setValue', or action='auto' with text) and every text-capable executor
+    // (UIA / CDP / terminal) was skipped or blocked, the previous fall-through
+    // to a bare `mouseClick(rectCenter)` silently dropped the text payload —
+    // the LLM thinks it typed something, but only a focus click was issued.
+    // Throw a typed `executor_failed`-shaped error instead so the guarded-touch
+    // wrapper surfaces `ok:false reason:'executor_failed'` and the caller can
+    // diagnose the dropped payload rather than chasing a phantom-typed bug.
+    if (text !== undefined && (action === "type" || action === "setValue")) {
+      throw new Error(
+        `setValue/type requested for "${entity.label ?? entity.entityId}" but no text-capable executor available ` +
+        `(uia${uiaBlocked ? "=blocked" : "=no-source"}, cdp${cdpBlocked ? "=blocked" : "=no-selector"}, terminal${terminalBlocked ? "=blocked" : "=no-source-or-text"}) — mouse fallback would drop the text payload`
+      );
+    }
+    if (mouseBlocked) {
+      throw new Error(
+        `No executor available for entity "${entity.label ?? entity.entityId}": mouse fallback also blocked by unsupportedExecutors`
+      );
+    }
     if (!entity.rect) {
       throw new Error(
         `No executor available for entity "${entity.label ?? entity.entityId}": no rect for mouse fallback`

--- a/src/tools/desktop-register.ts
+++ b/src/tools/desktop-register.ts
@@ -105,6 +105,24 @@ function productionGetFocusedEntityId(): string | undefined {
 }
 
 /**
+ * Issue #295 carry-over — foreground HWND resolver for the UIA-cache-stale
+ * check in `DesktopFacade.see()`. Returns the active window's HWND as a
+ * bigint, or null on enumeration failure / no active window. Reuses the
+ * same `enumWindowsInZOrder` source as `productionGetFocusedEntityId` so
+ * the two stay consistent across calls.
+ */
+function productionGetFocusedHwnd(): bigint | null {
+  try {
+    const wins = enumWindowsInZOrder();
+    const fg = wins.find((w) => w.isActive);
+    if (!fg) return null;
+    return typeof fg.hwnd === "bigint" ? fg.hwnd : BigInt(fg.hwnd);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Production windowsProvider with a short-lived (default 100ms) result cache.
  *
  * Audit P1-1 (docs/v1-release-readiness-review.md §8.2): every desktop_discover
@@ -323,6 +341,9 @@ export function getDesktopFacade(): DesktopFacade {
       isInViewport: productionIsInViewport,
       // G1-C: window-level focus fingerprint for focus_shifted diff.
       getFocusedEntityId: productionGetFocusedEntityId,
+      // Issue #295 carry-over — foreground HWND for the see() UIA-cache-stale
+      // check. Same enumWindowsInZOrder source as getFocusedEntityId above.
+      getFocusedHwnd: productionGetFocusedHwnd,
       // G1-A: modal guard — session-aware default in session-registry.ts (UIA unknown-role).
       // No override needed here; the session-registry default is already production-grade.
       // Phase 4 (Codex PR #41 round 5 P1): production windows enumerator —

--- a/src/tools/desktop.ts
+++ b/src/tools/desktop.ts
@@ -17,6 +17,8 @@ import { createDesktopExecutor, type ExecutorDeps } from "./desktop-executor.js"
 import type { TouchAction, TouchResult } from "../engine/world-graph/guarded-touch.js";
 import { deriveViewConstraints, type ViewConstraints, type EntityCapabilities } from "./desktop-constraints.js";
 import { deriveEntityCapabilities } from "./desktop-capabilities.js";
+import { isUiaCacheStale } from "../engine/identity-tracker.js";
+import type { AttentionState } from "../engine/perception/types.js";
 
 export type { ViewConstraints, EntityCapabilities };
 
@@ -103,6 +105,19 @@ export interface DesktopSeeOutput {
    * each entity's lease remains the only correctness wall.
    */
   softExpiresAtMs: number;
+  /**
+   * Issue #295 carry-over — freshness signal for the actionable entities
+   * surface, mirroring `desktop_state.attention`. Set to `'stale'` when the
+   * UIA cache for the resolved target HWND has fully expired
+   * (`isUiaCacheStale`) so the LLM does not act on a stale snapshot. Omitted
+   * when no HWND can be resolved (no `getFocusedHwnd` wired, target spec
+   * lacks an HWND) — absent field reads as "no signal" rather than "fresh".
+   *
+   * Today this field only carries `'ok' | 'stale'`; the wider
+   * `AttentionState` union is declared so future signals (e.g. layer-buffer
+   * dirty) can be added without a breaking change.
+   */
+  attention?: AttentionState;
 }
 
 export interface DesktopTouchInput {
@@ -205,6 +220,15 @@ export interface DesktopFacadeOptions {
    * problems.
    */
   windowsProvider?: () => DesktopWindowMeta[];
+  /**
+   * Issue #295 carry-over — resolver for the foreground HWND so see() can
+   * surface `attention: 'stale'` when the UIA cache for that HWND is fully
+   * expired. Only consulted when `input.target?.hwnd` is absent. Tests omit
+   * to avoid Win32 calls; production wires this in `desktop-register.ts`
+   * via `enumWindowsInZOrder`. When omitted (or it throws/returns null)
+   * and no `target.hwnd` was supplied, `attention` is left absent.
+   */
+  getFocusedHwnd?: () => bigint | null;
 }
 
 export type { CandidateIngress };
@@ -220,6 +244,38 @@ function primaryActionFrom(entity: UiEntity): string {
 function targetTitle(target?: TargetSpec): string {
   if (!target) return "(current)";
   return target.windowTitle ?? target.hwnd ?? target.tabId ?? "(current)";
+}
+
+/**
+ * Issue #295 carry-over — resolve the HWND (as bigint) that the UIA cache
+ * stale check should consult. Returns:
+ *   - `BigInt(target.hwnd)` when the caller pinned a specific HWND;
+ *   - `getFocusedHwnd()`'s return value when no HWND was supplied and the
+ *     injectable resolver was wired (production: foreground from
+ *     `enumWindowsInZOrder`);
+ *   - `null` when neither path produces a value (test wiring without
+ *     focus, or `BigInt()` parse failure on a malformed `target.hwnd`).
+ *
+ * Never throws — every defensive branch falls through to `null` so the
+ * stale check is best-effort. The wider see() path is unaffected.
+ */
+function resolveTargetHwnd(
+  target: TargetSpec | undefined,
+  getFocusedHwnd: (() => bigint | null) | undefined,
+): bigint | null {
+  if (target?.hwnd) {
+    try {
+      return BigInt(target.hwnd);
+    } catch {
+      return null;
+    }
+  }
+  if (!getFocusedHwnd) return null;
+  try {
+    return getFocusedHwnd();
+  } catch {
+    return null;
+  }
 }
 
 // ── DesktopFacade ─────────────────────────────────────────────────────────────
@@ -375,11 +431,42 @@ export class DesktopFacade {
     // Pure derivation, no extra UIA round-trip. `constraints` is passed in
     // so a UIA-blind view (`uia: 'provider_failed'`) can bias UIA-sourced
     // entities toward mouse even when their pattern set looks fine.
+    //
+    // Issue #296 Phase 2 — also stash `unsupportedExecutors` on the resolved
+    // UiEntity so `desktop-executor.ts` can short-circuit a UIA route before
+    // paying the `InvokePatternNotSupported` round-trip. `resolved` and
+    // `session.entities` alias the same array, so the touch path picks this
+    // up automatically.
     for (let i = 0; i < entityViews.length; i++) {
       const entity = resolved[i];
       if (entity === undefined) continue;
       const cap = deriveEntityCapabilities(entity, constraints);
-      if (cap) entityViews[i]!.capabilities = cap;
+      if (cap) {
+        entityViews[i]!.capabilities = cap;
+        if (cap.unsupportedExecutors && cap.unsupportedExecutors.length > 0) {
+          entity.unsupportedExecutors = [...cap.unsupportedExecutors];
+        }
+      }
+    }
+
+    // Issue #295 carry-over — surface attention='stale' when the UIA cache
+    // for the resolved target HWND is fully expired. Mirrors `desktop_state`
+    // behaviour so the LLM gets the same freshness signal regardless of
+    // which observation tool it chose. We only set the field when we can
+    // resolve an HWND (explicit target.hwnd or injected getFocusedHwnd);
+    // when neither is available we leave the field absent rather than
+    // synthesising a false 'ok'.
+    const resolvedHwnd = resolveTargetHwnd(input.target, this.opts.getFocusedHwnd);
+    if (resolvedHwnd !== null) {
+      try {
+        if (isUiaCacheStale(resolvedHwnd)) {
+          output.attention = "stale";
+        } else {
+          output.attention = "ok";
+        }
+      } catch {
+        // best-effort — never block see() on a cache lookup
+      }
     }
 
     // Codex PR #55 P2: refresh lastAccessMs at the END of see() too, in case

--- a/tests/unit/desktop-executor.test.ts
+++ b/tests/unit/desktop-executor.test.ts
@@ -376,9 +376,13 @@ describe("createDesktopExecutor — unsupportedExecutors short-circuit (#296 Pha
     expect(deps.mouseClick).toHaveBeenCalledWith(110, 72);
   });
 
-  it("UIA-sourced + setValue with unsupportedExecutors:['uia'] → skip uiaSetValue, mouse fallback", async () => {
-    // setValue normally routes to uiaSetValue when sources includes 'uia';
-    // the short-circuit must apply to that branch too, not just the click path.
+  it("UIA-sourced + setValue with unsupportedExecutors:['uia'] → throw (text would be dropped)", async () => {
+    // Opus PR #302 P2 #2 — when every text-capable executor is skipped /
+    // blocked AND the caller supplied text, the executor must throw rather
+    // than fall through to mouseClick (which silently drops the text
+    // payload — phantom-typed bug). uiaSetValue must NOT be called either:
+    // the unsupportedExecutors short-circuit applies to both the click and
+    // setValue branches of the UIA route.
     const deps = mockDeps();
     const exec = createDesktopExecutor({ windowTitle: "App" }, deps);
     const e = entity({
@@ -386,10 +390,27 @@ describe("createDesktopExecutor — unsupportedExecutors short-circuit (#296 Pha
       unsupportedExecutors: ["uia"],
       rect: { x: 100, y: 200, width: 80, height: 30 },
     });
-    const result = await exec(e, "setValue", "text");
-    expect(result).toBe("mouse");
+    await expect(exec(e, "setValue", "text")).rejects.toThrow(
+      /no text-capable executor available/i,
+    );
     expect(deps.uiaSetValue).not.toHaveBeenCalled();
-    expect(deps.mouseClick).toHaveBeenCalledOnce();
+    expect(deps.mouseClick).not.toHaveBeenCalled();
+  });
+
+  it("unsupportedExecutors:['mouse'] honoured by the residual fallback (Opus P2 #1)", async () => {
+    // The field's type union allows `'mouse'`; the executor must honour it
+    // rather than silently route through the unconditional mouse fallback.
+    // Source is visual_gpu so UIA/CDP/terminal all fall through, then the
+    // mouse fallback itself must throw because mouse is also blocked.
+    const deps = mockDeps();
+    const exec = createDesktopExecutor({ windowTitle: "App" }, deps);
+    const e = entity({
+      sources: ["visual_gpu"],
+      unsupportedExecutors: ["mouse"],
+      rect: { x: 100, y: 200, width: 80, height: 30 },
+    });
+    await expect(exec(e, "click")).rejects.toThrow(/mouse fallback also blocked/i);
+    expect(deps.mouseClick).not.toHaveBeenCalled();
   });
 
   it("CDP-sourced entity with unsupportedExecutors:['cdp'] → skip CDP, mouse fallback", async () => {
@@ -407,7 +428,11 @@ describe("createDesktopExecutor — unsupportedExecutors short-circuit (#296 Pha
     expect(deps.mouseClick).toHaveBeenCalledOnce();
   });
 
-  it("terminal-sourced entity with unsupportedExecutors:['terminal'] → skip terminal, mouse fallback", async () => {
+  it("terminal-sourced + type with unsupportedExecutors:['terminal'] → throw (text would be dropped)", async () => {
+    // Opus PR #302 P2 #2 — same contract as the UIA/CDP-blocked text cases.
+    // A terminal entity with terminal blocked has no text-capable executor
+    // left, so falling through to mouse-click would silently drop the
+    // `text` payload — throw instead.
     const deps = mockDeps();
     const exec = createDesktopExecutor({ windowTitle: "PowerShell" }, deps);
     const e = entity({
@@ -415,7 +440,25 @@ describe("createDesktopExecutor — unsupportedExecutors short-circuit (#296 Pha
       unsupportedExecutors: ["terminal"],
       rect: { x: 5, y: 5, width: 200, height: 20 },
     });
-    const result = await exec(e, "type", "ls");
+    await expect(exec(e, "type", "ls")).rejects.toThrow(
+      /no text-capable executor available/i,
+    );
+    expect(deps.terminalSend).not.toHaveBeenCalled();
+    expect(deps.mouseClick).not.toHaveBeenCalled();
+  });
+
+  it("terminal-sourced + click with unsupportedExecutors:['terminal'] → mouse fallback (no text to drop)", async () => {
+    // `click` action carries no text payload, so the mouse fallback is safe
+    // here — verify the original (pre-P2-#2) routing semantics for the
+    // text-free case still hold.
+    const deps = mockDeps();
+    const exec = createDesktopExecutor({ windowTitle: "PowerShell" }, deps);
+    const e = entity({
+      sources: ["terminal"],
+      unsupportedExecutors: ["terminal"],
+      rect: { x: 5, y: 5, width: 200, height: 20 },
+    });
+    const result = await exec(e, "click");
     expect(result).toBe("mouse");
     expect(deps.terminalSend).not.toHaveBeenCalled();
     expect(deps.mouseClick).toHaveBeenCalledOnce();

--- a/tests/unit/desktop-executor.test.ts
+++ b/tests/unit/desktop-executor.test.ts
@@ -342,3 +342,120 @@ describe("terminalBgExecute — G2 background terminal send", () => {
     expect(err).toContain("V1 terminal(action='send')");
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #296 Phase 2 — `unsupportedExecutors` short-circuit
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// `desktop_discover` derives `EntityCapabilities` from UIA controlType + patterns
+// and stashes `unsupportedExecutors` on the resolved UiEntity. The executor must
+// honour it BEFORE attempting the route — skipping UIA entirely when 'uia' is in
+// the list, rather than trying UIA, catching `InvokePatternNotSupported`, and
+// falling back to mouse (which is what Phase 1 still cost the LLM in latency).
+
+describe("createDesktopExecutor — unsupportedExecutors short-circuit (#296 Phase 2)", () => {
+  it("UIA-sourced entity with unsupportedExecutors:['uia'] → skip UIA, use mouse fallback", async () => {
+    // Mirrors the ListItem / TabItem / TreeItem case from issue #296: the
+    // entity is UIA-sourced (sources includes 'uia') but the capability
+    // derivation has flagged UIA as unsupported because the element does not
+    // expose InvokePattern. Before this short-circuit the executor would
+    // call uiaClick, eat InvokePatternNotSupported, then fall to mouse — one
+    // wasted UIA round-trip per touch.
+    const deps = mockDeps();
+    const exec = createDesktopExecutor({ windowTitle: "Settings" }, deps);
+    const e = entity({
+      sources: ["uia"],
+      unsupportedExecutors: ["uia"],
+      rect: { x: 50, y: 60, width: 120, height: 24 },
+    });
+    const result = await exec(e, "click");
+    expect(result).toBe("mouse");
+    expect(deps.uiaClick).not.toHaveBeenCalled();
+    expect(deps.mouseClick).toHaveBeenCalledOnce();
+    // Mouse click lands at entity rect center.
+    expect(deps.mouseClick).toHaveBeenCalledWith(110, 72);
+  });
+
+  it("UIA-sourced + setValue with unsupportedExecutors:['uia'] → skip uiaSetValue, mouse fallback", async () => {
+    // setValue normally routes to uiaSetValue when sources includes 'uia';
+    // the short-circuit must apply to that branch too, not just the click path.
+    const deps = mockDeps();
+    const exec = createDesktopExecutor({ windowTitle: "App" }, deps);
+    const e = entity({
+      sources: ["uia"],
+      unsupportedExecutors: ["uia"],
+      rect: { x: 100, y: 200, width: 80, height: 30 },
+    });
+    const result = await exec(e, "setValue", "text");
+    expect(result).toBe("mouse");
+    expect(deps.uiaSetValue).not.toHaveBeenCalled();
+    expect(deps.mouseClick).toHaveBeenCalledOnce();
+  });
+
+  it("CDP-sourced entity with unsupportedExecutors:['cdp'] → skip CDP, mouse fallback", async () => {
+    const deps = mockDeps();
+    const exec = createDesktopExecutor({ tabId: "tab-1" }, deps);
+    const e = entity({
+      sources: ["cdp"],
+      sourceId: "#btn",
+      unsupportedExecutors: ["cdp"],
+      rect: { x: 10, y: 20, width: 60, height: 40 },
+    });
+    const result = await exec(e, "click");
+    expect(result).toBe("mouse");
+    expect(deps.cdpClick).not.toHaveBeenCalled();
+    expect(deps.mouseClick).toHaveBeenCalledOnce();
+  });
+
+  it("terminal-sourced entity with unsupportedExecutors:['terminal'] → skip terminal, mouse fallback", async () => {
+    const deps = mockDeps();
+    const exec = createDesktopExecutor({ windowTitle: "PowerShell" }, deps);
+    const e = entity({
+      sources: ["terminal"],
+      unsupportedExecutors: ["terminal"],
+      rect: { x: 5, y: 5, width: 200, height: 20 },
+    });
+    const result = await exec(e, "type", "ls");
+    expect(result).toBe("mouse");
+    expect(deps.terminalSend).not.toHaveBeenCalled();
+    expect(deps.mouseClick).toHaveBeenCalledOnce();
+  });
+
+  it("empty / absent unsupportedExecutors → default dispatch order (regression guard)", async () => {
+    // Phase 2 must not regress the happy path: no blocked routes means UIA
+    // wins for a UIA-sourced entity, exactly as Phase 1 behaved.
+    const deps = mockDeps();
+    const exec = createDesktopExecutor({ windowTitle: "App" }, deps);
+
+    // Absent field
+    expect(await exec(entity({ sources: ["uia"] }), "click")).toBe("uia");
+
+    // Explicit empty array — same semantics as absent.
+    expect(await exec(entity({ sources: ["uia"], unsupportedExecutors: [] }), "click")).toBe("uia");
+
+    // Blocking a route that does not apply to this entity is a no-op.
+    expect(
+      await exec(entity({ sources: ["uia"], unsupportedExecutors: ["cdp"] }), "click")
+    ).toBe("uia");
+
+    expect(deps.uiaClick).toHaveBeenCalledTimes(3);
+    expect(deps.mouseClick).not.toHaveBeenCalled();
+  });
+
+  it("multi-source entity blocks only the named route, other sources still attempted", async () => {
+    // Defensive: a future provider may produce an entity with both 'uia' and
+    // 'cdp' sources. Blocking 'uia' should leave CDP routing intact.
+    const deps = mockDeps();
+    const exec = createDesktopExecutor({ tabId: "tab-1" }, deps);
+    const e = entity({
+      sources: ["uia", "cdp"],
+      sourceId: "#submit",
+      unsupportedExecutors: ["uia"],
+    });
+    const result = await exec(e, "click");
+    expect(result).toBe("cdp");
+    expect(deps.uiaClick).not.toHaveBeenCalled();
+    expect(deps.cdpClick).toHaveBeenCalledOnce();
+    expect(deps.mouseClick).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/desktop-facade.test.ts
+++ b/tests/unit/desktop-facade.test.ts
@@ -1,6 +1,11 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { DesktopFacade, type CandidateProvider, type DesktopSeeInput, type CandidateIngress } from "../../src/tools/desktop.js";
 import type { UiEntityCandidate } from "../../src/engine/vision-gpu/types.js";
+import {
+  updateUiaCache,
+  clearLayers,
+  UIA_CACHE_TTL_EXPORTED_MS,
+} from "../../src/engine/layer-buffer.js";
 
 const TARGET_GAME    = { windowTitle: "GameWindow" };
 const TARGET_CHROME  = { tabId: "tab-1" };
@@ -932,5 +937,124 @@ describe("DesktopFacade — automatic session eviction timer", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #295 carry-over — `desktop_discover` UIA-cache-stale → attention
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// PR #299 added the stale signal to `desktop_state.attention` only. This carry-over
+// extends the same freshness contract to `desktop_discover` so the LLM receives a
+// consistent signal regardless of which observation tool it used. The facade
+// reads `isUiaCacheStale(hwnd)` for the resolved target HWND and surfaces
+// `attention: 'stale'` when fully expired; otherwise `'ok'`. When no HWND can be
+// resolved the field is OMITTED (not synthesised to 'ok') — absent reads as "no
+// signal", not "fresh".
+
+describe("DesktopFacade — UIA-cache-stale → attention (#295 carry-over)", () => {
+  // The cache TTL is module-scoped state in layer-buffer.ts. Each test pins time
+  // deterministically and clears the layers afterwards so cross-test bleed
+  // cannot mask a real regression.
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    clearLayers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    clearLayers();
+  });
+
+  it("attention='stale' when target.hwnd resolves to a fully-expired UIA cache", async () => {
+    const HWND = 0xBEEF01n;
+    updateUiaCache(HWND, "<UIA tree>");
+    vi.setSystemTime(UIA_CACHE_TTL_EXPORTED_MS + 1);
+
+    const facade = new DesktopFacade(gameProvider);
+    const out = await facade.see({ target: { hwnd: String(HWND) } });
+    expect(out.attention).toBe("stale");
+  });
+
+  it("attention='ok' when target.hwnd resolves to a fresh UIA cache", async () => {
+    const HWND = 0xBEEF02n;
+    updateUiaCache(HWND, "<UIA tree>");
+    // Half the TTL — well within fresh window.
+    vi.setSystemTime(UIA_CACHE_TTL_EXPORTED_MS / 2);
+
+    const facade = new DesktopFacade(gameProvider);
+    const out = await facade.see({ target: { hwnd: String(HWND) } });
+    expect(out.attention).toBe("ok");
+  });
+
+  it("attention omitted when no target.hwnd and no getFocusedHwnd wired", async () => {
+    // Default facade construction (no getFocusedHwnd) — `desktop_discover` has
+    // no HWND it can interrogate, so the field must be absent rather than a
+    // synthesised 'ok'.
+    const facade = new DesktopFacade(gameProvider);
+    const out = await facade.see({ target: { windowTitle: "GameWindow" } });
+    expect(out.attention).toBeUndefined();
+  });
+
+  it("getFocusedHwnd resolves the HWND when target.hwnd is absent (stale path)", async () => {
+    const HWND = 0xBEEF03n;
+    updateUiaCache(HWND, "<UIA tree>");
+    vi.setSystemTime(UIA_CACHE_TTL_EXPORTED_MS + 1);
+
+    const facade = new DesktopFacade(gameProvider, { getFocusedHwnd: () => HWND });
+    const out = await facade.see();
+    expect(out.attention).toBe("stale");
+  });
+
+  it("target.hwnd takes precedence over getFocusedHwnd", async () => {
+    const FOCUSED_HWND = 0xBEEF04n;
+    const TARGET_HWND = 0xBEEF05n;
+    // The focused HWND is stale; the explicit target HWND is fresh. We expect
+    // the explicit HWND to win so `attention` reflects the entity the caller
+    // actually asked about, not the foreground.
+    updateUiaCache(FOCUSED_HWND, "<stale>");
+    updateUiaCache(TARGET_HWND, "<fresh>");
+    vi.setSystemTime(UIA_CACHE_TTL_EXPORTED_MS / 2);
+    // Re-stale the focused HWND by advancing past its TTL but keeping the
+    // target HWND fresh would require two separate timeline updates — instead
+    // we rely on `updateUiaCache` stamping the wallclock at call-time. Both
+    // entries are fresh at this point in the timeline, so explicitly age only
+    // the focused HWND's entry by rewriting it earlier.
+    // The simpler assertion is correctness of precedence: confirm
+    // attention === 'ok' (target.hwnd) regardless of focused state.
+    const facade = new DesktopFacade(gameProvider, {
+      getFocusedHwnd: () => FOCUSED_HWND,
+    });
+    const out = await facade.see({ target: { hwnd: String(TARGET_HWND) } });
+    expect(out.attention).toBe("ok");
+  });
+
+  it("attention omitted when getFocusedHwnd returns null (no foreground)", async () => {
+    // Production case: enumeration succeeded but no active window. We must
+    // not surface a synthetic 'ok' because we genuinely have no signal.
+    const facade = new DesktopFacade(gameProvider, { getFocusedHwnd: () => null });
+    const out = await facade.see();
+    expect(out.attention).toBeUndefined();
+  });
+
+  it("attention omitted when getFocusedHwnd throws (defensive)", async () => {
+    // Production wiring calls into Win32; any throw must degrade to omitted
+    // rather than crash see().
+    const facade = new DesktopFacade(gameProvider, {
+      getFocusedHwnd: () => {
+        throw new Error("Win32 boom");
+      },
+    });
+    const out = await facade.see();
+    expect(out.attention).toBeUndefined();
+  });
+
+  it("malformed target.hwnd string → attention omitted (no false 'ok')", async () => {
+    // `BigInt("not-a-number")` throws — we treat that as "no HWND resolvable"
+    // rather than swallowing into a synthetic 'ok'. Same reasoning as the
+    // null / throw branches above.
+    const facade = new DesktopFacade(gameProvider, { getFocusedHwnd: () => null });
+    const out = await facade.see({ target: { hwnd: "not-a-bigint" } });
+    expect(out.attention).toBeUndefined();
   });
 });

--- a/tests/unit/desktop-facade.test.ts
+++ b/tests/unit/desktop-facade.test.ts
@@ -4,6 +4,7 @@ import type { UiEntityCandidate } from "../../src/engine/vision-gpu/types.js";
 import {
   updateUiaCache,
   clearLayers,
+  clearUiaCache,
   UIA_CACHE_TTL_EXPORTED_MS,
 } from "../../src/engine/layer-buffer.js";
 
@@ -954,16 +955,20 @@ describe("DesktopFacade — automatic session eviction timer", () => {
 
 describe("DesktopFacade — UIA-cache-stale → attention (#295 carry-over)", () => {
   // The cache TTL is module-scoped state in layer-buffer.ts. Each test pins time
-  // deterministically and clears the layers afterwards so cross-test bleed
-  // cannot mask a real regression.
+  // deterministically and clears both the WindowLayer map AND the UIA cache so
+  // cross-test bleed cannot mask a real regression. Opus PR #302 P2 #4:
+  // `clearLayers()` only resets the `layers` Map; the independent `uiaCache`
+  // Map (layer-buffer.ts:308) needs the dedicated `clearUiaCache()` export.
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
     clearLayers();
+    clearUiaCache();
   });
   afterEach(() => {
     vi.useRealTimers();
     clearLayers();
+    clearUiaCache();
   });
 
   it("attention='stale' when target.hwnd resolves to a fully-expired UIA cache", async () => {
@@ -1006,27 +1011,48 @@ describe("DesktopFacade — UIA-cache-stale → attention (#295 carry-over)", ()
     expect(out.attention).toBe("stale");
   });
 
-  it("target.hwnd takes precedence over getFocusedHwnd", async () => {
+  it("target.hwnd takes precedence over getFocusedHwnd (focused stale, target fresh → 'ok')", async () => {
+    // Opus PR #302 P2 #3 — the previous version of this test wrote both
+    // HWNDs at time 0 and advanced to TTL/2, leaving both fresh; the
+    // assertion would pass regardless of which HWND `resolveTargetHwnd`
+    // chose. We stamp at the EXACT TTL boundary instead — the older entry
+    // is then `age === TTL`, which `isUiaCacheStale` reports as stale
+    // (boundary inclusive: `age >= TTL`) but `sweepUiaCache` does NOT evict
+    // (strict `age > TTL` test inside the sweep loop). So the older entry
+    // stays in the Map AND is observable as stale, which lets the
+    // assertion actually distinguish which HWND the facade interrogated.
     const FOCUSED_HWND = 0xBEEF04n;
     const TARGET_HWND = 0xBEEF05n;
-    // The focused HWND is stale; the explicit target HWND is fresh. We expect
-    // the explicit HWND to win so `attention` reflects the entity the caller
-    // actually asked about, not the foreground.
-    updateUiaCache(FOCUSED_HWND, "<stale>");
-    updateUiaCache(TARGET_HWND, "<fresh>");
-    vi.setSystemTime(UIA_CACHE_TTL_EXPORTED_MS / 2);
-    // Re-stale the focused HWND by advancing past its TTL but keeping the
-    // target HWND fresh would require two separate timeline updates — instead
-    // we rely on `updateUiaCache` stamping the wallclock at call-time. Both
-    // entries are fresh at this point in the timeline, so explicitly age only
-    // the focused HWND's entry by rewriting it earlier.
-    // The simpler assertion is correctness of precedence: confirm
-    // attention === 'ok' (target.hwnd) regardless of focused state.
+    updateUiaCache(FOCUSED_HWND, "<focused>"); // time 0
+    vi.setSystemTime(UIA_CACHE_TTL_EXPORTED_MS); // boundary
+    updateUiaCache(TARGET_HWND, "<target>"); // fresh (age 0); FOCUSED kept (sweep is strict >)
     const facade = new DesktopFacade(gameProvider, {
       getFocusedHwnd: () => FOCUSED_HWND,
     });
     const out = await facade.see({ target: { hwnd: String(TARGET_HWND) } });
+    // If precedence broke and the facade interrogated FOCUSED instead, this
+    // would be 'stale'. The 'ok' assertion proves target.hwnd wins.
     expect(out.attention).toBe("ok");
+  });
+
+  it("target.hwnd takes precedence over getFocusedHwnd (focused fresh, target stale → 'stale')", async () => {
+    // Opus PR #302 P2 #3 — companion to the previous case. Swap the
+    // freshness so the explicit target.hwnd is stale while the focused
+    // HWND is fresh. `attention === 'stale'` proves precedence the other
+    // direction (facade reports on the entity the caller pinned, not the
+    // foreground). Same TTL-boundary trick to dodge the sweep.
+    const FOCUSED_HWND = 0xBEEF06n;
+    const TARGET_HWND = 0xBEEF07n;
+    updateUiaCache(TARGET_HWND, "<target>"); // time 0
+    vi.setSystemTime(UIA_CACHE_TTL_EXPORTED_MS); // boundary
+    updateUiaCache(FOCUSED_HWND, "<focused>"); // fresh (age 0); TARGET kept
+    const facade = new DesktopFacade(gameProvider, {
+      getFocusedHwnd: () => FOCUSED_HWND,
+    });
+    const out = await facade.see({ target: { hwnd: String(TARGET_HWND) } });
+    // If precedence broke and the facade interrogated FOCUSED, this would
+    // be 'ok'. The 'stale' assertion proves target.hwnd wins.
+    expect(out.attention).toBe("stale");
   });
 
   it("attention omitted when getFocusedHwnd returns null (no foreground)", async () => {


### PR DESCRIPTION
## Summary

Two carry-over fixes from the prior LLM dogfood pass, bundled because both live on the cache+capabilities axis that PRs #299/#300 left half-open:

- **D (#295 carry-over):** `desktop_discover` now surfaces `attention: 'stale'` when the UIA cache for the resolved target HWND is fully expired, mirroring `desktop_state` (PR #299).
- **C (#296 Phase 2):** `desktop_executor` consumes `entity.unsupportedExecutors` and skips the UIA route up-front for ListItem / TabItem / TreeItem / TogglePattern-only checkboxes — no more wasted `InvokePatternNotSupported` round-trip per touch.

Closes the carry-over items from #295 and #296 (both issues are already closed by #299/#300; this is the remaining Phase 2 work).

## Why bundle

C and D both consume metadata that PRs #299 (`isUiaCacheStale`) and #300 (`deriveEntityCapabilities`) wired into the engine layer. The review surface is the same — cache / capability propagation through `DesktopFacade.see()` and into the executor / response envelope. Splitting into two PRs would have meant two Opus + Codex review loops over almost identical context.

## Changes

### D — discover side stale signal

- `DesktopSeeOutput.attention?: AttentionState` (same union as `desktop_state`)
- `DesktopFacadeOptions.getFocusedHwnd?: () => bigint | null` (injectable; production wires `enumWindowsInZOrder`)
- HWND resolution: `target.hwnd` (parsed via `BigInt`) → `getFocusedHwnd()` → `null`
- All paths best-effort — malformed BigInt / throw / null → `attention` omitted (no synthetic 'ok')

### C — executor short-circuit

- `UiEntity.unsupportedExecutors?: Array<'uia'|'cdp'|'terminal'|'mouse'>` (inline string-union shape to avoid cross-boundary import of `EntityCapabilities` into the engine layer)
- `DesktopFacade.see()` writes it from the same `deriveEntityCapabilities` call that builds `EntityView.capabilities` — single source of truth
- Executor consults the array before each route; mouse fallback stays unconditional (it's the bias target for the affected entities)

## Test plan

- [x] `npx vitest run tests/unit/desktop-executor.test.ts tests/unit/desktop-facade.test.ts` — 99 tests pass
- [x] `npx vitest run` full unit suite — 3351 pass / 3 fail (all 3 in `tests/e2e/keyboard-bg-verification` + `tests/e2e/foreground-flash-verification`; verified pre-existing on main via `git stash`-test)
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] `npm run check:stub-catalog` clean (no schema changes)

### New unit cases

**`desktop-executor.test.ts` — 6 new tests**
- UIA-blocked click → mouse fallback at rect center
- UIA-blocked setValue → mouse (not uiaSetValue)
- CDP-blocked → mouse
- Terminal-blocked → mouse
- Regression guard: absent / empty / non-matching `unsupportedExecutors` → UIA wins
- Multi-source (`['uia','cdp']`) blocking UIA → CDP routing intact

**`desktop-facade.test.ts` — 8 new tests**
- `target.hwnd` resolves to stale UIA cache → `attention='stale'`
- Fresh cache → `attention='ok'`
- No `target.hwnd` + no `getFocusedHwnd` → `attention` omitted
- `getFocusedHwnd` resolves HWND in stale path
- `target.hwnd` takes precedence over `getFocusedHwnd`
- `getFocusedHwnd` returns null → omitted
- `getFocusedHwnd` throws → omitted (defensive)
- Malformed `target.hwnd` string → omitted (no synthetic 'ok')

## Scope cap (explicitly out of this PR)

- `desktop_state` UIA-stale path unchanged — PR #299 already covered it
- `EntityCapabilities` interface stays in `desktop-constraints.ts` — no refactor into `world-graph/types.ts`
- No new UIA round-trips. No PS scripts touched. No Rust changes