### PR TITLE
feat(adr-019-mvp-1): UIA ScrollPercent read-only observation + verifyDelivery envelope hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   hint** when the dispatcher's chain-trust path runs (Excel cell grid /
   Word document body / similar MDI receivers). The new hint tells the
   LLM caller whether the delivery was independently observed or trusted
-  by the dispatcher without observation. Two values ship in this
+  by the dispatcher without observation. Three values ship in this
   release:
   - `observation.source: "uia_scroll_percent"` with `motion: "translation"`
     — the dispatcher read the receiver's scroll-percent via the
@@ -28,14 +28,18 @@
     "indeterminate"` — the receiver does not expose a `ScrollPattern`
     for reads (the common case for Excel `NUIScrollbar` / Word MFC
     custom-paint surfaces), so the dispatcher trusts the documented
-    receiver contract (PR #308 chain-table) without independent
-    observation. This is the same delivery contract as before, now
-    with an explicit "unverified at the observation layer" hint
-    instead of a silent assumption.
+    receiver contract for custom-painted scroll surfaces without
+    independent observation. This is the same delivery contract as
+    before, now with an explicit "unverified at the observation layer"
+    hint instead of a silent assumption.
 
   Existing callers that ignore the hint are unaffected. The field is
   optional and only attached when a chain-trust observation actually
   ran.
+
+### Fixed
+
+- **`scroll(action:'raw', windowTitle:'Book1 - Excel')` now actually scrolls
   the Excel cell grid.** Previously the call returned `ok:false code:'ScrollNotDelivered'`
   with `verifyDelivery.reason:'target_unreachable'` because `WM_MOUSEWHEEL`
   is delivered upward from a window to its parent, never downward to a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,40 @@
 
 ## [Unreleased]
 
-### Fixed
+### Added
 
-- **`scroll(action:'raw', windowTitle:'Book1 - Excel')` now actually scrolls
+- **`scroll(action:'raw', …)` now reports a `verifyDelivery.observation`
+  hint** when the dispatcher's chain-trust path runs (Excel cell grid /
+  Word document body / similar MDI receivers). The new hint tells the
+  LLM caller whether the delivery was independently observed or trusted
+  by the dispatcher without observation. Two values ship in this
+  release:
+  - `observation.source: "uia_scroll_percent"` with `motion: "translation"`
+    — the dispatcher read the receiver's scroll-percent via the
+    accessibility API before and after the wheel message, and the
+    percent changed. This is the most confident "delivered" signal
+    available for custom-painted receivers and applies when the
+    target exposes a UI Automation `ScrollPattern`.
+  - `observation.source: "uia_scroll_percent"` with `motion: "no_change"`
+    — same observation channel, but the percent did NOT change (boundary
+    case: the receiver got the wheel and decided not to scroll, for
+    example because the document is already at the top). The dispatcher
+    still reports `verifyDelivery.status: "delivered"` (matches Tier 1
+    boundary semantics), but the `motion: "no_change"` hint lets the
+    LLM caller distinguish "actually moved" from "reached the receiver
+    but no-op."
+  - `observation.source: "chain_trust_unverified"` with `motion:
+    "indeterminate"` — the receiver does not expose a `ScrollPattern`
+    for reads (the common case for Excel `NUIScrollbar` / Word MFC
+    custom-paint surfaces), so the dispatcher trusts the documented
+    receiver contract (PR #308 chain-table) without independent
+    observation. This is the same delivery contract as before, now
+    with an explicit "unverified at the observation layer" hint
+    instead of a silent assumption.
+
+  Existing callers that ignore the hint are unaffected. The field is
+  optional and only attached when a chain-trust observation actually
+  ran.
   the Excel cell grid.** Previously the call returned `ok:false code:'ScrollNotDelivered'`
   with `verifyDelivery.reason:'target_unreachable'` because `WM_MOUSEWHEEL`
   is delivered upward from a window to its parent, never downward to a

--- a/docs/adr-018-input-pipeline-3tier.md
+++ b/docs/adr-018-input-pipeline-3tier.md
@@ -162,6 +162,7 @@ The existing `ScrollVerifyOutcome` (`src/tools/mouse.ts:943-985`) has two orthog
 - `status: "delivered" | "unverifiable" | "not_delivered"` — 3-value outcome (unchanged)
 - `reason?:` — context for non-`delivered` outcomes (currently 4 values, replaced below)
 - `channel:` — transport identifier (currently `"wheel_send_input"`); ADR-018 extends to 4 values
+- `observation?:` — **ADR-019 MVP-1 additive field** carrying a `VisualMotionObservation` (Temporal Motion Observation Layer / TMOL primitive output). The canonical `source` enum is defined in **`docs/adr-019-anti-fukuwarai-v3-temporal-motion-observation.md` §2.1** (single source of truth, 8-value enum: `uia_scroll_percent` / `block_motion_vectors` / `tiled_phase_correlation` / `ssim_residual` / `dxgi_dirty_rect` / `optical_flow` / `temporal_ring_observation_only` / `chain_trust_unverified`). Existing callers that ignore the field are unaffected. The field is populated when a TMOL primitive produced an observation (today: Stage 1 UIA `ScrollPercent` pre/post observation on the `postWheelToHwnd` chain-trust branch); absent on legacy Tier 1 / 2 / 3 paths that have not yet been wired through TMOL.
 
 #### 2.6.1 `verifyDelivery.channel` (transport identifier, 4 values)
 

--- a/docs/adr-018-phase-5-followup-verification-pathway-analysis.md
+++ b/docs/adr-018-phase-5-followup-verification-pathway-analysis.md
@@ -1,0 +1,371 @@
+# ADR-018 Phase 5+N+1 — Verification pathway analysis (north-star re-evaluation)
+
+- Status: **Analysis / draft (pre-PR)** — re-evaluates the path-A/B/C decision from a system-wide detection-capability lens
+- Date: 2026-05-16
+- Parent: `docs/adr-018-input-pipeline-3tier.md` §2.6 / `docs/adr-018-phase-5-followup-leaf-walker-subplan.md` §2.1 reverted-note
+- Authors: Claude (Sonnet drafting, Opus initial judgment B → user pushback → re-evaluation under north star)
+- Trigger: 2026-05-16 user prompt — "北極星を基準として EXCEL のスクロール対応のピンポイントでは無く、将来的な全体の検出能力の底上げという前提とした場合にその選択がただしいの？"
+
+---
+
+## 1. Why this document exists
+
+PR #308 closed with a chain-trust assertion and a documented Codex P1 trade-off (boundary case → false-positive `delivered`). A follow-up "robust verification" effort was scoped against 3 candidate paths (A: UIA + phase correlation / B: existing MAE port / C: pHash 32×32). Opus recommended **B** on the grounds of "reuse existing helpers, low cost, ~100-150 lines, no new Rust dep."
+
+The user pushed back: **the question wasn't "smallest delta" — it was "what raises overall system detection capability across the MCP surface."** This document re-evaluates A/B/C against that broader north star.
+
+---
+
+## 2. North star (re-statement)
+
+ADR-018 §1.3 frames the underlying problem as:
+
+> Without this fix, every user with a stay-resident accessibility / display-management tool (Dell DDPM, Logitech Options+, NVIDIA Game Filter, MS PowerToys FancyZones, AutoHotKey scripts, RDP shadow sessions) sees scroll silently degrade to a no-op. This is the most-used class of tool in the MCP surface and the silent-failure mode is unrecoverable from the LLM side — `ok:true` masks a 0-px scroll.
+
+Restated as design invariants:
+
+1. **Destination-explicit IO** — HWND on the wire end-to-end, no cursor-pixel routing.
+2. **Honest observation per tier** — observation must NEVER silently degrade into a false-positive `delivered`. The LLM side must be able to act on the reported delivery status.
+3. **Generality across custom-paint apps** — Excel cell grid is one instance of a class: Word `_WwG`, PowerPoint slide canvas, OneNote canvas, Photoshop/Blender custom controls, GPU-rendered games, RDP shadow surfaces. The solution must scale to that class, not bolt one-off heuristics per app.
+4. **System-wide, not just scroll** — the same observation primitive should ideally serve click verification (`mouse_click.verifyDelivery`), keyboard input verification (`keyboard` BG `BackgroundInputNotDelivered`), and `desktop_act` post-state — wherever the MCP layer needs to confirm "did the user-visible state change."
+
+Path B's strongest argument ("re-use existing helpers") is a code-organisation virtue. It is **silent on whether the resulting capability lifts the north star vs. encoding a one-off Excel scroll patch.** The pushback is that we picked the path with the lowest LOC, not the path that builds the right shared primitive for the next 12 months of verification work.
+
+---
+
+## 3. Capability surface — what each path produces
+
+| Path | Primitive produced | Output shape | Re-usable for | Re-usable for | Re-usable for |
+|---|---|---|---|---|---|
+| | | | scroll | click verify | keyboard verify |
+| **A** | (a) UIA `ScrollPattern.VerticalScrollPercent` pre/post; (b) phase correlation `(dx, dy)` shift vector | structured: numeric percent OR a 2D shift in pixels | ✓ canonical | ✓ click → focus shift → repaint detected as small (dx,dy) | ✓ keyboard type → text repaints in field → repaint detected |
+| **B** | (a) `computeChangeFraction` (boolean over 1% threshold); (b) `findNewRows`/`findNewColumns` MAE search returning row-count | unstructured: "did it change a lot" + scroll-row count | ✓ for scroll-overlap (its design target) | △ "did anything change" but no localisation | △ same — no localisation |
+| **C** | pHash 32×32 Hamming distance | unstructured: bits-different scalar | ✓ generic delta detector | ✓ same | ✓ same |
+
+**Phase correlation in A returns a *vector*.** That's a structured signal that other tiers can consume: did the page move down by 50 px? was there only a 1 px drift (anti-aliasing)? did the focus rectangle move sideways (focus shift)? `computeChangeFraction` returns "did >1% of blocks change." That answers a yes/no, not a "what changed how."
+
+**UIA `ScrollPattern.VerticalScrollPercent` is the canonical accessibility API observation.** When the app exposes it, it gives an exact numeric percent — by definition the most reliable observation channel. ADR-018 Tier 1 already uses it for *dispatch*; using it symmetrically for *observation* is the natural design (and was originally listed as the Tier 1 observation in ADR-018 §2.2).
+
+---
+
+## 4. Empirical risk re-check on path B
+
+Opus's path-B recommendation rested on this claim:
+
+> 0.36% raw-byte change on a 1422400-byte buffer ≈ 5120 changed bytes ≈ thousands of changed blocks — orders of magnitude above the existing 2-5% block-fraction thresholds.
+
+This is true only **if the 5120 byte changes are distributed across many 8×8 blocks**. The empirical data was:
+
+```
+pre[0:60]  = 525252ff 525252ff 525252ff … (dark-gray row-label strip)
+post[0:60] = 525252ff 525252ff 525252ff …
+byte diff: 5120 / 1422400 ( 0.36 %)
+```
+
+A 1422400-byte buffer at 4 channels × 889 width × 400 height = 4 × 8 × 8 = 256 bytes per 8×8 block. That gives 1422400 / 256 ≈ **5556 blocks**. If the 5120 byte changes are concentrated (e.g., in the thin row-number column on the left edge, ~30 px wide × 400 tall × 4 channels = ~48000 bytes total — even all-pixels-changed there is at most 48000 bytes), they'd live in roughly 30/889 ≈ 3.4% of blocks horizontally × 100% vertically = ~190 affected blocks.
+
+- 5120 changed bytes across 190 blocks ≈ 27 bytes per block average — **above** `NOISE_THRESHOLD=16` per block, so those blocks WOULD register.
+- Path B might work. **But Opus's calculation didn't account for spatial concentration**, and the threshold (NOISE_THRESHOLD=16 *per channel*) interacts with the 4-channel layout in a way that needs verification.
+
+The honest answer is: **B might work empirically — but it hasn't been verified, and its detection ceiling is "did something move", not "what moved by how much."**
+
+Path A's UIA pre-snapshot is empirically known to be exact when the pattern is exposed. Path A's phase correlation gives sub-pixel `(dx, dy)` regardless of content. **Neither requires the empirical verification step B does.**
+
+---
+
+## 5. Cost re-evaluation (LOC ≠ value)
+
+| Path | LOC | New crate | Days | Capability ceiling |
+|---|---|---|---|---|
+| A | ~200-300 (Rust + TS) | `rustfft` | 3-5 | (dx,dy) vector + UIA percent — structured, generalises |
+| B | ~100-150 (TS) | none | 1 | "did >1% change" + scroll row count — unstructured |
+| C | ~50 (Rust + TS) | `image_hasher` | 1 | "did pHash diff exceed bits-threshold" — unstructured |
+
+Opus weighted **LOC × time** heavily; the user's frame is **capability × longevity**. A's 200 lines build a primitive that the rest of the MCP can lean on for the next 12 months. B's 100 lines is glue specific to one PostMessage path.
+
+ADR-018 itself (§1.3) is a single ADR that spent ~6 weeks of trunk land + 7 sub-plan PRs. The cost of one more ~5-day PR to install a foundational primitive is small relative to the system-wide debt it pays down.
+
+---
+
+## 6. Re-evaluation against decision criteria
+
+| Criterion | A (UIA + phase correlation) | B (MAE port) | C (pHash 32×32) |
+|---|---|---|---|
+| Empirical Excel robustness | UIA path: exact when exposed; phase correlation: sub-pixel shift regardless | Block-SAD: spatial-concentration-dependent (unverified) | Aliases on periodic grid (per Hacker Factor / pHash discussions) |
+| Generalisation to Word `_WwG` / PowerPoint / OneNote / RDP / games | ✓ phase correlation is content-agnostic | △ scroll-row MAE is scroll-specific | △ same hash, same alias risk per app |
+| Re-use as click / keyboard verify primitive | ✓ phase correlation gives (dx,dy) shift for any visual state change | △ "did it change >1%" — useful but coarse | △ "did pHash differ" — coarse |
+| Engineering cost | high (200-300 lines, new dep, 3-5 days) | low (100-150 lines, no dep, 1 day) | very low (50 lines, new dep, 1 day) |
+| Maintenance burden | rustfft is stable, pure-Rust SIMD | none (existing helpers) | image_hasher is maintained but external |
+| Risk: false positive on caret blink / Excel marching-ants | phase correlation: peak amplitude < threshold filters these out | block-SAD: HIGH (every block-change counts) | pHash: HIGH (any bit-flip counts) |
+| Risk: false negative on Excel | UIA: zero if exposed; phase correlation: very low (frequency-domain shift detect) | spatial-concentration-dependent (unverified) | structural alias on periodic grid |
+| PR scope discipline | one PR feasible (helper + tests + docs) | one PR feasible (smaller) | one PR feasible (smallest) |
+| Aligned with ADR-018 north star (§1.3, §2.2, §2.3) | ✓ destination-explicit, honest, generalises | △ honest (boundary still wrong), partial generalisation | △ same |
+
+---
+
+## 7. Verdict under the north-star lens
+
+**Path A is correct when the goal is system-wide detection-capability lift.** Path B is correct when the goal is "fix Excel scroll observation with minimum delta." The user's framing is the former — therefore A.
+
+Concretely:
+
+1. **UIA pre/post `ScrollPattern.VerticalScrollPercent`** lifts the Tier 1 observation surface — symmetric with the Tier 1 dispatch path that already exists. When Excel/Word/PowerPoint expose the pattern, the dispatcher gets an exact percent.
+2. **Phase correlation (FFT via `rustfft`)** lifts the Tier 3+4 fallback observation surface — content-agnostic, gives a structured (dx,dy) shift vector. The same primitive serves:
+   - Tier 3 `PostMessage` chain-trust verification (the immediate use case)
+   - Future `mouse_click.verifyDelivery` "did the click cause a visible focus/repaint shift" — a known gap in the current heuristic
+   - Future `keyboard` BG verification when UIA TextPattern read-back is unavailable
+   - Future `desktop_act` post-state verification
+
+Path B remains valuable as a **fall-back tier** when neither UIA nor phase correlation produce a confident signal (e.g., capture failure, FFT cost prohibitive on a hot path). But it is not the primary primitive — it's the existing 8×8 block-SAD already in the codebase.
+
+Path C is **superseded**: pHash 32×32's structural alias on periodic grids is the same failure mode that motivated this work. The "smallest delta" virtue isn't enough to justify replacing the existing dHash without solving the periodic-grid problem.
+
+---
+
+## 8. Round 2 — User review findings (2026-05-16)
+
+The Round 1 verdict (Path A as a pair of "UIA pre/post + phase correlation") was reviewed and pushed back on. Verbatim findings:
+
+- **P1 — phase correlation 過信** — "Excel のような周期格子、低テクスチャ、行ヘッダだけ変わるケースではピークが曖昧になり得ます。`peak amplitude > 0.05` だけでなく、`peak / secondPeak`、軸方向の符号、タイルごとの一致率、低テクスチャ判定を入れる前提にした方が安全です。"
+- **P1 — click / keyboard verification への一般化が広すぎる** — "スクロールの『平行移動検知』と、クリック/入力の『局所 repaint 検知』を同じ primitive で扱っています。クリックや文字入力は全体 shift が 0 のことが多いので、phase correlation は主役ではなく `motion vector + dirty/residual map` の一要素にした方がよいです。"
+- **P2 — multi-frame temporal が中心になっていない** — "pre/post 1 組の検知に寄っています。今回の本丸はむしろここで、`t=0, 50, 100, 200 ms` のような低周波 multi-frame ring buffer を持ち、N フレーム内の最大変化/安定後変化を見る設計にすると、かなり北極星っぽくなります。"
+- **P2 — UIA 観測 API の実装形が ADR で曖昧** — "PostMessage 後の leaf HWND に対して『read-only に percent を取る』公開 API としては ADR 上でまだ曖昧です。`uia_read_scroll_percent_at_hwnd(hwnd, axis)` のような additive napi を明記すると実装者が迷わないです。"
+
+All four findings are accepted. The Round 1 verdict over-claimed phase correlation as a single primitive that solves both translation detection and local-repaint detection; collapsed scroll/click/keyboard into one primitive (whereas click/keyboard are local-repaint problems, fundamentally different from scroll's global translation); and centred the design on a single pre/post pair when the right architecture is a multi-frame ring buffer.
+
+---
+
+## 9. Round 2 — A2 framework: Temporal Motion Observation Layer
+
+Rename Path A to **A2 — Temporal Motion Observation Layer (TMOL)**. The framework is a *layered observation pipeline*, not a single algorithm. Each layer is a candidate implementation that plugs into a stable contract; layers are stacked highest-confidence-first.
+
+### 9.1 Architecture (single contract, pluggable implementations)
+
+```
+verifyVisualMotion(
+  leafHwnd,
+  region,
+  axisHint?: "vertical" | "horizontal" | null,
+  capability: "scroll_translation" | "local_repaint" | "any_change",
+): VisualMotionObservation
+```
+
+`VisualMotionObservation`:
+```ts
+{
+  motion: "translation" | "local_repaint" | "no_change" | "indeterminate";
+  // present iff motion === "translation"
+  shift?: { dx: number; dy: number; confidence: number };  // sub-pixel possible
+  // present iff motion === "local_repaint"
+  residual?: { fractionChanged: number; centroid?: { x: number; y: number } };
+  // metadata
+  source: "uia_scroll_percent" | "block_motion" | "tiled_phase_correlation"
+         | "ssim_residual" | "optical_flow" | "dxgi_dirty_rect"
+         | "chain_trust_unverified";
+  framesSampled: number;
+  totalElapsedMs: number;
+}
+```
+
+The dispatcher picks layers based on `capability`:
+
+| Capability | Primary layer | Fallback chain |
+|---|---|---|
+| `scroll_translation` (scroll dispatcher) | UIA `ScrollPattern.VerticalScrollPercent` if exposed | block motion vectors → tiled phase correlation → SSIM residual → chain_trust_unverified |
+| `local_repaint` (click verify, BG keyboard verify) | SSIM residual on focused element rect (if known) | block motion vectors with `dy=0` constraint → optical flow sparse → chain_trust_unverified |
+| `any_change` (general verifyDelivery) | DXGI Desktop Duplication dirty/move rect (if available) | block motion vectors → SSIM residual → chain_trust_unverified |
+
+### 9.2 Multi-frame ring buffer (the north-star part)
+
+This is the architectural feature the user named as the load-bearing piece. Instead of "capture pre, post, compare":
+
+1. Capture `pre` snapshot right before the dispatch action.
+2. Issue the action (PostMessage / SendInput / CDP / UIA).
+3. Sample `post` frames at `t = 30, 60, 120, 240 ms` (4 frames; cap total settle at 240 ms).
+4. **Decision rule**: motion observed iff `∃ post_frame ∈ ring such that motion(pre, post_frame) ≥ threshold` AND `post_frame_last` is stable (within `noise_threshold` of `post_frame_last - 1`).
+
+The dual condition ("motion → settle → final-differs-from-pre") catches:
+- **GPU staleness** — `PrintWindow` at t=30 ms returns the pre-paint cached frame; t=120 ms returns the post-paint. Without the ring buffer, we'd capture only t=30 and miss the real change.
+- **Transient animations** (cursor blink, marching-ants, hover effects) — motion observed in middle frames but final frame matches pre → reject as transient noise, not a real delivery.
+- **Real scrolls** — motion observed AND final frame differs from pre by the same shift → accept.
+
+This is what the user named "動画エンコード的な" — analogous to I/P/B inter-frame coding's residual + motion compensation, applied to UI-state verification rather than video compression.
+
+### 9.3 Candidate implementations per primitive
+
+For `scroll_translation` (priority order):
+
+1. **UIA `CurrentVerticalScrollPercent`** — exact, when exposed. Probe required (see §10 OQ1).
+2. **Block motion vectors (16×16 SAD coarse-to-fine)** — robust to Excel periodic grid because each 16×16 block carries enough local structure to register a `dy`. Majority vote across all blocks gives the global scroll amount. Already partially implemented in `src/pixel_diff.rs` (SSE2 SAD on 8×8 blocks); extending to 16×16 with `(dx, dy)` search radius ±row_height is a moderate Rust addition.
+3. **Tiled phase correlation** — `rustfft` on each of N tiles (e.g. 4×4 grid of 64×64 tiles), majority vote on `dy`. Robust against the periodic-grid-vs-row-header pathology because each tile sees mixed-frequency local content. Cost: 16 FFTs vs Round 1's 1 FFT. Still under 20 ms on 1080p with rustfft SIMD.
+4. **SSIM residual map** — Wang et al. 2004 metric; converts to a "did this region change" signal. Used as a confidence floor (if SSIM ≥ 0.99 everywhere → no_change regardless of motion-vector noise).
+5. **DXGI Desktop Duplication dirty/move rects** — Windows-native OS-level frame-diff metadata. Captured by the OS-side compositor, not by our PrintWindow. Highly accurate but tied to the desktop-duplication surface, not a single window. Suitable for full-screen / multi-window observation; integration is heavier (DXGI desktop duplication session lifecycle).
+
+For `local_repaint` (click verify, BG keyboard verify):
+
+1. **SSIM residual on focused-element rect** — the click's expected effect is a local visual change inside a known rect (the clicked element's UIA bounds). SSIM there gives a clean delta.
+2. **Block motion vectors constrained to `dy=0`** — for click feedback (highlight, focus rectangle), the "movement" is a content change without translation. Block-SAD with `dy=0` (or ε bound) captures this as a residual term.
+3. **Optical flow (Lucas-Kanade sparse)** — generic; samples N sparse feature points, computes per-point flow. Lower priority — block motion + SSIM cover most cases.
+
+For `any_change` (general verifyDelivery):
+
+1. **DXGI Desktop Duplication dirty/move rects** — best signal when available; OS knows authoritatively what changed.
+2. **Block motion vectors** + **SSIM residual map** — software-only fallback when DXGI not in scope (or window not on the primary desktop).
+
+### 9.4 phase correlation, properly gated
+
+The original Round 1 framing was "phase correlation peak amplitude > 0.05 → motion." That's insufficient on Excel-class periodic grids. Round 2 gating:
+
+```
+phase_correlation_pass(pre, post):
+  let (peak1_loc, peak1_val) = argmax(crossspec_inverse(pre, post))
+  let peak2_val = max(crossspec_inverse(pre, post) \ neighbourhood(peak1_loc))
+  let ratio = peak1_val / peak2_val           // ≥ 3 → confident peak
+  let texture = variance(pre)                  // ≥ noise_floor → enough texture
+  let tile_agreement = ratio_of_tiles_with_same_dy   // ≥ 0.5 → coherent shift
+  return ratio ≥ 3 AND texture ≥ noise_floor AND tile_agreement ≥ 0.5
+```
+
+Tile agreement is the load-bearing add. A single FFT on a 256×256 patch of Excel's row-header strip can produce ambiguous peaks; computing per-tile correlation and requiring a majority of tiles to agree on the same `(dx, dy)` distinguishes "genuine global shift" from "ambiguous low-texture pattern match."
+
+References: Guizar-Sicairos et al. 2008 (sub-pixel phase correlation via local oversampling) — the canonical algorithm for the high-confidence peak detection.
+
+### 9.5 Concrete UIA napi (P2 finding 4)
+
+Add to `src/uia/scroll.rs`:
+
+```rust
+#[napi]
+pub fn uia_read_scroll_percent_at_hwnd(
+  hwnd: BigInt,
+  axis: String,  // "vertical" | "horizontal"
+) -> napi::Result<Option<f64>>;
+```
+
+Implementation: `ElementFromHandle(hwnd)` → walk UIA ancestors via `RawViewWalker` looking for `IUIAutomationScrollPattern` → if found, read `CurrentVerticalScrollPercent` / `CurrentHorizontalScrollPercent` → return as `Option<f64>` (None when no pattern). Read-only; no `SetScrollPercent` side effect.
+
+This is the additive observation API the dispatcher consults *before* falling through to block motion / phase correlation. The existing `uia_scroll_by_wheel_at_hwnd` (Tier 1 dispatch) is a *write* path; this is its read-only sibling.
+
+### 9.6 Renamed envelope shape
+
+ADR-018 §2.6.2 reason taxonomy is unchanged. The new envelope field is `verifyDelivery.observation`:
+
+```
+verifyDelivery: {
+  status: "delivered" | "not_delivered" | "unverifiable";
+  channel: "uia" | "cdp" | "postmessage" | "send_input";
+  reason: …;                       // existing
+  observation?: {                  // additive, optional
+    source: "uia_scroll_percent" | "block_motion" | "tiled_phase_correlation"
+           | "ssim_residual" | "dxgi_dirty_rect" | "chain_trust_unverified";
+    shift?: { dx: number; dy: number; confidence: number };
+    residual?: { fractionChanged: number };
+    framesSampled?: number;
+  };
+}
+```
+
+Existing callers that ignore `observation` are unaffected.
+
+---
+
+## 10. Recommended pathway (Phase 5+N+1, Round 2)
+
+**Land in stages — not one PR.** The TMOL framework's surface is too large for one PR; the user's framing requires building the *primitive*, which is multiple sub-PRs:
+
+### Stage 1 — UIA observation read-only API (1 PR, ~1-2 days)
+
+- Add `uia_read_scroll_percent_at_hwnd(hwnd, axis)` napi in `src/uia/scroll.rs` per §9.5.
+- Wire into `postWheelToHwnd` chain-trust path: pre-snapshot the percent, post-snapshot after settle, compare against `SCROLL_PERCENT_EPSILON`. When pattern exposed AND moved → emit `delivered_via_postmessage` with `observation.source: "uia_scroll_percent"`. When pattern not exposed → fall through to Stage 2 (or chain-trust if Stage 2 not yet landed).
+- Empirical probe: does EXCEL7 expose `ScrollPattern` for reads? If yes, this single stage resolves Excel observation without any image processing.
+- Carry-over: `mouse_click.verifyDelivery` / `keyboard` BG verify can reuse the read-only UIA percent for any element that exposes ScrollPattern in its ancestor chain.
+
+### Stage 2 — Multi-frame ring buffer + block motion vectors (1 PR, ~3-4 days)
+
+- Add `captureMultiFrameRing(hwnd, region, schedule: number[])` in `src/engine/layer-buffer.ts` — captures `pre + post[]` at the requested ms offsets, returns the ring as a typed array.
+- Add `computeBlockMotion(pre, post, blockSize, searchRadius)` in `src/pixel_diff.rs` (Rust SSE2 extension of existing block-SAD). Returns per-block `(dx, dy)` + a global vote.
+- Wire into `postWheelToHwnd` chain-trust path: capture ring → for each post-frame, compute motion vs pre → return motion observed when (a) ≥ 1 post-frame shows coherent shift AND (b) the last post-frame is stable (within noise) → emit `delivered_via_postmessage` with `observation.source: "block_motion"` and `shift: { dx, dy }`.
+- Excel periodic-grid case: 16×16 blocks each carry enough local structure for unambiguous `dy` register; majority vote across blocks gives the row count. Empirical bench required to confirm `0.36% byte change` translates to a non-zero majority vote.
+
+### Stage 3 — Tiled phase correlation (1 PR, ~2-3 days)
+
+- Add `rustfft` Rust crate; new `src/image/phase_correlation.rs` module with the proper gating from §9.4 (peak/secondPeak ratio, texture floor, tile agreement).
+- Wire as a fallback under block motion: when block-motion's majority vote has low confidence (e.g., tile agreement < 0.5), invoke tiled phase correlation as the higher-resolution disambiguator.
+- Out-of-scope: full-window single FFT (the Round 1 framing) — explicitly rejected in favour of tiled.
+
+### Stage 4 — SSIM residual map for click/keyboard verify (1 PR, ~2-3 days)
+
+- Different primitive from scroll's "did it translate?". SSIM detects "did the focused-element rect change."
+- Wire into `mouse_click.verifyDelivery` and `keyboard` BG verify. **Not in the scroll path.**
+- This is the click/keyboard generalization that Round 1 conflated with phase correlation; Round 2 cleanly separates it.
+
+### Stage 5 — DXGI Desktop Duplication dirty/move rects (1 PR, ~5-7 days, exploratory)
+
+- Tied to the desktop-duplication surface; integration is heavier than the per-window paths above.
+- Carry-over: not blocking scroll/click verification; investigate as a Phase 5+N+2 carry-over.
+
+### Stage 6 — Optical flow (defer until Stage 1-4 telemetry)
+
+- Lucas-Kanade sparse / Farneback dense. Generic visual-state-change observation. Likely overkill for scroll/click/keyboard once Stages 1-4 are wired.
+- Defer to telemetry-driven decision.
+
+### What lands first
+
+**Stage 1 alone resolves Excel observation if EXCEL7 exposes ScrollPattern for reads** — empirical probe is the gating step. If yes, Stages 2-6 become optional optimisations for non-UIA-friendly apps. If no, Stage 2 becomes the primary work, with Stage 1 as the lightweight pre-check.
+
+Recommended ordering: **Stage 1 → empirical probe → decide Stage 2 priority based on outcome.**
+
+---
+
+## 11. Round 2 — Trade-offs explicitly accepted
+
+By adopting A2 over Path A Round 1:
+
+- **Larger scope** (5 stages vs. 1 PR), but each stage is independently shippable and provides observable LLM-side capability. Reflects the user's "system-wide" framing.
+- **No single "phase correlation = solved" bet.** The framework lists 6 candidate implementations across 3 primitives (`scroll_translation` / `local_repaint` / `any_change`), each chosen for its specific failure mode.
+- **Multi-frame ring buffer is central**, not optional. This was the user's named load-bearing architectural feature.
+- **Click / keyboard primitive is `local_repaint`, not `scroll_translation`** — explicit primitive split.
+
+By NOT adopting Path A Round 1 (single-FFT phase correlation):
+
+- We give up the "single elegant primitive" framing. The Round 1 framing was simpler but conflated translation and local-repaint detection — a category error the user flagged.
+
+By NOT adopting Path B:
+
+- Path B's `computeChangeFraction` + `findNewRows` is folded into A2 Stage 2 as the **starting point** for block motion vectors. The existing helper is the foundation; the extension is the per-block `(dx, dy)` search.
+
+By NOT adopting Path C:
+
+- Same as Round 1: pHash structurally aliases on periodic grids.
+
+---
+
+## 12. Round 2 — Open questions
+
+1. **Does EXCEL7 expose `IUIAutomationScrollPattern` for reads?** Empirical probe needed before Stage 1 implementation. If yes, Stage 1 alone resolves Excel; if no, Stage 2 becomes primary.
+2. **Block motion vector latency budget** on 1080p windows — bench `pre + 4 post-frames @ 30/60/120/240 ms` capture + per-frame 16×16 block SAD on a 889×400 region. If > 50 ms p99, downsample to 444×200 first.
+3. **Multi-frame ring buffer trigger conditions** — how aggressive should the schedule be? `[30, 60, 120, 240]` is a starting point; settling apps (Excel) may need `[30, 60, 120, 240, 500]`; over-aggressive scheduling wastes capture cost.
+4. **DXGI Desktop Duplication scope** — does it fit our per-window observation model, or is it strictly a screen-wide signal? Separate ADR likely.
+5. **Click / keyboard primitive boundary** — for click verification, the "focused-element rect" isn't always knowable (e.g., custom-paint canvas like Photoshop). SSIM on the full window rect is the fallback; calibrate threshold.
+6. **Phase correlation gating params** — `peak/secondPeak ≥ 3`, `texture ≥ noise_floor`, `tile_agreement ≥ 0.5` are rule-of-thumb thresholds; per-app empirical calibration needed.
+
+---
+
+## 13. Final recommendation (Round 2)
+
+**Adopt A2 — Temporal Motion Observation Layer (TMOL)** as the Phase 5+N+1 verification framework. Five stages, each independently shippable, with Stage 1 (read-only UIA `ScrollPercent`) as the empirical probe and likely-sufficient fix for Excel scroll observation. The multi-frame ring buffer is the architectural backbone (user's "動画エンコード的な"). Scroll uses `scroll_translation` primitive (block motion / tiled phase correlation); click/keyboard use `local_repaint` primitive (SSIM residual). Phase correlation is one implementation candidate inside `scroll_translation`, properly gated with peak/secondPeak ratio + tile agreement, NOT a stand-alone primitive.
+
+Open Stage 1 as the next PR after user approval of this revised analysis. The empirical probe (does EXCEL7 expose `ScrollPattern` for reads?) decides the priority of Stage 2+.
+
+---
+
+## 14. References (Round 2 additions)
+
+- Wang et al., "Image quality assessment: from error visibility to structural similarity" (SSIM, 2004) — IEEE Trans. Image Process.
+- Guizar-Sicairos, Thurman, Fienup, "Efficient subpixel image registration algorithms" (2008) — Optics Letters, the canonical sub-pixel phase correlation paper
+- [Microsoft DXGI Desktop Duplication](https://learn.microsoft.com/en-us/windows/win32/direct3ddxgi/desktop-dup-api) — `IDXGIOutputDuplication::AcquireNextFrame` returns dirty / move rect metadata
+- [Windows.Graphics.Capture](https://learn.microsoft.com/en-us/windows/uwp/audio-video-camera/screen-capture) — per-window capture (alternative to PrintWindow)
+- [OpenCV Optical Flow tutorial](https://docs.opencv.org/4.x/d4/dee/tutorial_optical_flow.html) — Lucas-Kanade / Farneback patterns
+- [`rustfft` crate](https://docs.rs/rustfft/) — pure-Rust SIMD FFT for phase correlation
+- [Phase correlation — Wikipedia](https://en.wikipedia.org/wiki/Phase_correlation)
+- ADR-018 §1.3 (system-wide silent-failure framing) — `docs/adr-018-input-pipeline-3tier.md`

--- a/docs/adr-018-phase-5-followup-verification-pathway-analysis.md
+++ b/docs/adr-018-phase-5-followup-verification-pathway-analysis.md
@@ -159,9 +159,9 @@ verifyVisualMotion(
   // present iff motion === "local_repaint"
   residual?: { fractionChanged: number; centroid?: { x: number; y: number } };
   // metadata
-  source: "uia_scroll_percent" | "block_motion" | "tiled_phase_correlation"
-         | "ssim_residual" | "optical_flow" | "dxgi_dirty_rect"
-         | "chain_trust_unverified";
+  source: "uia_scroll_percent" | "block_motion_vectors" | "tiled_phase_correlation"
+         | "ssim_residual" | "dxgi_dirty_rect" | "optical_flow"
+         | "temporal_ring_observation_only" | "chain_trust_unverified";
   framesSampled: number;
   totalElapsedMs: number;
 }
@@ -256,8 +256,9 @@ verifyDelivery: {
   channel: "uia" | "cdp" | "postmessage" | "send_input";
   reason: …;                       // existing
   observation?: {                  // additive, optional
-    source: "uia_scroll_percent" | "block_motion" | "tiled_phase_correlation"
-           | "ssim_residual" | "dxgi_dirty_rect" | "chain_trust_unverified";
+    source: "uia_scroll_percent" | "block_motion_vectors" | "tiled_phase_correlation"
+           | "ssim_residual" | "dxgi_dirty_rect" | "optical_flow"
+           | "temporal_ring_observation_only" | "chain_trust_unverified";
     shift?: { dx: number; dy: number; confidence: number };
     residual?: { fractionChanged: number };
     framesSampled?: number;
@@ -284,7 +285,7 @@ Existing callers that ignore `observation` are unaffected.
 
 - Add `captureMultiFrameRing(hwnd, region, schedule: number[])` in `src/engine/layer-buffer.ts` — captures `pre + post[]` at the requested ms offsets, returns the ring as a typed array.
 - Add `computeBlockMotion(pre, post, blockSize, searchRadius)` in `src/pixel_diff.rs` (Rust SSE2 extension of existing block-SAD). Returns per-block `(dx, dy)` + a global vote.
-- Wire into `postWheelToHwnd` chain-trust path: capture ring → for each post-frame, compute motion vs pre → return motion observed when (a) ≥ 1 post-frame shows coherent shift AND (b) the last post-frame is stable (within noise) → emit `delivered_via_postmessage` with `observation.source: "block_motion"` and `shift: { dx, dy }`.
+- Wire into `postWheelToHwnd` chain-trust path: capture ring → for each post-frame, compute motion vs pre → return motion observed when (a) ≥ 1 post-frame shows coherent shift AND (b) the last post-frame is stable (within noise) → emit `delivered_via_postmessage` with `observation.source: "block_motion_vectors"` and `shift: { dx, dy }`.
 - Excel periodic-grid case: 16×16 blocks each carry enough local structure for unambiguous `dy` register; majority vote across blocks gives the row count. Empirical bench required to confirm `0.36% byte change` translates to a non-zero majority vote.
 
 ### Stage 3 — Tiled phase correlation (1 PR, ~2-3 days)

--- a/docs/adr-019-anti-fukuwarai-v3-temporal-motion-observation.md
+++ b/docs/adr-019-anti-fukuwarai-v3-temporal-motion-observation.md
@@ -1,0 +1,611 @@
+# ADR-019 — Anti-fukuwarai v3: Temporal Motion Observation Layer (TMOL) for `verifyDelivery`
+
+- Status: **Draft (Round 0)** — initial framework draft from the PR #308 dHash failure post-mortem + user north-star pushback
+- Date: 2026-05-16
+- Authors: Claude (Sonnet drafting, Opus initial recommendation B → user Round 2 pushback → Sonnet revision)
+- Related:
+  - **ADR-005** (vision-gpu backend — ONNX Runtime + DirectML / ROCm / CUDA) — existing GPU compute path TMOL Stage 8 opportunistically reuses (§4.6)
+  - **ADR-018** (`docs/adr-018-input-pipeline-3tier.md`) §1.3 / §2.2 / §2.6 — destination-explicit input pipeline; TMOL is its symmetric *observation* counterpart for verifyDelivery
+  - **PR #307 / #308** — chain-trust assertion path that exposed the dHash macro-pattern collapse on Excel's cell grid (commit `926c69b`, 2026-05-16 dogfood)
+  - **`docs/adr-018-phase-5-followup-verification-pathway-analysis.md`** — Round 1 vs Round 2 pathway analysis (preserves the A / B / C / A2 decision audit)
+  - **Anti-fukuwarai genealogy**:
+    - **v1** — v0.6.0 Anti-Fukuwarai (focus / modal / perception baseline; 2026-04 release line)
+    - **v2** — v0.9 – v0.11 RPG (Reactive Perception Graph; lensId, perception guards)
+    - **v3** — *this ADR* (temporal observation: "did the user-visible state actually move?")
+- Blocks: none
+- Blocked by: ADR-019 review and acceptance
+
+---
+
+## 1. Context
+
+### 1.1 The recurring failure mode
+
+"Anti-fukuwarai" — the metaphor where a blindfolded agent places facial features on a face — is the project's standing description of the LLM-agent failure mode this codebase exists to prevent. v1 (focus / modal observation) and v2 (perception graph) closed the *pre-action* observation gap: the agent knows what's on the screen before acting. They did **not** close the *post-action* observation gap: did the action actually change the user-visible state?
+
+ADR-018 §1.3 reframes this for the dispatch side:
+
+> the silent-failure mode is unrecoverable from the LLM side — `ok:true` masks a 0-px scroll.
+
+PR #307 / #308 closed the *dispatch* leg (destination-explicit, leaf-walker for MDI scroll receivers). The *observation* leg — "did the post-action state actually differ from pre-action?" — remains partially fukuwarai-blind in the following cases:
+
+1. **Scroll on custom-painted MDI apps** (Excel cell grid, Word `_WwG`, PowerPoint slide canvas, OneNote canvas): `GetScrollInfo(SB_VERT)` returns null (custom `NUIScrollbar`, MFC paint). Chain-trust assertion (PR #308) emits `delivered_via_postmessage` without observation; Codex P1 boundary case is documented unverified.
+2. **Click verify**: `mouse_click.verifyDelivery` reports `delivered` / `focus_only` / `unverifiable` based on focused-element heuristics; for custom-paint canvases (Photoshop, Blender, GPU games) the heuristic is silent.
+3. **Keyboard BG verify**: `BackgroundInputNotDelivered` returns `unverifiable` when the target doesn't expose `TextPattern` — silent for the same custom-paint surfaces.
+4. **`desktop_act` post-state**: relies on the perception graph's diff — works for UIA-exposed elements, silent for custom-paint.
+
+The dHash gate (PR #308 Round 2, reverted Round 3) tried to address #1 with a single 8×8 perceptual hash pre/post. Empirical dogfood (Excel A1 → A74, raw byte diff 0.36 %, 8×8 dHash byte-identical) showed the gate **demoted real scrolls to `target_unreachable`** — opposite of the user-visible truth. Documented in `docs/adr-018-phase-5-followup-leaf-walker-subplan.md` §2.1 reverted-note.
+
+### 1.2 Why "v3"
+
+v1 and v2 closed the **structured-state pre-action observation gap** (focus / modal / UIA tree / perception graph; with some image-based helpers like terminal_read and browser_search). They're fukuwarai-defending where the OS / accessibility layer cooperates AND on the *pre-action* axis. (Round 1 P2-5 — earlier draft over-claimed "v1/v2 = structured only"; v1 v0.6.0 included terminal_read/send + browser_search image-adjacent components per `memory/project_v0_6_anti_fukuwarai`.)
+
+v3 must read **visual state across time** when the structured layer is silent. The mechanisms — multi-frame temporal capture, motion vector estimation, residual change detection, OS-level dirty-rect metadata — overlap with modern video coding (inter-frame motion compensation + residual coding). The user named the analogy: "まるで、最新の動画エンコードのようだ" (2026-05-16).
+
+This ADR formalises that observation layer.
+
+### 1.3 The four primitives that emerged from Round 2 review
+
+User pushback on the Round 1 framing (single phase correlation primitive) surfaced four distinct observation problems that share architecture but **not the same algorithm**:
+
+| Primitive | Question answered | Example use case |
+|---|---|---|
+| `scroll_translation` | Did the content shift by `(dx, dy)` pixels? | scroll dispatcher's chain-trust verify |
+| `local_repaint` | Did a known sub-rect change without translating? | click verify (focus rectangle drew) |
+| `any_change` | Did any pixel change in the window? | desktop_act post-state diff |
+| `structured_state` | Did a UIA-exposed property change? | UIA `ScrollPattern.VerticalScrollPercent` pre/post |
+
+Conflating these primitives into a single algorithm is a category error: phase correlation answers `scroll_translation` well but is wrong for `local_repaint` (no global shift). SSIM answers `local_repaint` well but is wrong for `scroll_translation` (a 1-pixel shift drops SSIM far below the no-change threshold even when the user-visible state is identical-up-to-translation, which the dispatcher needs to distinguish from real translation).
+
+---
+
+## 2. Decision
+
+Adopt a **Temporal Motion Observation Layer (TMOL)** built around three architectural pillars:
+
+1. **Single contract, pluggable implementations** — one observation contract (`VisualMotionObservation`), N candidate algorithms beneath, dispatcher picks per `capability` field.
+2. **Multi-frame ring buffer** — capture pre + multiple post frames at low-frequency sampling intervals (default `[30, 60, 120, 240 ms]`), apply a **dual-condition decision rule** (motion observed AND last frame stable AND last frame differs from pre).
+3. **Primitive split** — `scroll_translation` / `local_repaint` / `any_change` / `structured_state` are distinct primitives with distinct algorithm preferences.
+
+### 2.1 The contract
+
+```ts
+type VisualMotionObservation = {
+  motion:
+    | "translation"
+    | "local_repaint"
+    | "no_change"
+    | "indeterminate";
+  /** present iff motion === "translation" */
+  shift?: { dx: number; dy: number; confidence: number };
+  /** present iff motion === "local_repaint" */
+  residual?: { fractionChanged: number; centroid?: { x: number; y: number } };
+  /** algorithm that produced this observation. **Canonical 8-value enum** — single
+   *  source of truth for the surface; ADR-018 §2.6 envelope reference and
+   *  TS / Rust type definitions MUST bit-equal-mirror this list. */
+  source:
+    | "uia_scroll_percent"
+    | "block_motion_vectors"
+    | "tiled_phase_correlation"
+    | "ssim_residual"
+    | "dxgi_dirty_rect"
+    | "optical_flow"
+    | "temporal_ring_observation_only" // Stage 2a telemetry-only emission (no decision)
+    | "chain_trust_unverified";
+  /** Stage 2a telemetry — populated when source === "temporal_ring_observation_only"
+   *  or as a sibling diagnostic field on other sources. Carries the per-frame
+   *  `computeChangeFraction` series captured by the multi-frame ring buffer. */
+  ringTelemetry?: {
+    framesSampled: number;
+    elapsedMsPerFrame: number[];
+    changedFractions: number[];
+    maxChangedFraction: number;
+  };
+  framesSampled: number;
+  totalElapsedMs: number;
+};
+
+interface TmolObserver {
+  verifyVisualMotion(opts: {
+    hwnd: bigint;
+    region?: { x: number; y: number; width: number; height: number };
+    axisHint?: "vertical" | "horizontal";
+    capability: "scroll_translation" | "local_repaint" | "any_change";
+    /** Multi-frame ring buffer settle schedule in milliseconds. The default
+     *  [30, 60, 120, 240] is the **Stage 2a contract** (§4.5.6 bench gate);
+     *  Stage 2a explicitly wires the parameter through (not just declared
+     *  here). Per OQ3, the default may evolve to an adaptive schedule
+     *  (`capture until last-stable holds, cap at 500 ms total`) in a
+     *  Stage 2a follow-up. The fixed-schedule default ships first; the
+     *  adaptive form is deferred. */
+    settleSchedule?: number[];
+  }): Promise<VisualMotionObservation>;
+}
+```
+
+### 2.2 The multi-frame ring buffer (the load-bearing architectural feature)
+
+User Round 2 P2: "今回の本丸はむしろここで、`t=0, 50, 100, 200 ms` のような低周波 multi-frame ring buffer を持ち、N フレーム内の最大変化/安定後変化を見る設計にすると、かなり北極星っぽくなります。"
+
+Single pre/post is structurally fragile against:
+- **GPU staleness** — `PrintWindow(PW_RENDERFULLCONTENT)` can return a cached pre-paint frame for ~16-50 ms after the receiver processes the message; the post-paint frame appears only after the next composition cycle (`DwmGetCompositionTimingInfo::cFramesPresented`).
+- **Animation transients** — caret blink, marching-ants selection, hover effects, loading spinners all introduce motion between pre and post that isn't related to our action.
+- **Receiver settle time** — Excel's row-label strip repaint happens incrementally; capturing at t=30 ms might catch only a partial repaint that doesn't resemble the final state.
+
+The ring buffer captures `pre` + `post[k]` for k post-frames at the requested schedule. Decision rule:
+
+```
+motion_observed = ∃ k such that motion(pre, post[k]) ≥ threshold
+last_stable    = motion(post[k_last - 1], post[k_last]) < noise_floor
+final_differs  = motion(pre, post[k_last]) ≥ threshold
+
+deliver(translation | local_repaint) iff motion_observed AND last_stable AND final_differs
+```
+
+This catches:
+- **Real scrolls** → motion in some k AND final frame stable AND final differs from pre → accept.
+- **Transient animations** (caret) → motion in middle frames AND final matches pre → reject (no_change).
+- **GPU staleness** → motion observed at later k → accept.
+- **Boundary cases (Codex PR #308 P1)** → no motion at any k → reject (no_change, downgrades chain-trust to honest `unverifiable` / `target_unreachable` depending on caller policy).
+
+### 2.3 Primitive split + candidate implementations
+
+#### 2.3.1 `scroll_translation`
+
+The question: did content shift by `(dx, dy)` pixels (a global translation, possibly with edges fading in/out)?
+
+| Priority | Algorithm | Why this primitive | Cost (est.) | Failure mode |
+|---|---|---|---|---|
+| 1 | **UIA `CurrentVerticalScrollPercent`** (read-only) | exact numeric, OS-canonical | ~1-5 ms RPC | only when ScrollPattern exposed on the leaf or an ancestor |
+| 2 | **Block motion vectors (16×16 SAD coarse-to-fine)** | majority `dy` across blocks votes the global shift; robust against periodic grids because each 16×16 block carries enough local entropy for unambiguous register | ~5-15 ms Rust SSE2 on 1080p | low texture (uniform background) drops vote confidence |
+| 3 | **Tiled phase correlation (4×4 grid of 64×64 tiles)** | per-tile FFT, majority `(dx, dy)` vote, gated by `peak/secondPeak ≥ 3` + texture floor + tile agreement ≥ 0.5 | ~10-20 ms in `rustfft` SIMD | very-low-texture and exact-periodic regions can still alias |
+| 4 | **SSIM residual map** | confidence-floor cross-check: SSIM ≥ 0.99 → certainly no_change, regardless of motion-vector noise | ~5-15 ms `dssim` crate | doesn't quantify shift |
+| 5 | **DXGI Desktop Duplication dirty/move rects** | OS-side compositor metadata; authoritative `(dx, dy)` per move-rect | depends on Desktop Duplication session lifecycle | per-window scope is mixed with full-desktop; integration heavier |
+
+#### 2.3.2 `local_repaint`
+
+The question: did a known sub-rect (or an unknown sub-rect inside the window) change while the rest stayed?
+
+| Priority | Algorithm | Why this primitive | Cost | Failure mode |
+|---|---|---|---|---|
+| 1 | **SSIM residual on focused-element rect** | when the click's expected effect rect is knowable (UIA element bounds), SSIM there gives a clean delta | ~5-15 ms | when rect is unknowable (custom canvas) |
+| 2 | **Block motion vectors with `dy ≈ 0` constraint** | for click feedback (highlight, focus rectangle) the "movement" is local repaint with global shift = 0; per-block residual on `dy=0` captures this | ~5-15 ms | overlaps with animation; need ring buffer to distinguish |
+| 3 | **Optical flow (Lucas-Kanade sparse)** | sparse N feature points; ignores periodic-grid translation; localised motion only | ~20-50 ms | feature point selection brittle |
+| 4 | **DXGI dirty rect** | OS-side per-region metadata; if the dirty rect is small relative to window → `local_repaint` | shared with `scroll_translation` | same DXGI integration cost |
+
+#### 2.3.3 `any_change`
+
+The question: did anything change in the window?
+
+| Priority | Algorithm | Why | Cost | Failure mode |
+|---|---|---|---|---|
+| 1 | **DXGI Desktop Duplication dirty/move rects** | OS authoritative answer | DXGI session | per-window scope |
+| 2 | **Block motion vectors + SSIM residual map** | software fallback | shared | shared |
+| 3 | **`computeChangeFraction` (existing 8×8 block SAD)** | the legacy helper; useful as final fall-back | very fast | low resolution |
+
+#### 2.3.4 `structured_state`
+
+The question: did a UIA / Win32-exposed numeric property change?
+
+| Priority | Algorithm | Why | Cost | Failure mode |
+|---|---|---|---|---|
+| 1 | **UIA `CurrentVerticalScrollPercent` / `CurrentHorizontalScrollPercent`** | OS canonical, exact | ~1-5 ms RPC | pattern not exposed |
+| 2 | **UIA `ValuePattern.Value`** (existing in keyboard verify) | exact, OS canonical | ~1-5 ms RPC | pattern not exposed |
+| 3 | **Win32 `GetScrollInfo` (legacy SB_VERT path)** | for apps with a real Win32 scrollbar | <1 ms | null on custom-paint |
+
+### 2.4 Phase correlation, properly gated
+
+Round 1 framing: "phase correlation peak > 0.05 → motion." Round 2 finding: that's insufficient for Excel-class periodic grids.
+
+Correct gating (referenced via Guizar-Sicairos et al. 2008 for sub-pixel registration):
+
+```
+phase_correlation_pass(pre, post):
+  let cross = fft2(pre) × conj(fft2(post)) / |fft2(pre) × conj(fft2(post))|
+  let r = ifft2(cross)
+  let (peak1_loc, peak1_val) = argmax(r)
+  let peak2_val = max(r excluding neighbourhood(peak1_loc, radius=3))
+  let ratio = peak1_val / peak2_val
+  let texture = variance(grayscale(pre))
+  let per_tile_dy = [phase_correlation(pre_tile_i, post_tile_i) for i in tiles]
+  let tile_agreement = count(per_tile_dy ≈ median(per_tile_dy)) / len(per_tile_dy)
+
+  PASS iff:
+    ratio ≥ 3
+    AND texture ≥ noise_floor
+    AND tile_agreement ≥ 0.5
+    AND |peak1_loc - median(per_tile_dy)| ≤ 1 px
+```
+
+The four gates compose: a single bright peak with no second peak, enough texture to register at all, majority of tiles agreeing on the shift, and the global FFT agreeing with the per-tile majority.
+
+### 2.5 Concrete new APIs
+
+#### 2.5.1 napi `uia_read_scroll_percent_at_hwnd`
+
+```rust
+/// ADR-019 §2.3.4 — read-only sibling of `uia_scroll_by_wheel_at_hwnd`.
+/// Walks UIA ancestors via RawViewWalker looking for an element that exposes
+/// IUIAutomationScrollPattern. Returns None when no pattern is exposed (the
+/// "custom-paint" case). Pure observation; no SetScrollPercent side effect.
+#[napi]
+pub fn uia_read_scroll_percent_at_hwnd(
+  hwnd: BigInt,
+  axis: String,  // "vertical" | "horizontal"
+) -> napi::Result<Option<f64>>;
+```
+
+#### 2.5.2 TS `captureMultiFrameRing`
+
+```ts
+/** ADR-019 §2.2 — multi-frame ring buffer for temporal motion analysis. */
+export async function captureMultiFrameRing(
+  hwnd: bigint,
+  region: { x: number; y: number; width: number; height: number },
+  scheduleMs: number[], // e.g. [30, 60, 120, 240]
+): Promise<{
+  pre: RawFrame;
+  post: RawFrame[]; // length === scheduleMs.length
+  elapsedMs: number;
+}>;
+```
+
+#### 2.5.3 Rust `compute_block_motion_vectors`
+
+```rust
+/// ADR-019 §2.3.1 priority 2 — coarse-to-fine block matching motion estimation.
+/// Returns a (dx, dy, confidence) per 16×16 block + a global majority vote.
+#[napi]
+pub fn compute_block_motion_vectors(
+  pre: Buffer,
+  post: Buffer,
+  width: u32,
+  height: u32,
+  channels: u32,
+  block_size: u32,      // default 16
+  search_radius: u32,   // default 32 (covers typical line-scroll heights)
+) -> napi::Result<BlockMotionResult>;
+```
+
+---
+
+## 3. Affected components (initial SSOT table)
+
+| File | Change | Stage |
+|---|---|---|
+| `src/uia/scroll.rs` | new `uia_read_scroll_percent_at_hwnd` napi (§2.5.1) | Stage 1 |
+| `src/engine/native-engine.ts` | `NativeUia.uiaReadScrollPercentAtHwnd?` extension | Stage 1 |
+| `index.d.ts` / `index.js` | hand-maintained re-export of the new napi | Stage 1 |
+| `src/tools/_input-pipeline.ts` | (a) wire UIA percent pre/post into `postWheelToHwnd` chain-trust path; (b) **extend `DispatchOutcome` to additively carry `observation?: VisualMotionObservation`** (Round 1 P1-3) so the new field reaches the envelope; (c) caller-side fall-through to chain-trust assertion when UIA pattern not exposed | Stage 1 |
+| `src/tools/mouse.ts` | (a) **extend `ScrollVerifyOutcome` (lines 971-982) to thread `observation?` through** (Round 1 P1-3); (b) `scrollHandler` propagates `observation` from dispatcher outcome into the `verifyDelivery` envelope hint | Stage 1 |
+| `docs/adr-018-input-pipeline-3tier.md` §2.6 | **add additive `verifyDelivery.observation` paragraph** (Round 1 P1-2) that references this ADR-019 as the canonical `source` enum SoT. Lands in the MVP-1 PR alongside the wire-up. | Stage 1 |
+| `src/engine/layer-buffer.ts` | new `captureMultiFrameRing` helper (§2.5.2) | Stage 2 |
+| `src/pixel_diff.rs` | extend existing 8×8 block SAD to coarse-to-fine 16×16 block motion estimation | Stage 2 |
+| `src/engine/image.ts` | `compute_block_motion_vectors` TS wrapper | Stage 2 |
+| `src/image/phase_correlation.rs` | **new module**, `rustfft` SIMD FFT + gating (§2.4) | Stage 3 |
+| `Cargo.toml` | add `rustfft` dep | Stage 3 |
+| `src/image/ssim.rs` | **new module**, SSIM residual map (Wang et al. 2004) | Stage 4 |
+| `src/tools/mouse.ts` (`mouse_click.verifyDelivery`) | wire SSIM into focused-element-rect path | Stage 4 |
+| `src/tools/keyboard.ts` (BG `BackgroundInputNotDelivered`) | wire SSIM into TextPattern-unavailable fallback | Stage 4 |
+| `src/image/dxgi_duplication.rs` | **new module**, IDXGIOutputDuplication session lifecycle + dirty-rect parsing | Stage 5 |
+| `src/image/optical_flow.rs` | **new module**, Lucas-Kanade sparse + Farneback dense | Stage 6 (defer) |
+| `docs/adr-018-input-pipeline-3tier.md` §2.6.2 | reference TMOL observation in `verifyDelivery.observation` envelope (additive) | Stage 1 |
+| `tests/unit/tmol-*.test.ts` | per-primitive contract pin | each stage |
+| `benches/tmol_*.mjs` | per-primitive latency bench | each stage |
+
+---
+
+## 4. Phase split
+
+### Stage 1 — UIA read-only `ScrollPercent` (1 PR, 1-2 days) — **MVP-1**
+
+Empirical probe + minimal observation upgrade. If EXCEL7 exposes `ScrollPattern` for reads (independent question from dispatch), this stage alone resolves Excel scroll observation without any image processing.
+
+Deliverables (matches §3 SSOT rows for Stage 1):
+
+- New `uia_read_scroll_percent_at_hwnd` napi (`src/uia/scroll.rs`).
+- TS surface: `NativeUia.uiaReadScrollPercentAtHwnd?` (`src/engine/native-engine.ts`) + hand-maintained `index.d.ts` / `index.js` re-export.
+- **Type extension**: `DispatchOutcome` in `_input-pipeline.ts` and `ScrollVerifyOutcome` in `mouse.ts:971-982` additively carry `observation?: VisualMotionObservation` (Round 1 P1-3 fix).
+- Wire pre/post into `postWheelToHwnd` chain-trust branch; emit `delivered_via_postmessage` with `observation.source: "uia_scroll_percent"` when pre/post differ by ≥ `SCROLL_PERCENT_EPSILON`.
+- Fall-through to chain-trust assertion (unchanged) when pattern not exposed → `observation.source: "chain_trust_unverified"`.
+- **ADR-018 §2.6 additive paragraph** (Round 1 P1-2 fix): document `verifyDelivery.observation` as an additive field whose `source` enum lives in ADR-019 §2.1 as canonical SoT.
+- 3 unit test cases: mock `uiaReadScrollPercentAtHwnd` (returns null / same percent / different percent) — pin each branch's `observation.source`.
+
+**G1 acceptance**: probe via `node -e ...uiaReadScrollPercentAtHwnd(excelLeafHwnd, 'vertical')` returns a non-null number for Excel EXCEL7. If yes, dogfood Excel scroll returns `observation.source: "uia_scroll_percent"` and `observation.shift` carries the percent delta. If no, dogfood returns `observation.source: "chain_trust_unverified"` (preserves PR #308 chain-trust behaviour with explicit observation field — no regression).
+
+### Stage 2a — Multi-frame ring buffer (observation-only, 1 PR, 1-2 days)
+
+> **MVP split 2026-05-16**: the original Stage 2 was "ring buffer + block motion vectors + dispatcher wiring" in one PR — too much for a single review. Stage 2a is the ring buffer ALONE, using the existing `computeChangeFraction` (8×8 block SAD, SSE2 SIMD) for per-frame diff. It produces *telemetry* in `verifyDelivery.observation` but does NOT change the chain-trust decision yet. This empirically validates the multi-frame thesis ("does temporal observation actually catch what single pre/post misses?") before any new algorithm work.
+
+- `captureMultiFrameRing(hwnd, region, scheduleMs)` in `layer-buffer.ts` — returns `pre + post[]` raw frames.
+- Reuse `computeChangeFraction(pre, post[i])` for each post-frame; collect `changedFractions: number[]` over the ring.
+- Add telemetry-only `observation` field: `{ source: "temporal_ring_observation_only", framesSampled, elapsedMs, changedFractions, maxChangedFraction }`. **No behaviour change in `verifyDelivery.status` / `.reason` / `.channel`** — Stage 2a is observation telemetry only.
+- **G2a acceptance**: dogfood Excel + Word + Notepad scrolls; `verifyDelivery.observation.changedFractions` array is populated; the `maxChangedFraction` empirically discriminates real scrolls (> noise) from no-ops (≈ noise). Bench captures the actual values so Stage 2b's threshold can be data-calibrated.
+
+### Stage 2b — Block motion vectors as a decision gate (1 PR, 3-4 days)
+
+> **MVP split 2026-05-16**: 2b lands the new algorithm + dispatcher wiring **after** Stage 2a's empirical data tells us whether the simpler `changedFractions` alone is sufficient. **Quantitative gate (Round 1 P2-2 fix)**: Stage 2a telemetry over **≥ 30 dogfood scroll attempts** (Excel + Word + Notepad + Explorer + 1 custom-paint canvas of choice) shows real-scroll `maxChangedFraction` is **≥ 5× the no-op median**. If yes → Stage 2b ships with `computeChangeFraction` reused as the gate (no new algorithm); block motion vectors are deferred to a later sub-stage. If no → Stage 2b adds `compute_block_motion_vectors` napi as the new gate.
+
+- `compute_block_motion_vectors(pre, post, ...)` napi in `pixel_diff.rs` (extend existing SSE2 8×8 SAD to 16×16 coarse-to-fine with search radius — only if Stage 2a says we need it).
+- Wire into `postWheelToHwnd` chain-trust as a fall-back when Stage 1 UIA returns null AND `changedFractions` is ambiguous.
+- Decision rule per §2.2: motion observed AND last-stable AND final-differs → emit `delivered_via_postmessage` with `observation.source: "block_motion_vectors"` and `observation.shift`.
+- **G2b acceptance**: Excel cell-grid scroll (rows 1 → 30 via wheel) returns `observation.shift.dy ≈ <expected px>` with `confidence ≥ 0.7`. Word `_WwG` similarly. Caret-blink test fixture returns `motion: "no_change"`.
+
+### Stage 3 — Tiled phase correlation (1 PR, 2-3 days)
+
+- New `src/image/phase_correlation.rs` with `rustfft` SIMD FFT + §2.4 gating.
+- Wire as Stage 2 disambiguator when block-motion confidence < 0.7.
+- **G3 acceptance**: synthetic test fixture with periodic grid + 50 px scroll returns `(dx, dy) = (0, 50)` with the four-gate pass. Same fixture with caret-blink-only returns `motion: "no_change"`.
+
+### Stage 4 — SSIM residual for click / keyboard verify (1 PR, 2-3 days)
+
+- New `src/image/ssim.rs` (Wang et al. 2004 reference impl).
+- Wire into `mouse_click.verifyDelivery` (focused-element-rect SSIM) and `keyboard` BG verify (TextPattern-unavailable fallback rect SSIM).
+- Different code path from scroll; this is the `local_repaint` primitive.
+- **G4 acceptance**: synthetic test fixture with click → focus rectangle drawn at known rect returns `motion: "local_repaint"` with `residual.fractionChanged > 0.05` inside that rect.
+
+### Stage 5 — DXGI Desktop Duplication (exploratory, 5-7 days)
+
+- `src/image/dxgi_duplication.rs` with session lifecycle, dirty / move rect parsing.
+- Wire as priority-1 source for `any_change` primitive when on the primary desktop.
+- Carry-over to a separate sub-ADR if the session-lifecycle complexity warrants.
+
+### Stage 6 — Optical flow (deferred)
+
+- Lucas-Kanade sparse + Farneback dense. Defer to telemetry-driven decision after Stages 1-4 land.
+
+### Stage 7 — AVX-512 SIMD acceleration (deferred, conditional)
+
+- Add AVX-512 code paths to Stages 2-4 if AVX2 benches miss the 50 ms p99 budget on consumer hardware. Runtime dispatch (`is_x86_feature_detected!("avx512f")`) keeps backward compatibility. Skip if AVX2 is sufficient.
+
+### Stage 8 — GPU compute path (deferred, opportunistic)
+
+- Reuse the ADR-005 vision-gpu backend (ONNX Runtime + DirectML) to dispatch Stages 2-4 compute on GPU when the window size warrants. CPU SIMD remains the baseline; GPU is opportunistic acceleration for ≥ 1080p × 4-frame batches or ≥ 4K windows. See §4.6 for the dispatch logic and algorithm-to-graph mapping.
+
+### Total
+
+6 production stages (1, 2a, 2b, 3, 4, 5) + 3 conditional stages (6 optical flow, 7 AVX-512, 8 GPU compute), ~13-19 days base + per-conditional-stage exploration. Stages independently shippable; each one provides observable LLM-side capability (`observation.source` field).
+
+### MVP ordering (2026-05-16 user feedback)
+
+- **MVP-0**: ADR fixes (this revision) — split AC6 latency into fast / temporal / compute, split Stage 2 → 2a + 2b. **Already applied in this draft.**
+- **MVP-1**: Stage 1 ONLY (UIA read-only `ScrollPercent`). Smallest possible PR — `_input-pipeline.ts:596` chain-trust branch gets `observation.source: "uia_scroll_percent" | "chain_trust_unverified"` only. Resolves the biggest single empirical uncertainty: does EXCEL7 expose `ScrollPattern` for reads? If yes, Excel is fixed with zero image processing. If no, MVP-2a is the next move.
+- **MVP-2a**: Multi-frame ring buffer (observation-only telemetry) — empirically validate the temporal observation thesis before any new algorithm work.
+- **MVP-2b**: Conditional on Stage 2a telemetry — only land block motion vectors if `changedFractions` alone is insufficient.
+- **MVP-3 / MVP-4 / MVP-5+**: Stages 3-5 / 6-8 per the per-stage gating criteria.
+
+The user-named load-bearing insight: **観測の時間軸をサーバに持ち込む** — bringing the temporal observation surface into the server is the foundational move; new algorithms are downstream of it.
+
+---
+
+## 4.5 SIMD strategy (per-stage computational budget)
+
+The TMOL primitives sit on the hot path of every `verifyDelivery`-bearing tool call (scroll, click, BG keyboard). The latency budget is ≤ 50 ms p99 (AC6); on a 1080p window that translates to ~40 GB/s of effective pixel throughput when comparing pre/post raw frames. SIMD is mandatory, not optional, for the image-processing stages.
+
+### 4.5.1 Existing SIMD in the codebase
+
+- **`src/pixel_diff.rs`** — SSE2 `psadbw` (Sum of Absolute Differences) on 8×8 blocks; foundation for `computeChangeFraction`. Already SIMD; baseline.
+- **`src/dhash.rs`** — Rust f32 bilinear resize + grayscale; some scalar work, some auto-vectorised. dHash is being replaced by motion vectors in TMOL Stage 2; this path will be deprecated.
+
+### 4.5.2 Per-stage SIMD plan
+
+| Stage | Algorithm | SIMD strategy | Rationale |
+|---|---|---|---|
+| 1 | UIA `ScrollPercent` read | none (RPC) | OS-side call; SIMD irrelevant |
+| 2 | Block motion vectors (16×16 SAD, search ±32 px) | **AVX2 `vpsadbw`** with SSE2 fallback (cpuid runtime check) | inner SAD loop is the hottest path; AVX2 doubles `psadbw` throughput vs SSE2. Use `is_x86_feature_detected!("avx2")` at runtime, build with both code paths via Rust's `target_feature` |
+| 3 | Tiled phase correlation | `rustfft` (already SIMD-optimised: AVX2 / NEON / scalar dispatch) + custom AVX2 for the magnitude-normalisation and IFFT-peak-detection steps | `rustfft` 0.31+ has automatic ISA dispatch; we add SIMD only for the wrapper |
+| 4 | SSIM | **AVX2** for the per-window mean / variance / covariance (Wang 8×8 sliding); SSE2 fallback | sliding-window stats vectorise naturally; `dssim` crate uses AVX2 internally — consider direct dep over hand-rolling |
+| 5 | DXGI Desktop Duplication | none (OS does the diff) | dirty-rect metadata is OS-computed; pixel work is zero |
+| 6 | Optical flow | **AVX2** Lucas-Kanade gradient pyramid; or use `imageproc` crate's existing SIMD | deferred |
+
+### 4.5.3 Build-time vs run-time dispatch
+
+The repo already builds for `x86_64-pc-windows-msvc` / `x86_64-pc-windows-gnu` (Cargo.toml). Pure compile-time `-C target-feature=+avx2` would refuse to run on pre-Haswell CPUs (≤2013), which we don't want to require.
+
+**Use runtime dispatch** via Rust's `is_x86_feature_detected!` macro:
+
+```rust
+pub fn block_motion_vectors(pre: &[u8], post: &[u8], ...) -> Vec<MotionVector> {
+    if is_x86_feature_detected!("avx2") {
+        unsafe { block_motion_vectors_avx2(pre, post, ...) }
+    } else if is_x86_feature_detected!("sse2") {
+        // SSE2 is x86-64 baseline; always present on our target
+        unsafe { block_motion_vectors_sse2(pre, post, ...) }
+    } else {
+        block_motion_vectors_scalar(pre, post, ...)
+    }
+}
+```
+
+The dispatch overhead is ~1 ns per call (after JIT warms up); negligible compared to the ms-scale work.
+
+### 4.5.4 AVX-512 ROI
+
+AVX-512 (512-bit SIMD) doubles throughput again over AVX2 but:
+- only available on a subset of consumer CPUs (Intel Ice Lake / Tiger Lake / Rocket Lake; AMD Zen 4+);
+- causes downclocking on older Intel implementations (Skylake-X);
+- Rust support is `target_feature` gated.
+
+**Decision**: skip AVX-512 in initial impl. Add later as a Stage 7 optimisation if Stage 2-4 latency benches exceed the 50 ms p99 budget on AVX2-only systems. Cost is the dispatch path expansion; benefit is marginal for our window sizes.
+
+### 4.5.5 Cargo features
+
+Initial impl adds two Cargo features for opt-out / build-time control:
+
+```toml
+[features]
+default = ["tmol-simd"]
+tmol-simd = []           # enables AVX2/SSE2 runtime dispatch; disable for pure-scalar testing
+tmol-avx512 = []         # future: AVX-512 path, off by default
+```
+
+The `default` is `tmol-simd` so production builds get the fast path.
+
+### 4.5.6 Bench gate
+
+Each SIMD stage lands with a `benches/tmol_<stage>.mjs` (criterion or vitest bench). Budgets are **compute-only** (algorithm time per pre/post pair, excluding settle waits):
+
+- Stage 2b block motion (1080p, single pre/post): p99 ≤ 30 ms
+- Stage 3 tiled phase correlation (256×256 downsample): p99 ≤ 20 ms
+- Stage 4 SSIM (400×400 focused-element rect): p99 ≤ 15 ms
+
+The temporal fallback wall-clock budget (≤ 300 ms end-to-end, AC6) is the bench gate for the *integration* path (capture + ring + compute combined); the per-algorithm budgets above are the *unit* gates that feed it.
+
+If any stage misses its compute budget, the SIMD path is the first place to look (compare AVX2 vs SSE2 via the runtime dispatch; the bench can force-disable AVX2 via `RUSTFLAGS=-C target-feature=-avx2` to measure the floor). The GPU path (§4.6 Stage 8) is the second place to look when SIMD-CPU still misses budget on large windows.
+
+---
+
+## 4.6 GPU compute path (reuse ADR-005 vision-gpu backend)
+
+**Existing asset**: the repo ships a vision-gpu backend (ADR-005) — Rust `src/vision_backend/` + TS `src/engine/vision-gpu/` — backed by ONNX Runtime with DirectML / ROCm / CUDA execution providers (`src/vision_backend/ep_select.rs`). Today it's used for vision-AI inference (PaddleOCR, Florence-2, OmniParser, dirty-rect tracking). It is **not** currently used for general image-diff compute, but the GPU device + ORT session lifecycle infrastructure is in place.
+
+TMOL can opportunistically dispatch its image-processing primitives to the GPU when:
+1. **Window size large** (4K+ or multi-monitor capture where 1920×1080 SIMD-CPU paths would exceed the 50 ms p99 budget).
+2. **Multi-frame ring buffer batch** (4-8 post-frames processed in parallel rather than serial CPU loops).
+3. **Algorithm GPU-friendly** (FFT, block matching, convolution-based motion estimation, optical flow) — all of which map naturally to DirectCompute / DirectML graphs.
+
+### 4.6.1 GPU vs CPU tier dispatch
+
+```
+Image size budget × frame count → tier dispatch:
+
+  ≤ 1080p × 1-2 frames    → AVX2 SIMD CPU (already fast enough; PCIe upload overhead would dominate)
+  ≤ 1080p × 4-8 frames    → AVX2 SIMD CPU (parallelisable with rayon over frames) OR GPU if available
+  > 1080p × 1-8 frames    → GPU preferred (DirectML)
+  > 4K       × any        → GPU mandatory (CPU SIMD would miss latency budget)
+```
+
+PCIe upload of a 1080p RGBA frame is ~8 MB → ~1 ms at PCIe 3.0 x16 (16 GB/s). 4-frame batch is ~32 MB → ~2 ms. Round-trip ~4 ms. For 50 ms budget, GPU breaks even around 8-16 ms of compute saved vs SIMD.
+
+### 4.6.2 Algorithm → GPU mapping
+
+| Primitive | GPU-friendly form | Backend |
+|---|---|---|
+| Block motion vectors (16×16 SAD) | 2D convolution against shifted post-frame, per-shift candidate; or motion-estimation compute shader | DirectCompute HLSL (custom shader) OR DirectML `Convolution` op |
+| Tiled phase correlation | FFT via DirectML's existing FFT op (if available) OR a Cooley-Tukey compute shader | DirectML (if FFT supported) OR DirectCompute |
+| SSIM | Sliding-window mean / variance / covariance via 2D convolution (Gaussian kernel) | DirectML `Convolution` |
+| Optical flow (Lucas-Kanade) | Per-pixel gradient + linear-solve; or use ONNX-exported PyTorch model | DirectML / CUDA |
+| dHash / pHash (legacy) | Resize + DCT + threshold | DirectML (overkill for 8×8) |
+
+### 4.6.3 GPU integration cost
+
+Reusing the ADR-005 path means:
+- ONNX Runtime session per algorithm graph (or one shared session with multiple inputs)
+- Tensor I/O (upload pre/post frames → run graph → download motion vectors)
+- Existing `nativeVisionGpu` napi exports (`src/engine/native-engine.ts`) extended with `compute_motion_vectors_gpu` etc.
+
+New work:
+- Author the algorithm ONNX graphs (or DirectCompute HLSL shaders)
+- Pipeline: capture (CPU) → upload (PCIe) → compute (GPU) → download → consume (CPU)
+- Async / non-blocking dispatch so the scroll dispatcher isn't blocked on GPU work
+
+### 4.6.4 Recommended scope
+
+- **Stage 2 (block motion vectors)**: ship CPU SIMD first; add GPU path as Stage 7 if the latency bench shows CPU > 30 ms p99 on 1080p (unlikely with AVX2; very likely on 4K).
+- **Stage 3 (tiled phase correlation)**: same — `rustfft` SIMD is fast enough at 256×256; GPU FFT becomes interesting at 1024×1024 or larger.
+- **Stage 4 (SSIM)**: same — sliding-window stats vectorise well in AVX2.
+- **Stage 5 (DXGI dirty-rect)**: this *is* a GPU path already — the OS compositor computes dirty rects on the GPU and exposes them via DXGI metadata. Reusing it is free.
+- **Stage 8 (NEW: GPU compute path for Stages 2-4)**: lands after the CPU SIMD path is benched and the gap is empirically identified. Carry-over to a sub-ADR if the scope grows.
+
+### 4.6.5 Practical note
+
+DirectML's strength is *inference* — fixed graphs executed many times. For TMOL's per-call image diff, the graph is run once per `verifyVisualMotion` call. The session-setup cost may dominate at small windows; the wall-clock win shows up only when the per-frame work is large enough to amortise.
+
+If the practical sweet spot is "GPU for >1080p windows, CPU SIMD otherwise," the dispatch logic looks like:
+
+```rust
+fn dispatch_block_motion(pre: &Frame, post: &Frame) -> BlockMotionResult {
+    let area = pre.width * pre.height;
+    let gpu_available = nativeVisionGpu::is_available();
+    if area >= 1920 * 1080 * 2 && gpu_available {  // > 2 megapixels AND GPU ready
+        return compute_block_motion_gpu(pre, post);
+    }
+    compute_block_motion_avx2(pre, post)  // fall back to CPU SIMD path
+}
+```
+
+GPU path is **opportunistic, not required**. Stages 2-4 ship on CPU SIMD; GPU dispatch is a transparent acceleration that activates only on large windows or when the CPU bench gate fails.
+
+---
+
+## 5. Risks
+
+- **R1 — UIA read-only `ScrollPercent` not exposed by EXCEL7**: empirical probe in Stage 1 may return null. Mitigation: **Stage 2b (block motion vectors) is the fallback**; until Stages 2a + 2b land, Stage 1 null on Excel preserves the current PR #308 chain-trust behaviour with the new `observation.source: "chain_trust_unverified"` field — no regression vs current main, just an explicit "we don't yet know" envelope hint. (Round 1 P2-4 clarification.)
+- **R2 — Block motion vector latency on 1080p**: 16×16 blocks × full-window search may exceed 30 ms p99. Mitigation: downsample to 512×512 first; bench in Stage 2.
+- **R3 — Phase correlation alias on perfectly periodic grids**: even tiled. Mitigation: the four-gate pass (§2.4) rejects ambiguous cases; fall back to block motion vectors (Stage 2) which is more local-structure-driven.
+- **R4 — SSIM false-positive on cursor blink**: a blinking caret inside the focused-element rect would raise SSIM residual. Mitigation: multi-frame ring per §2.2 — caret blink resolves as transient (last frame matches pre).
+- **R5 — DXGI Desktop Duplication scope creep**: session lifecycle, multi-monitor, cross-desktop. Mitigation: carry-over to sub-ADR; not blocking Stages 1-4.
+- **R6 — Observation envelope migration**: callers that read `verifyDelivery.reason` directly are unaffected; callers that consult `verifyDelivery.observation` are new (additive). No backwards-compat break.
+- **R7 — CLAUDE.md §3.1 multi-table fact sweep**: `observation.source` enum lives in 3 surfaces (ADR-019 §2.1 contract, ADR-018 §2.6 reason table, TS / Rust type definitions). Keep in bit-equal sync.
+- **R8 — Anti-fukuwarai v1 / v2 / v3 dependency**: TMOL consumes the perception graph's focused-element rect (v2 RPG output) for the SSIM `local_repaint` primitive. If RPG is unavailable, fall back to full-window SSIM with a higher threshold.
+
+---
+
+## 6. Acceptance criteria
+
+- **AC1** — Stage 1: `uia_read_scroll_percent_at_hwnd(excelLeafHwnd, 'vertical')` returns a non-null number when Excel is in foreground with a default workbook open, OR an empirical confirmation note in the ADR §10 OQ1 with the rationale for falling through to Stage 2.
+- **AC2** — Stage 2: `verifyVisualMotion({hwnd: excelHwnd, capability: 'scroll_translation'})` after a 3-notch wheel post returns `motion: "translation"` with `shift.dy > 0` and `confidence ≥ 0.7`. Same call on a caret-blinking-only Notepad with no scroll returns `motion: "no_change"`.
+- **AC3** — Stage 3: synthetic test fixture (periodic grid + 50 px scroll) returns `(dx, dy) = (0, 50)` via tiled phase correlation, all four gates passing.
+- **AC4** — Stage 4: `mouse_click.verifyDelivery` with `narrate: "rich"` returns `observation.source: "ssim_residual"` with `residual.fractionChanged > 0.05` on a synthetic click that draws a focus rectangle.
+- **AC5** — System-wide: 3 of 4 primitives (`scroll_translation`, `local_repaint`, `structured_state`) wired into at least one tool each. `any_change` deferred to Stage 5.
+- **AC6** — Performance: split latency budgets by tier of `verifyVisualMotion` for `scroll_translation`. The dispatcher selects **at most one primary algorithm per call** (cascade short-circuits on the first confident answer); the compute-only umbrella below is per-call, not per-algorithm. (Round 1 P2-1 fix.)
+  - **Fast path** (Stage 1 UIA `ScrollPercent` read-only when pattern exposed): p99 ≤ **50 ms** wall-clock (no capture, just 2× UIA RPC). Bench-asserted.
+  - **Temporal fallback** (Stages 2a/2b: ring buffer + per-frame diff) wall-clock: p99 ≤ **300 ms** end-to-end. This includes the ring buffer's settle schedule (`[30, 60, 120, 240 ms]` → max 240 ms) + capture + compute. The wall-clock budget is intentionally larger than the fast path because the temporal observation thesis (§2.2) requires actual time to pass for "last frame stable" to be observable; this is not optimisation slack, it is the algorithm's defined cost. Bench-asserted.
+  - **Compute-only umbrella per call** (excluding settle waits, sum of algorithm time per pre/post pair across the cascade-short-circuit path): p99 ≤ **70 ms**. Raised from the original 50 ms to accommodate the worst-case cascade Stage 2b → Stage 3 → Stage 4 (30+20+15=65 ms). In the common case the cascade short-circuits on Stage 1 or Stage 2b, well under the umbrella. Bench-asserted.
+  - Per-algorithm compute-only sub-budgets (these are the unit gates that feed the umbrella):
+    - Stage 2b block motion (1080p, single pre/post pair): p99 ≤ **30 ms**.
+    - Stage 3 tiled phase correlation (256×256 downsample): p99 ≤ **20 ms**.
+    - Stage 4 SSIM (400×400 focused-element rect): p99 ≤ **15 ms**.
+    Sum 65 ms = within the 70 ms umbrella. Bench-asserted per stage.
+- **AC7** — CLAUDE.md §3.1 sweep: `observation.source` enum values exactly match across the ADR-019 §2.1 contract, ADR-018 §2.6 reason-table reference, and TS / Rust type definitions.
+
+---
+
+## 7. Open questions
+
+1. **Does EXCEL7 expose `IUIAutomationScrollPattern` for reads** (separately from dispatch failure)? Resolved in Stage 1 empirical probe.
+2. **Block motion vector search radius** — line scroll heights vary per app (Excel ~20 px row, Word ~24 px line, Notepad varies). Default `±row_height` is app-specific. Initial default 32 px; per-app tuning carry-over.
+3. **Ring buffer schedule** — `[30, 60, 120, 240 ms]` is a starting point. Excel may need `+500 ms` for full settle on slow systems. Adaptive schedule (capture until last-stable holds, cap at 500 ms total) is the right design; **initial impl ships the fixed-schedule default AND wires `settleSchedule?: number[]` through the §2.1 contract** (Round 1 P2-3 fix — earlier draft contradicted itself by declaring the parameter in the contract while OQ3 said fixed schedule). The adaptive form is deferred to a Stage 2a follow-up.
+4. **DXGI Desktop Duplication per-window** — IDXGIOutputDuplication is a *display output* surface, not per-window. Mapping back to a single window's region requires the window rect + clip. Defer to Stage 5 sub-ADR.
+5. **Phase correlation gating thresholds** — `peak/secondPeak ≥ 3`, `texture floor`, `tile_agreement ≥ 0.5` are rule-of-thumb; per-app empirical calibration carry-over.
+6. **SSIM threshold for `local_repaint`** — Wang et al. recommend 0.95 as "perceptually identical" cutoff; for click feedback that's likely too coarse. Initial impl uses 0.98; per-app calibration carry-over.
+7. **Anti-fukuwarai v4** — is there one? Likely: combining v2 RPG's reactive graph with v3 TMOL's temporal observation to produce a continuous "what changed since last action" stream for the LLM. Out of scope for v3.
+
+---
+
+## 8. Out of scope
+
+- **GPU shader-based diff (CUDA / DirectCompute)** — performance optimisation; current SIMD path is sufficient for the latency budget.
+- **Audio observation** — Excel chime / Windows error sound as a delivery signal. Different primitive; separate ADR.
+- **OCR-based delta** — text-content change detection. Already exists for `scroll(action='read')`; not part of TMOL's pixel-motion focus.
+- **Network-side observation** (e.g., Office365 cloud telemetry) — out of scope.
+- **Cross-process automation** (Excel COM `Application.ActiveWindow.ScrollRow`) — separate channel; Tier 0 of the input pipeline, not the TMOL observation layer.
+
+---
+
+## 9. Anti-fukuwarai genealogy summary
+
+| Version | Era | What it addressed | Primary channel |
+|---|---|---|---|
+| **v1** | v0.6.0 (2026-04) | Focus / modal / static window observation | UIA tree + focused-element |
+| **v2** | v0.9 – v0.11 RPG (2026-04) | Reactive perception graph; lensId-pinned targets; cross-action perception continuity | UIA + perception graph (v2) |
+| **v3** | *this ADR* (2026-05) | Temporal post-action observation; "did the visual state actually move?" | TMOL = UIA `ScrollPercent` + block motion + tiled phase correlation + SSIM + DXGI dirty-rect |
+
+Each version closes a different fukuwarai gap. v1 says "I see what's there now." v2 says "I see what changed in the structured graph." v3 says "I see whether my action moved the world."
+
+---
+
+## 10. References
+
+- ADR-018 §1.3 — system-wide silent-failure framing
+- PR #307 / #308 — chain-trust assertion + dHash gate revert (`docs/adr-018-phase-5-followup-leaf-walker-subplan.md`)
+- `docs/adr-018-phase-5-followup-verification-pathway-analysis.md` — Round 1 vs Round 2 audit trail leading to this ADR
+- Wang, Bovik, Sheikh, Simoncelli, "Image quality assessment: from error visibility to structural similarity" (2004) — SSIM
+- Guizar-Sicairos, Thurman, Fienup, "Efficient subpixel image registration algorithms" (2008) — sub-pixel phase correlation
+- [Microsoft DXGI Desktop Duplication](https://learn.microsoft.com/en-us/windows/win32/direct3ddxgi/desktop-dup-api) — dirty / move rect metadata
+- [Windows.Graphics.Capture](https://learn.microsoft.com/en-us/windows/uwp/audio-video-camera/screen-capture) — per-window capture
+- [OpenCV Optical Flow tutorial](https://docs.opencv.org/4.x/d4/dee/tutorial_optical_flow.html) — Lucas-Kanade / Farneback
+- [`rustfft` crate](https://docs.rs/rustfft/) — pure-Rust SIMD FFT
+- [Phase correlation — Wikipedia](https://en.wikipedia.org/wiki/Phase_correlation)
+- [Block-matching algorithm — Wikipedia](https://en.wikipedia.org/wiki/Block-matching_algorithm)
+- MEMORY index entries: `project_v0_6_anti_fukuwarai`, `project_v0_9_rpg`, `project_v0_12_auto_perception` — v1 / v2 genealogy

--- a/index.d.ts
+++ b/index.d.ts
@@ -236,6 +236,14 @@ export declare function uiaScrollIntoView(opts: { windowTitle: string; name?: st
 export declare function uiaGetScrollAncestors(opts: { windowTitle: string; elementName: string }): Promise<Array<NativeScrollAncestor>>
 export declare function uiaScrollByPercent(opts: { windowTitle: string; elementName: string; verticalPercent: number; horizontalPercent: number }): Promise<NativeScrollResult>
 export declare function uiaScrollByWheelAtHwnd(opts: { hwnd: string; wheelDeltaY: number; wheelDeltaX: number }): Promise<NativeScrollResult>
+/**
+ * ADR-019 MVP-1 (Stage 1) — read-only ScrollPercent companion to
+ * `uiaScrollByWheelAtHwnd`. Returns the percent (0.0..=100.0) on the requested
+ * axis when a ScrollPattern ancestor / descendant exposes it; `null` when no
+ * pattern is exposed (custom-paint receivers like Excel `NUIScrollbar`, Word
+ * MFC document body). Pure observation; no SetScrollPercent side effect.
+ */
+export declare function uiaReadScrollPercentAtHwnd(opts: { hwnd: string; axis: "vertical" | "horizontal" }): Promise<number | null>
 export declare function uiaGetVirtualDesktopStatus(hwndIntegers: Array<string>): Promise<Record<string, boolean>>
 
 export declare function preprocessImage(opts: NativePreprocessOptions): Promise<NativeImageProcessingResult>

--- a/index.js
+++ b/index.js
@@ -55,6 +55,8 @@ export const uiaScrollIntoView = nativeBinding.uiaScrollIntoView;
 export const uiaGetScrollAncestors = nativeBinding.uiaGetScrollAncestors;
 export const uiaScrollByPercent = nativeBinding.uiaScrollByPercent;
 export const uiaScrollByWheelAtHwnd = nativeBinding.uiaScrollByWheelAtHwnd;
+// ADR-019 MVP-1 (Stage 1) — read-only ScrollPercent observation
+export const uiaReadScrollPercentAtHwnd = nativeBinding.uiaReadScrollPercentAtHwnd;
 export const uiaGetVirtualDesktopStatus = nativeBinding.uiaGetVirtualDesktopStatus;
 export const uiaClickElement = nativeBinding.uiaClickElement;
 export const uiaSetValue = nativeBinding.uiaSetValue;

--- a/src/engine/native-engine.ts
+++ b/src/engine/native-engine.ts
@@ -260,6 +260,18 @@ export interface NativeUia {
     wheelDeltaY: number;
     wheelDeltaX: number;
   }): Promise<NativeScrollResult>;
+  /**
+   * ADR-019 MVP-1 (Stage 1) — read-only `ScrollPercent` observation. Walks
+   * UIA ancestors then DFS subtree to find a ScrollPattern whose requested
+   * axis is scrollable, returns `CurrentVertical/HorizontalScrollPercent`
+   * (0.0..=100.0). Returns `null` when no pattern is exposed (custom-paint
+   * receivers like Excel `NUIScrollbar`, Word MFC). Pure observation;
+   * never writes.
+   */
+  uiaReadScrollPercentAtHwnd?(opts: {
+    hwnd: string;
+    axis: "vertical" | "horizontal";
+  }): Promise<number | null>;
   uiaGetVirtualDesktopStatus?(
     hwndIntegers: string[],
   ): Promise<Record<string, boolean>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,6 +243,27 @@ impl Task for UiaScrollByWheelAtHwndTask {
     }
 }
 
+/// ADR-019 MVP-1 (Stage 1) — read-only ScrollPercent observation task.
+/// Read-only sibling of `UiaScrollByWheelAtHwndTask`; no `SetScrollPercent`
+/// side effect. Returns `Some(percent)` (0.0..=100.0) or `None` when no
+/// ScrollPattern is exposed on the leaf or its ancestors.
+#[cfg(windows)]
+pub struct UiaReadScrollPercentAtHwndTask(uia::scroll::ReadScrollPercentAtHwndOptions);
+
+#[cfg(windows)]
+impl Task for UiaReadScrollPercentAtHwndTask {
+    type Output = Option<f64>;
+    type JsValue = Option<f64>;
+
+    fn compute(&mut self) -> Result<Self::Output> {
+        uia::scroll::read_scroll_percent_at_hwnd(self.0.clone())
+    }
+
+    fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
+        Ok(output)
+    }
+}
+
 #[cfg(windows)]
 pub struct UiaGetVirtualDesktopStatusTask(Vec<String>);
 
@@ -300,6 +321,25 @@ pub fn uia_scroll_by_wheel_at_hwnd(
     opts: uia::scroll::ScrollByWheelAtHwndOptions,
 ) -> AsyncTask<UiaScrollByWheelAtHwndTask> {
     AsyncTask::new(UiaScrollByWheelAtHwndTask(opts))
+}
+
+/// ADR-019 MVP-1 (Stage 1) — read-only `ScrollPercent` companion to
+/// `uia_scroll_by_wheel_at_hwnd`. Resolves HWND → IUIAutomationElement, walks
+/// ancestors then DFS subtree looking for a ScrollPattern whose requested
+/// axis is scrollable, then reads `CurrentVertical/HorizontalScrollPercent`.
+/// Returns `Some(percent)` (0.0..=100.0) on success, `None` otherwise.
+///
+/// Used by the TS dispatcher (`src/tools/_input-pipeline.ts::postWheelToHwnd`
+/// chain-trust branch) for pre/post percent snapshot verification when the
+/// receiver is in `SCROLL_LEAF_CHAINS` but `Win32 GetScrollInfo(SB_VERT)`
+/// returns null (Excel `NUIScrollbar`, Word MFC custom-paint). Pure
+/// observation; no `SetScrollPercent` side effect.
+#[cfg(windows)]
+#[napi]
+pub fn uia_read_scroll_percent_at_hwnd(
+    opts: uia::scroll::ReadScrollPercentAtHwndOptions,
+) -> AsyncTask<UiaReadScrollPercentAtHwndTask> {
+    AsyncTask::new(UiaReadScrollPercentAtHwndTask(opts))
 }
 
 /// Query which HWNDs are on the current virtual desktop.

--- a/src/tools/_input-pipeline.ts
+++ b/src/tools/_input-pipeline.ts
@@ -748,10 +748,23 @@ export async function postWheelToHwnd(
     // under the budget; the 100 ms ceiling caps the worst-case dispatch
     // delay at a level acceptable for an interactive scroll. Timeout →
     // observation falls back to `chain_trust_unverified` honestly.
+    //
+    // **Gate** (Codex PR #309 Round 4 P2): the UIA pre-read is only useful
+    // when `pre === null` (Case 2a chain-trust branch). For Case 1
+    // (`getScrollInfoAvailable === false`) and Case 3 (`pre !== null`,
+    // standard Tier 3 path) the value is never consumed, so issuing the
+    // RPC would only pay up-to-100 ms latency for no benefit (and load
+    // the native UIA worker queue unnecessarily). Skip the read in those
+    // paths.
     const readUiaPercent = nativeUia?.uiaReadScrollPercentAtHwnd;
     let preUiaPercent: number | null = null;
     let preUiaElapsedMs = 0;
-    if (retargetedByLeafWalker && typeof readUiaPercent === "function") {
+    if (
+      retargetedByLeafWalker &&
+      pre === null &&
+      getScrollInfoAvailable &&
+      typeof readUiaPercent === "function"
+    ) {
       const tPreStart = performance.now();
       const preReadPromise = readUiaPercent({
         hwnd: effectiveHwnd.toString(),

--- a/src/tools/_input-pipeline.ts
+++ b/src/tools/_input-pipeline.ts
@@ -110,6 +110,38 @@ const SCROLL_PERCENT_EPSILON_OBSERVATION = 1e-3;
 const UIA_PRE_READ_TIMEOUT_MS = 100;
 
 /**
+ * ADR-019 MVP-1 (Stage 1) — same budget for the post-snapshot UIA read
+ * inside `observeViaUiaOrChainTrust`. Without this bound, the post-read
+ * could block the dispatcher's return for the full 8 s Rust thread
+ * timeout when the UIA provider hangs (Codex PR #309 Round 3 P2 — same
+ * blocking concern as the pre-read, applied symmetrically to post).
+ * Timeout → observation falls back to `chain_trust_unverified`.
+ */
+const UIA_POST_READ_TIMEOUT_MS = 100;
+
+/**
+ * ADR-019 MVP-1 (Stage 1) — known limitation, Codex PR #309 Round 3 P2:
+ *
+ * `Promise.race` against `UIA_PRE_READ_TIMEOUT_MS` / `UIA_POST_READ_TIMEOUT_MS`
+ * lets the JS path return quickly when the UIA read is slow, BUT the
+ * losing `readUiaPercent` Promise is never cancelled — the underlying
+ * Rust napi task (`thread::execute_with_timeout` in `src/uia/scroll.rs`)
+ * continues running until its own 8 s timeout. Under repeated scrolls
+ * against a slow / hung provider, each call enqueues another long-running
+ * UIA read into the native worker queue, causing backlog and sustained
+ * degraded behaviour even though the JS path returns fast with
+ * `chain_trust_unverified`.
+ *
+ * Mitigation deferred to Stage 2a (multi-frame ring buffer) where the
+ * temporal observation surface naturally batches / coalesces per-HWND
+ * in-flight reads; a per-HWND in-flight gate or an AbortSignal wired
+ * through the napi task lifecycle is the proper structural fix and is
+ * out of scope for MVP-1. For Stage 1, the JS-side timeout is a
+ * meaningful improvement over the pre-PR-309-Round-2 8 s wallclock-stall
+ * even without native cancellation.
+ */
+
+/**
  * ADR-018 Phase 4 — Tier 3 PostMessage minimum observable `nPos` delta to
  * classify the scroll as `delivered_via_postmessage`. Scrollbar position is
  * reported in app-defined units (often pixels for a custom scrollbar, line
@@ -480,10 +512,23 @@ async function observeViaUiaOrChainTrust(
   if (preUiaPercent !== null && typeof readUiaPercent === "function") {
     const tPostStart = performance.now();
     try {
-      const postUiaPercent = await readUiaPercent({
+      // Same bounded-await pattern as the pre-read site (Codex PR #309
+      // Round 3 P2 — post must also not block the dispatcher's return
+      // for seconds on a slow / hung UIA provider). 100 ms cap; timeout
+      // → observation falls back to `chain_trust_unverified`. See
+      // `UIA_POST_READ_TIMEOUT_MS` docstring for the rationale and the
+      // known native-cancellation limitation.
+      const postReadPromise = readUiaPercent({
         hwnd: effectiveHwnd.toString(),
         axis,
-      });
+      }).catch(() => null);
+      const postTimeoutPromise = new Promise<null>((resolve) =>
+        setTimeout(() => resolve(null), UIA_POST_READ_TIMEOUT_MS),
+      );
+      const postUiaPercent = await Promise.race([
+        postReadPromise,
+        postTimeoutPromise,
+      ]);
       const postElapsedMs = performance.now() - tPostStart;
       // ADR-019 §2.1: `framesSampled` is documented to be the number of
       // pre/post observation samples this primitive captured. For Stage 1

--- a/src/tools/_input-pipeline.ts
+++ b/src/tools/_input-pipeline.ts
@@ -86,6 +86,16 @@ const CDP_SCROLL_DELIVERY_EPSILON_PX = 1;
 const POSTMESSAGE_SETTLE_MS = 16;
 
 /**
+ * ADR-019 MVP-1 (Stage 1) — UIA `ScrollPercent` pre/post delta threshold for
+ * `observation.source: "uia_scroll_percent"`. Aligned with `mouse.ts`
+ * `SCROLL_PERCENT_EPSILON = 1e-6` baseline; the chain-trust observation
+ * needs a slightly larger floor because UIA percent reads on custom-paint
+ * receivers may exhibit sub-percent jitter on idle frames. 1e-3 (0.001 %)
+ * is empirically a safe gate.
+ */
+const SCROLL_PERCENT_EPSILON_OBSERVATION = 1e-3;
+
+/**
  * ADR-018 Phase 4 — Tier 3 PostMessage minimum observable `nPos` delta to
  * classify the scroll as `delivered_via_postmessage`. Scrollbar position is
  * reported in app-defined units (often pixels for a custom scrollbar, line
@@ -198,6 +208,62 @@ export interface DispatchOutcome {
     | "delivered_via_cdp"
     | "delivered_via_postmessage"
     | null;
+  /**
+   * ADR-019 MVP-1 (Stage 1) — additive observation telemetry. Populated
+   * when a TMOL primitive (UIA `ScrollPercent` for Stage 1; block motion /
+   * tiled phase correlation / SSIM / DXGI for Stages 2-5) produces a
+   * concrete observation; absent on legacy Tier 1 / 2 / 3 paths that have
+   * not yet been wired through TMOL. The `source` enum is canonically
+   * defined in `docs/adr-019-anti-fukuwarai-v3-temporal-motion-observation.md`
+   * §2.1; keep all surfaces (this type, `ScrollVerifyOutcome.observation`,
+   * the envelope hint, ADR-018 §2.6 reference, ADR-019 §2.1) bit-equal.
+   */
+  observation?: VisualMotionObservation;
+}
+
+/**
+ * ADR-019 §2.1 — `VisualMotionObservation`. Carried additively in
+ * `DispatchOutcome.observation` / `ScrollVerifyOutcome.observation` /
+ * `verifyDelivery.observation` envelope hint. Existing callers that ignore
+ * the field are unaffected (CLAUDE.md §3.2 carry-over scope shrink).
+ */
+export interface VisualMotionObservation {
+  motion: "translation" | "local_repaint" | "no_change" | "indeterminate";
+  /** present iff motion === "translation" */
+  shift?: { dx: number; dy: number; confidence: number };
+  /** present iff motion === "local_repaint" */
+  residual?: {
+    fractionChanged: number;
+    centroid?: { x: number; y: number };
+  };
+  /**
+   * Algorithm that produced this observation. Stage 1 emits
+   * `"uia_scroll_percent"` (success) or `"chain_trust_unverified"`
+   * (UIA pattern not exposed, chain-trust fall-through). Stages 2-5+
+   * add the remaining values.
+   */
+  source:
+    | "uia_scroll_percent"
+    | "block_motion_vectors"
+    | "tiled_phase_correlation"
+    | "ssim_residual"
+    | "dxgi_dirty_rect"
+    | "optical_flow"
+    | "temporal_ring_observation_only"
+    | "chain_trust_unverified";
+  /**
+   * Stage 2a multi-frame ring buffer telemetry (Stage 1 leaves undefined).
+   * Populated when the temporal observation layer captured a ring; carries
+   * the per-frame `computeChangeFraction` series for empirical calibration.
+   */
+  ringTelemetry?: {
+    framesSampled: number;
+    elapsedMsPerFrame: number[];
+    changedFractions: number[];
+    maxChangedFraction: number;
+  };
+  framesSampled: number;
+  totalElapsedMs: number;
 }
 
 // ─── Resolver ────────────────────────────────────────────────────────────────
@@ -363,6 +429,81 @@ export function assertTier4Reachable(dest: InputDestination): void {
   }
 }
 
+/**
+ * ADR-019 MVP-1 (Stage 1) — chain-trust observation gate. Called inside the
+ * `postWheelToHwnd` Case 2a branch (leaf walker retargeted + `GetScrollInfo`
+ * returns null) AFTER the PostMessage chunking loop has posted at least one
+ * chunk. Reads UIA `ScrollPercent` post-snapshot, compares with the supplied
+ * pre-snapshot, and returns the corresponding `VisualMotionObservation`.
+ *
+ *   - pre + post both non-null AND |delta| ≥ epsilon → translation observed
+ *     via UIA percent. Stage 1 doesn't convert the percent to a pixel shift
+ *     (different observers carry different units — block motion vectors will
+ *     carry pixels in Stage 2b); just record `source: "uia_scroll_percent"`
+ *     and let the caller trust the result.
+ *   - pre non-null + post non-null AND |delta| < epsilon → no_change. The
+ *     wheel reached the receiver but the receiver did not advance (boundary
+ *     case Codex PR #308 P1 honest signal).
+ *   - any failure (UIA pattern not exposed on either snapshot, post read
+ *     throws) → fall through to chain-trust assertion: `source:
+ *     "chain_trust_unverified"`.
+ *
+ * Stages 2-5 add additional observers (block motion vectors / phase
+ * correlation / SSIM / DXGI dirty-rect); this helper is the first one wired.
+ */
+async function observeViaUiaOrChainTrust(
+  effectiveHwnd: bigint,
+  axisName: string,
+  preUiaPercent: number | null,
+  readUiaPercent:
+    | ((opts: {
+        hwnd: string;
+        axis: "vertical" | "horizontal";
+      }) => Promise<number | null>)
+    | undefined,
+): Promise<VisualMotionObservation> {
+  if (preUiaPercent !== null && typeof readUiaPercent === "function") {
+    try {
+      const postUiaPercent = await readUiaPercent({
+        hwnd: effectiveHwnd.toString(),
+        axis: axisName as "vertical" | "horizontal",
+      });
+      if (postUiaPercent !== null) {
+        const delta = postUiaPercent - preUiaPercent;
+        if (Math.abs(delta) >= SCROLL_PERCENT_EPSILON_OBSERVATION) {
+          return {
+            motion: "translation",
+            source: "uia_scroll_percent",
+            framesSampled: 2,
+            totalElapsedMs: 0,
+          };
+        }
+        // pre and post both readable, but no meaningful delta. Honest "no
+        // movement" signal — the UIA observer says the receiver did not
+        // scroll (boundary / non-scrollable / receiver chose not to act).
+        return {
+          motion: "no_change",
+          source: "uia_scroll_percent",
+          framesSampled: 2,
+          totalElapsedMs: 0,
+        };
+      }
+    } catch {
+      // Any throw during post-snapshot falls through to chain-trust.
+    }
+  }
+  // Chain-trust fall-through: UIA pattern wasn't exposed on the leaf OR the
+  // post-snapshot failed. The dispatcher still emits delivered_via_postmessage
+  // (PR #308 chain-table trust), but the observation field signals that the
+  // delivery is unverified at the observation layer (LLM honest signal).
+  return {
+    motion: "indeterminate",
+    source: "chain_trust_unverified",
+    framesSampled: 0,
+    totalElapsedMs: 0,
+  };
+}
+
 // ─── Tier 3 PostMessage helpers (ADR-018 §4 Phase 4) ─────────────────────────
 
 /**
@@ -513,6 +654,26 @@ export async function postWheelToHwnd(
       ? getScrollInfo(effectiveHwnd, axisName)
       : null;
 
+    // ADR-019 MVP-1 (Stage 1) — read-only UIA `ScrollPercent` pre-snapshot.
+    // The dispatcher's chain-trust branch (Case 2a below) prefers UIA percent
+    // when available because it's the OS-canonical observation (TMOL
+    // `scroll_translation` fast path). Best-effort: null preUiaPercent or any
+    // throw falls back to the bare chain-trust assertion (observation.source:
+    // "chain_trust_unverified"). Only meaningful when retargetedByLeafWalker
+    // is true; for non-MDI apps the Win32 SB_VERT pre-snapshot is the path.
+    const readUiaPercent = nativeUia?.uiaReadScrollPercentAtHwnd;
+    let preUiaPercent: number | null = null;
+    if (retargetedByLeafWalker && typeof readUiaPercent === "function") {
+      try {
+        preUiaPercent = await readUiaPercent({
+          hwnd: effectiveHwnd.toString(),
+          axis: axisName as "vertical" | "horizontal",
+        });
+      } catch {
+        preUiaPercent = null;
+      }
+    }
+
     // Chunk the wheel delta into ≤ 16-bit signed messages so the receiver's
     // `GET_WHEEL_DELTA_WPARAM` (signed short) does not wrap. For typical
     // notch counts (1-10) this loops once. For `notch >= 274` the previous
@@ -595,10 +756,25 @@ export async function postWheelToHwnd(
     //       caller emits `target_unreachable` per ADR §2.6.2 path-(b).
     if (pre === null) {
       if (retargetedByLeafWalker) {
+        // ADR-019 MVP-1 Case 2a: try UIA `ScrollPercent` observation BEFORE
+        // emitting the bare chain-trust assertion. When the leaf (or one of
+        // its UIA ancestors / descendants) exposes a ScrollPattern whose
+        // pre/post percent differ by ≥ SCROLL_PERCENT_EPSILON_OBSERVATION,
+        // attach an `observation.source: "uia_scroll_percent"` with the
+        // numeric percent delta. Otherwise attach `observation.source:
+        // "chain_trust_unverified"` so the caller knows the delivery is
+        // unverified (Stage 1 honest signal; Stages 2-5 upgrade this).
+        const observation = await observeViaUiaOrChainTrust(
+          effectiveHwnd,
+          axisName,
+          preUiaPercent,
+          readUiaPercent,
+        );
         return {
           scrolled: true,
           channel: "postmessage",
           reason: "delivered_via_postmessage",
+          observation,
         };
       }
       return null;

--- a/src/tools/_input-pipeline.ts
+++ b/src/tools/_input-pipeline.ts
@@ -96,6 +96,20 @@ const POSTMESSAGE_SETTLE_MS = 16;
 const SCROLL_PERCENT_EPSILON_OBSERVATION = 1e-3;
 
 /**
+ * ADR-019 MVP-1 (Stage 1) — `Promise.race` budget for the pre-snapshot UIA
+ * `ScrollPercent` read in `postWheelToHwnd`'s chain-trust path. The wheel
+ * dispatch must NOT block for seconds on a slow UIA provider (Codex PR #309
+ * Round 1 P2), but the pre-snapshot ALSO MUST be a genuine pre-dispatch
+ * sample (Codex PR #309 Round 2 P2 — a fire-and-forget Promise that
+ * resolves after the chunk loop would carry a post-scroll value). 100 ms
+ * is the compromise: UIA reads typically return in 1-5 ms (well under
+ * budget) while the worst-case dispatch delay is bounded at an
+ * interactive-acceptable ceiling. Timeout → `preUiaPercent = null` →
+ * observation falls back to `chain_trust_unverified` honestly.
+ */
+const UIA_PRE_READ_TIMEOUT_MS = 100;
+
+/**
  * ADR-018 Phase 4 — Tier 3 PostMessage minimum observable `nPos` delta to
  * classify the scroll as `delivered_via_postmessage`. Scrollbar position is
  * reported in app-defined units (often pixels for a custom scrollbar, line
@@ -677,30 +691,33 @@ export async function postWheelToHwnd(
     // throw falls back to the bare chain-trust assertion (observation.source:
     // "chain_trust_unverified"). Only meaningful when retargetedByLeafWalker
     // is true; for non-MDI apps the Win32 SB_VERT pre-snapshot is the path.
-    // ADR-019 MVP-1 (Stage 1) — fire-and-forget pre-snapshot UIA read.
-    // Issued BEFORE the chunking loop, but **NOT awaited here**: the wheel
-    // dispatch must not block on the optional observation path. A slow UIA
-    // provider (e.g. an off-thread COM call that takes seconds) would
-    // otherwise delay sending wheel messages themselves (Codex PR #309
-    // Round 1 P2). The Promise is captured and `.catch`-converted to null
-    // so the later `await` in the chain-trust branch never throws.
+    // ADR-019 MVP-1 (Stage 1) — bounded-await pre-snapshot UIA read. The
+    // value MUST be a real pre-dispatch sample (Codex PR #309 Round 2 P2 —
+    // a fire-and-forget Promise that resolves AFTER the chunk loop would
+    // carry a *post-scroll* value, breaking the chain-trust observation
+    // contract). The value MUST NOT block dispatch for seconds (Codex PR
+    // #309 Round 1 P2 — a slow/hung UIA provider should not delay sending
+    // wheel messages). Resolution: `Promise.race` the pre-read against a
+    // tight wallclock budget (`UIA_PRE_READ_TIMEOUT_MS = 100ms`), then
+    // proceed with chunking. UIA reads typically return in ~1-5 ms, well
+    // under the budget; the 100 ms ceiling caps the worst-case dispatch
+    // delay at a level acceptable for an interactive scroll. Timeout →
+    // observation falls back to `chain_trust_unverified` honestly.
     const readUiaPercent = nativeUia?.uiaReadScrollPercentAtHwnd;
-    let preUiaPromise: Promise<{ percent: number | null; elapsedMs: number }> =
-      Promise.resolve({ percent: null, elapsedMs: 0 });
+    let preUiaPercent: number | null = null;
+    let preUiaElapsedMs = 0;
     if (retargetedByLeafWalker && typeof readUiaPercent === "function") {
       const tPreStart = performance.now();
-      preUiaPromise = readUiaPercent({
+      const preReadPromise = readUiaPercent({
         hwnd: effectiveHwnd.toString(),
         axis: axisName,
-      })
-        .then((percent) => ({
-          percent,
-          elapsedMs: performance.now() - tPreStart,
-        }))
-        .catch(() => ({
-          percent: null,
-          elapsedMs: performance.now() - tPreStart,
-        }));
+      }).catch(() => null);
+      const timeoutPromise = new Promise<null>((resolve) =>
+        setTimeout(() => resolve(null), UIA_PRE_READ_TIMEOUT_MS),
+      );
+      const result = await Promise.race([preReadPromise, timeoutPromise]);
+      preUiaPercent = result;
+      preUiaElapsedMs = performance.now() - tPreStart;
     }
 
     // Chunk the wheel delta into ≤ 16-bit signed messages so the receiver's
@@ -793,14 +810,11 @@ export async function postWheelToHwnd(
         // numeric percent delta. Otherwise attach `observation.source:
         // "chain_trust_unverified"` so the caller knows the delivery is
         // unverified (Stage 1 honest signal; Stages 2-5 upgrade this).
-        // Await the pre-snapshot UIA read that was issued before the
-        // chunking loop (fire-and-forget pattern — Codex PR #309 Round 1
-        // P2). By now the chunks have all been posted + we waited the
-        // settle delay, so the UIA read has had its full duration to
-        // complete in parallel; in practice the await here returns
-        // immediately.
-        const { percent: preUiaPercent, elapsedMs: preUiaElapsedMs } =
-          await preUiaPromise;
+        // `preUiaPercent` and `preUiaElapsedMs` were captured ABOVE the
+        // chunking loop via `Promise.race` against `UIA_PRE_READ_TIMEOUT_MS`
+        // (Codex PR #309 Round 2 P2 — pre value must be a real pre-dispatch
+        // sample; Round 1 P2 — bounded so a slow provider does not stall
+        // dispatch for seconds).
         const observation = await observeViaUiaOrChainTrust(
           effectiveHwnd,
           axisName,

--- a/src/tools/_input-pipeline.ts
+++ b/src/tools/_input-pipeline.ts
@@ -677,20 +677,30 @@ export async function postWheelToHwnd(
     // throw falls back to the bare chain-trust assertion (observation.source:
     // "chain_trust_unverified"). Only meaningful when retargetedByLeafWalker
     // is true; for non-MDI apps the Win32 SB_VERT pre-snapshot is the path.
+    // ADR-019 MVP-1 (Stage 1) — fire-and-forget pre-snapshot UIA read.
+    // Issued BEFORE the chunking loop, but **NOT awaited here**: the wheel
+    // dispatch must not block on the optional observation path. A slow UIA
+    // provider (e.g. an off-thread COM call that takes seconds) would
+    // otherwise delay sending wheel messages themselves (Codex PR #309
+    // Round 1 P2). The Promise is captured and `.catch`-converted to null
+    // so the later `await` in the chain-trust branch never throws.
     const readUiaPercent = nativeUia?.uiaReadScrollPercentAtHwnd;
-    let preUiaPercent: number | null = null;
-    let preUiaElapsedMs = 0;
+    let preUiaPromise: Promise<{ percent: number | null; elapsedMs: number }> =
+      Promise.resolve({ percent: null, elapsedMs: 0 });
     if (retargetedByLeafWalker && typeof readUiaPercent === "function") {
       const tPreStart = performance.now();
-      try {
-        preUiaPercent = await readUiaPercent({
-          hwnd: effectiveHwnd.toString(),
-          axis: axisName,
-        });
-      } catch {
-        preUiaPercent = null;
-      }
-      preUiaElapsedMs = performance.now() - tPreStart;
+      preUiaPromise = readUiaPercent({
+        hwnd: effectiveHwnd.toString(),
+        axis: axisName,
+      })
+        .then((percent) => ({
+          percent,
+          elapsedMs: performance.now() - tPreStart,
+        }))
+        .catch(() => ({
+          percent: null,
+          elapsedMs: performance.now() - tPreStart,
+        }));
     }
 
     // Chunk the wheel delta into ≤ 16-bit signed messages so the receiver's
@@ -783,6 +793,14 @@ export async function postWheelToHwnd(
         // numeric percent delta. Otherwise attach `observation.source:
         // "chain_trust_unverified"` so the caller knows the delivery is
         // unverified (Stage 1 honest signal; Stages 2-5 upgrade this).
+        // Await the pre-snapshot UIA read that was issued before the
+        // chunking loop (fire-and-forget pattern — Codex PR #309 Round 1
+        // P2). By now the chunks have all been posted + we waited the
+        // settle delay, so the UIA read has had its full duration to
+        // complete in parallel; in practice the await here returns
+        // immediately.
+        const { percent: preUiaPercent, elapsedMs: preUiaElapsedMs } =
+          await preUiaPromise;
         const observation = await observeViaUiaOrChainTrust(
           effectiveHwnd,
           axisName,

--- a/src/tools/_input-pipeline.ts
+++ b/src/tools/_input-pipeline.ts
@@ -453,8 +453,9 @@ export function assertTier4Reachable(dest: InputDestination): void {
  */
 async function observeViaUiaOrChainTrust(
   effectiveHwnd: bigint,
-  axisName: string,
+  axis: "vertical" | "horizontal",
   preUiaPercent: number | null,
+  preElapsedMs: number,
   readUiaPercent:
     | ((opts: {
         hwnd: string;
@@ -463,11 +464,19 @@ async function observeViaUiaOrChainTrust(
     | undefined,
 ): Promise<VisualMotionObservation> {
   if (preUiaPercent !== null && typeof readUiaPercent === "function") {
+    const tPostStart = performance.now();
     try {
       const postUiaPercent = await readUiaPercent({
         hwnd: effectiveHwnd.toString(),
-        axis: axisName as "vertical" | "horizontal",
+        axis,
       });
+      const postElapsedMs = performance.now() - tPostStart;
+      // ADR-019 §2.1: `framesSampled` is documented to be the number of
+      // pre/post observation samples this primitive captured. For Stage 1
+      // UIA percent reads, that is exactly 2 (pre + post). `totalElapsedMs`
+      // is the actual wallclock spent on the pre and post reads — feeds the
+      // AC6 fast-path budget bench (Opus Round 1 P2-2).
+      const totalElapsedMs = preElapsedMs + postElapsedMs;
       if (postUiaPercent !== null) {
         const delta = postUiaPercent - preUiaPercent;
         if (Math.abs(delta) >= SCROLL_PERCENT_EPSILON_OBSERVATION) {
@@ -475,7 +484,7 @@ async function observeViaUiaOrChainTrust(
             motion: "translation",
             source: "uia_scroll_percent",
             framesSampled: 2,
-            totalElapsedMs: 0,
+            totalElapsedMs,
           };
         }
         // pre and post both readable, but no meaningful delta. Honest "no
@@ -485,7 +494,7 @@ async function observeViaUiaOrChainTrust(
           motion: "no_change",
           source: "uia_scroll_percent",
           framesSampled: 2,
-          totalElapsedMs: 0,
+          totalElapsedMs,
         };
       }
     } catch {
@@ -631,7 +640,14 @@ export async function postWheelToHwnd(
 
     const axisIsVertical =
       params.direction === "up" || params.direction === "down";
-    const axisName = axisIsVertical ? "vertical" : "horizontal";
+    // `axisName` is narrowed to `"vertical" | "horizontal"` by the ternary;
+    // both `getScrollInfo` and `uiaReadScrollPercentAtHwnd` accept that union
+    // directly so no `as` cast is needed downstream (Opus PR #309 Round 1 P2-1
+    // / P2-3 — eliminate the duplicate axis-cast that previously existed at
+    // the two call sites).
+    const axisName: "vertical" | "horizontal" = axisIsVertical
+      ? "vertical"
+      : "horizontal";
 
     // Pre-snapshot is best-effort. Two distinct "no observation" cases must
     // be kept apart (Codex PR #305 review P2-A):
@@ -663,15 +679,18 @@ export async function postWheelToHwnd(
     // is true; for non-MDI apps the Win32 SB_VERT pre-snapshot is the path.
     const readUiaPercent = nativeUia?.uiaReadScrollPercentAtHwnd;
     let preUiaPercent: number | null = null;
+    let preUiaElapsedMs = 0;
     if (retargetedByLeafWalker && typeof readUiaPercent === "function") {
+      const tPreStart = performance.now();
       try {
         preUiaPercent = await readUiaPercent({
           hwnd: effectiveHwnd.toString(),
-          axis: axisName as "vertical" | "horizontal",
+          axis: axisName,
         });
       } catch {
         preUiaPercent = null;
       }
+      preUiaElapsedMs = performance.now() - tPreStart;
     }
 
     // Chunk the wheel delta into ≤ 16-bit signed messages so the receiver's
@@ -768,6 +787,7 @@ export async function postWheelToHwnd(
           effectiveHwnd,
           axisName,
           preUiaPercent,
+          preUiaElapsedMs,
           readUiaPercent,
         );
         return {

--- a/src/tools/mouse.ts
+++ b/src/tools/mouse.ts
@@ -39,6 +39,7 @@ import {
   resolveInputDestination,
   dispatchScrollWheel,
   assertTier4Reachable,
+  type VisualMotionObservation,
 } from "./_input-pipeline.js";
 
 /**
@@ -982,6 +983,15 @@ export interface ScrollVerifyOutcome {
     | "target_unreachable";
   /** Axis on which silent drop / unverifiable was detected (for context). */
   axis?: "vertical" | "horizontal";
+  /**
+   * ADR-019 MVP-1 (Stage 1) — additive TMOL observation telemetry. Forwarded
+   * from `DispatchOutcome.observation` (set by Stage 1+ TMOL primitives such
+   * as UIA `ScrollPercent` reading). Existing callers that ignore the field
+   * are unaffected (CLAUDE.md §3.2 carry-over scope shrink). The canonical
+   * shape lives in `src/tools/_input-pipeline.ts::VisualMotionObservation`
+   * and is referenced by ADR-019 §2.1 / ADR-018 §2.6 envelope hint.
+   */
+  observation?: VisualMotionObservation;
 }
 
 /**
@@ -1318,17 +1328,27 @@ export const scrollHandler = async ({
       );
     }
 
+    // ADR-019 MVP-1 (Stage 1) — propagate `observation` from dispatcher
+    // outcome into the verifyDelivery envelope additively. Existing callers
+    // that ignore the field are unaffected (CLAUDE.md §3.2 carry-over scope
+    // shrink). The field is only attached when the dispatcher emitted one
+    // (today: chain-trust branch of `postWheelToHwnd` for Stage 1).
+    const dispatcherObservation: VisualMotionObservation | undefined =
+      tier1 !== null ? tier1.observation : undefined;
+
     const verifyDelivery = outcome.status === "delivered"
       ? {
           status: "delivered" as const,
           channel: effectiveChannel,
           ...(tier1 !== null && tier1.reason !== null ? { reason: tier1.reason } : {}),
+          ...(dispatcherObservation ? { observation: dispatcherObservation } : {}),
         }
       : {
           status: "unverifiable" as const,
           channel: "wheel_send_input" as const,
           reason: outcome.reason ?? "read_back_unsupported",
           ...(outcome.axis ? { axis: outcome.axis } : {}),
+          ...(dispatcherObservation ? { observation: dispatcherObservation } : {}),
         };
 
     const hints: Record<string, unknown> = {

--- a/src/uia/scroll.rs
+++ b/src/uia/scroll.rs
@@ -59,6 +59,24 @@ pub struct ScrollByWheelAtHwndOptions {
     pub wheel_delta_x: i32,
 }
 
+/// ADR-019 MVP-1 (Stage 1) — read-only sibling of `ScrollByWheelAtHwndOptions`.
+/// Walks UIA ancestors then a bounded DFS subtree (mirroring the dispatch path's
+/// Phase A / Phase B walk) looking for the first `IUIAutomationScrollPattern`
+/// whose `CurrentVerticallyScrollable` / `CurrentHorizontallyScrollable` matches
+/// the requested axis. Returns the percent value when found, `None` otherwise
+/// (custom-paint receivers like Excel `NUIScrollbar` / Word `_WwG`).
+///
+/// Pure observation: never writes (no `SetScrollPercent` side effect). Used by
+/// the `postWheelToHwnd` chain-trust branch in `src/tools/_input-pipeline.ts`
+/// for pre/post percent snapshot verification (TMOL `scroll_translation`
+/// primitive, fast path).
+#[napi_derive::napi(object)]
+#[derive(Debug, Clone)]
+pub struct ReadScrollPercentAtHwndOptions {
+    pub hwnd: String,
+    pub axis: String, // "vertical" | "horizontal"
+}
+
 // ─── Public API ──────────────────────────────────────────────────────────────
 
 pub fn scroll_into_view(opts: ScrollIntoViewOptions) -> napi::Result<ScrollResult> {
@@ -90,6 +108,24 @@ pub fn scroll_by_percent(opts: ScrollByPercentOptions) -> napi::Result<ScrollRes
 pub fn scroll_by_wheel_at_hwnd(opts: ScrollByWheelAtHwndOptions) -> napi::Result<ScrollResult> {
     thread::execute_with_timeout(
         move |ctx| scroll_by_wheel_at_hwnd_impl(ctx, &opts),
+        DEFAULT_TIMEOUT_MS,
+    )
+}
+
+/// ADR-019 MVP-1 (Stage 1) — read-only `ScrollPercent` observation companion to
+/// `scroll_by_wheel_at_hwnd`. Returns `Some(percent)` (0.0..=100.0) when a
+/// ScrollPattern ancestor / descendant exposes the requested axis as scrollable
+/// AND `CurrentVerticalScrollPercent` / `CurrentHorizontalScrollPercent` returns
+/// Ok; `None` otherwise. Mirrors the Phase A ancestor walk + Phase B DFS
+/// subtree search in `scroll_by_wheel_at_hwnd_impl` but never writes. The TS
+/// dispatcher (`src/tools/_input-pipeline.ts::postWheelToHwnd`) calls this
+/// pre/post the PostMessage chunking loop; a meaningful diff witnesses
+/// `observation.source: "uia_scroll_percent"` per ADR-019 §2.1.
+pub fn read_scroll_percent_at_hwnd(
+    opts: ReadScrollPercentAtHwndOptions,
+) -> napi::Result<Option<f64>> {
+    thread::execute_with_timeout(
+        move |ctx| read_scroll_percent_at_hwnd_impl(ctx, &opts),
         DEFAULT_TIMEOUT_MS,
     )
 }
@@ -392,6 +428,111 @@ fn scroll_by_wheel_at_hwnd_impl(
             "No ScrollPattern found (ancestor walk + subtree DFS both exhausted)".into(),
         ),
     })
+}
+
+/// ADR-019 MVP-1 (Stage 1) — read-only `ScrollPercent` observation. Mirrors the
+/// Phase A ancestor walk + Phase B DFS subtree search in
+/// `scroll_by_wheel_at_hwnd_impl`, but never writes. Returns `Some(percent)`
+/// (0.0..=100.0) when a ScrollPattern element exposes the requested axis as
+/// scrollable AND `Current*ScrollPercent` returns Ok; `None` for any failure
+/// (invalid HWND, no pattern in tree, axis not scrollable, percent read error).
+fn read_scroll_percent_at_hwnd_impl(
+    ctx: &UiaContext,
+    opts: &ReadScrollPercentAtHwndOptions,
+) -> napi::Result<Option<f64>> {
+    let want_vertical = match opts.axis.as_str() {
+        "vertical" => true,
+        "horizontal" => false,
+        other => {
+            return Err(napi::Error::from_reason(format!(
+                "ReadScrollPercentAtHwndOptions.axis must be 'vertical' or 'horizontal', got: {other}"
+            )));
+        }
+    };
+    let hwnd_i64: i64 = opts.hwnd.parse().map_err(|e| {
+        napi::Error::from_reason(format!(
+            "ReadScrollPercentAtHwndOptions.hwnd parse error: {e}"
+        ))
+    })?;
+    if hwnd_i64 == 0 {
+        return Ok(None);
+    }
+    let hwnd = HWND(hwnd_i64 as *mut std::ffi::c_void);
+
+    let elem: IUIAutomationElement = match unsafe { ctx.automation.ElementFromHandle(hwnd) } {
+        Ok(e) => e,
+        Err(_) => return Ok(None),
+    };
+    let elem_for_dfs = elem.clone();
+
+    // Axis flags match the write path's gate logic (Phase A / Phase B) so a
+    // pattern is only accepted when it's scrollable on the requested axis.
+    let need_vertical = want_vertical;
+    let need_horizontal = !want_vertical;
+
+    // Phase A — walk from the element itself up through ancestors.
+    let root: IUIAutomationElement = unsafe { ctx.automation.GetRootElement().map_err(win_err)? };
+    let mut current: Option<IUIAutomationElement> = Some(elem);
+    while let Some(e) = current {
+        let is_root = unsafe {
+            ctx.automation
+                .CompareElements(&e, &root)
+                .unwrap_or_default()
+        };
+        if is_root == true {
+            break;
+        }
+        unsafe {
+            if let Ok(pat) = e.GetCurrentPattern(UIA_ScrollPatternId)
+                && let Ok(scroll) = pat.cast::<IUIAutomationScrollPattern>()
+            {
+                let v_ok = !need_vertical
+                    || scroll.CurrentVerticallyScrollable().map(|b| b.0 != 0).unwrap_or(false);
+                let h_ok = !need_horizontal
+                    || scroll.CurrentHorizontallyScrollable().map(|b| b.0 != 0).unwrap_or(false);
+                if v_ok && h_ok {
+                    return read_scroll_percent_from_pattern(&scroll, want_vertical);
+                }
+            }
+        }
+        current = unsafe { ctx.walker.GetParentElement(&e).ok() };
+    }
+
+    // Phase B — DFS subtree under the original element, constrained to
+    // `target_hwnd`'s Win32 child window family (per `find_scroll_pattern_in_subtree`).
+    let mut dfs_budget = MAX_SCROLL_DFS_NODES;
+    if let Some(scroll) = find_scroll_pattern_in_subtree(
+        ctx,
+        &elem_for_dfs,
+        MAX_SEARCH_DEPTH,
+        hwnd_i64 as isize,
+        need_vertical,
+        need_horizontal,
+        &mut dfs_budget,
+    ) {
+        return read_scroll_percent_from_pattern(&scroll, want_vertical);
+    }
+
+    Ok(None)
+}
+
+/// Read a single axis percent from an already-obtained `IUIAutomationScrollPattern`.
+/// Returns `None` when the COM call fails (some apps expose `IsScrollable=true`
+/// but reject `CurrentVerticalScrollPercent` reads when the document is in a
+/// transient state — better to fall through to chain-trust than to throw).
+fn read_scroll_percent_from_pattern(
+    scroll: &IUIAutomationScrollPattern,
+    want_vertical: bool,
+) -> napi::Result<Option<f64>> {
+    let result = if want_vertical {
+        unsafe { scroll.CurrentVerticalScrollPercent() }
+    } else {
+        unsafe { scroll.CurrentHorizontalScrollPercent() }
+    };
+    match result {
+        Ok(v) => Ok(Some(v)),
+        Err(_) => Ok(None),
+    }
 }
 
 /// Apply one scroll step using an already-obtained `IUIAutomationScrollPattern`.

--- a/src/uia/scroll.rs
+++ b/src/uia/scroll.rs
@@ -530,7 +530,20 @@ fn read_scroll_percent_from_pattern(
         unsafe { scroll.CurrentHorizontalScrollPercent() }
     };
     match result {
-        Ok(v) => Ok(Some(v)),
+        Ok(v) => {
+            // Microsoft UIA defines `UIA_ScrollPatternNoScroll = -1.0` as the
+            // sentinel returned when the axis is not scrollable / no valid
+            // position is available (transient provider state). Treat it as
+            // observation-unavailable so the TS layer falls back to
+            // chain-trust (Codex PR #309 Round 1 P1). The sentinel is exactly
+            // -1.0; allow a small numeric slack (negative below the legal
+            // 0.0..=100.0 range) so providers that round are also captured.
+            if !v.is_finite() || v < 0.0 || v > 100.0 {
+                Ok(None)
+            } else {
+                Ok(Some(v))
+            }
+        }
         Err(_) => Ok(None),
     }
 }

--- a/tests/unit/input-pipeline-dispatch.test.ts
+++ b/tests/unit/input-pipeline-dispatch.test.ts
@@ -36,8 +36,21 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // `uiaScrollByWheelAtHwnd` property. `nativeWin32Mock` is the Phase 4 Tier 3
 // PostMessage surface (`win32PostMessage` + `win32GetScrollInfo`).
 const uiaScrollByWheelAtHwndMock = vi.fn();
-const nativeUiaMock: { uiaScrollByWheelAtHwnd?: unknown } = {
+// ADR-019 MVP-1 (Stage 1) — read-only ScrollPercent observation mock.
+// Default impl returns `null` (no UIA pattern exposed) so existing tests
+// stay bit-equal with the chain-trust fall-through path (observation.source:
+// "chain_trust_unverified"). Stage 1 tests override to return numeric
+// pre/post percents and exercise the `uia_scroll_percent` observation path.
+const uiaReadScrollPercentAtHwndMock = vi.fn<
+  [{ hwnd: string; axis: "vertical" | "horizontal" }],
+  Promise<number | null>
+>(async () => null);
+const nativeUiaMock: {
+  uiaScrollByWheelAtHwnd?: unknown;
+  uiaReadScrollPercentAtHwnd?: unknown;
+} = {
   uiaScrollByWheelAtHwnd: uiaScrollByWheelAtHwndMock,
+  uiaReadScrollPercentAtHwnd: uiaReadScrollPercentAtHwndMock,
 };
 const win32PostMessageMock = vi.fn<[bigint, number, bigint, bigint], boolean>();
 const win32GetScrollInfoMock = vi.fn<
@@ -897,10 +910,17 @@ describe("ADR-018 Phase 5+N — postWheelToHwnd scroll-leaf walker (Excel / Word
     win32GetScrollInfoMock.mockReset();
     getWindowRectByHwndMock.mockReset();
     win32FindScrollLeafForTopLevelMock.mockReset();
+    // ADR-019 MVP-1 (Stage 1) — reset UIA percent mock; default impl returns
+    // null (no pattern exposed) so the chain-trust fall-through is the
+    // baseline observation. Tests that exercise the UIA observation path
+    // override per-call (`mockResolvedValueOnce`).
+    uiaReadScrollPercentAtHwndMock.mockReset();
+    uiaReadScrollPercentAtHwndMock.mockImplementation(async () => null);
     nativeWin32Mock.win32PostMessage = win32PostMessageMock;
     nativeWin32Mock.win32GetScrollInfo = win32GetScrollInfoMock;
     nativeWin32Mock.win32FindScrollLeafForTopLevel =
       win32FindScrollLeafForTopLevelMock;
+    nativeUiaMock.uiaReadScrollPercentAtHwnd = uiaReadScrollPercentAtHwndMock;
     win32PostMessageMock.mockReturnValue(true);
   });
 
@@ -1033,12 +1053,19 @@ describe("ADR-018 Phase 5+N — postWheelToHwnd scroll-leaf walker (Excel / Word
     );
   });
 
-  it("leaf retargeted AND getScrollInfo(leaf, axis) returns null (Excel NUIScrollbar / Word MFC custom paint) → trust the chain table and emit delivered_via_postmessage (Case 2a, dogfood 2026-05-16)", async () => {
+  it("leaf retargeted AND getScrollInfo(leaf, axis) returns null AND UIA pattern not exposed → trust the chain table, emit delivered_via_postmessage with observation.source 'chain_trust_unverified' (Case 2a, dogfood 2026-05-16; ADR-019 MVP-1)", async () => {
     // Excel EXCEL7 (and similar MDI scroll-leaves) use custom-painted
     // scrollbars (`NUIScrollbar` etc.) that GetScrollInfo(SB_VERT) cannot
     // observe — `pre === null` here is the "no SB_VERT" signal, NOT the
     // "wheel was rejected" signal. The chain-table assertion (leaf is a
     // documented scroll receiver) means we trust PostMessage success.
+    // **ADR-019 MVP-1 (Stage 1) addendum**: the dispatcher now also tries
+    // `uiaReadScrollPercentAtHwnd` for pre/post percent observation. When
+    // that returns null (UIA pattern not exposed on the leaf — the test
+    // here doesn't mock the napi), the chain-trust assertion fall-through
+    // emits `observation.source: "chain_trust_unverified"`, signalling to
+    // the LLM caller that the delivery is unverified at the observation
+    // layer (honest signal — Codex PR #308 P1 trade-off).
     const TOP = 0xACE5n; // fake XLMAIN
     const LEAF = 0xCE117n; // fake EXCEL7
     win32FindScrollLeafForTopLevelMock.mockReturnValue(LEAF);
@@ -1057,6 +1084,12 @@ describe("ADR-018 Phase 5+N — postWheelToHwnd scroll-leaf walker (Excel / Word
       scrolled: true,
       channel: "postmessage",
       reason: "delivered_via_postmessage",
+      observation: {
+        motion: "indeterminate",
+        source: "chain_trust_unverified",
+        framesSampled: 0,
+        totalElapsedMs: 0,
+      },
     });
     expect(win32PostMessageMock).toHaveBeenCalledWith(
       LEAF,
@@ -1064,6 +1097,68 @@ describe("ADR-018 Phase 5+N — postWheelToHwnd scroll-leaf walker (Excel / Word
       expect.any(BigInt),
       expect.any(BigInt),
     );
+  });
+
+  it("ADR-019 MVP-1 (Stage 1) — leaf retargeted AND UIA pattern exposed AND percent moved → observation.source 'uia_scroll_percent', motion 'translation'", async () => {
+    const TOP = 0xACE5n;
+    const LEAF = 0xCE117n;
+    win32FindScrollLeafForTopLevelMock.mockReturnValue(LEAF);
+    getWindowRectByHwndMock.mockReturnValue({
+      x: 53,
+      y: 240,
+      width: 1424,
+      height: 598,
+    });
+    win32GetScrollInfoMock.mockReturnValue(null);
+    // UIA pre/post percent differ — observation upgrade fires.
+    uiaReadScrollPercentAtHwndMock
+      .mockResolvedValueOnce(10.0) // pre
+      .mockResolvedValueOnce(15.0); // post (post - pre = 5.0 ≥ epsilon)
+    const result = await postWheelToHwnd(TOP, { direction: "down", notch: 1 });
+    expect(result).toEqual({
+      scrolled: true,
+      channel: "postmessage",
+      reason: "delivered_via_postmessage",
+      observation: {
+        motion: "translation",
+        source: "uia_scroll_percent",
+        framesSampled: 2,
+        totalElapsedMs: 0,
+      },
+    });
+    expect(uiaReadScrollPercentAtHwndMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("ADR-019 MVP-1 (Stage 1) — leaf retargeted AND UIA pattern exposed AND percent unchanged (boundary / no-op) → observation.source 'uia_scroll_percent', motion 'no_change' (honest signal, Codex PR #308 P1 trade-off)", async () => {
+    const TOP = 0xACE5n;
+    const LEAF = 0xCE117n;
+    win32FindScrollLeafForTopLevelMock.mockReturnValue(LEAF);
+    getWindowRectByHwndMock.mockReturnValue({
+      x: 53,
+      y: 240,
+      width: 1424,
+      height: 598,
+    });
+    win32GetScrollInfoMock.mockReturnValue(null);
+    // UIA pre/post percent IDENTICAL — receiver at boundary or non-scrollable.
+    // The dispatcher still emits delivered_via_postmessage (chain-trust trusts
+    // the queue), but the observation field carries motion='no_change' so the
+    // LLM caller can disambiguate "actually moved" vs "reached but no-op."
+    uiaReadScrollPercentAtHwndMock
+      .mockResolvedValueOnce(0.0)
+      .mockResolvedValueOnce(0.0);
+    const result = await postWheelToHwnd(TOP, { direction: "down", notch: 1 });
+    expect(result).toEqual({
+      scrolled: true,
+      channel: "postmessage",
+      reason: "delivered_via_postmessage",
+      observation: {
+        motion: "no_change",
+        source: "uia_scroll_percent",
+        framesSampled: 2,
+        totalElapsedMs: 0,
+      },
+    });
   });
 
   it("NOT retargeted AND getScrollInfo returns null (input HWND is not in the chain table) → return null (Case 2b — caller emits target_unreachable)", async () => {

--- a/tests/unit/input-pipeline-dispatch.test.ts
+++ b/tests/unit/input-pipeline-dispatch.test.ts
@@ -1212,6 +1212,44 @@ describe("ADR-018 Phase 5+N — postWheelToHwnd scroll-leaf walker (Excel / Word
     expect(elapsed).toBeLessThan(500);
   });
 
+  it("ADR-019 MVP-1 (Stage 1) — post-snapshot UIA read EXCEEDS UIA_POST_READ_TIMEOUT_MS (slow / hung provider after dispatch) → chain_trust_unverified (Codex Round 3 P2 — post-read symmetrical bounded await)", async () => {
+    // Mirrors the pre-read timeout test, applied to the post-snapshot
+    // path inside `observeViaUiaOrChainTrust`. Pre-read resolves cleanly
+    // (so the dispatcher enters the chain-trust branch with a valid
+    // pre-percent), but the post-read hangs indefinitely. The internal
+    // 100 ms Promise.race fires; the helper treats post as null and
+    // returns chain_trust_unverified. Wall-clock < 500 ms regression
+    // guard against the timeout being silently un-wired.
+    const TOP = 0xACE5n;
+    const LEAF = 0xCE117n;
+    win32FindScrollLeafForTopLevelMock.mockReturnValue(LEAF);
+    getWindowRectByHwndMock.mockReturnValue({
+      x: 53,
+      y: 240,
+      width: 1424,
+      height: 598,
+    });
+    win32GetScrollInfoMock.mockReturnValue(null);
+    uiaReadScrollPercentAtHwndMock
+      // pre resolves immediately
+      .mockResolvedValueOnce(10.0)
+      // post hangs forever
+      .mockImplementationOnce(() => new Promise(() => {}));
+    const tStart = performance.now();
+    const result = await postWheelToHwnd(TOP, { direction: "down", notch: 1 });
+    const elapsed = performance.now() - tStart;
+    expect(result).toMatchObject({
+      scrolled: true,
+      channel: "postmessage",
+      reason: "delivered_via_postmessage",
+      observation: {
+        motion: "indeterminate",
+        source: "chain_trust_unverified",
+      },
+    });
+    expect(elapsed).toBeLessThan(500);
+  });
+
   it("ADR-019 MVP-1 (Stage 1) — pre-snapshot UIA read REJECTS (slow / hung provider, native crash) → chain_trust_unverified (Codex Round 1 P2 `.catch` shim regression guard)", async () => {
     // The fire-and-forget `preUiaPromise` in `postWheelToHwnd` wraps the
     // pre-read in `.catch(() => null)` so a rejection does not propagate

--- a/tests/unit/input-pipeline-dispatch.test.ts
+++ b/tests/unit/input-pipeline-dispatch.test.ts
@@ -1170,6 +1170,41 @@ describe("ADR-018 Phase 5+N — postWheelToHwnd scroll-leaf walker (Excel / Word
     expect(result?.observation?.totalElapsedMs).toBeGreaterThanOrEqual(0);
   });
 
+  it("ADR-019 MVP-1 (Stage 1) — pre-snapshot UIA read REJECTS (slow / hung provider, native crash) → chain_trust_unverified (Codex Round 1 P2 `.catch` shim regression guard)", async () => {
+    // The fire-and-forget `preUiaPromise` in `postWheelToHwnd` wraps the
+    // pre-read in `.catch(() => null)` so a rejection does not propagate
+    // through the dispatch path. Without this, a slow / hung UIA provider
+    // would unhandled-reject inside the chain-trust branch and break the
+    // delivered_via_postmessage contract silently. This test locks the
+    // shim in place — a future refactor that drops the `.catch` will fail
+    // this assertion before the contract regresses.
+    const TOP = 0xACE5n;
+    const LEAF = 0xCE117n;
+    win32FindScrollLeafForTopLevelMock.mockReturnValue(LEAF);
+    getWindowRectByHwndMock.mockReturnValue({
+      x: 53,
+      y: 240,
+      width: 1424,
+      height: 598,
+    });
+    win32GetScrollInfoMock.mockReturnValue(null);
+    uiaReadScrollPercentAtHwndMock.mockRejectedValueOnce(
+      new Error("simulated UIA provider crash"),
+    );
+    const result = await postWheelToHwnd(TOP, { direction: "down", notch: 1 });
+    expect(result).toMatchObject({
+      scrolled: true,
+      channel: "postmessage",
+      reason: "delivered_via_postmessage",
+      observation: {
+        motion: "indeterminate",
+        source: "chain_trust_unverified",
+        framesSampled: 0,
+        totalElapsedMs: 0,
+      },
+    });
+  });
+
   it("NOT retargeted AND getScrollInfo returns null (input HWND is not in the chain table) → return null (Case 2b — caller emits target_unreachable)", async () => {
     const TOP = 0xBEEFn;
     win32FindScrollLeafForTopLevelMock.mockReturnValue(null); // no retarget

--- a/tests/unit/input-pipeline-dispatch.test.ts
+++ b/tests/unit/input-pipeline-dispatch.test.ts
@@ -1115,7 +1115,11 @@ describe("ADR-018 Phase 5+N — postWheelToHwnd scroll-leaf walker (Excel / Word
       .mockResolvedValueOnce(10.0) // pre
       .mockResolvedValueOnce(15.0); // post (post - pre = 5.0 ≥ epsilon)
     const result = await postWheelToHwnd(TOP, { direction: "down", notch: 1 });
-    expect(result).toEqual({
+    // totalElapsedMs is `performance.now()` delta — non-deterministic;
+    // match the rest of the shape exactly and assert the field is a
+    // finite non-negative number separately (Opus PR #309 Round 1 P2-2:
+    // emit real wallclock instead of the misleading `0` placeholder).
+    expect(result).toMatchObject({
       scrolled: true,
       channel: "postmessage",
       reason: "delivered_via_postmessage",
@@ -1123,9 +1127,11 @@ describe("ADR-018 Phase 5+N — postWheelToHwnd scroll-leaf walker (Excel / Word
         motion: "translation",
         source: "uia_scroll_percent",
         framesSampled: 2,
-        totalElapsedMs: 0,
+        totalElapsedMs: expect.any(Number),
       },
     });
+    expect(result?.observation?.totalElapsedMs).toBeGreaterThanOrEqual(0);
+    expect(Number.isFinite(result?.observation?.totalElapsedMs ?? NaN)).toBe(true);
     expect(uiaReadScrollPercentAtHwndMock).toHaveBeenCalledTimes(2);
   });
 
@@ -1148,7 +1154,9 @@ describe("ADR-018 Phase 5+N — postWheelToHwnd scroll-leaf walker (Excel / Word
       .mockResolvedValueOnce(0.0)
       .mockResolvedValueOnce(0.0);
     const result = await postWheelToHwnd(TOP, { direction: "down", notch: 1 });
-    expect(result).toEqual({
+    // totalElapsedMs is `performance.now()` delta — non-deterministic;
+    // see the translation test above for the rationale (Opus P2-2).
+    expect(result).toMatchObject({
       scrolled: true,
       channel: "postmessage",
       reason: "delivered_via_postmessage",
@@ -1156,9 +1164,10 @@ describe("ADR-018 Phase 5+N — postWheelToHwnd scroll-leaf walker (Excel / Word
         motion: "no_change",
         source: "uia_scroll_percent",
         framesSampled: 2,
-        totalElapsedMs: 0,
+        totalElapsedMs: expect.any(Number),
       },
     });
+    expect(result?.observation?.totalElapsedMs).toBeGreaterThanOrEqual(0);
   });
 
   it("NOT retargeted AND getScrollInfo returns null (input HWND is not in the chain table) → return null (Case 2b — caller emits target_unreachable)", async () => {

--- a/tests/unit/input-pipeline-dispatch.test.ts
+++ b/tests/unit/input-pipeline-dispatch.test.ts
@@ -1170,6 +1170,48 @@ describe("ADR-018 Phase 5+N — postWheelToHwnd scroll-leaf walker (Excel / Word
     expect(result?.observation?.totalElapsedMs).toBeGreaterThanOrEqual(0);
   });
 
+  it("ADR-019 MVP-1 (Stage 1) — pre-snapshot UIA read EXCEEDS UIA_PRE_READ_TIMEOUT_MS (slow / hung provider) → chain_trust_unverified (Codex Round 1 P2 + Round 2 P2 — bounded await, dispatch not stalled, pre value not stale)", async () => {
+    // The pre-snapshot UIA read is raced against UIA_PRE_READ_TIMEOUT_MS
+    // (100 ms). When the read hangs longer than that, the dispatcher
+    // treats it as a null pre-sample and falls back to chain-trust. This
+    // test simulates a provider that never resolves; the Promise.race
+    // timeout wins, dispatch proceeds, and observation lands as
+    // chain_trust_unverified.
+    const TOP = 0xACE5n;
+    const LEAF = 0xCE117n;
+    win32FindScrollLeafForTopLevelMock.mockReturnValue(LEAF);
+    getWindowRectByHwndMock.mockReturnValue({
+      x: 53,
+      y: 240,
+      width: 1424,
+      height: 598,
+    });
+    win32GetScrollInfoMock.mockReturnValue(null);
+    // Pre-read hangs (never resolves) — the race timer fires at 100 ms.
+    uiaReadScrollPercentAtHwndMock.mockImplementationOnce(
+      () => new Promise(() => {}),
+    );
+    const tStart = performance.now();
+    const result = await postWheelToHwnd(TOP, { direction: "down", notch: 1 });
+    const elapsed = performance.now() - tStart;
+    expect(result).toMatchObject({
+      scrolled: true,
+      channel: "postmessage",
+      reason: "delivered_via_postmessage",
+      observation: {
+        motion: "indeterminate",
+        source: "chain_trust_unverified",
+        framesSampled: 0,
+        totalElapsedMs: 0,
+      },
+    });
+    // Wall-clock bound: <= UIA_PRE_READ_TIMEOUT_MS (100 ms) + chunking +
+    // settle + observer ms + scheduling jitter. 500 ms is a generous
+    // upper bound that still catches a regression where the timeout
+    // wasn't wired (which would block until the 8 s Rust thread timeout).
+    expect(elapsed).toBeLessThan(500);
+  });
+
   it("ADR-019 MVP-1 (Stage 1) — pre-snapshot UIA read REJECTS (slow / hung provider, native crash) → chain_trust_unverified (Codex Round 1 P2 `.catch` shim regression guard)", async () => {
     // The fire-and-forget `preUiaPromise` in `postWheelToHwnd` wraps the
     // pre-read in `.catch(() => null)` so a rejection does not propagate

--- a/tests/unit/input-pipeline-dispatch.test.ts
+++ b/tests/unit/input-pipeline-dispatch.test.ts
@@ -1212,6 +1212,42 @@ describe("ADR-018 Phase 5+N — postWheelToHwnd scroll-leaf walker (Excel / Word
     expect(elapsed).toBeLessThan(500);
   });
 
+  it("ADR-019 MVP-1 (Stage 1) — Case 3 (getScrollInfo returns non-null Win32 scrollbar info) → UIA pre-read is NOT issued (Codex Round 4 P2 — skip UIA when Win32 scroll info is available, avoid up-to-100ms latency for unused value)", async () => {
+    // When `getScrollInfo` returns a valid pre-snapshot, the dispatcher
+    // takes the standard Tier 3 path (Case 3) and never consumes a UIA
+    // percent value. Issuing the UIA RPC anyway would only pay the
+    // 100 ms timeout ceiling for nothing AND load the native UIA worker
+    // queue unnecessarily. The gate at the pre-read site
+    // (`pre === null && retargetedByLeafWalker && getScrollInfoAvailable`)
+    // skips the RPC for Case 1 / Case 3 — this test pins that gate.
+    const TOP = 0xACE5n;
+    const LEAF = 0xCE117n;
+    win32FindScrollLeafForTopLevelMock.mockReturnValue(LEAF);
+    getWindowRectByHwndMock.mockReturnValue({
+      x: 53,
+      y: 240,
+      width: 1424,
+      height: 598,
+    });
+    // Case 3: Win32 scrollbar present, pre/post differ → standard Tier 3.
+    win32GetScrollInfoMock
+      .mockReturnValueOnce(scrollInfo(50))
+      .mockReturnValueOnce(scrollInfo(80));
+    // Mock UIA so we can assert it was NOT called.
+    uiaReadScrollPercentAtHwndMock.mockResolvedValue(42.0);
+    const result = await postWheelToHwnd(TOP, { direction: "down", notch: 1 });
+    expect(result).toMatchObject({
+      scrolled: true,
+      channel: "postmessage",
+      reason: "delivered_via_postmessage",
+    });
+    // Case 3 path: NO observation field attached (TMOL chain-trust
+    // observation is Case 2a only).
+    expect((result as { observation?: unknown }).observation).toBeUndefined();
+    // The UIA pre-read MUST NOT have been issued.
+    expect(uiaReadScrollPercentAtHwndMock).not.toHaveBeenCalled();
+  });
+
   it("ADR-019 MVP-1 (Stage 1) — post-snapshot UIA read EXCEEDS UIA_POST_READ_TIMEOUT_MS (slow / hung provider after dispatch) → chain_trust_unverified (Codex Round 3 P2 — post-read symmetrical bounded await)", async () => {
     // Mirrors the pre-read timeout test, applied to the post-snapshot
     // path inside `observeViaUiaOrChainTrust`. Pre-read resolves cleanly


### PR DESCRIPTION
## Summary

ADR-019 (Temporal Motion Observation Layer / anti-fukuwarai v3) Stage 1 MVP. Adds the smallest possible observation upgrade on the PR #308 chain-trust path: read the leaf's UIA `ScrollPercent` pre/post the PostMessage chunking loop, emit a new `verifyDelivery.observation` hint that tells the LLM caller whether the delivery was observation-verified or trusted by the dispatcher without observation.

Empirical gating step: if Excel `EXCEL7` exposes `ScrollPattern` for reads, this stage alone resolves Excel scroll observation without any image processing. If not, the chain-trust fall-through preserves PR #308 behaviour with an explicit "unverified" hint, and Stages 2a / 2b / 3 / 4 / 5 follow.

Three observation outcomes:

- `observation.source: "uia_scroll_percent"` + `motion: "translation"` — exposed AND moved → confident "delivered" with movement confirmed.
- `observation.source: "uia_scroll_percent"` + `motion: "no_change"` — exposed AND NOT moved (boundary / no-op) → honest signal; dispatcher still says delivered (matches Tier 1 boundary semantics) but the LLM can distinguish "actually scrolled" from "reached but no-op". Codex PR #308 P1 trade-off honest answer.
- `observation.source: "chain_trust_unverified"` + `motion: "indeterminate"` — pattern not exposed → chain-trust assertion as in PR #308, with explicit "we don't yet know" envelope hint.

## Files changed

- `src/uia/scroll.rs` — new `uia_read_scroll_percent_at_hwnd` napi (Phase A ancestor walk + Phase B DFS subtree, mirroring `scroll_by_wheel_at_hwnd` but read-only)
- `src/lib.rs` — `UiaReadScrollPercentAtHwndTask` AsyncTask + napi export
- `src/engine/native-engine.ts` — `NativeUia.uiaReadScrollPercentAtHwnd?` extension
- `index.d.ts` / `index.js` — hand-maintained re-export
- `src/tools/_input-pipeline.ts`:
  - extend `DispatchOutcome` with additive `observation?: VisualMotionObservation`
  - new exported `VisualMotionObservation` type (canonical 8-value `source` enum per ADR-019 §2.1)
  - read pre UIA percent before chunking loop (chain-trust branch only)
  - new `observeViaUiaOrChainTrust` helper
  - chain-trust branch attaches observation to dispatcher outcome
- `src/tools/mouse.ts`:
  - extend `ScrollVerifyOutcome` with additive `observation?` field
  - `scrollHandler` propagates the observation into `verifyDelivery` envelope additively
- `tests/unit/input-pipeline-dispatch.test.ts`:
  - 3 new Stage 1 cases (UIA null / moved / unchanged)
  - update existing Case 2a chain-trust test to expect the new observation hint
- `docs/adr-019-anti-fukuwarai-v3-temporal-motion-observation.md` — **new ADR** (Round 0 Draft + Round 1 user pushback applied + Round 2 Opus approved)
- `docs/adr-018-phase-5-followup-verification-pathway-analysis.md` — **new** pathway analysis (Round 1 vs Round 2 audit trail)
- `docs/adr-018-input-pipeline-3tier.md` §2.6 — additive observation envelope reference pointing at ADR-019 §2.1 as canonical `source` enum SoT
- `CHANGELOG.md` `[Unreleased]` — user-facing hint description

## Test plan

- [x] `npm run build` (tsc) green
- [x] `npm run build:rs` Rust cargo green (manual `cp` worked around napi-cli artifact-copy hiccup; CI rebuilds clean)
- [x] `npx vitest run --project=unit` — 3120 pass / 5 skipped (no regressions)
- [x] `npx vitest run tests/unit/input-pipeline-dispatch.test.ts` — 66 cases pass (was 64; +2 new Stage 1 cases, 1 existing case updated for observation hint)
- [x] `node scripts/check-native-types.mjs` — Rust ↔ index.d.ts sync verified
- [ ] **Pre-merge dogfood (G1 acceptance)**: probe `node -e "import('./index.js').then(m => m.uiaReadScrollPercentAtHwnd({hwnd: '<excel-EXCEL7-hwnd>', axis: 'vertical'}).then(console.log))"` to determine whether EXCEL7 exposes ScrollPattern for reads. Outcome decides Stage 2a priority.
- [ ] **Pre-merge dogfood**: MCP reconnect → `scroll({action:'raw', windowTitle:'Book1 - Excel', direction:'down'})` → expect `verifyDelivery.observation.source: "uia_scroll_percent"` IF probe succeeded, `"chain_trust_unverified"` otherwise.

## Review guidance (CLAUDE.md §3.3)

**Step 1 Opus focus**:
- ADR-019 §3 SSOT row alignment with the actual landed files (8 surfaces, CLAUDE.md §3.1 multi-table fact sweep)
- `VisualMotionObservation` 8-value enum bit-equal across ADR-019 §2.1, `_input-pipeline.ts` type, ADR-018 §2.6 reference
- CLAUDE.md §3.2 carry-over scope shrink: existing `verifyDelivery.status / .reason / .channel` callers unaffected (observation is additive)
- Lesson 1-4 sweep: 3+1=4 new/updated tests, sequential UIA pre→post ordering, no race in `observeViaUiaOrChainTrust`

**Step 2 Codex focus**:
- Rust `uia_read_scroll_percent_at_hwnd` UTF-16 / unsafe windows-rs interop correctness (read-only, never writes)
- TS dispatcher: pre UIA read captured BEFORE chunking loop (must not block the chunk dispatch); post read after settle
- `DispatchOutcome` / `ScrollVerifyOutcome` additive extension does not break existing serialisation / typed-error paths
- 8-value `source` enum drift across surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)