### PR TITLE
fix(duplication): populate OutputBounds from DesktopCoordinates (multi-monitor)

### DIFF
--- a/src/duplication/device.rs
+++ b/src/duplication/device.rs
@@ -20,8 +20,11 @@ use super::types::{DuplicationError, OutputBounds};
 
 pub struct DuplicationContext {
     pub duplication: IDXGIOutputDuplication,
-    // bounds.x/y are added to dirty-rect coordinates (output→desktop offset).
-    // Phase 3: single primary monitor, offset = 0.
+    // bounds.x/y are added to dirty-rect coordinates by `thread.rs:271-272`
+    // (output-local → desktop coord translation). For the primary monitor
+    // (output 0) DesktopCoordinates is typically (0, 0, primaryW, primaryH)
+    // so the offset is a no-op; for secondary monitors with positive or
+    // negative desktop placement, this offset is load-bearing.
     pub bounds: OutputBounds,
     // Keep device alive — IDXGIOutputDuplication holds an implicit ref,
     // but we pin it here to ensure drop order is predictable.
@@ -71,10 +74,24 @@ pub fn create_context(output_index: u32) -> Result<DuplicationContext, Duplicati
                 DuplicationError::InitFailed(format!("output {output_index} not found"))
             })?;
 
-        // Phase 3: use (0, 0) offset. Dirty rects from Desktop Duplication are in
-        // desktop coordinates for the primary monitor. Multi-monitor offset support
-        // is deferred to Phase 4.
-        let bounds = OutputBounds { x: 0, y: 0, width: 0, height: 0 };
+        // ADR-019 Stage 5 multi-monitor prerequisite — query the output's actual
+        // DesktopCoordinates so `thread.rs` can translate output-local dirty rects
+        // into desktop coords for cross-monitor windows. windows 0.62 returns the
+        // descriptor by value (same pattern as `vision_backend/capability.rs:128`
+        // for IDXGIAdapter1::GetDesc1). For primary monitor this typically gives
+        // `(0, 0, primaryW, primaryH)` so the addition is a no-op; for secondary
+        // monitors positioned to the right `(1920, 0, ...)` or left `(-1920, 0, ...)`
+        // the offset is load-bearing.
+        let desc = output
+            .GetDesc()
+            .map_err(|e| DuplicationError::InitFailed(format!("IDXGIOutput::GetDesc: {e}")))?;
+        let r = desc.DesktopCoordinates;
+        let bounds = OutputBounds {
+            x: r.left,
+            y: r.top,
+            width: r.right - r.left,
+            height: r.bottom - r.top,
+        };
 
         // 5. Cast to IDXGIOutput1 for DuplicateOutput.
         let output1: IDXGIOutput1 = output


### PR DESCRIPTION
## Summary

PR #102 (ADR-007 P5c-2) deferred multi-monitor support and left \`src/duplication/device.rs:77\` with a placeholder \`OutputBounds = {0,0,0,0}\`. This fixes that gap as a prerequisite for ADR-019 Stage 5 multi-monitor support.

## The bug

The placeholder works transparently for **primary monitor** (output 0's DesktopCoordinates origin is (0,0) so the \`+bounds.x/y\` translation in \`thread.rs:271-272\` is a no-op). On **secondary monitors** the DirtyRect coords returned from \`next()\` are output-LOCAL and never get translated to desktop coords. Any consumer that intersects DirtyRects with window rects (desktop coords from \`GetWindowRect\`) on secondary monitors gets a silent gap.

## The fix

Query \`IDXGIOutput::GetDesc()\` (windows-rs 0.62 returns the descriptor by value, matching the existing precedent at \`src/vision_backend/capability.rs:128\` for IDXGIAdapter1::GetDesc1) and fill bounds from DesktopCoordinates.

```rust
let desc = output.GetDesc().map_err(...)?;
let r = desc.DesktopCoordinates;
let bounds = OutputBounds {
  x: r.left,
  y: r.top,
  width: r.right - r.left,
  height: r.bottom - r.top,
};
```

Coverage by monitor placement:
- **Primary**: \`(0, 0, primaryW, primaryH)\` — translation is no-op (**bit-equal** to placeholder).
- **Secondary right of primary**: \`(1920, 0, ...)\` — \`+1920\` x translation.
- **Secondary left of primary**: \`(-1920, 0, ...)\` — \`-1920\` x translation.

## Scope

Standalone Rust fix. No public API change. Existing consumers (\`src/engine/vision-gpu/dirty-rect-source.ts\`, \`src/l3_bridge/dirty_rect_pump.rs\`) inherit correct multi-monitor coords transparently.

## What this unblocks

\`docs/adr-019-stage-5-plan.md\` §6 R10 + §7 OQ #6: Stage 5 v1 was scoped to "primary monitor only" precisely because this gap existed. With this fix landed, Stage 5 impl can target full multi-monitor in a single PR (vs. v1 → v2 split).

## Test plan

- [x] \`npm run build:rs\` succeeds (cargo release profile, 1m 26s, 12 pre-existing dead-code warnings, no new warnings)
- [x] No existing tests assert placeholder bounds = {0,0,0,0} (grep verified)
- [x] Primary monitor behaviour is bit-equal to pre-fix (since primary's DesktopCoordinates IS (0,0)-origin)
- [x] No public API change — \`OutputBounds\` shape unchanged, \`bounds\` field still on \`DuplicationContext\`
- [ ] Secondary monitor verification deferred to ADR-019 Stage 5 dogfood (next sub-task) on dual-monitor host

🤖 Generated with [Claude Code](https://claude.com/claude-code)