### PR TITLE
fix(desktop_act): UIA setValue → keyboardTypeBg fallback ladder (#327 item E)

### DIFF
--- a/src/engine/world-graph/types.ts
+++ b/src/engine/world-graph/types.ts
@@ -22,7 +22,18 @@ export interface EntityLocator {
 }
 export type AffordanceVerb = "invoke" | "click" | "type" | "select" | "scrollTo" | "read";
 export type EntitySourceKind = "uia" | "cdp" | "win32" | "ocr" | "som" | "visual_gpu" | "terminal" | "inferred";
-export type ExecutorKind = "uia" | "cdp" | "terminal" | "mouse";
+/**
+ * `"keyboard"` is a sub-executor used as a fallback from the UIA `setValue` route
+ * when `uiaSetValue` throws (e.g. Notepad's RichEditD2DPT exposes `ValuePattern` but
+ * `makeSetElementValueScript`'s `name -like '*…*'` locator filter cannot reach the
+ * entity — issue #327 item E). The fallback posts WM_CHAR to the focused child via
+ * `bg-input.ts::postCharsToHwnd` (same primitive `terminalSend` uses). It is NOT
+ * a primary executor advertised in `UiAffordance.executors` or `unsupportedExecutors`
+ * — those remain the 4-executor union (`uia | cdp | terminal | mouse`). The
+ * path-class refactor epic may promote it to a first-class executor once the
+ * capability registry consolidates the ladder.
+ */
+export type ExecutorKind = "uia" | "cdp" | "terminal" | "mouse" | "keyboard";
 
 export interface UiAffordance {
   verb: AffordanceVerb;

--- a/src/tools/_errors.ts
+++ b/src/tools/_errors.ts
@@ -283,7 +283,7 @@ const SUGGESTS: Record<string, string[]> = {
   // matching the wiring the dogfood confirmed actually works.
   ExecutorFailed: [
     "For action='click', fall back to mouse_click({clickAt}) using the entity rect center from desktop_discover — common when UIA InvokePattern is missing on the control",
-    "For action='type' or action='setValue', fall back to keyboard({action:'type', text}) after focusing the target — common when UIA ValuePattern is missing or the locator filter cannot re-find the entity",
+    "For action='type' or action='setValue': desktop_act has already tried UIA setValue and background WM_CHAR (post-#327 E ladder) before reporting executor_failed. The remaining rung is keyboard({action:'type', text, method:'foreground'}) — foreground SendInput uses the OS input queue and bypasses BG injection blocks that stopped the internal ladder (Chromium hosts, WT-XAML, etc.). Focus the target window first with focus_window or mouse_click",
     "If the entity has a stable name or automationId, try click_element({name|automationId}) — uses a different UIA path than desktop_act and may succeed where this executor threw",
     "Re-run desktop_discover — the entity may have moved or been re-keyed between discover and act, in which case the executor saw a stale locator",
   ],

--- a/src/tools/desktop-executor.ts
+++ b/src/tools/desktop-executor.ts
@@ -37,6 +37,16 @@ export interface ExecutorDeps {
    * On failure, caller sees ok:false reason:"executor_failed" and can fall back to V1 terminal({action:'send'}).
    */
   terminalSend(windowTitle: string, text: string): Promise<void>;
+  /**
+   * Issue #327 item E: UIA `setValue` fallback. Posts WM_CHAR to the focused child
+   * of the target window via `bg-input.ts::postCharsToHwnd`. Used when the primary
+   * UIA `ValuePattern` route throws (e.g. Notepad's RichEditD2DPT entity whose
+   * locator name/automationId cannot be re-found by `makeSetElementValueScript`).
+   * Throws on unsupported windows (Chromium / WT-XAML) — caller surfaces
+   * executor_failed and the LLM's `if_unexpected.try_next` from PR #329 points
+   * at `mouse_click({clickAt})` as the next rung.
+   */
+  keyboardTypeBg(windowTitle: string, text: string): Promise<void>;
   /** Mouse: click at absolute screen coordinates. */
   mouseClick(x: number, y: number): Promise<void>;
 }
@@ -151,9 +161,31 @@ export function createDesktopExecutor(
       const name         = entity.locator?.uia?.name ?? entity.label;
       // Phase 4: 'setValue' absorbs former set_element_value tool — same UIA
       // ValuePattern path as 'type'. Both actions land here for any UIA entity.
+      //
+      // Issue #327 item E: when `uiaSetValue` throws (most commonly because the
+      // PowerShell `name -like '*…*'` locator filter in `makeSetElementValueScript`
+      // cannot re-find the entity — Notepad's RichEditD2DPT with empty/unstable name
+      // is the canonical dogfood case), fall back to background WM_CHAR injection
+      // via `keyboardTypeBg`. The fallback uses the same primitive as `terminalSend`
+      // and respects `canInjectAtTarget` so Chromium / UWP / WT-XAML hosts still
+      // surface executor_failed cleanly. On combined failure we surface a joint
+      // error message so the LLM sees both rungs' diagnostics in one envelope.
       if ((action === "type" || action === "setValue") && text !== undefined) {
-        await d.uiaSetValue(winTitle, text, name, automationId);
-        return "uia";
+        try {
+          await d.uiaSetValue(winTitle, text, name, automationId);
+          return "uia";
+        } catch (uiaErr) {
+          try {
+            await d.keyboardTypeBg(winTitle, text);
+            return "keyboard";
+          } catch (kbErr) {
+            throw new Error(
+              `Type fallback ladder exhausted for "${entity.label ?? entity.entityId}": ` +
+              `uia=${uiaErr instanceof Error ? uiaErr.message : String(uiaErr)} / ` +
+              `keyboard=${kbErr instanceof Error ? kbErr.message : String(kbErr)}`,
+            );
+          }
+        }
       }
       try {
         await d.uiaClick(winTitle, name, automationId);
@@ -296,6 +328,35 @@ function getSharedRealDeps(): ExecutorDeps {
         canBgSend:  (hwnd) => canInjectViaPostMessage(hwnd),
         bgSend:     (hwnd, t) => postCharsToHwnd(hwnd, t),
       });
+    },
+
+    async keyboardTypeBg(windowTitle, text) {
+      // Issue #327 item E: UIA setValue fallback. Uses the same WM_CHAR primitive
+      // as terminalSend but resolves to the focused child via `canInjectAtTarget`
+      // so the BG class check classifies the actual key-receiving HWND (Notepad's
+      // RichEditD2DPT child rather than the "Notepad" top-level). Chromium / WT-XAML
+      // hosts surface "Background keyboard type not supported" so the joint error
+      // message above (`Type fallback ladder exhausted: ...`) carries the diagnostic.
+      const { enumWindowsInZOrder } = await import("../engine/win32.js");
+      const { canInjectAtTarget, postCharsToHwnd } = await import("../engine/bg-input.js");
+      const wins = enumWindowsInZOrder();
+      const win = wins.find((w) => w.title.toLowerCase().includes(windowTitle.toLowerCase()));
+      if (!win) {
+        throw new Error(`Window not found for keyboardTypeBg: "${windowTitle}"`);
+      }
+      const check = canInjectAtTarget(win.hwnd);
+      if (!check.supported) {
+        throw new Error(
+          `Background keyboard type not supported for "${windowTitle}" ` +
+          `(${check.reason ?? "unknown"}, class: ${check.className ?? "?"}).`,
+        );
+      }
+      const r = postCharsToHwnd(win.hwnd, text);
+      if (!r.full) {
+        throw new Error(
+          `Background keyboard type incomplete: sent ${r.sent}/${text.length} chars to "${windowTitle}"`,
+        );
+      }
     },
 
     async mouseClick(x, y) {

--- a/src/tools/desktop-executor.ts
+++ b/src/tools/desktop-executor.ts
@@ -44,7 +44,14 @@ export interface ExecutorDeps {
    * locator name/automationId cannot be re-found by `makeSetElementValueScript`).
    * Throws on unsupported windows (Chromium / WT-XAML) — caller surfaces
    * executor_failed and the LLM's `if_unexpected.try_next` from PR #329 points
-   * at `mouse_click({clickAt})` as the next rung.
+   * at `keyboard({action:'type', text, method:'foreground'})` as the next rung
+   * (FG SendInput bypasses BG injection restrictions).
+   *
+   * Success returns the `"keyboard"` ExecutorKind. Note that `"keyboard"` is an
+   * internal-fallback-only executor — it is NOT advertised in
+   * `UiAffordance.executors` / `UiEntity.unsupportedExecutors` (both remain the
+   * 4-executor union). See `types.ts::ExecutorKind` JSDoc for the
+   * advertised-surface rationale.
    */
   keyboardTypeBg(windowTitle: string, text: string): Promise<void>;
   /** Mouse: click at absolute screen coordinates. */
@@ -183,6 +190,7 @@ export function createDesktopExecutor(
               `Type fallback ladder exhausted for "${entity.label ?? entity.entityId}": ` +
               `uia=${uiaErr instanceof Error ? uiaErr.message : String(uiaErr)} / ` +
               `keyboard=${kbErr instanceof Error ? kbErr.message : String(kbErr)}`,
+              { cause: kbErr },
             );
           }
         }
@@ -337,6 +345,15 @@ function getSharedRealDeps(): ExecutorDeps {
       // RichEditD2DPT child rather than the "Notepad" top-level). Chromium / WT-XAML
       // hosts surface "Background keyboard type not supported" so the joint error
       // message above (`Type fallback ladder exhausted: ...`) carries the diagnostic.
+      //
+      // Opus Round 1 P2-2 note (PR #330): the LLM-visible BG path at
+      // `keyboard.ts:973` gates on `canInjectViaPostMessage(top-level hwnd)` and
+      // delegates to `postCharsToHwnd` which internally resolves the child via
+      // `resolveTarget`. The asymmetry is deliberate here — the child-class check
+      // is the right semantic for "send keys to the active edit control" and the
+      // Notepad RichEditD2DPT case is exactly where the parent-class check is too
+      // coarse. The path-class refactor epic should reconcile both BG paths under
+      // a single semantic (tracked in memory `project_path_class_refactor_pending`).
       const { enumWindowsInZOrder } = await import("../engine/win32.js");
       const { canInjectAtTarget, postCharsToHwnd } = await import("../engine/bg-input.js");
       const wins = enumWindowsInZOrder();

--- a/tests/unit/desktop-executor.test.ts
+++ b/tests/unit/desktop-executor.test.ts
@@ -26,12 +26,13 @@ function entity(overrides: Partial<UiEntity> = {}): UiEntity {
 
 function mockDeps(overrides: Partial<ExecutorDeps> = {}): ExecutorDeps {
   return {
-    uiaClick:     vi.fn(async () => {}),
-    uiaSetValue:  vi.fn(async () => {}),
-    cdpClick:     vi.fn(async () => {}),
-    cdpFill:      vi.fn(async () => {}),
-    terminalSend: vi.fn(async () => {}),
-    mouseClick:   vi.fn(async () => {}),
+    uiaClick:       vi.fn(async () => {}),
+    uiaSetValue:    vi.fn(async () => {}),
+    cdpClick:       vi.fn(async () => {}),
+    cdpFill:        vi.fn(async () => {}),
+    terminalSend:   vi.fn(async () => {}),
+    keyboardTypeBg: vi.fn(async () => {}),
+    mouseClick:     vi.fn(async () => {}),
     ...overrides,
   };
 }
@@ -179,6 +180,63 @@ describe("createDesktopExecutor — error handling and UIA fallback", () => {
     const deps = mockDeps({ cdpClick: vi.fn(async () => { throw new Error("CDP error"); }) });
     const exec = createDesktopExecutor({ tabId: "t" }, deps);
     await expect(exec(entity({ sources: ["cdp"], sourceId: "#x" }), "click")).rejects.toThrow("CDP error");
+  });
+});
+
+// ─── Issue #327 item E — UIA setValue → keyboardTypeBg fallback ladder ────────
+
+describe("createDesktopExecutor — UIA setValue → keyboardTypeBg fallback (#327 item E)", () => {
+  it("uiaSetValue success path: no keyboardTypeBg call, returns 'uia' (regression pin)", async () => {
+    const deps = mockDeps();
+    const exec = createDesktopExecutor({ windowTitle: "Notepad" }, deps);
+    const result = await exec(entity({ sources: ["uia"] }), "type", "hello");
+    expect(result).toBe("uia");
+    expect(deps.uiaSetValue).toHaveBeenCalledOnce();
+    expect(deps.keyboardTypeBg).not.toHaveBeenCalled();
+  });
+
+  it("uiaSetValue throws + keyboardTypeBg succeeds → returns 'keyboard' (the E1 fix)", async () => {
+    const deps = mockDeps({
+      uiaSetValue: vi.fn(async () => { throw new Error("Element not found"); }),
+    });
+    const exec = createDesktopExecutor({ windowTitle: "Notepad" }, deps);
+    const result = await exec(entity({ sources: ["uia"] }), "type", "hello");
+    expect(result).toBe("keyboard");
+    expect(deps.uiaSetValue).toHaveBeenCalledOnce();
+    expect(deps.keyboardTypeBg).toHaveBeenCalledWith("Notepad", "hello");
+  });
+
+  it("setValue action also falls through to keyboardTypeBg on uiaSetValue failure", async () => {
+    const deps = mockDeps({
+      uiaSetValue: vi.fn(async () => { throw new Error("PowerShell locator filter mismatch"); }),
+    });
+    const exec = createDesktopExecutor({ windowTitle: "App" }, deps);
+    const result = await exec(entity({ sources: ["uia"] }), "setValue", "x");
+    expect(result).toBe("keyboard");
+    expect(deps.keyboardTypeBg).toHaveBeenCalledWith("App", "x");
+  });
+
+  it("both uiaSetValue AND keyboardTypeBg throw → combined error surfaces both diagnostics", async () => {
+    const deps = mockDeps({
+      uiaSetValue:    vi.fn(async () => { throw new Error("UIA name mismatch"); }),
+      keyboardTypeBg: vi.fn(async () => { throw new Error("WT-XAML host blocked"); }),
+    });
+    const exec = createDesktopExecutor({ windowTitle: "Terminal" }, deps);
+    await expect(exec(entity({ sources: ["uia"] }), "type", "x"))
+      .rejects.toThrow(/Type fallback ladder exhausted.*uia=UIA name mismatch.*keyboard=WT-XAML host blocked/);
+  });
+
+  it("text=undefined (no type/setValue): no keyboardTypeBg call (scope pin — click/invoke unchanged)", async () => {
+    const deps = mockDeps({
+      uiaClick: vi.fn(async () => { throw new Error("InvokePattern missing"); }),
+    });
+    const exec = createDesktopExecutor({ hwnd: "1" }, deps);
+    const result = await exec(
+      entity({ sources: ["uia"], rect: { x: 100, y: 200, width: 80, height: 30 } }),
+      "click",
+    );
+    expect(result).toBe("mouse"); // existing click → mouse fallback path unchanged
+    expect(deps.keyboardTypeBg).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

Issue #327 item E: `desktop_act({action:'type'|'setValue'})` against a UIA entity returns `executor_failed` when `makeSetElementValueScript`'s PowerShell name filter cannot re-find the entity. The canonical dogfood case is Notepad's RichEditD2DPT main edit area (empty / unstable name) — a path Claude Code will hit constantly, and today it fails outright.

This PR adds a tactical fallback ladder inside the UIA route: when `uiaSetValue` throws, fall back to a new `keyboardTypeBg` dep that posts WM_CHAR to the focused child via the same primitive `terminalSend` already uses (`bg-input.ts::postCharsToHwnd`). The combined-failure path surfaces both diagnostics in one error so the LLM (and PR #329's `if_unexpected.try_next`) sees the full ladder context.

## Why this approach

| | UIA setValue (today) | UIA setValue + keyboardTypeBg (this PR) |
|---|---|---|
| Notepad text input | ❌ `executor_failed` (PowerShell `-like '*…*'` filter rejects empty name) | ✅ Posts WM_CHAR to RichEditD2DPT child |
| Chromium / WT-XAML | ❌ Same failure mode | ❌ Same — `canInjectAtTarget` returns unsupported, joint error carries both diagnostics |
| Already-working UIA-named text fields | ✅ Works | ✅ Same (uiaSetValue succeeds, fallback not invoked) |
| Click / invoke action | (no fallback ladder for these) | (unchanged — scope pin test enforces) |

`keyboardTypeBg` uses **`canInjectAtTarget`** (not `canInjectViaPostMessage`) so the BG class check resolves to the *focused child* — Notepad's RichEditD2DPT child rather than the top-level "Notepad" window. This mirrors `_focus.ts`'s use of the same primitive and is the correct semantic for "send keys to the active edit control".

## Diff

| File | Change |
|---|---|
| `src/engine/world-graph/types.ts:25` | `ExecutorKind` extended with `"keyboard"`. Documented as internal-fallback-only — NOT added to `UiAffordance.executors` or `unsupportedExecutors` (those remain the 4-executor union). Promotion to first-class is a path-class refactor question. |
| `src/tools/desktop-executor.ts` | `ExecutorDeps.keyboardTypeBg(windowTitle, text)` added, real impl in `getSharedRealDeps` (mirrors `terminalSend` but uses `canInjectAtTarget`), UIA route at L154+ wraps `uiaSetValue` in try/catch and falls back to `keyboardTypeBg`. Combined-failure throw carries both diagnostics. |
| `tests/unit/desktop-executor.test.ts` | `mockDeps` updated + 5 new tests (success regression pin, `type` fallback, `setValue` fallback, combined failure, click-action scope pin). |

## Scope discipline

Per `project_path_class_refactor_pending` memory and the user's "リファクタリングのタイミングでやる" directive, **this PR does NOT**:

- Add `"keyboard"` to `AFFORDANCE_MAP.type.executors` (advertised capability stays the same — promotion is a refactor question).
- Add `"keyboard"` to `unsupportedExecutors` union (keeps the LLM-facing capabilities surface stable).
- Touch the CDP `cdpFill` or terminal `terminalSend` paths.
- Add a similar fallback ladder to the UIA click path (that's item C's territory, separate PR).

The new test `text=undefined (no type/setValue): no keyboardTypeBg call (scope pin — click/invoke unchanged)` mechanically prevents future widening.

## Test plan

- [x] `npm run build` clean
- [x] `npx vitest run tests/unit/desktop-executor.test.ts` → 42/42 pass (5 new)
- [x] Full `npm run test:capture` → 3499 pass / 1 pre-existing flake (`benchmark-gates.test.ts` ReplayBackend cold-vs-warm — same flake observed in other recent PRs, not introduced here)
- [ ] Opus phase-boundary review (§3.3 Step 1)
- [ ] Codex review (`@codex review`, §3.3 Step 2 — production code change)

Closes part of #327 (item E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
