### PR TITLE
fix(input): flatten failWith context + scroll page-end + browser-top modal exclusion

### DIFF
--- a/src/tools/desktop-state.ts
+++ b/src/tools/desktop-state.ts
@@ -631,6 +631,11 @@ export const desktopStateHandler = async (args: {
     for (const w of wins) {
       if (!MODAL_RE.test(w.title)) continue;
       if (isBrowserTopLevelClass(w.className)) {
+        // `getWindowIdentity` is an OpenProcess + QueryFullProcessImageName
+        // pair (≈ tens of µs per call). The double gate above keeps this
+        // out of the hot path — only runs for windows that BOTH match
+        // MODAL_RE AND carry the Chromium widget class, typically 0-1
+        // per desktop_state call.
         const identity = getWindowIdentity(w.hwnd);
         if (isBrowserProcessName(identity.processName)) continue;
       }

--- a/src/tools/desktop-state.ts
+++ b/src/tools/desktop-state.ts
@@ -62,6 +62,29 @@ const _defaultPort = getCdpPort();
  */
 export const MODAL_RE = /\b(?:dialog|confirm|alert|error|warning|save as)\b|警告|エラー|確認|通知|ダイアログ|名前を付けて/i;
 
+/**
+ * Window class names for browser top-level windows. The `hasModal` heuristic
+ * skips these because browsers render their own modals (alert / confirm /
+ * print preview / file picker) INSIDE the tab via CDP / a child dialog
+ * window; the top-level window is page content. Without this exclusion,
+ * any browser tab whose title matches MODAL_RE (e.g. a Japanese-language
+ * "通知" page, a Stack Overflow "Save As" QA, a GitHub "Errors" issue
+ * tracker) falsely sets `hasModal: true`. Exported so a unit test can pin
+ * the contract.
+ *
+ * Chrome / Edge / Brave / Opera / Vivaldi / Arc / Thorium all share
+ * `Chrome_WidgetWin_1` (Chromium's widget class). Firefox-derived browsers
+ * use `MozillaWindowClass`.
+ */
+const BROWSER_TOP_LEVEL_CLASSES = new Set<string>([
+  "Chrome_WidgetWin_1",
+  "MozillaWindowClass",
+]);
+
+export function isBrowserTopLevelClass(className: string | undefined): boolean {
+  return className !== undefined && BROWSER_TOP_LEVEL_CLASSES.has(className);
+}
+
 // ─── Focused-element builders (D2-B-2) ───────────────────────────────────────
 // Three pure functions that project the engine's three focus sources
 // (perception view / UIA / CDP) into the same `ElementInfo` shape so
@@ -559,8 +582,21 @@ export const desktopStateHandler = async (args: {
     }
 
     // Modal heuristic — title-substring detection.
+    //
+    // Browser top-level windows (Chrome/Edge `Chrome_WidgetWin_1`, Firefox
+    // `MozillaWindowClass`) are excluded because browsers never present a
+    // modal dialog as a separate top-level window — their alert/confirm
+    // dialogs render inside the tab via CDP. A browser tab whose page title
+    // happens to contain "通知" / "Save As" / "Error" / "警告" etc. is page
+    // content, NOT a modal. Without this gate, any Japanese-language page
+    // mentioning notifications (Twitter 通知 timeline, Gmail 通知設定 page,
+    // a Stack Overflow "Save As" QA thread, etc.) falsely sets
+    // `hasModal: true` on every desktop_state call, breaking e2e tests like
+    // `context-consistency.test.ts` that rely on a clean modal baseline.
+    // Tested by `tests/unit/modal-detection-browser-exclusion.test.ts`.
     let hasModal = false;
     for (const w of wins) {
+      if (isBrowserTopLevelClass(w.className)) continue;
       if (MODAL_RE.test(w.title)) { hasModal = true; break; }
     }
 

--- a/src/tools/desktop-state.ts
+++ b/src/tools/desktop-state.ts
@@ -11,6 +11,7 @@ import {
   getVirtualScreen,
   getWindowProcessId,
   getProcessIdentityByPid,
+  getWindowIdentity,
 } from "../engine/win32.js";
 import { getHistorySnapshot } from "./_post.js";
 import { listRecentTargetKeys } from "../engine/perception/target-timeline.js";
@@ -63,18 +64,18 @@ const _defaultPort = getCdpPort();
 export const MODAL_RE = /\b(?:dialog|confirm|alert|error|warning|save as)\b|警告|エラー|確認|通知|ダイアログ|名前を付けて/i;
 
 /**
- * Window class names for browser top-level windows. The `hasModal` heuristic
- * skips these because browsers render their own modals (alert / confirm /
- * print preview / file picker) INSIDE the tab via CDP / a child dialog
- * window; the top-level window is page content. Without this exclusion,
- * any browser tab whose title matches MODAL_RE (e.g. a Japanese-language
- * "通知" page, a Stack Overflow "Save As" QA, a GitHub "Errors" issue
- * tracker) falsely sets `hasModal: true`. Exported so a unit test can pin
+ * Window class names that REAL browsers (Chrome / Edge / Firefox / Brave /
+ * etc.) AND Electron / CEF embedded apps (VS Code / Discord / Slack /
+ * Cursor / Claude Desktop / Obsidian / …) share. Used together with
+ * `isBrowserProcessName(processName)` below to gate the `hasModal`
+ * heuristic — class match alone is NOT sufficient because most Electron
+ * apps also report `Chrome_WidgetWin_1`. Exported so a unit test can pin
  * the contract.
  *
- * Chrome / Edge / Brave / Opera / Vivaldi / Arc / Thorium all share
- * `Chrome_WidgetWin_1` (Chromium's widget class). Firefox-derived browsers
- * use `MozillaWindowClass`.
+ * - `Chrome_WidgetWin_1` — Chromium's widget class (Chrome / Edge / Brave /
+ *   Opera / Vivaldi / Arc / Thorium + every Electron / CEF app).
+ * - `MozillaWindowClass` — Firefox-derived browsers (Firefox / Waterfox /
+ *   LibreWolf / Tor Browser).
  */
 const BROWSER_TOP_LEVEL_CLASSES = new Set<string>([
   "Chrome_WidgetWin_1",
@@ -83,6 +84,35 @@ const BROWSER_TOP_LEVEL_CLASSES = new Set<string>([
 
 export function isBrowserTopLevelClass(className: string | undefined): boolean {
   return className !== undefined && BROWSER_TOP_LEVEL_CLASSES.has(className);
+}
+
+/**
+ * Process names of REAL browser executables (case-insensitive, no `.exe`).
+ * Matches `getProcessIdentityByPid().processName` shape (which strips the
+ * extension per its TSDoc, e.g. `chrome.exe` → `chrome`). Together with
+ * `isBrowserTopLevelClass` this isolates the "browser tab title accidentally
+ * matches MODAL_RE" false positive from genuine Electron / CEF app modals
+ * (Codex P1 review on PR #324: VS Code etc. would otherwise be unable to
+ * raise `hasModal:true`).
+ *
+ * Lowercase only; compare via `processName.toLowerCase()`.
+ */
+const BROWSER_PROCESS_NAMES = new Set<string>([
+  "chrome",
+  "msedge",
+  "firefox",
+  "brave",
+  "opera",
+  "vivaldi",
+  "arc",
+  "thorium",
+  "iexplore",
+  "waterfox",
+  "librewolf",
+]);
+
+export function isBrowserProcessName(processName: string | undefined): boolean {
+  return processName !== undefined && BROWSER_PROCESS_NAMES.has(processName.toLowerCase());
 }
 
 // ─── Focused-element builders (D2-B-2) ───────────────────────────────────────
@@ -581,23 +611,31 @@ export const desktopStateHandler = async (args: {
       }
     }
 
-    // Modal heuristic — title-substring detection.
+    // Modal heuristic — title-substring detection with browser-tab exclusion.
     //
-    // Browser top-level windows (Chrome/Edge `Chrome_WidgetWin_1`, Firefox
-    // `MozillaWindowClass`) are excluded because browsers never present a
-    // modal dialog as a separate top-level window — their alert/confirm
-    // dialogs render inside the tab via CDP. A browser tab whose page title
+    // Title is checked first (cheap regex); the process-identity lookup runs
+    // only for the rare windows that BOTH match `MODAL_RE` AND carry a
+    // Chromium widget class. The exclusion fires only when the owning process
+    // is a real browser executable (chrome / msedge / firefox / …) — Electron
+    // / CEF apps (VS Code / Discord / Slack / …) share `Chrome_WidgetWin_1`
+    // but their MODAL_RE-matching titles ARE modals and must keep raising
+    // `hasModal: true` (Codex P1 review on PR #324).
+    //
+    // The false-positive being suppressed: a browser tab whose page title
     // happens to contain "通知" / "Save As" / "Error" / "警告" etc. is page
-    // content, NOT a modal. Without this gate, any Japanese-language page
-    // mentioning notifications (Twitter 通知 timeline, Gmail 通知設定 page,
-    // a Stack Overflow "Save As" QA thread, etc.) falsely sets
-    // `hasModal: true` on every desktop_state call, breaking e2e tests like
-    // `context-consistency.test.ts` that rely on a clean modal baseline.
+    // content, not a modal. Browsers render their own alert/confirm modals
+    // inside the tab via CDP, never as a separate top-level window.
+    //
     // Tested by `tests/unit/modal-detection-browser-exclusion.test.ts`.
     let hasModal = false;
     for (const w of wins) {
-      if (isBrowserTopLevelClass(w.className)) continue;
-      if (MODAL_RE.test(w.title)) { hasModal = true; break; }
+      if (!MODAL_RE.test(w.title)) continue;
+      if (isBrowserTopLevelClass(w.className)) {
+        const identity = getWindowIdentity(w.hwnd);
+        if (isBrowserProcessName(identity.processName)) continue;
+      }
+      hasModal = true;
+      break;
     }
 
     // ── Semantic level: focusedElement + cursorOverElement ─────────────────

--- a/src/tools/keyboard.ts
+++ b/src/tools/keyboard.ts
@@ -924,9 +924,10 @@ export const keyboardTypeHandler = async ({
         { pressEnter: false }, // keyboard:type は Enter 自動押下しない
       );
       if (!flashResult.ok) {
-        // `failWith` itself nests non-hoisted keys under `context` (see
-        // line 775-776 comment); pass them flat so the LLM-facing shape is
-        // `r.context.reason` (not `r.context.context.reason`). E2E tests
+        // Flat context (`failWith` auto-wraps non-hoisted keys into
+        // `context` — see `ROOT_HOISTED_KEYS` + the splitter at
+        // `src/tools/_errors.ts:685-693`). LLM-facing shape is
+        // `r.context.reason`, not `r.context.context.reason`. E2E tests
         // `tests/e2e/foreground-flash-verification.test.ts` pin
         // `r.context.reason` directly.
         return failWith(

--- a/src/tools/keyboard.ts
+++ b/src/tools/keyboard.ts
@@ -924,15 +924,18 @@ export const keyboardTypeHandler = async ({
         { pressEnter: false }, // keyboard:type は Enter 自動押下しない
       );
       if (!flashResult.ok) {
+        // `failWith` itself nests non-hoisted keys under `context` (see
+        // line 775-776 comment); pass them flat so the LLM-facing shape is
+        // `r.context.reason` (not `r.context.context.reason`). E2E tests
+        // `tests/e2e/foreground-flash-verification.test.ts` pin
+        // `r.context.reason` directly.
         return failWith(
           new Error(flashResult.reason ?? "ForegroundFlashFailed"),
           "keyboard:type",
           {
-            context: {
-              reason: flashResult.reason,
-              rawError: flashResult.rawError,
-              windowTitle: effectiveWindowTitle,
-            },
+            reason: flashResult.reason,
+            rawError: flashResult.rawError,
+            windowTitle: effectiveWindowTitle,
             ...(ffPerception && { _perceptionForPost: ffPerception }),
           }
         );

--- a/src/tools/mouse.ts
+++ b/src/tools/mouse.ts
@@ -18,6 +18,7 @@ import {
 import { getElementBounds } from "../engine/uia-bridge.js";
 import { captureWindowRawAndHash } from "../engine/layer-buffer.js";
 import { hammingDistance } from "../engine/image.js";
+import { nativeWin32 } from "../engine/native-engine.js";
 import { coercedBoolean } from "./_coerce.js";
 import { ok } from "./_types.js";
 import type { ToolResult } from "./_types.js";
@@ -1285,6 +1286,14 @@ export const scrollHandler = async ({
             (direction === "left" && atLowerBoundary) ||
             (direction === "right" && atUpperBoundary);
           if (atDirectionalBoundary) {
+            // `scrollObserved.delta: "unverifiable"` (vs canonical
+            // `{x:0, y:0}` at L1124) is intentional. Canonical takes a
+            // post-snapshot in evaluateScrollDelivery so it has measured
+            // numbers; this Tier 1+3 exhausted path skips the post-snapshot
+            // entirely (we already know the dispatcher returned without
+            // observable delta), so "unverifiable" is the honest signal.
+            // Both shapes satisfy the public `{x,y}|"unverifiable"` union
+            // (Opus PR #324 Round 2 P3-NEW-1).
             return {
               content: [{
                 type: "text" as const,
@@ -1316,25 +1325,36 @@ export const scrollHandler = async ({
         // "page-end" test (Notepad at top of buffer, no Win32 scrollbar
         // exposed).
         if (pre.vertical === null && pre.horizontal === null) {
-          return {
-            content: [{
-              type: "text" as const,
-              text: JSON.stringify({
-                ok: true,
-                scrolled: direction,
-                steps: amount,
-                hints: {
-                  scrollObserved: { delta: "unverifiable" as const },
-                  verifyDelivery: {
-                    status: "unverifiable" as const,
-                    channel: "postmessage" as const,
-                    reason: "scrollbar_unavailable" as const,
-                    axis: direction === "up" || direction === "down" ? "vertical" : "horizontal",
+          // Codex PR #324 Round 2 P1 — `unverifiable` is only honest if we
+          // can presume PostMessage dispatch was actually attempted. In a
+          // mixed-version `.node` build where `win32PostMessage` itself is
+          // unavailable, `postWheelToHwnd` returns null at
+          // `_input-pipeline.ts:1028` immediately — NO dispatch happened.
+          // Without this gate we'd silently report `ok:true unverifiable`
+          // and mask a guaranteed delivery failure, preventing callers from
+          // retrying / falling back. Fall through to `ScrollNotDelivered`
+          // when the API is missing.
+          if (typeof nativeWin32?.win32PostMessage === "function") {
+            return {
+              content: [{
+                type: "text" as const,
+                text: JSON.stringify({
+                  ok: true,
+                  scrolled: direction,
+                  steps: amount,
+                  hints: {
+                    scrollObserved: { delta: "unverifiable" as const },
+                    verifyDelivery: {
+                      status: "unverifiable" as const,
+                      channel: "postmessage" as const,
+                      reason: "scrollbar_unavailable" as const,
+                      axis: direction === "up" || direction === "down" ? "vertical" : "horizontal",
+                    },
                   },
-                },
-              }),
-            }],
-          };
+                }),
+              }],
+            };
+          }
         }
         // Flat context (`failWith` auto-wraps non-hoisted keys into
         // `context` — see `ROOT_HOISTED_KEYS` + the splitter at

--- a/src/tools/mouse.ts
+++ b/src/tools/mouse.ts
@@ -1264,6 +1264,19 @@ export const scrollHandler = async ({
       // branch surfaces the typed envelope explicitly with `channel:'postmessage'`
       // (the last attempted tier) so callers see the proper transport identifier.
       if (dest.kind === "hwnd" || dest.kind === "uia") {
+        // Codex PR #324 Round 2 P1 + Round 3 P1 — both the page-end fast
+        // path and the null-null `unverifiable` path can only honestly
+        // claim that PostMessage was attempted when the native API itself
+        // exists. In a mixed-version `.node` build where
+        // `win32PostMessage` is missing, `postWheelToHwnd` returns null at
+        // `_input-pipeline.ts:1028` immediately — NO dispatch happened.
+        // Without this gate, BOTH paths would silently mask a guaranteed
+        // delivery failure (page-end would claim `delivered`, null-null
+        // would claim `unverifiable`). Fall through to
+        // `ScrollNotDelivered` for both paths when the API is missing.
+        const postMessageAvailable =
+          typeof nativeWin32?.win32PostMessage === "function";
+
         // Page-end disambiguation: when the pre-snapshot shows the scrollbar
         // is already AT the directional boundary (top/bottom/left/right),
         // a no-observable-delta result is a legitimate no-op, NOT a silent
@@ -1277,7 +1290,7 @@ export const scrollHandler = async ({
         // E2E pin: `tests/e2e/scroll-raw-verify.test.ts` "page-end" test.
         const preOnAxis =
           direction === "up" || direction === "down" ? pre.vertical : pre.horizontal;
-        if (preOnAxis !== null) {
+        if (preOnAxis !== null && postMessageAvailable) {
           const atUpperBoundary = preOnAxis >= 1 - SCROLL_PERCENT_BOUNDARY_TOL;
           const atLowerBoundary = preOnAxis <= SCROLL_PERCENT_BOUNDARY_TOL;
           const atDirectionalBoundary =
@@ -1324,37 +1337,30 @@ export const scrollHandler = async ({
         // WinUI hosts land here. E2E pin: `tests/e2e/scroll-raw-verify.test.ts`
         // "page-end" test (Notepad at top of buffer, no Win32 scrollbar
         // exposed).
-        if (pre.vertical === null && pre.horizontal === null) {
-          // Codex PR #324 Round 2 P1 — `unverifiable` is only honest if we
-          // can presume PostMessage dispatch was actually attempted. In a
-          // mixed-version `.node` build where `win32PostMessage` itself is
-          // unavailable, `postWheelToHwnd` returns null at
-          // `_input-pipeline.ts:1028` immediately — NO dispatch happened.
-          // Without this gate we'd silently report `ok:true unverifiable`
-          // and mask a guaranteed delivery failure, preventing callers from
-          // retrying / falling back. Fall through to `ScrollNotDelivered`
-          // when the API is missing.
-          if (typeof nativeWin32?.win32PostMessage === "function") {
-            return {
-              content: [{
-                type: "text" as const,
-                text: JSON.stringify({
-                  ok: true,
-                  scrolled: direction,
-                  steps: amount,
-                  hints: {
-                    scrollObserved: { delta: "unverifiable" as const },
-                    verifyDelivery: {
-                      status: "unverifiable" as const,
-                      channel: "postmessage" as const,
-                      reason: "scrollbar_unavailable" as const,
-                      axis: direction === "up" || direction === "down" ? "vertical" : "horizontal",
-                    },
+        if (
+          pre.vertical === null &&
+          pre.horizontal === null &&
+          postMessageAvailable
+        ) {
+          return {
+            content: [{
+              type: "text" as const,
+              text: JSON.stringify({
+                ok: true,
+                scrolled: direction,
+                steps: amount,
+                hints: {
+                  scrollObserved: { delta: "unverifiable" as const },
+                  verifyDelivery: {
+                    status: "unverifiable" as const,
+                    channel: "postmessage" as const,
+                    reason: "scrollbar_unavailable" as const,
+                    axis: direction === "up" || direction === "down" ? "vertical" : "horizontal",
                   },
-                }),
-              }],
-            };
-          }
+                },
+              }),
+            }],
+          };
         }
         // Flat context (`failWith` auto-wraps non-hoisted keys into
         // `context` — see `ROOT_HOISTED_KEYS` + the splitter at

--- a/src/tools/mouse.ts
+++ b/src/tools/mouse.ts
@@ -1237,18 +1237,18 @@ export const scrollHandler = async ({
       // we surface the typed envelope explicitly so callers see the proper
       // status / channel / reason rather than catching a thrown guard.
       if (dest.kind === "cdp") {
+        // Flat context (see keyboard.ts:775-776) — `failWith` auto-wraps
+        // non-hoisted keys; LLM-facing shape is `r.context.direction`.
         return failWith(
           new Error("ScrollNotDelivered"),
           "scroll",
           {
-            context: {
-              hint: "CDP wheel dispatch or scroll observation returned no delta — Tier 4 SendInput suppressed for resolved CDP destinations",
-              direction,
-              verifyDelivery: {
-                status: "not_delivered" as const,
-                channel: "cdp" as const,
-                reason: "target_unreachable" as const,
-              },
+            hint: "CDP wheel dispatch or scroll observation returned no delta — Tier 4 SendInput suppressed for resolved CDP destinations",
+            direction,
+            verifyDelivery: {
+              status: "not_delivered" as const,
+              channel: "cdp" as const,
+              reason: "target_unreachable" as const,
             },
           },
         );
@@ -1261,18 +1261,85 @@ export const scrollHandler = async ({
       // branch surfaces the typed envelope explicitly with `channel:'postmessage'`
       // (the last attempted tier) so callers see the proper transport identifier.
       if (dest.kind === "hwnd" || dest.kind === "uia") {
+        // Page-end disambiguation: when the pre-snapshot shows the scrollbar
+        // is already AT the directional boundary (top/bottom/left/right),
+        // a no-observable-delta result is a legitimate no-op, NOT a silent
+        // drop. Mirror the boundary logic in `evaluateScrollDelivery` below
+        // (the post-Tier-4 path) so HWND targets get the same page-end
+        // treatment regardless of which tier was last attempted.
+        // E2E pin: `tests/e2e/scroll-raw-verify.test.ts` "page-end" test.
+        const preOnAxis =
+          direction === "up" || direction === "down" ? pre.vertical : pre.horizontal;
+        if (preOnAxis !== null) {
+          const atUpperBoundary = preOnAxis >= 1 - SCROLL_PERCENT_BOUNDARY_TOL;
+          const atLowerBoundary = preOnAxis <= SCROLL_PERCENT_BOUNDARY_TOL;
+          const atDirectionalBoundary =
+            (direction === "up" && atLowerBoundary) ||
+            (direction === "down" && atUpperBoundary) ||
+            (direction === "left" && atLowerBoundary) ||
+            (direction === "right" && atUpperBoundary);
+          if (atDirectionalBoundary) {
+            return {
+              content: [{
+                type: "text" as const,
+                text: JSON.stringify({
+                  ok: true,
+                  scrolled: direction,
+                  hints: {
+                    scrollObserved: { delta: { x: null, y: null } },
+                    verifyDelivery: {
+                      status: "delivered" as const,
+                      channel: "postmessage" as const,
+                      reason: "page_end_inferred" as const,
+                      axis: direction === "up" || direction === "down" ? "vertical" : "horizontal",
+                    },
+                  },
+                }),
+              }],
+            };
+          }
+        }
+        // No observation channel exposed at all (no Win32 scrollbar on either
+        // axis): we cannot distinguish "scroll-at-boundary no-op" from
+        // "silent drop". Matrix doc §3.1 + `evaluateScrollDelivery`
+        // line 1086-1095 explicitly require a boundary signal — without it
+        // we degrade to `unverifiable` (ok:true with diagnostic hint), NOT
+        // `target_unreachable` failure. Win11 Notepad / WinUI hosts land
+        // here. E2E pin: `tests/e2e/scroll-raw-verify.test.ts` "page-end"
+        // test (Notepad at top of buffer, no Win32 scrollbar exposed).
+        if (pre.vertical === null && pre.horizontal === null) {
+          return {
+            content: [{
+              type: "text" as const,
+              text: JSON.stringify({
+                ok: true,
+                scrolled: direction,
+                hints: {
+                  scrollObserved: { delta: "unverifiable" as const },
+                  verifyDelivery: {
+                    status: "unverifiable" as const,
+                    channel: "postmessage" as const,
+                    reason: "read_back_unsupported" as const,
+                  },
+                },
+              }),
+            }],
+          };
+        }
+        // `failWith` itself nests non-hoisted keys under `context` (see
+        // keyboard.ts:775-776 comment); pass them flat so the LLM-facing
+        // shape is `r.context.direction` (not `r.context.context.direction`).
+        // E2E pin: `tests/e2e/scroll-raw-verify.test.ts` test #1.
         return failWith(
           new Error("ScrollNotDelivered"),
           "scroll",
           {
-            context: {
-              hint: "Tier 1 UIA + Tier 3 PostMessage both exhausted on the resolved destination (no ScrollPattern AND no observable scrollbar diff after WM_MOUSEWHEEL) — Tier 4 SendInput suppressed per ADR-018 §2.6.2 path-(b)",
-              direction,
-              verifyDelivery: {
-                status: "not_delivered" as const,
-                channel: "postmessage" as const,
-                reason: "target_unreachable" as const,
-              },
+            hint: "Tier 1 UIA + Tier 3 PostMessage both exhausted on the resolved destination (no ScrollPattern AND no observable scrollbar diff after WM_MOUSEWHEEL) — Tier 4 SendInput suppressed per ADR-018 §2.6.2 path-(b)",
+            direction,
+            verifyDelivery: {
+              status: "not_delivered" as const,
+              channel: "postmessage" as const,
+              reason: "target_unreachable" as const,
             },
           },
         );
@@ -1310,19 +1377,19 @@ export const scrollHandler = async ({
     ) {
       const tmolObservation: VisualMotionObservation | undefined =
         tier1.observation;
+      // Flat context (see keyboard.ts:775-776) — `failWith` auto-wraps
+      // non-hoisted keys; LLM-facing shape is `r.context.direction`.
       return failWith(
         new Error("ScrollNotDelivered"),
         "scroll",
         {
-          context: {
-            hint: "Stage 2b TMOL gate observed motion='no_change' on the chain-trust path (PostMessage queued but pixels did not change) — emitting target_unreachable per ADR-018 §2.6.2 path-(b) Stage 2b row",
-            direction,
-            verifyDelivery: {
-              status: "not_delivered" as const,
-              channel: "postmessage" as const,
-              reason: "target_unreachable" as const,
-              ...(tmolObservation ? { observation: tmolObservation } : {}),
-            },
+          hint: "Stage 2b TMOL gate observed motion='no_change' on the chain-trust path (PostMessage queued but pixels did not change) — emitting target_unreachable per ADR-018 §2.6.2 path-(b) Stage 2b row",
+          direction,
+          verifyDelivery: {
+            status: "not_delivered" as const,
+            channel: "postmessage" as const,
+            reason: "target_unreachable" as const,
+            ...(tmolObservation ? { observation: tmolObservation } : {}),
           },
         },
       );
@@ -1393,23 +1460,23 @@ export const scrollHandler = async ({
       // requires channel to survive in the failure envelope — thread it
       // through context.verifyDelivery so callers reading the error envelope
       // (issue #179) see the consistent shape with success envelopes.
+      // Flat context (see keyboard.ts:775-776) — `failWith` auto-wraps
+      // non-hoisted keys; LLM-facing shape is `r.context.direction`.
       return failWith(
         new Error("ScrollNotDelivered"),
         "scroll",
         {
-          context: {
-            hint: "post-state observation found no scroll movement on the requested axis (pre was off-boundary)",
-            axis: outcome.axis,
-            preVerticalPercent: pre.vertical,
-            preHorizontalPercent: pre.horizontal,
-            postVerticalPercent: post.vertical,
-            postHorizontalPercent: post.horizontal,
-            direction,
-            verifyDelivery: {
-              status: "not_delivered" as const,
-              channel: effectiveChannel,
-              ...(outcome.axis ? { axis: outcome.axis } : {}),
-            },
+          hint: "post-state observation found no scroll movement on the requested axis (pre was off-boundary)",
+          axis: outcome.axis,
+          preVerticalPercent: pre.vertical,
+          preHorizontalPercent: pre.horizontal,
+          postVerticalPercent: post.vertical,
+          postHorizontalPercent: post.horizontal,
+          direction,
+          verifyDelivery: {
+            status: "not_delivered" as const,
+            channel: effectiveChannel,
+            ...(outcome.axis ? { axis: outcome.axis } : {}),
           },
         },
       );

--- a/src/tools/mouse.ts
+++ b/src/tools/mouse.ts
@@ -1237,8 +1237,10 @@ export const scrollHandler = async ({
       // we surface the typed envelope explicitly so callers see the proper
       // status / channel / reason rather than catching a thrown guard.
       if (dest.kind === "cdp") {
-        // Flat context (see keyboard.ts:775-776) — `failWith` auto-wraps
-        // non-hoisted keys; LLM-facing shape is `r.context.direction`.
+        // Flat context (`failWith` auto-wraps non-hoisted keys into
+        // `context` — see `ROOT_HOISTED_KEYS` + the splitter at
+        // `src/tools/_errors.ts:685-693`). LLM-facing shape is
+        // `r.context.direction`.
         return failWith(
           new Error("ScrollNotDelivered"),
           "scroll",
@@ -1264,9 +1266,13 @@ export const scrollHandler = async ({
         // Page-end disambiguation: when the pre-snapshot shows the scrollbar
         // is already AT the directional boundary (top/bottom/left/right),
         // a no-observable-delta result is a legitimate no-op, NOT a silent
-        // drop. Mirror the boundary logic in `evaluateScrollDelivery` below
-        // (the post-Tier-4 path) so HWND targets get the same page-end
-        // treatment regardless of which tier was last attempted.
+        // drop. Mirror the boundary logic in `evaluateScrollDelivery`
+        // (post-Tier-4 path, line 1116-1124) so HWND targets get the same
+        // page-end treatment regardless of which tier was last attempted.
+        // The verifyDelivery shape mirrors canonical exactly: `delivered` +
+        // channel, no `reason`/`axis` (Opus PR #324 P1-A: canonical does NOT
+        // attach `reason:"page_end_inferred"` here — that reason is bound to
+        // `unverifiable` status only at line 1091-1096).
         // E2E pin: `tests/e2e/scroll-raw-verify.test.ts` "page-end" test.
         const preOnAxis =
           direction === "up" || direction === "down" ? pre.vertical : pre.horizontal;
@@ -1285,13 +1291,12 @@ export const scrollHandler = async ({
                 text: JSON.stringify({
                   ok: true,
                   scrolled: direction,
+                  steps: amount,
                   hints: {
-                    scrollObserved: { delta: { x: null, y: null } },
+                    scrollObserved: { delta: "unverifiable" as const },
                     verifyDelivery: {
                       status: "delivered" as const,
                       channel: "postmessage" as const,
-                      reason: "page_end_inferred" as const,
-                      axis: direction === "up" || direction === "down" ? "vertical" : "horizontal",
                     },
                   },
                 }),
@@ -1302,11 +1307,14 @@ export const scrollHandler = async ({
         // No observation channel exposed at all (no Win32 scrollbar on either
         // axis): we cannot distinguish "scroll-at-boundary no-op" from
         // "silent drop". Matrix doc §3.1 + `evaluateScrollDelivery`
-        // line 1086-1095 explicitly require a boundary signal — without it
-        // we degrade to `unverifiable` (ok:true with diagnostic hint), NOT
-        // `target_unreachable` failure. Win11 Notepad / WinUI hosts land
-        // here. E2E pin: `tests/e2e/scroll-raw-verify.test.ts` "page-end"
-        // test (Notepad at top of buffer, no Win32 scrollbar exposed).
+        // line 1099-1104 explicitly require a boundary signal — without it
+        // we degrade to `unverifiable` with `scrollbar_unavailable`
+        // (canonical mirror; Opus PR #324 P1-B: `read_back_unsupported` is
+        // bound to the Win32 GetScrollInfo unsupported context per
+        // ADR-018 §2.6.3, not "no observation channel"). Win11 Notepad /
+        // WinUI hosts land here. E2E pin: `tests/e2e/scroll-raw-verify.test.ts`
+        // "page-end" test (Notepad at top of buffer, no Win32 scrollbar
+        // exposed).
         if (pre.vertical === null && pre.horizontal === null) {
           return {
             content: [{
@@ -1314,21 +1322,24 @@ export const scrollHandler = async ({
               text: JSON.stringify({
                 ok: true,
                 scrolled: direction,
+                steps: amount,
                 hints: {
                   scrollObserved: { delta: "unverifiable" as const },
                   verifyDelivery: {
                     status: "unverifiable" as const,
                     channel: "postmessage" as const,
-                    reason: "read_back_unsupported" as const,
+                    reason: "scrollbar_unavailable" as const,
+                    axis: direction === "up" || direction === "down" ? "vertical" : "horizontal",
                   },
                 },
               }),
             }],
           };
         }
-        // `failWith` itself nests non-hoisted keys under `context` (see
-        // keyboard.ts:775-776 comment); pass them flat so the LLM-facing
-        // shape is `r.context.direction` (not `r.context.context.direction`).
+        // Flat context (`failWith` auto-wraps non-hoisted keys into
+        // `context` — see `ROOT_HOISTED_KEYS` + the splitter at
+        // `src/tools/_errors.ts:685-693`). LLM-facing shape is
+        // `r.context.direction`, not `r.context.context.direction`.
         // E2E pin: `tests/e2e/scroll-raw-verify.test.ts` test #1.
         return failWith(
           new Error("ScrollNotDelivered"),
@@ -1377,8 +1388,10 @@ export const scrollHandler = async ({
     ) {
       const tmolObservation: VisualMotionObservation | undefined =
         tier1.observation;
-      // Flat context (see keyboard.ts:775-776) — `failWith` auto-wraps
-      // non-hoisted keys; LLM-facing shape is `r.context.direction`.
+      // Flat context (`failWith` auto-wraps non-hoisted keys into `context`
+      // — see `ROOT_HOISTED_KEYS` + the splitter at
+      // `src/tools/_errors.ts:685-693`). LLM-facing shape is
+      // `r.context.direction`.
       return failWith(
         new Error("ScrollNotDelivered"),
         "scroll",
@@ -1460,8 +1473,10 @@ export const scrollHandler = async ({
       // requires channel to survive in the failure envelope — thread it
       // through context.verifyDelivery so callers reading the error envelope
       // (issue #179) see the consistent shape with success envelopes.
-      // Flat context (see keyboard.ts:775-776) — `failWith` auto-wraps
-      // non-hoisted keys; LLM-facing shape is `r.context.direction`.
+      // Flat context (`failWith` auto-wraps non-hoisted keys into `context`
+      // — see `ROOT_HOISTED_KEYS` + the splitter at
+      // `src/tools/_errors.ts:685-693`). LLM-facing shape is
+      // `r.context.direction`.
       return failWith(
         new Error("ScrollNotDelivered"),
         "scroll",

--- a/tests/e2e/scroll-raw-verify.test.ts
+++ b/tests/e2e/scroll-raw-verify.test.ts
@@ -92,6 +92,11 @@ describe("scroll(action:'raw') delivery verification", () => {
       // typed envelope (matrix doc §3.1 silent-drop case).
       expect(p.code).toBe("ScrollNotDelivered");
       expect(p.context?.direction).toBe("down");
+      // Pin the flat-context contract structurally: `failWith()` splits
+      // its 3rd argument so non-hoisted keys land on `context.X`, NOT
+      // `context.context.X` (regression guard for the double-wrap bug
+      // fixed in this PR — see `src/tools/_errors.ts:685-693`).
+      expect((p.context as Record<string, unknown>)?.context).toBeUndefined();
       return;
     }
     expect(p.scrolled).toBe("down");
@@ -99,12 +104,13 @@ describe("scroll(action:'raw') delivery verification", () => {
     // Always present per matrix doc §3.1 / §4.2: scrollObserved + verifyDelivery.
     expect(p.hints!.scrollObserved).toBeDefined();
     expect(p.hints!.verifyDelivery).toBeDefined();
-    // ADR-018 Phase 4 (Tier 1/2/3 destination-explicit) widened the channel
-    // enum to {uia, cdp, postmessage, send_input/wheel_send_input}. The exact
-    // value depends on which tier handled (or was last attempted on) the
-    // resolved destination. Notepad on Win11 routes through Tier 3 PostMessage
-    // because Modern Notepad has no Win32 scrollbar; legacy hosts route
-    // through Tier 4 SendInput. Accept any of the 4 documented channels.
+    // ADR-018 Phase 4 (Tier 1/2/3 destination-explicit) defines 4 transport
+    // channels: {uia, cdp, postmessage, send_input}. `wheel_send_input` is a
+    // legacy alias for `send_input` retained for Phase 5+N migration
+    // deferral (ADR-018 §2.6.3 migration table). Notepad on Win11 routes
+    // through Tier 3 PostMessage because Modern Notepad has no Win32
+    // scrollbar; legacy hosts route through Tier 4 SendInput. Accept any of
+    // the 4 ADR-018 channels plus the legacy alias.
     expect(["uia", "cdp", "postmessage", "send_input", "wheel_send_input"]).toContain(
       p.hints!.verifyDelivery!.channel,
     );
@@ -172,8 +178,9 @@ describe("scroll(action:'raw') delivery verification", () => {
     const vd = p.hints!.verifyDelivery!;
     // Required: status, channel.
     expect(typeof vd.status).toBe("string");
-    // Channel is one of the 4 ADR-018 transport tiers — exact value depends
-    // on which tier handled the resolved destination (see test #1 comment).
+    // Channel is one of the 4 ADR-018 transport tiers (+ legacy alias
+    // `wheel_send_input`) — exact value depends on which tier handled the
+    // resolved destination (see test #1 comment).
     expect(["uia", "cdp", "postmessage", "send_input", "wheel_send_input"]).toContain(vd.channel);
     if (vd.status === "unverifiable") {
       // reason is required when status=unverifiable (matrix doc §4.4).

--- a/tests/e2e/scroll-raw-verify.test.ts
+++ b/tests/e2e/scroll-raw-verify.test.ts
@@ -99,7 +99,15 @@ describe("scroll(action:'raw') delivery verification", () => {
     // Always present per matrix doc §3.1 / §4.2: scrollObserved + verifyDelivery.
     expect(p.hints!.scrollObserved).toBeDefined();
     expect(p.hints!.verifyDelivery).toBeDefined();
-    expect(p.hints!.verifyDelivery!.channel).toBe("wheel_send_input");
+    // ADR-018 Phase 4 (Tier 1/2/3 destination-explicit) widened the channel
+    // enum to {uia, cdp, postmessage, send_input/wheel_send_input}. The exact
+    // value depends on which tier handled (or was last attempted on) the
+    // resolved destination. Notepad on Win11 routes through Tier 3 PostMessage
+    // because Modern Notepad has no Win32 scrollbar; legacy hosts route
+    // through Tier 4 SendInput. Accept any of the 4 documented channels.
+    expect(["uia", "cdp", "postmessage", "send_input", "wheel_send_input"]).toContain(
+      p.hints!.verifyDelivery!.channel,
+    );
     expect(["delivered", "unverifiable"]).toContain(p.hints!.verifyDelivery!.status);
     // delta is either "unverifiable" or {x, y} with possibly-null fields.
     const delta = p.hints!.scrollObserved!.delta;
@@ -164,7 +172,9 @@ describe("scroll(action:'raw') delivery verification", () => {
     const vd = p.hints!.verifyDelivery!;
     // Required: status, channel.
     expect(typeof vd.status).toBe("string");
-    expect(vd.channel).toBe("wheel_send_input");
+    // Channel is one of the 4 ADR-018 transport tiers — exact value depends
+    // on which tier handled the resolved destination (see test #1 comment).
+    expect(["uia", "cdp", "postmessage", "send_input", "wheel_send_input"]).toContain(vd.channel);
     if (vd.status === "unverifiable") {
       // reason is required when status=unverifiable (matrix doc §4.4).
       expect(typeof vd.reason).toBe("string");

--- a/tests/unit/modal-detection-browser-exclusion.test.ts
+++ b/tests/unit/modal-detection-browser-exclusion.test.ts
@@ -1,20 +1,30 @@
 /**
- * modal-detection-browser-exclusion.test.ts — pin the browser-class
- * exclusion contract used by `desktop_state.hasModal` (see
- * `src/tools/desktop-state.ts` line ~562). A Chrome / Edge / Firefox
- * top-level window whose page title happens to match MODAL_RE (e.g.
- * Japanese "通知" / Stack Overflow "Save As" thread) is page content,
- * NOT a modal — the browser renders its own dialogs inside the tab
- * via CDP. Without this exclusion, every desktop_state call from a
- * machine with such a tab open falsely returns `hasModal: true` and
- * breaks e2e tests like `context-consistency.test.ts`.
+ * modal-detection-browser-exclusion.test.ts — pin the
+ * (class × process-name) double-gate used by `desktop_state.hasModal`
+ * (see `src/tools/desktop-state.ts` line ~599). Both axes must match for
+ * exclusion to fire, so Electron / CEF apps (VS Code, Discord, Slack,
+ * Cursor, Claude Desktop, Obsidian, …) that ALSO use the Chromium widget
+ * class continue to raise `hasModal: true` when their modal title matches
+ * MODAL_RE (Codex P1 review on PR #324).
+ *
+ * The false-positive being suppressed: a real-browser tab whose page title
+ * happens to contain "通知" / "Save As" / "Error" / "警告" etc. is page
+ * content, NOT a modal. Browsers render their own dialogs inside the tab
+ * via CDP; the top-level window is the tab itself.
  */
 
 import { describe, it, expect } from "vitest";
-import { isBrowserTopLevelClass, MODAL_RE } from "../../src/tools/desktop-state.js";
+import {
+  isBrowserTopLevelClass,
+  isBrowserProcessName,
+  MODAL_RE,
+} from "../../src/tools/desktop-state.js";
 
 describe("isBrowserTopLevelClass", () => {
-  it("matches Chromium-family classes (Chrome / Edge / Brave / Vivaldi / Arc)", () => {
+  it("matches Chromium-family widget class (Chrome / Edge / Brave / Vivaldi / Arc / + Electron / CEF)", () => {
+    // Chromium widget class is SHARED with every Electron / CEF app — the
+    // helper just identifies the class family. Exclusion also requires the
+    // process-name gate below.
     expect(isBrowserTopLevelClass("Chrome_WidgetWin_1")).toBe(true);
   });
 
@@ -34,10 +44,58 @@ describe("isBrowserTopLevelClass", () => {
   });
 });
 
-describe("MODAL_RE — browser-class exclusion regression", () => {
+describe("isBrowserProcessName", () => {
+  it("matches Chromium-engine real browsers (case-insensitive)", () => {
+    expect(isBrowserProcessName("chrome")).toBe(true);
+    expect(isBrowserProcessName("CHROME")).toBe(true); // case-insensitive
+    expect(isBrowserProcessName("msedge")).toBe(true);
+    expect(isBrowserProcessName("brave")).toBe(true);
+    expect(isBrowserProcessName("opera")).toBe(true);
+    expect(isBrowserProcessName("vivaldi")).toBe(true);
+    expect(isBrowserProcessName("arc")).toBe(true);
+    expect(isBrowserProcessName("thorium")).toBe(true);
+  });
+
+  it("matches Gecko-engine browsers", () => {
+    expect(isBrowserProcessName("firefox")).toBe(true);
+    expect(isBrowserProcessName("waterfox")).toBe(true);
+    expect(isBrowserProcessName("librewolf")).toBe(true);
+  });
+
+  it("does NOT match Electron / CEF apps (Codex P1 regression guard)", () => {
+    // These apps share `Chrome_WidgetWin_1` but their modal titles ARE
+    // legitimate modals — `hasModal` MUST still raise true for them.
+    expect(isBrowserProcessName("Code")).toBe(false); // VS Code
+    expect(isBrowserProcessName("code")).toBe(false); // lowercase variant
+    expect(isBrowserProcessName("Discord")).toBe(false);
+    expect(isBrowserProcessName("Slack")).toBe(false);
+    expect(isBrowserProcessName("Cursor")).toBe(false);
+    expect(isBrowserProcessName("Claude")).toBe(false);
+    expect(isBrowserProcessName("Obsidian")).toBe(false);
+    expect(isBrowserProcessName("Notion")).toBe(false);
+    expect(isBrowserProcessName("Atom")).toBe(false);
+  });
+
+  it("does NOT match unrelated apps", () => {
+    expect(isBrowserProcessName("notepad")).toBe(false);
+    expect(isBrowserProcessName("powershell")).toBe(false);
+    expect(isBrowserProcessName("explorer")).toBe(false);
+  });
+
+  it("handles empty string and undefined safely (lookup failure)", () => {
+    // `getProcessIdentityByPid` returns `processName: ""` on lookup failure
+    // — must NOT treat empty as a browser (errs toward keeping `hasModal`
+    // honest rather than over-suppressing).
+    expect(isBrowserProcessName("")).toBe(false);
+    expect(isBrowserProcessName(undefined)).toBe(false);
+  });
+});
+
+describe("MODAL_RE — false-positive titles regex still matches (gate is class × process)", () => {
   // These titles WOULD trigger MODAL_RE if checked directly, but when they
-  // appear on a Chrome_WidgetWin_1 / MozillaWindowClass top-level window
-  // they must be ignored because the browser handles modals internally.
+  // appear on a (Chrome_WidgetWin_1 × `chrome`) or (MozillaWindowClass ×
+  // `firefox`) window the production logic suppresses them. The regex
+  // itself stays permissive — exclusion happens at the loop level.
   const falsePositiveBrowserTitles = [
     "Twitter 通知 - Twitter",
     "Gmail - 通知設定 - Google",
@@ -50,9 +108,6 @@ describe("MODAL_RE — browser-class exclusion regression", () => {
 
   for (const title of falsePositiveBrowserTitles) {
     it(`MODAL_RE matches "${title}" on its own (regex itself unchanged)`, () => {
-      // Confirms the regex still matches — the gate is the class check,
-      // not a regex change. This pins the architecture: the regex stays
-      // permissive; the production heuristic excludes by class.
       expect(MODAL_RE.test(title)).toBe(true);
     });
   }

--- a/tests/unit/modal-detection-browser-exclusion.test.ts
+++ b/tests/unit/modal-detection-browser-exclusion.test.ts
@@ -1,0 +1,59 @@
+/**
+ * modal-detection-browser-exclusion.test.ts — pin the browser-class
+ * exclusion contract used by `desktop_state.hasModal` (see
+ * `src/tools/desktop-state.ts` line ~562). A Chrome / Edge / Firefox
+ * top-level window whose page title happens to match MODAL_RE (e.g.
+ * Japanese "通知" / Stack Overflow "Save As" thread) is page content,
+ * NOT a modal — the browser renders its own dialogs inside the tab
+ * via CDP. Without this exclusion, every desktop_state call from a
+ * machine with such a tab open falsely returns `hasModal: true` and
+ * breaks e2e tests like `context-consistency.test.ts`.
+ */
+
+import { describe, it, expect } from "vitest";
+import { isBrowserTopLevelClass, MODAL_RE } from "../../src/tools/desktop-state.js";
+
+describe("isBrowserTopLevelClass", () => {
+  it("matches Chromium-family classes (Chrome / Edge / Brave / Vivaldi / Arc)", () => {
+    expect(isBrowserTopLevelClass("Chrome_WidgetWin_1")).toBe(true);
+  });
+
+  it("matches Firefox class", () => {
+    expect(isBrowserTopLevelClass("MozillaWindowClass")).toBe(true);
+  });
+
+  it("does NOT match non-browser classes", () => {
+    expect(isBrowserTopLevelClass("Notepad")).toBe(false);
+    expect(isBrowserTopLevelClass("#32770")).toBe(false); // standard Win32 dialog
+    expect(isBrowserTopLevelClass("CASCADIA_HOSTING_WINDOW_CLASS")).toBe(false);
+    expect(isBrowserTopLevelClass("ConsoleWindowClass")).toBe(false);
+  });
+
+  it("handles undefined className safely (older addon builds)", () => {
+    expect(isBrowserTopLevelClass(undefined)).toBe(false);
+  });
+});
+
+describe("MODAL_RE — browser-class exclusion regression", () => {
+  // These titles WOULD trigger MODAL_RE if checked directly, but when they
+  // appear on a Chrome_WidgetWin_1 / MozillaWindowClass top-level window
+  // they must be ignored because the browser handles modals internally.
+  const falsePositiveBrowserTitles = [
+    "Twitter 通知 - Twitter",
+    "Gmail - 通知設定 - Google",
+    "Save As - Stack Overflow",
+    "Error 404 - GitHub",
+    "Warning: chemicals exposure - Wikipedia",
+    "Confirm Delete Account - Service Settings",
+    "Google Gemini - LINE通知音が出ない原因調査 - Google Gemini",
+  ];
+
+  for (const title of falsePositiveBrowserTitles) {
+    it(`MODAL_RE matches "${title}" on its own (regex itself unchanged)`, () => {
+      // Confirms the regex still matches — the gate is the class check,
+      // not a regex change. This pins the architecture: the regex stays
+      // permissive; the production heuristic excludes by class.
+      expect(MODAL_RE.test(title)).toBe(true);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Three independent structural bugs surfaced during ADR-019 Stage 5 wiring rehearsal that together flaked 7 e2e tests. Fixing structurally (per CLAUDE.md §7 "仕組みで対応") so we can run targeted suites instead of the full one on every iteration.

- **failWith context double-wrap** — `failWith()` auto-nests non-hoisted keys under `context`, so passing `{context:{reason,…}}` produced `r.context.context.reason`. E2E tests pin `r.context.reason` directly. Flatten across keyboard.ts L924-939 + mouse.ts 4 scroll-failure sites per the canonical pattern at `keyboard.ts:775-776`.
- **Scroll page-end disambiguation** (mouse.ts Tier 1+3 exhausted path) — Mirror `evaluateScrollDelivery`'s boundary logic for HWND/UIA destinations: pre-snapshot at the directional boundary → `ok:true` + `page_end_inferred` (legitimate no-op, not a silent drop). When the host exposes no Win32 scrollbar on either axis (modern Notepad, WinUI hosts), degrade to `unverifiable + read_back_unsupported` rather than `target_unreachable`.
- **Browser top-level modal false-positive** (desktop-state.ts) — `hasModal` now skips `Chrome_WidgetWin_1` / `MozillaWindowClass` top-level windows. Browsers render their modals inside tabs via CDP; the top-level window is page content. Without this, any Japanese-language page mentioning "通知" / "警告" / Stack Overflow "Save As" QA / etc. set `hasModal: true` on every `desktop_state` call.

`scroll-raw-verify.test.ts` channel assertions widened to accept all 4 ADR-018 Phase 4 transport tiers (`uia` / `cdp` / `postmessage` / `send_input`).

New: `tests/unit/modal-detection-browser-exclusion.test.ts` (11 cases) pins the browser-exclusion contract.

## Test plan

- [x] `npx vitest run tests/unit/modal-detection-browser-exclusion.test.ts` → 11 / 11 pass
- [x] `npm run build` clean (no TS errors)
- [ ] CI green on full suite
- [ ] E2E `context-consistency.test.ts` no longer flakes (was failing on browser-class hasModal false-positive)
- [ ] E2E `scroll-raw-verify.test.ts` no longer flakes (channel enum + page-end coverage)
- [ ] E2E `foreground-flash-verification.test.ts` no longer flakes (failWith context shape)

## Out of scope

PR-2 = ADR-019 Stage 5 impl follows once this lands. Stage 5 changes are held locally on `main` working tree; this PR is purely the e2e flake closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)