### PR TITLE
fix(touch): isModalLike sync with isModalCandidate (#327 item D, completes #297)

### DIFF
--- a/src/engine/world-graph/guarded-touch.ts
+++ b/src/engine/world-graph/guarded-touch.ts
@@ -1,6 +1,7 @@
 import type { UiEntity, EntityLease, ExecutorKind, UiAffordance } from "./types.js";
 import type { LeaseStore } from "./lease-store.js";
 import type { VisualMotionObservation } from "../../tools/_input-pipeline.js";
+import { isChromeControlType } from "./session-registry.js";
 
 export type TouchAction = "auto" | "invoke" | "click" | "type" | "setValue" | "select";
 
@@ -161,9 +162,20 @@ function hasEntityMoved(pre: UiEntity, post: UiEntity): boolean {
  * Conservative — plain toolbar buttons have specific roles and are excluded.
  * A richer heuristic (ControlType=Dialog, IsModal=true) requires UIA property access
  * not yet wired.
+ *
+ * Issue #327 item D / Issue #297 closure completion: UI chrome
+ * (MenuBar / TitleBar / StatusBar / ToolBar / ScrollBar / Tab / Menu / MenuItem)
+ * also surfaces as `role: "unknown"` on UIA, so without a controlType check
+ * Notepad's TitleBar / MenuBar / StatusBar fire `modal_appeared` every time the
+ * UIA snapshot re-keys those entities. The shared `isChromeControlType` helper
+ * from `session-registry.ts` keeps this predicate bit-equal with the pre-touch
+ * `isModalCandidate` path so the two modal detectors cannot diverge again.
  */
 function isModalLike(e: UiEntity): boolean {
-  return e.sources.includes("uia") && e.role === "unknown";
+  if (!e.sources.includes("uia")) return false;
+  if (e.role !== "unknown") return false;
+  if (isChromeControlType(e.controlType)) return false;
+  return true;
 }
 
 /**

--- a/src/engine/world-graph/session-registry.ts
+++ b/src/engine/world-graph/session-registry.ts
@@ -37,6 +37,22 @@ const NON_MODAL_CHROME_CONTROL_TYPES = new Set([
 ]);
 
 /**
+ * Issue #297 / #327 item D: shared predicate for "is this `controlType` a UI
+ * chrome bucket that the modal detectors must always exclude?". Originally
+ * inlined in `isModalCandidate` (pre-touch) only; #327 item D surfaced that
+ * the post-touch diff classifier `isModalLike` (guarded-touch.ts) was applying
+ * the same intent on a different signal set, so Notepad's TitleBar / MenuBar /
+ * StatusBar fired `modal_appeared` on every entity-ID churn. The shared helper
+ * makes the SSOT explicit — adding a new chrome bucket requires updating
+ * `NON_MODAL_CHROME_CONTROL_TYPES` here, and every caller picks it up. Entities
+ * without `controlType` (legacy / non-UIA producers) fall through to the
+ * caller's prior behaviour for back-compat.
+ */
+export function isChromeControlType(controlType: string | undefined): boolean {
+  return controlType !== undefined && NON_MODAL_CHROME_CONTROL_TYPES.has(controlType);
+}
+
+/**
  * Shared predicate used by the default `isModalBlocking` and `findBlockingModal`
  * implementations so they cannot diverge. UIA exposes system dialogs and
  * overlays as `role: "unknown"` elements; the self-exclusion (entityId !==)
@@ -78,12 +94,7 @@ export function isModalCandidate(target: UiEntity, candidate: UiEntity): boolean
   if (candidate.entityId === target.entityId) return false;
   if (!candidate.sources.includes("uia")) return false;
   if (candidate.role !== "unknown") return false;
-  if (
-    candidate.controlType !== undefined &&
-    NON_MODAL_CHROME_CONTROL_TYPES.has(candidate.controlType)
-  ) {
-    return false;
-  }
+  if (isChromeControlType(candidate.controlType)) return false;
   return true;
 }
 

--- a/tests/unit/guarded-touch.test.ts
+++ b/tests/unit/guarded-touch.test.ts
@@ -333,6 +333,69 @@ describe("GuardedTouchLoop — semantic diff", () => {
     if (result.ok) expect(result.diff).not.toContain("modal_appeared");
   });
 
+  // Issue #327 item D / Issue #297 closure completion: post-touch isModalLike
+  // must exclude the same NON_MODAL_CHROME_CONTROL_TYPES list that pre-touch
+  // isModalCandidate uses, otherwise Notepad-style chrome entities (TitleBar /
+  // MenuBar / StatusBar) fire spurious modal_appeared whenever the UIA snapshot
+  // re-keys them — exactly what dogfood saw on Notepad text-area clicks.
+  for (const chromeType of ["MenuBar", "TitleBar", "StatusBar", "ToolBar", "ScrollBar", "Tab", "Menu", "MenuItem"] as const) {
+    it(`UIA role=unknown chrome with controlType=${chromeType} does NOT trigger modal_appeared (#327 item D)`, async () => {
+      const btn    = entity("btn", GEN, { sources: ["visual_gpu"] });
+      const chrome = entity("chrome", GEN, {
+        sources: ["uia"],
+        role: "unknown",
+        controlType: chromeType,
+      });
+      const store = new LeaseStore({ nowFn: () => 0, defaultTtlMs: 60_000 });
+      const lease = store.issue(btn, "v1");
+      const loop  = new GuardedTouchLoop(store, makeEnv({
+        resolveLiveEntities:      () => [btn],
+        resolvePostTouchEntities: async () => [btn, chrome],
+      }));
+      const result = await loop.touch({ lease });
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.diff).not.toContain("modal_appeared");
+    });
+  }
+
+  it("UIA role=unknown with controlType=Pane (no chrome exclusion) DOES trigger modal_appeared — scope pin", async () => {
+    // Genuine dialogs / overlays surface as role=unknown without a chrome controlType
+    // (often controlType=Pane / Window for modal dialogs). The chrome filter must
+    // NOT swallow these — this test pins that direction of the rule.
+    const btn    = entity("btn", GEN, { sources: ["visual_gpu"] });
+    const dialog = entity("dialog", GEN, {
+      sources: ["uia"],
+      role: "unknown",
+      controlType: "Pane",
+    });
+    const store = new LeaseStore({ nowFn: () => 0, defaultTtlMs: 60_000 });
+    const lease = store.issue(btn, "v1");
+    const loop  = new GuardedTouchLoop(store, makeEnv({
+      resolveLiveEntities:      () => [btn],
+      resolvePostTouchEntities: async () => [btn, dialog],
+    }));
+    const result = await loop.touch({ lease });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.diff).toContain("modal_appeared");
+  });
+
+  it("UIA role=unknown without controlType (legacy producer) DOES trigger modal_appeared — back-compat pin", async () => {
+    // Entities from non-UIA-fronted producers (legacy bridge, visual-only) won't
+    // have a controlType field. The chrome filter must fall through and the
+    // role-based heuristic must keep firing — preserves pre-#297 behaviour.
+    const btn    = entity("btn", GEN, { sources: ["visual_gpu"] });
+    const modal  = entity("modal", GEN, { sources: ["uia"], role: "unknown" });
+    const store  = new LeaseStore({ nowFn: () => 0, defaultTtlMs: 60_000 });
+    const lease  = store.issue(btn, "v1");
+    const loop   = new GuardedTouchLoop(store, makeEnv({
+      resolveLiveEntities:      () => [btn],
+      resolvePostTouchEntities: async () => [btn, modal],
+    }));
+    const result = await loop.touch({ lease });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.diff).toContain("modal_appeared");
+  });
+
   it("diff is empty and next='none' when nothing changed", async () => {
     const e = entity("e1", GEN);
     const store = new LeaseStore({ nowFn: () => 0, defaultTtlMs: 60_000 });


### PR DESCRIPTION
## Summary

Issue #327 item D, also **Issue #297 closure completion**: PR #301 added `NON_MODAL_CHROME_CONTROL_TYPES` exclusion to the pre-touch `isModalCandidate` predicate, but the post-touch diff classifier `isModalLike` was left without the matching check. As a result Notepad's TitleBar / MenuBar / StatusBar entities — all `role: "unknown"` on UIA — triggered spurious `modal_appeared` on every text-area click during #327 Stage 5 dogfood.

**D is NOT a new regression** — the predicate drift existed since PR #301 landed, but the canonical dogfood target (Notepad) only lit it up now.

## Diff

| File | Change |
|---|---|
| `src/engine/world-graph/session-registry.ts` | Extracted `export function isChromeControlType(controlType: string \| undefined): boolean` wrapping the `NON_MODAL_CHROME_CONTROL_TYPES` set check. `isModalCandidate` now calls the helper (mechanical refactor, no semantic change). |
| `src/engine/world-graph/guarded-touch.ts` | `isModalLike` now applies the same `isChromeControlType` exclusion. Function body restructured into three guards matching `isModalCandidate` so the two cannot diverge structurally again. |
| `tests/unit/guarded-touch.test.ts` | +10 tests (8 parametric per chrome type + Pane scope-pin + no-controlType back-compat pin) |

## Why the helper extraction (rather than inline)

Adding a new chrome bucket to the `NON_MODAL_CHROME_CONTROL_TYPES` set in the future used to be a single-file change that silently regressed `isModalLike`. With the shared helper:

1. The set lives in one place.
2. Both predicates derive from it.
3. The drift class that caused #327 item D is structurally eliminated — a future bucket addition cannot revive the regression.

This matches the agent triage's option 1 (low rollout risk, Issue #297 completion intent) and CLAUDE.md §3.1 SSOT pattern.

## Test coverage

10 new tests pin the rule mechanically:

- **8 parametric** (one per chrome `controlType`): `MenuBar / TitleBar / StatusBar / ToolBar / ScrollBar / Tab / Menu / MenuItem` with `role: "unknown"` must NOT trigger `modal_appeared` post-touch.
- **Scope pin** (`controlType: "Pane"`): genuine `role: "unknown"` dialog / overlay still triggers `modal_appeared` — the chrome filter must NOT swallow real modals.
- **Back-compat pin** (no `controlType`): legacy non-UIA-fronted producers that emit `role: "unknown"` without `controlType` fall through to the prior role-based heuristic. Preserves pre-#297 behaviour.

## Scope discipline

Per `project_path_class_refactor_pending` memory, the broader unification of pre-touch and post-touch modal classifiers under a single `computeDiff`-aware helper (agent option 2) is deferred to the path-class refactor epic. This PR is the minimal mechanical change to close #327 item D and complete the Issue #297 fix.

## Test plan

- [x] `npm run build` clean
- [x] `npx vitest run tests/unit/guarded-touch.test.ts tests/unit/session-registry.test.ts` → 59/59 pass (10 new)
- [x] Full `npm run test:capture` → 3507 pass / 3 pre-existing env / timing flakes (`ui-pattern-store-persistence` ENOENT, `input-pipeline-dispatch` timing threshold, `native-win32-panic-fuzz` 30s timeout — none related to this change)
- [ ] Opus phase-boundary review (§3.3 Step 1)
- [ ] Codex review (`@codex review`, §3.3 Step 2 — production code change)

Closes part of #327 (item D) and completes #297.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
