### PR TITLE
fix(desktop_act): attach if_unexpected on executor_failed (#327 item G)

### DIFF
--- a/src/tools/_errors.ts
+++ b/src/tools/_errors.ts
@@ -273,6 +273,20 @@ const SUGGESTS: Record<string, string[]> = {
     "Try click_element + keyboard({action:'type'}) manually",
     "Check context.attempts for per-channel error codes",
   ],
+  // Issue #327 item G: `desktop_act` returned `reason: "executor_failed"` —
+  // the GuardedTouchLoop selected an executor and the executor threw
+  // (`guarded-touch.ts:315-319`). Most common dogfood causes (issue #327):
+  // (C) UIA Edit/Document control without InvokePattern, so click fell
+  // through then mouse-fallback was also skipped, and (E) UIA Edit without
+  // a usable name/automationId for the `setValue` PowerShell locator filter.
+  // The hints below point to the alternate channels for each action,
+  // matching the wiring the dogfood confirmed actually works.
+  ExecutorFailed: [
+    "For action='click', fall back to mouse_click({clickAt}) using the entity rect center from desktop_discover — common when UIA InvokePattern is missing on the control",
+    "For action='type' or action='setValue', fall back to keyboard({action:'type', text}) after focusing the target — common when UIA ValuePattern is missing or the locator filter cannot re-find the entity",
+    "If the entity has a stable name or automationId, try click_element({name|automationId}) — uses a different UIA path than desktop_act and may succeed where this executor threw",
+    "Re-run desktop_discover — the entity may have moved or been re-keyed between discover and act, in which case the executor saw a stale locator",
+  ],
   // Phase 2a F4 / Phase 5 I1: keyboard({action:'type'}) Focus Leash Phase B
   // mid-stream focus theft. matrix §3.1 line 141 規範:
   // foreground-stealing protection が caller の send 中に他 window へ focus

--- a/src/tools/desktop-register.ts
+++ b/src/tools/desktop-register.ts
@@ -538,6 +538,15 @@ const desktopDiscoverRawHandler = async (input: unknown): Promise<ToolResult> =>
  * recovery hint. We attach it here so the LLM client gets the same recovery surface
  * documented in the tool description. The advisory ↔ runtime drift is tracked for the
  * path-class refactor epic per `project_path_class_refactor_pending` memory.
+ *
+ * Envelope-mode position note (Opus Round 1 P2): the attach lands at the raw payload
+ * level (alongside `ok` / `reason`), so in raw mode (`compatHoist` optIn=false) it
+ * hoists to envelope top-level as expected. In envelope mode (`include=["envelope"]`)
+ * the field surfaces at `envelope.data.if_unexpected`, **not** at `envelope.if_unexpected`
+ * where `buildFailureEnvelope`-driven paths (lease validation / handler throw / typed
+ * N-upper-bound paths) place it. This asymmetry is a known scope trade-off for this
+ * tactical PR; the path-class refactor epic normalises both paths through a single
+ * failure envelope hook.
  */
 function buildExecutorFailedIfUnexpected(): {
   most_likely_cause: "ExecutorFailed";
@@ -572,12 +581,23 @@ export const desktopActRawHandler = async (
     }
   }
 
-  const payload: Record<string, unknown> = { ...result };
+  // Opus Round 1 P3-1: keep the TouchResult discriminated-union narrowed inside
+  // the executor_failed branch by spreading the already-narrowed `result` into
+  // the JSON payload directly, instead of widening through Record<string, unknown>.
   if (!result.ok && result.reason === "executor_failed") {
-    payload["if_unexpected"] = buildExecutorFailedIfUnexpected();
+    return {
+      content: [{
+        type: "text" as const,
+        text: JSON.stringify(
+          { ...result, if_unexpected: buildExecutorFailedIfUnexpected() },
+          null,
+          2,
+        ),
+      }],
+    };
   }
 
-  return { content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }] };
+  return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
 };
 
 /**

--- a/src/tools/desktop-register.ts
+++ b/src/tools/desktop-register.ts
@@ -34,6 +34,7 @@ import {
 import { nativeViewFocus } from "../engine/native-engine.js";
 import type { NativeLeaseTokenSummary } from "../engine/native-types.js";
 import type { ToolResult } from "./_types.js";
+import { getSuggestsForCode } from "./_errors.js";
 import type { TouchAction } from "../engine/world-graph/guarded-touch.js";
 import {
   SnapshotIngress,
@@ -529,7 +530,26 @@ const desktopDiscoverRawHandler = async (input: unknown): Promise<ToolResult> =>
  *  `DESKTOP_TOUCH_STAGE5_DXGI !== "0"` (default ON; opt-out by setting
  *  to `"0"`). Failures degrade silently — observation absence is
  *  bit-equal to the pre-Stage-5 envelope. */
-const desktopActRawHandler = async (
+/**
+ * Issue #327 item G: `GuardedTouchLoop.touch` returns `{ok:false, reason:"executor_failed"}`
+ * on executor exception (`guarded-touch.ts:315-319`). The handler-return path bypasses
+ * the L5 wrapper's `buildFailureEnvelope` typed-injection (which only fires on lease
+ * validation failure or handler throw), so the envelope ships with no `if_unexpected`
+ * recovery hint. We attach it here so the LLM client gets the same recovery surface
+ * documented in the tool description. The advisory ↔ runtime drift is tracked for the
+ * path-class refactor epic per `project_path_class_refactor_pending` memory.
+ */
+function buildExecutorFailedIfUnexpected(): {
+  most_likely_cause: "ExecutorFailed";
+  try_next: Array<{ action: string }>;
+} {
+  return {
+    most_likely_cause: "ExecutorFailed",
+    try_next: getSuggestsForCode("ExecutorFailed").map((action) => ({ action })),
+  };
+}
+
+export const desktopActRawHandler = async (
   input: { lease: EntityLease; action?: TouchAction; text?: string },
 ): Promise<ToolResult> => {
   const validationError = validateDesktopTouchTextRequirement(input.action, input.text);
@@ -552,7 +572,12 @@ const desktopActRawHandler = async (
     }
   }
 
-  return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+  const payload: Record<string, unknown> = { ...result };
+  if (!result.ok && result.reason === "executor_failed") {
+    payload["if_unexpected"] = buildExecutorFailedIfUnexpected();
+  }
+
+  return { content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }] };
 };
 
 /**

--- a/tests/unit/desktop-register.test.ts
+++ b/tests/unit/desktop-register.test.ts
@@ -5,8 +5,10 @@ import {
   getDesktopFacade,
   _resetFacadeForTest,
   createCachedProductionWindowsProvider,
+  desktopActRawHandler,
 } from "../../src/tools/desktop-register.js";
 import { DesktopFacade } from "../../src/tools/desktop.js";
+import type { EntityLease } from "../../src/engine/world-graph/types.js";
 
 afterEach(() => {
   _resetFacadeForTest();
@@ -294,5 +296,86 @@ describe("createCachedProductionWindowsProvider — TTL cache", () => {
 
     expect(second[0]!.title).toBe("Second");
     expect(enumerate).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ─── Issue #327 item G — executor_failed envelope carries if_unexpected ───────
+
+describe("desktopActRawHandler — executor_failed if_unexpected attach (#327 item G)", () => {
+  const fakeLease: EntityLease = {
+    entityId: "e1",
+    viewId: "v1",
+    targetGeneration: "g1",
+    expiresAtMs: Number.MAX_SAFE_INTEGER,
+    evidenceDigest: "d1",
+  };
+
+  function parseHandlerResult(content: ReadonlyArray<{ type: string; text?: string }>): Record<string, unknown> {
+    const block = content[0];
+    if (!block || block.type !== "text" || typeof block.text !== "string") {
+      throw new Error("expected text content");
+    }
+    return JSON.parse(block.text) as Record<string, unknown>;
+  }
+
+  it("attaches if_unexpected.most_likely_cause='ExecutorFailed' + try_next when touch returns executor_failed", async () => {
+    const facade = getDesktopFacade();
+    vi.spyOn(facade, "touch").mockResolvedValue({
+      ok: false,
+      reason: "executor_failed",
+      diff: [],
+    });
+    const result = await desktopActRawHandler({ lease: fakeLease, action: "click" });
+    const parsed = parseHandlerResult(result.content);
+
+    expect(parsed["ok"]).toBe(false);
+    expect(parsed["reason"]).toBe("executor_failed");
+
+    const ifUnexpected = parsed["if_unexpected"] as { most_likely_cause?: unknown; try_next?: unknown } | undefined;
+    expect(ifUnexpected).toBeDefined();
+    expect(ifUnexpected?.most_likely_cause).toBe("ExecutorFailed");
+    expect(Array.isArray(ifUnexpected?.try_next)).toBe(true);
+    const tryNext = ifUnexpected?.try_next as Array<{ action?: unknown }>;
+    expect(tryNext.length).toBeGreaterThan(0);
+    expect(typeof tryNext[0]!.action).toBe("string");
+  });
+
+  it("does NOT attach if_unexpected when touch fails with a different reason (e.g. modal_blocking) — scope pin", async () => {
+    const facade = getDesktopFacade();
+    vi.spyOn(facade, "touch").mockResolvedValue({
+      ok: false,
+      reason: "modal_blocking",
+      diff: [],
+    });
+    const result = await desktopActRawHandler({ lease: fakeLease, action: "click" });
+    const parsed = parseHandlerResult(result.content);
+
+    expect(parsed["ok"]).toBe(false);
+    expect(parsed["reason"]).toBe("modal_blocking");
+    expect(parsed["if_unexpected"]).toBeUndefined();
+  });
+
+  it("does NOT attach if_unexpected when touch succeeds", async () => {
+    const facade = getDesktopFacade();
+    vi.spyOn(facade, "touch").mockResolvedValue({
+      ok: true,
+      executor: "uia",
+      diff: [],
+      next: "none",
+    });
+    const previousStage5 = process.env["DESKTOP_TOUCH_STAGE5_DXGI"];
+    process.env["DESKTOP_TOUCH_STAGE5_DXGI"] = "0";
+    try {
+      const result = await desktopActRawHandler({ lease: fakeLease, action: "click" });
+      const parsed = parseHandlerResult(result.content);
+      expect(parsed["ok"]).toBe(true);
+      expect(parsed["if_unexpected"]).toBeUndefined();
+    } finally {
+      if (previousStage5 === undefined) {
+        delete process.env["DESKTOP_TOUCH_STAGE5_DXGI"];
+      } else {
+        process.env["DESKTOP_TOUCH_STAGE5_DXGI"] = previousStage5;
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary

Issue #327 item G: `desktop_act` returns `reason: "executor_failed"` with no `if_unexpected` / `suggest` recovery hint, despite the tool description advertising one. The agent triaging #327 ranked this as the second-cheapest fix with meaningful LLM-recovery improvement.

This is a **tactical local fix** per `project_path_class_refactor_pending` memory — the broader advisory ↔ runtime drift class (G + C + D + E shared pattern) is deferred to the path-class refactor epic, where the structural fix (unified `Result<Ok, Err>` failure path) will land. Here we just close the executor_failed hole.

## Root cause (three-layer drift)

1. `GuardedTouchLoop.touch` returns `{ok:false, reason:"executor_failed"}` at `src/engine/world-graph/guarded-touch.ts:315-319` — a **return**, not a throw.
2. The L5 wrapper `makeCommitWrapper` (`src/tools/_envelope.ts:2904-3003`) only fires `buildFailureEnvelope` (which injects typed `if_unexpected`) on (a) lease validation failure or (b) handler throw. Handler-return failures skip the typed-injection path entirely.
3. `src/tools/_errors.ts` SUGGESTS dict had **no** `ExecutorFailed` entry (zero hits across 60+ codes). Even if the path fired there was nothing to surface.

## Diff

| File | Change |
|---|---|
| `src/tools/_errors.ts` | New `ExecutorFailed` SUGGESTS entry (4 recovery hints derived from #327 dogfood evidence) |
| `src/tools/desktop-register.ts` | Import `getSuggestsForCode`, export `desktopActRawHandler`, attach `if_unexpected` after `facade.touch()` when `result.ok===false && result.reason==="executor_failed"` only |
| `tests/unit/desktop-register.test.ts` | +3 tests (executor_failed attaches, modal_blocking does NOT, success does NOT) |

## Scope discipline

Other failure reasons (`modal_blocking` / `lease_expired` / `entity_outside_viewport` / etc.) have the same structural drift — they return through the handler-return path that bypasses `buildFailureEnvelope`. **Those are intentionally NOT touched** by this PR. The path-class refactor will fix them all in one structural pass; piecemeal local attaches per-reason is the wrong investment.

The new test `does NOT attach if_unexpected when touch fails with a different reason (e.g. modal_blocking) — scope pin` mechanically enforces this scope: if a future PR widens the attach to other reasons, this test must be updated explicitly.

## Recovery-hint content

The four entries derive from #327 dogfood evidence:

1. `action='click'` → `mouse_click({clickAt})` (covers UIA InvokePattern missing — #327 item C symptom)
2. `action='type'` / `action='setValue'` → `keyboard({action:'type', text})` (covers UIA ValuePattern missing / PowerShell locator filter mismatch — #327 item E symptom)
3. `click_element({name|automationId})` (different UIA path, may succeed when desktop_act's threw)
4. Re-run `desktop_discover` (stale-locator case)

## Test plan

- [x] `npm run build` clean
- [x] `npx vitest run tests/unit/desktop-register.test.ts` → 24/24 pass (3 new)
- [x] Full `npm run test:capture` → 3495 pass / 0 fail / 32 skip / 5 todo
- [ ] Opus phase-boundary review (§3.3 Step 1)
- [ ] Codex review (`@codex review`, §3.3 Step 2 — production code change)

Closes part of #327 (item G).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
