### PR TITLE
fix(desktop_act): surface UIA→mouse downgrade marker on TouchResult (#327 item C)

### DIFF
--- a/src/engine/world-graph/guarded-touch.ts
+++ b/src/engine/world-graph/guarded-touch.ts
@@ -1,4 +1,4 @@
-import type { UiEntity, EntityLease, ExecutorKind, UiAffordance } from "./types.js";
+import type { UiEntity, EntityLease, ExecutorKind, ExecutorOutcome, UiAffordance } from "./types.js";
 import type { LeaseStore } from "./lease-store.js";
 import type { VisualMotionObservation } from "../../tools/_input-pipeline.js";
 import { isChromeControlType } from "./session-registry.js";
@@ -62,6 +62,17 @@ export type TouchResult =
        * unaffected (additive — sub-plan §2.5 + CLAUDE.md §3.2 carry-over).
        */
       observation?: VisualMotionObservation;
+      /**
+       * Issue #327 item C: surfaced when the executor silently fell back from a
+       * higher-priority executor (e.g. UIA InvokePattern threw and the mouse
+       * rect-center fallback succeeded). Without this marker the LLM sees
+       * `capabilities.preferredExecutors: ["uia"]` ↔ `executor: "mouse"` and
+       * cannot distinguish "UIA was tried and failed" from "UIA was not the
+       * chosen route". The `from` field names the executor that was originally
+       * selected; `reason` is the underlying error message. Absent (= field
+       * undefined) when no fallback happened.
+       */
+      downgrade?: ExecutorOutcome["downgrade"];
     }
   | {
       ok: false;
@@ -94,8 +105,17 @@ export interface TouchEnvironment {
   findBlockingModal?(entity: UiEntity): UiEntity | null;
   /** True if the entity rect is fully or partially within the active viewport. */
   isInViewport(entity: UiEntity): boolean;
-  /** Perform the action and return which executor was used. Throw on failure. */
-  execute(entity: UiEntity, action: TouchAction, text?: string): Promise<ExecutorKind>;
+  /**
+   * Perform the action and return which executor was used. Throw on failure.
+   *
+   * Issue #327 item C: returning the rich `ExecutorOutcome` shape lets the
+   * executor signal a silent fallback (e.g. UIA InvokePattern threw, mouse
+   * rect-center succeeded). Returning a bare `ExecutorKind` means "no
+   * downgrade happened" and stays back-compat with pre-#327 callers.
+   * `GuardedTouchLoop` normalises both shapes and surfaces `TouchResult.downgrade`
+   * on the success variant.
+   */
+  execute(entity: UiEntity, action: TouchAction, text?: string): Promise<ExecutorKind | ExecutorOutcome>;
   /** Return entities after the touch for diff computation. May wait for UI to settle. */
   resolvePostTouchEntities(): Promise<UiEntity[]>;
   /**
@@ -323,12 +343,17 @@ export class GuardedTouchLoop {
     const preFocusId = this.env.getFocusedEntityId?.();
 
     // 5. Execute — no await between validate and execute (TOCTOU prevention).
-    let executor: ExecutorKind;
+    let outcome: ExecutorKind | ExecutorOutcome;
     try {
-      executor = await this.env.execute(entity, concreteAction, text);
+      outcome = await this.env.execute(entity, concreteAction, text);
     } catch {
       return { ok: false, reason: "executor_failed", diff: [] };
     }
+    // Issue #327 item C: normalise bare-kind / rich-outcome return shapes so
+    // downstream stays single-shape.
+    const executor: ExecutorKind = typeof outcome === "string" ? outcome : outcome.kind;
+    const downgrade: ExecutorOutcome["downgrade"] | undefined =
+      typeof outcome === "string" ? undefined : outcome.downgrade;
 
     // 6. Compute semantic diff against the pre-touch snapshot.
     const post        = await this.env.resolvePostTouchEntities();
@@ -336,6 +361,12 @@ export class GuardedTouchLoop {
 
     const diff = computeDiff({ touched: entity, preEntities: live, postEntities: post, preFocusId, postFocusId });
 
-    return { ok: true, executor, diff, next: diff.length > 0 ? "refresh_view" : "none" };
+    return {
+      ok: true,
+      executor,
+      diff,
+      next: diff.length > 0 ? "refresh_view" : "none",
+      ...(downgrade ? { downgrade } : {}),
+    };
   }
 }

--- a/src/engine/world-graph/session-registry.ts
+++ b/src/engine/world-graph/session-registry.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { UiEntityCandidate } from "../vision-gpu/types.js";
-import type { UiEntity, ExecutorKind } from "./types.js";
+import type { UiEntity, ExecutorKind, ExecutorOutcome } from "./types.js";
 import { LeaseStore } from "./lease-store.js";
 import {
   GuardedTouchLoop,
@@ -105,11 +105,17 @@ export type TargetSessionKey =
 
 // ── Executor type ─────────────────────────────────────────────────────────────
 
+/**
+ * Issue #327 item C: returning the rich `ExecutorOutcome` shape lets the executor
+ * signal a silent fallback (e.g. UIA InvokePattern threw, mouse rect-center
+ * succeeded). Bare `ExecutorKind` return remains the back-compat shape for
+ * executors that never downgrade.
+ */
 export type ExecutorFn = (
   entity: UiEntity,
   action: TouchAction,
   text?: string
-) => Promise<ExecutorKind>;
+) => Promise<ExecutorKind | ExecutorOutcome>;
 
 // ── Session state ─────────────────────────────────────────────────────────────
 

--- a/src/engine/world-graph/types.ts
+++ b/src/engine/world-graph/types.ts
@@ -35,6 +35,28 @@ export type EntitySourceKind = "uia" | "cdp" | "win32" | "ocr" | "som" | "visual
  */
 export type ExecutorKind = "uia" | "cdp" | "terminal" | "mouse" | "keyboard";
 
+/**
+ * Issue #327 item C: rich return shape for `ExecutorFn` / `TouchEnvironment.execute`
+ * that lets the executor signal a silent fallback (e.g. UIA InvokePattern threw, mouse
+ * rect-center succeeded) without losing observability. The dogfood symptom was
+ * `capabilities.preferredExecutors: ["uia"]` ↔ `executor: "mouse"` with no marker
+ * explaining the gap.
+ *
+ * Convention: an executor that succeeded without downgrading returns a bare
+ * `ExecutorKind` (back-compat); only the downgrade path returns the rich
+ * `ExecutorOutcome`. `GuardedTouchLoop` normalises both and surfaces
+ * `TouchResult.downgrade` on the success variant.
+ */
+export interface ExecutorOutcome {
+  kind: ExecutorKind;
+  downgrade?: {
+    /** The originally selected executor that threw / was infeasible. */
+    from: ExecutorKind;
+    /** Short human-readable reason — the underlying error message is the canonical source. */
+    reason: string;
+  };
+}
+
 export interface UiAffordance {
   verb: AffordanceVerb;
   executors: ExecutorKind[];

--- a/src/tools/desktop-executor.ts
+++ b/src/tools/desktop-executor.ts
@@ -15,7 +15,7 @@
  *     gets ok:false reason:"executor_failed" and can fall back to V1 terminal({action:'send'}).
  */
 
-import type { UiEntity, ExecutorKind } from "../engine/world-graph/types.js";
+import type { UiEntity, ExecutorKind, ExecutorOutcome } from "../engine/world-graph/types.js";
 import type { TouchAction } from "../engine/world-graph/guarded-touch.js";
 import type { TargetSpec } from "../engine/world-graph/session-registry.js";
 
@@ -138,7 +138,7 @@ function rectCenter(rect: { x: number; y: number; width: number; height: number 
 export function createDesktopExecutor(
   target: TargetSpec | undefined,
   deps?: ExecutorDeps
-): (entity: UiEntity, action: TouchAction, text?: string) => Promise<ExecutorKind> {
+): (entity: UiEntity, action: TouchAction, text?: string) => Promise<ExecutorKind | ExecutorOutcome> {
   const d = deps ?? getSharedRealDeps();
 
   return async (entity, action, text) => {
@@ -198,17 +198,23 @@ export function createDesktopExecutor(
       try {
         await d.uiaClick(winTitle, name, automationId);
         return "uia";
-      } catch {
+      } catch (uiaErr) {
         // UIA click failed (element not found, stale tree, etc.).
         // Prefer entity.rect (freshest, from most-recent candidate) over locator.visual.rect
         // which may be stale (captured at recognition time, before the element moved).
         const rect = entity.rect ?? entity.locator?.visual?.rect;
         if (!rect) throw new Error(
-          `UIA click failed for "${entity.label ?? entity.entityId}" and no rect for mouse fallback`
+          `UIA click failed for "${entity.label ?? entity.entityId}" and no rect for mouse fallback`,
+          { cause: uiaErr },
         );
         const { x, y } = rectCenter(rect);
         await d.mouseClick(x, y);
-        return "mouse";
+        // Issue #327 item C: signal the silent downgrade so the LLM sees
+        // `executor: "mouse"` AND `downgrade: { from: "uia", reason: ... }`
+        // — without the marker the dogfood envelope cannot distinguish
+        // "UIA was tried and failed" from "UIA was not the chosen route".
+        const reason = uiaErr instanceof Error ? uiaErr.message : String(uiaErr);
+        return { kind: "mouse", downgrade: { from: "uia", reason } };
       }
     }
 

--- a/tests/unit/desktop-executor.test.ts
+++ b/tests/unit/desktop-executor.test.ts
@@ -163,7 +163,12 @@ describe("createDesktopExecutor — error handling and UIA fallback", () => {
       entity({ sources: ["uia"], rect: { x: 100, y: 200, width: 80, height: 30 } }),
       "click"
     );
-    expect(result).toBe("mouse");
+    // Issue #327 item C: silent UIA-to-mouse fallback now returns the rich
+    // ExecutorOutcome shape so observability of the downgrade reaches the LLM.
+    expect(result).toEqual({
+      kind: "mouse",
+      downgrade: { from: "uia", reason: "element not found" },
+    });
     expect(deps.mouseClick).toHaveBeenCalledWith(140, 215);
   });
 
@@ -180,6 +185,56 @@ describe("createDesktopExecutor — error handling and UIA fallback", () => {
     const deps = mockDeps({ cdpClick: vi.fn(async () => { throw new Error("CDP error"); }) });
     const exec = createDesktopExecutor({ tabId: "t" }, deps);
     await expect(exec(entity({ sources: ["cdp"], sourceId: "#x" }), "click")).rejects.toThrow("CDP error");
+  });
+});
+
+// ─── Issue #327 item C — UIA click silent fallback observability ──────────────
+
+describe("createDesktopExecutor — UIA click → mouse downgrade marker (#327 item C)", () => {
+  it("UIA click succeeds → returns bare 'uia' (back-compat, no downgrade marker)", async () => {
+    const deps = mockDeps();
+    const exec = createDesktopExecutor({ hwnd: "1" }, deps);
+    const result = await exec(entity({ sources: ["uia"] }), "click");
+    expect(result).toBe("uia");
+  });
+
+  it("UIA click fails + entity.rect present → returns ExecutorOutcome with downgrade.from='uia' + reason", async () => {
+    const deps = mockDeps({
+      uiaClick: vi.fn(async () => { throw new Error("InvokePatternNotSupported"); }),
+    });
+    const exec = createDesktopExecutor({ hwnd: "1" }, deps);
+    const result = await exec(
+      entity({ sources: ["uia"], rect: { x: 100, y: 200, width: 80, height: 30 } }),
+      "click",
+    );
+    expect(result).toEqual({
+      kind: "mouse",
+      downgrade: { from: "uia", reason: "InvokePatternNotSupported" },
+    });
+  });
+
+  it("UIA click fails + no rect → throws (no silent mouse fallback) — downgrade marker reserved for the success case", async () => {
+    const deps = mockDeps({
+      uiaClick: vi.fn(async () => { throw new Error("element not found"); }),
+    });
+    const exec = createDesktopExecutor({ hwnd: "1" }, deps);
+    await expect(exec(entity({ sources: ["uia"], rect: undefined }), "click"))
+      .rejects.toThrow("no rect for mouse fallback");
+  });
+
+  it("downgrade marker carries non-Error throwables as String(...) for the reason field", async () => {
+    const deps = mockDeps({
+      uiaClick: vi.fn(async () => { throw "string-only error"; }),
+    });
+    const exec = createDesktopExecutor({ hwnd: "1" }, deps);
+    const result = await exec(
+      entity({ sources: ["uia"], rect: { x: 0, y: 0, width: 10, height: 10 } }),
+      "click",
+    );
+    expect(result).toEqual({
+      kind: "mouse",
+      downgrade: { from: "uia", reason: "string-only error" },
+    });
   });
 });
 
@@ -235,7 +290,11 @@ describe("createDesktopExecutor — UIA setValue → keyboardTypeBg fallback (#3
       entity({ sources: ["uia"], rect: { x: 100, y: 200, width: 80, height: 30 } }),
       "click",
     );
-    expect(result).toBe("mouse"); // existing click → mouse fallback path unchanged
+    // Click path falls through to mouse with the #327 item C downgrade marker.
+    expect(result).toEqual({
+      kind: "mouse",
+      downgrade: { from: "uia", reason: "InvokePattern missing" },
+    });
     expect(deps.keyboardTypeBg).not.toHaveBeenCalled();
   });
 });
@@ -321,7 +380,7 @@ describe("createDesktopExecutor — locator-based routing (P2-A)", () => {
       locator: { uia: { automationId: "btn-x" }, visual: { rect: { x: 50, y: 60, width: 100, height: 40 } } },
     });
     const result = await exec(e, "click");
-    expect(result).toBe("mouse");
+    expect(result).toEqual({ kind: "mouse", downgrade: { from: "uia", reason: "not found" } });
     expect(deps.mouseClick).toHaveBeenCalledWith(100, 80); // center of locator.visual.rect
 
     // entity.rect present → entity.rect wins over locator.visual.rect

--- a/tests/unit/guarded-touch.test.ts
+++ b/tests/unit/guarded-touch.test.ts
@@ -63,7 +63,52 @@ describe("GuardedTouchLoop — happy path", () => {
     }));
     const result = await loop.touch({ lease });
     expect(result.ok).toBe(true);
-    if (result.ok) expect(result.executor).toBe("uia");
+    if (result.ok) {
+      expect(result.executor).toBe("uia");
+      expect(result.downgrade).toBeUndefined();
+    }
+  });
+
+  // Issue #327 item C: when env.execute() returns the rich ExecutorOutcome shape
+  // (downgrade signalled), GuardedTouchLoop normalises and surfaces it on the
+  // success TouchResult so the LLM can distinguish "advised executor was tried
+  // and failed" from "advised executor was not the chosen route".
+  it("surfaces downgrade on TouchResult when execute() returns ExecutorOutcome with downgrade (#327 item C)", async () => {
+    const e = entity("e1", GEN);
+    const store = new LeaseStore({ nowFn: () => 0, defaultTtlMs: 60_000 });
+    const lease = store.issue(e, "v1");
+    const loop = new GuardedTouchLoop(store, makeEnv({
+      resolveLiveEntities: () => [e],
+      execute: async () => ({
+        kind: "mouse",
+        downgrade: { from: "uia", reason: "InvokePatternNotSupported" },
+      }),
+    }));
+    const result = await loop.touch({ lease });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.executor).toBe("mouse");
+      expect(result.downgrade).toEqual({ from: "uia", reason: "InvokePatternNotSupported" });
+    }
+  });
+
+  it("ExecutorOutcome without downgrade field omits TouchResult.downgrade (no spurious undefined)", async () => {
+    const e = entity("e1", GEN);
+    const store = new LeaseStore({ nowFn: () => 0, defaultTtlMs: 60_000 });
+    const lease = store.issue(e, "v1");
+    const loop = new GuardedTouchLoop(store, makeEnv({
+      resolveLiveEntities: () => [e],
+      execute: async () => ({ kind: "uia" }), // rich shape but no downgrade
+    }));
+    const result = await loop.touch({ lease });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.executor).toBe("uia");
+      expect(result.downgrade).toBeUndefined();
+      // Field omitted entirely (not `downgrade: undefined`) so JSON.stringify
+      // produces the same shape as the bare-kind path.
+      expect("downgrade" in result).toBe(false);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Issue #327 item C: `desktop_act` against a UIA-sourced entity could return `executor: "mouse"` despite `capabilities.preferredExecutors: ["uia"]` because the UIA route at `desktop-executor.ts:158-172` silently caught `uiaClick` failure and fell through to mouseClick. From the LLM's point of view this was indistinguishable from "UIA was never the chosen route", so capability advisories drifted out of sync with runtime evidence.

This PR adds an **observability marker** without changing the silent-fallback behaviour itself (per agent option 1, low rollout risk). The TouchResult now carries `downgrade: { from: "uia", reason }` when the fallback happened, so the LLM can distinguish "advised executor was tried and failed" from "advised executor was not the chosen route".

## Shape change

### Before
```jsonc
// silent UIA→mouse fallback envelope
{ "ok": true, "executor": "mouse", "diff": [...] }
```

### After
```jsonc
// successful UIA route (unchanged — no downgrade marker)
{ "ok": true, "executor": "uia", "diff": [...] }

// silent UIA→mouse fallback (new marker)
{ "ok": true, "executor": "mouse", "diff": [...],
  "downgrade": { "from": "uia", "reason": "InvokePatternNotSupported" } }
```

The `downgrade` field is **absent** (key omitted, not `undefined`) on the no-fallback path so JSON envelopes stay byte-equal to today on the happy path.

## Diff

| File | Change |
|---|---|
| `src/engine/world-graph/types.ts` | New `ExecutorOutcome` interface — rich return shape signalling silent fallback |
| `src/engine/world-graph/guarded-touch.ts` | `TouchEnvironment.execute` return widened to union; `TouchResult` success variant gains `downgrade?`; `touch()` normalises both shapes and omits the field when no downgrade |
| `src/engine/world-graph/session-registry.ts` | `ExecutorFn` type matches widened return |
| `src/tools/desktop-executor.ts` | UIA route silent fallback returns `{ kind: "mouse", downgrade: { from: "uia", reason } }`; no-rect fallback path attaches `cause` to the thrown Error |
| `tests/unit/desktop-executor.test.ts` | 3 existing UIA-fallback assertions updated + 4 new tests in a new describe block (success regression pin, downgrade shape pin, no-rect-throw without downgrade, non-Error throwable handling) |
| `tests/unit/guarded-touch.test.ts` | 2 new tests injecting `execute()` to return `ExecutorOutcome` directly and asserting `TouchResult.downgrade` propagation + an "executor:'uia' has no downgrade" pin |

## Scope discipline (per `project_path_class_refactor_pending`)

- **No change to advertised capabilities, `AFFORDANCE_MAP`, or `unsupportedExecutors`** — those remain the 4-executor union.
- **No change to other silent-fallback paths**: the UIA setValue ladder added in PR #330 is already explicit (different shape); CDP `cdpFill` and terminal `terminalSend` do not fall through silently — when they fail, `executor_failed` is surfaced directly.
- The path-class refactor epic will fold this marker into the unified `CapabilityRegistry` failure-envelope surface alongside G's `if_unexpected` injection and D's `isChromeControlType` helper.

## Behaviour pin (back-compat)

The bare-string `ExecutorKind` return remains valid — every existing test that injects `execute: async () => "mouse"` etc. still passes without modification. Only the new UIA-fallback path emits the rich shape, and only the new tests assert against it.

## Test plan

- [x] `npm run build` clean
- [x] `npx eslint` clean on all 6 changed files (no `preserve-caught-error` regression)
- [x] `npx vitest run` desktop-executor + guarded-touch + session-registry → 107 / 107 pass (3 existing updated, 6 new)
- [x] Full `npm run test:capture` → 3516 pass / **0 fail** / 32 skip / 5 todo
- [ ] Opus phase-boundary review (§3.3 Step 1)
- [ ] Codex review (`@codex review`, §3.3 Step 2 — production code change with API surface widening)

Closes part of #327 (item C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
