### PR TITLE
fix(lease): bump lease TTL baseMs 5000 -> 15000 (#327 item F)

### DIFF
--- a/docs/anti-fukuwarai-v2-h1-lease-ttl-plan.md
+++ b/docs/anti-fukuwarai-v2-h1-lease-ttl-plan.md
@@ -542,3 +542,24 @@ debug view は rect 情報を含む → operator が手で検証する。10 秒 
 - `docs/Anti-Fukuwarai-V2.md` § 9 関連ドキュメント末尾に `anti-fukuwarai-v2-h1-lease-ttl-plan.md` の参照を足す（任意）
 
 これらは implementation commit とは別 commit で行って良い。
+
+---
+
+## 9. Amendments (post-H1)
+
+本 plan は 2026-04-23 起草の H1 batch 起源 SSOT。policy 本体はその後 2 度更新されているため、**本ドキュメント §2.x / §4.1 / §5.1 / §7 の具体数値は historical 記述**であり、**live SSOT は `src/engine/world-graph/lease-ttl-policy.ts` (`LEASE_TTL_POLICY` const + JSDoc header)**。本 §9 は forward-pointing amendment 集約点として運用する (option (a) per CLAUDE.md §3.1 fact 整合 sweep)。
+
+### 9.1 2026-04-XX — no-compromise A: payload-size aware TTL + cap 60s
+
+- `payloadBonus` 軸を追加 (`max(0, payloadBytes - 2_000) * 0.5`、cap `+10_000`)。`action` / `explore` / `debug` 全 view で stack。
+- `cap` を `30_000` → `60_000` に拡張 (大 payload が cap 早期到達して LLM の読了時間を吸収しきれない事案への対処)。
+- `softExpiryFraction = 0.6` 追加 (LLM 向け advisory、hard `expiresAtMs` は correctness wall として独立)。
+- 本 doc §2.1 上限 30s / §2.2 算定式 / §7 acceptance "cap 30s で頭打ち" は **stale**。
+
+### 9.2 2026-05-17 — issue #327 item F: base 5_000 → 15_000
+
+- `baseMs` を `5_000` → `15_000` に引き上げ。
+- 動機: Stage 5 dogfood (issue #327 item F) で `desktop_discover → desktop_act` の Claude Code round-trip (10-30s) が `view=action` の 5-8s 実効 TTL を超え、`lease_expired` が日常使用で頻発したため。
+- 影響: `action` view base が round-trip 下端に到達。explore / debug bonus + entityBonus + payloadBonus は不変、hard cap 60_000 も不変。
+- 本 doc §2.1 基準 TTL 5,000 ms / §2.2 算定式 base (5000) / §7 acceptance "view=action は 5s 維持" / "view=explore 50 entities で 13s" は **stale**。
+- live SSOT は `src/engine/world-graph/lease-ttl-policy.ts:33-49`、関連テストは `tests/unit/lease-ttl-policy.test.ts` + `tests/unit/desktop-facade.test.ts` H1 describe。

--- a/src/engine/world-graph/lease-ttl-policy.ts
+++ b/src/engine/world-graph/lease-ttl-policy.ts
@@ -8,8 +8,8 @@
  *
  * 2026-05-17 update (issue #327 item F): base bumped 5_000 → 15_000.
  *   Real Claude Code round-trip (user utterance + reasoning + next tool call)
- *   is typically 10-30s, so the 5s baseline tripped `lease_expired` on every
- *   `desktop_discover → desktop_act` cycle during dogfood. 15s base brings
+ *   is typically 10-30s, so the 5s baseline often tripped `lease_expired`
+ *   on `action` and short-`explore` cycles during dogfood. 15s base brings
  *   the `action` view into the lower edge of typical round-trip; explore and
  *   debug stack on top as before. The hard cap (60_000) remains unchanged.
  *

--- a/src/engine/world-graph/lease-ttl-policy.ts
+++ b/src/engine/world-graph/lease-ttl-policy.ts
@@ -6,9 +6,16 @@
  *   LLM read + reason + next-tool-call latency commonly exceeds 5s. Dogfood
  *   scenarios S1 (browser-form) and S3 (terminal) hit `lease_expired` there.
  *
+ * 2026-05-17 update (issue #327 item F): base bumped 5_000 → 15_000.
+ *   Real Claude Code round-trip (user utterance + reasoning + next tool call)
+ *   is typically 10-30s, so the 5s baseline tripped `lease_expired` on every
+ *   `desktop_discover → desktop_act` cycle during dogfood. 15s base brings
+ *   the `action` view into the lower edge of typical round-trip; explore and
+ *   debug stack on top as before. The hard cap (60_000) remains unchanged.
+ *
  * Policy:
  *   ttlMs = clamp(base + viewBonus + entityBonus + payloadBonus, floor, cap)
- *     base         = 5_000
+ *     base         = 15_000
  *     viewBonus    = action:0 / explore:+5_000 / debug:+10_000
  *     entityBonus  = max(0, entityCount - 20) * 100        [all views]
  *     payloadBonus = max(0, payloadBytes - 2_000) * 0.5    [capped at +10_000]
@@ -31,7 +38,7 @@
  */
 
 export const LEASE_TTL_POLICY = {
-  baseMs:             5_000,
+  baseMs:             15_000,
   floor:              2_000,
   cap:                60_000,
   viewBonus: {

--- a/tests/unit/desktop-facade.test.ts
+++ b/tests/unit/desktop-facade.test.ts
@@ -627,11 +627,11 @@ describe("DesktopFacade — response-size aware lease TTL (H1)", () => {
     expect(expiryExplore).toBeGreaterThan(expiryAction);
   });
 
-  it("action view with few entities keeps TTL at base 5s", async () => {
+  it("action view with few entities keeps TTL at base 15s", async () => {
     const facade = new DesktopFacade(gameProvider, { nowFn: () => 0 });
     const view = await facade.see({ view: "action" });
-    // base 5000 + no view bonus + no entity bonus (2 entities)
-    expect(view.entities[0].lease.expiresAtMs).toBe(5_000);
+    // base 15000 + no view bonus + no entity bonus (2 entities)
+    expect(view.entities[0].lease.expiresAtMs).toBe(15_000);
   });
 
   it("explore view with 50 entities adds meaningful TTL bonus", async () => {
@@ -639,12 +639,12 @@ describe("DesktopFacade — response-size aware lease TTL (H1)", () => {
       Array.from({ length: 60 }, (_, i) => cand(`Item ${i}`, "uia", { digest: `d${i}` }));
     const facade = new DesktopFacade(manyProvider, { nowFn: () => 0 });
     const view = await facade.see({ view: "explore" }); // 50 entities after maxEntities slice
-    // 5000 base + 5000 explore + (50-20)*100 entityBonus + payloadBonus
+    // 15000 base + 5000 explore + (50-20)*100 entityBonus + payloadBonus
     // (no-compromise A: payload-size aware). Estimate:
     //   estimatedPayloadBytes = 500 + 50*250 + 0*180 + 0 warnings = 13_000
     //   payloadBonus = (13_000 - 2_000) * 0.5 = 5_500
-    // total = 5000 + 5000 + 3000 + 5500 = 18_500
-    expect(view.entities[0].lease.expiresAtMs).toBe(18_500);
+    // total = 15000 + 5000 + 3000 + 5500 = 28_500
+    expect(view.entities[0].lease.expiresAtMs).toBe(28_500);
   });
 
   it("stale lease safety: TTL extension does NOT bypass generation eviction", async () => {

--- a/tests/unit/desktop-facade.test.ts
+++ b/tests/unit/desktop-facade.test.ts
@@ -658,14 +658,14 @@ describe("DesktopFacade — response-size aware lease TTL (H1)", () => {
     if (!result.ok) expect(result.reason).toBe("entity_not_found");
   });
 
-  it("stale lease safety: expired lease rejected even at high TTL (past 30s)", async () => {
+  it("stale lease safety: expired lease rejected even at high TTL (past 40s clock)", async () => {
     let now = 0;
     const manyProvider: CandidateProvider = () =>
       Array.from({ length: 80 }, (_, i) => cand(`Item ${i}`, "uia", { digest: `d${i}` }));
     const facade = new DesktopFacade(manyProvider, { nowFn: () => now });
     const view = await facade.see({ view: "explore" });
     const lease = view.entities[0].lease;
-    // Push clock well past the maximum possible TTL (cap: 30s)
+    // Push clock past the lease expiry (high-TTL explore lease still well under the 60s cap)
     now = 40_000;
     const result = await facade.touch({ lease });
     expect(result.ok).toBe(false);
@@ -678,7 +678,7 @@ describe("DesktopFacade — response-size aware lease TTL (H1)", () => {
       defaultTtlMs: 1_000,
       nowFn: () => now,
     });
-    const view = await facade.see({ view: "explore" }); // policy would give 10s, but override wins
+    const view = await facade.see({ view: "explore" }); // policy would give 20s, but override wins
     expect(view.entities[0].lease.expiresAtMs).toBe(1_000);
     now = 2_000; // past the 1s override TTL
     const result = await facade.touch({ lease: view.entities[0].lease });

--- a/tests/unit/lease-ttl-policy.test.ts
+++ b/tests/unit/lease-ttl-policy.test.ts
@@ -6,20 +6,20 @@ import {
 } from "../../src/engine/world-graph/lease-ttl-policy.js";
 
 describe("computeLeaseTtlMs — view dimension", () => {
-  it("action view has no bonus (base 5000ms)", () => {
-    expect(computeLeaseTtlMs({ view: "action", entityCount: 5 })).toBe(5_000);
+  it("action view has no bonus (base 15000ms)", () => {
+    expect(computeLeaseTtlMs({ view: "action", entityCount: 5 })).toBe(15_000);
   });
 
   it("undefined view defaults to action", () => {
-    expect(computeLeaseTtlMs({ view: undefined, entityCount: 5 })).toBe(5_000);
+    expect(computeLeaseTtlMs({ view: undefined, entityCount: 5 })).toBe(15_000);
   });
 
   it("explore view adds 5000ms bonus", () => {
-    expect(computeLeaseTtlMs({ view: "explore", entityCount: 5 })).toBe(10_000);
+    expect(computeLeaseTtlMs({ view: "explore", entityCount: 5 })).toBe(20_000);
   });
 
   it("debug view adds 10000ms bonus", () => {
-    expect(computeLeaseTtlMs({ view: "debug", entityCount: 5 })).toBe(15_000);
+    expect(computeLeaseTtlMs({ view: "debug", entityCount: 5 })).toBe(25_000);
   });
 
   it("explore TTL is strictly greater than action TTL for same entityCount", () => {
@@ -31,15 +31,15 @@ describe("computeLeaseTtlMs — view dimension", () => {
 
 describe("computeLeaseTtlMs — entity count dimension", () => {
   it("entityCount <= 20 yields no bonus", () => {
-    expect(computeLeaseTtlMs({ view: "action", entityCount: 0  })).toBe(5_000);
-    expect(computeLeaseTtlMs({ view: "action", entityCount: 20 })).toBe(5_000);
+    expect(computeLeaseTtlMs({ view: "action", entityCount: 0  })).toBe(15_000);
+    expect(computeLeaseTtlMs({ view: "action", entityCount: 20 })).toBe(15_000);
   });
 
   it("each entity above 20 adds 100ms", () => {
-    // action(base 5000) + (40 - 20) * 100 = 7000
-    expect(computeLeaseTtlMs({ view: "action",  entityCount: 40 })).toBe(7_000);
-    // explore(base 10000) + (50 - 20) * 100 = 13000
-    expect(computeLeaseTtlMs({ view: "explore", entityCount: 50 })).toBe(13_000);
+    // action(base 15000) + (40 - 20) * 100 = 17000
+    expect(computeLeaseTtlMs({ view: "action",  entityCount: 40 })).toBe(17_000);
+    // explore(base 20000) + (50 - 20) * 100 = 23000
+    expect(computeLeaseTtlMs({ view: "explore", entityCount: 50 })).toBe(23_000);
   });
 
   it("bonus is monotonically non-decreasing in entityCount (same view)", () => {
@@ -84,34 +84,34 @@ describe("computeLeaseTtlMs — payload-size dimension", () => {
   it("payloadBytes <= baseline yields no payload bonus", () => {
     // Baseline = 2000 bytes. Inputs at or below baseline behave like the
     // no-payload path.
-    expect(computeLeaseTtlMs({ view: "action", entityCount: 5, payloadBytes: 0    })).toBe(5_000);
-    expect(computeLeaseTtlMs({ view: "action", entityCount: 5, payloadBytes: 2000 })).toBe(5_000);
+    expect(computeLeaseTtlMs({ view: "action", entityCount: 5, payloadBytes: 0    })).toBe(15_000);
+    expect(computeLeaseTtlMs({ view: "action", entityCount: 5, payloadBytes: 2000 })).toBe(15_000);
   });
 
   it("each byte over baseline adds 0.5ms", () => {
-    // 5_000 base + (10_000 - 2_000) * 0.5 = 5_000 + 4_000 = 9_000
-    expect(computeLeaseTtlMs({ view: "action", entityCount: 5, payloadBytes: 10_000 })).toBe(9_000);
+    // 15_000 base + (10_000 - 2_000) * 0.5 = 15_000 + 4_000 = 19_000
+    expect(computeLeaseTtlMs({ view: "action", entityCount: 5, payloadBytes: 10_000 })).toBe(19_000);
   });
 
   it("payload bonus is itself capped at 10000ms", () => {
     // Even an absurd 1 MB payload can only contribute 10s on top of the
     // other dimensions.
     const ttl = computeLeaseTtlMs({ view: "action", entityCount: 5, payloadBytes: 1_000_000 });
-    // base(5000) + payloadCap(10000) = 15000
-    expect(ttl).toBe(15_000);
+    // base(15000) + payloadCap(10000) = 25000
+    expect(ttl).toBe(25_000);
   });
 
   it("payloadBytes undefined / NaN / negative is silently treated as zero (defensive)", () => {
-    expect(computeLeaseTtlMs({ view: "action", entityCount: 5 })).toBe(5_000);
-    expect(computeLeaseTtlMs({ view: "action", entityCount: 5, payloadBytes: NaN  })).toBe(5_000);
-    expect(computeLeaseTtlMs({ view: "action", entityCount: 5, payloadBytes: -100 })).toBe(5_000);
+    expect(computeLeaseTtlMs({ view: "action", entityCount: 5 })).toBe(15_000);
+    expect(computeLeaseTtlMs({ view: "action", entityCount: 5, payloadBytes: NaN  })).toBe(15_000);
+    expect(computeLeaseTtlMs({ view: "action", entityCount: 5, payloadBytes: -100 })).toBe(15_000);
   });
 
   it("all bonuses stack and respect the cap", () => {
     // explore(+5000) + entityBonus((50-20)*100=3000) + payloadCap(10000)
-    // base(5000) + 5000 + 3000 + 10000 = 23000  (well under cap 60000)
+    // base(15000) + 5000 + 3000 + 10000 = 33000  (still under cap 60000)
     const ttl = computeLeaseTtlMs({ view: "explore", entityCount: 50, payloadBytes: 100_000 });
-    expect(ttl).toBe(23_000);
+    expect(ttl).toBe(33_000);
   });
 });
 


### PR DESCRIPTION
## Summary

Issue #327 item F: every `desktop_discover → desktop_act` cycle currently risks tripping `lease_expired` during normal Claude Code use. Root cause is `LEASE_TTL_POLICY.baseMs = 5_000` in `src/engine/world-graph/lease-ttl-policy.ts`. The effective TTL for `view=action` is **base + entityBonus + payloadBonus = 5-8 seconds**, but Claude Code round-trip (user utterance + reasoning + next tool call) is typically 10-30 seconds — expiry is mechanical, and there is no lease-renewal API today.

This PR raises `baseMs` to **15_000**, bringing the `action` view into the lower edge of a typical round-trip. Bonuses (viewBonus 0/5_000/10_000, entityBonus +100/entity above 20, payloadBonus 0.5/byte above 2_000 capped at +10_000) and the hard cap (60_000) are unchanged. The agent triaging #327 ranked this as the cheapest fix with the largest UX impact among the seven blockers.

## Diff

| File | Change |
|---|---|
| `src/engine/world-graph/lease-ttl-policy.ts` | `baseMs: 5_000 → 15_000`; JSDoc 2026-05-17 note pointing to #327 |
| `tests/unit/lease-ttl-policy.test.ts` | 10 assertions rebased on new baseline |
| `tests/unit/desktop-facade.test.ts` | 2 assertions rebased (action view few-entities 5_000 → 15_000; explore view 50 entities with payloadBonus 18_500 → 28_500) |

No source change outside the policy file: `src/tools/desktop.ts` calls `computeLeaseTtlMs()` and picks up the new value automatically.

## Effective TTL after this change

| view | entityCount | payloadBytes | TTL before | TTL after |
|---|---|---|---|---|
| action | ≤20 | 0 | 5_000 | 15_000 |
| explore | ≤20 | 0 | 10_000 | 20_000 |
| debug | ≤20 | 0 | 15_000 | 25_000 |
| action | 40 | 0 | 7_000 | 17_000 |
| explore | 50 | 100_000 (capped) | 23_000 | 33_000 |
| (any) | extreme | extreme | 60_000 (cap) | 60_000 (cap) |

The cap is unchanged, so the upper bound on stale-lease exposure remains identical to today.

## Risk

- **Stale-lease window widens**: the soft+hard expiry now sit further out. `generation_mismatch` / `digest_mismatch` / `entity_not_found` are independent of TTL and continue to evict stale leases mechanically — only the `expired` reason path moves. The existing `tests/unit/desktop-facade.test.ts` "stale lease safety: TTL extension does NOT bypass generation eviction" test still passes.
- **No production-code wiring change**: `src/tools/desktop.ts` and `src/engine/world-graph/lease-store.ts` both consume `computeLeaseTtlMs()` / the policy object dynamically; no hard-coded references to 5_000 elsewhere (`grep` confirmed).

## Test plan

- [x] `npm run build` (clean)
- [x] `npx vitest run tests/unit/lease-ttl-policy.test.ts tests/unit/desktop-facade.test.ts tests/unit/lease-store.test.ts` → 97 / 97 pass
- [x] Full `npm run test:capture` → 3480 pass / 12 pre-existing fail (PERSIST-14 env-dependent rename target; BenchmarkHarness idle flake; browser-cdp e2e needs Chrome with CDP). Zero lease / TTL / expires failures.
- [ ] Opus phase-boundary review
- [ ] Codex review (`@codex review`)

Closes part of #327 (item F).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
