### PR TITLE
fix(stage-5): negative-backoff TTL on cache invalidate + cacheState marker (#327 item B; A deferred)

### DIFF
--- a/docs/adr-019-stage-5-followups.md
+++ b/docs/adr-019-stage-5-followups.md
@@ -168,6 +168,12 @@ The pixel-level positive verification (`motion: any_change` with non-zero `resid
 - **Stage 5b** (DXGI move rects): no new items yet.
 - **Stage 5c** (cross-monitor straddle simultaneous subscription): no new items yet.
 
+### 2026-05-17 — `VisualMotionObservation.cacheState` instrumentation (#327 item B)
+
+Issue #327 item B added an optional `cacheState` field (5-value union: `hit-subscription` / `hit-unavailable` / `hit-negative-backoff` / `miss-init` / `miss-init-unavailable`) on `VisualMotionObservation` so dogfood logs can audit the cache hit/miss ratio directly. The field is **instrumentation-only**, optional, and adds no contract to the `desktop_act` envelope surface — Stage 5 sub-plan §2.6 documented fail-soft contract is unchanged.
+
+Dogfood usage: after the first DXGI failure on a host (vision-gpu coexistence, RDP, virtual display, etc.), back-to-back calls must report `cacheState: "hit-negative-backoff"` — NOT `cacheState: "miss-init"`. Reporting `miss-init` repeatedly would indicate the back-off marker is failing to be set (a regression of the #327 item B fix). The unit tests at `tests/unit/dirty-rect-subscription-cache.test.ts` + `tests/unit/any-change-orchestrator.test.ts` mechanically pin the contract.
+
 ### Deferred validations (dual-monitor environment required)
 
 The following two scenarios are deferred until a dual-monitor host is available; they must be re-attempted before Stage 5c v2 is shipped, because Stage 5c relies on multi-output subscription correctness that v1 only partially proves:

--- a/src/engine/any-change.ts
+++ b/src/engine/any-change.ts
@@ -73,7 +73,39 @@ export interface SubscriptionLike {
  *  RDP / virtual-display hosts (Stage 5 sub-plan §6 R4). */
 type CacheEntry =
   | { kind: "subscription"; sub: SubscriptionLike; lastUsedAt: number }
-  | { kind: "unavailable"; recordedAt: number };
+  | { kind: "unavailable"; recordedAt: number }
+  /**
+   * Issue #327 item B: short-lived back-off marker set by `invalidate()` so a
+   * `sub.next()` failure does not delete the cache entry outright and trigger
+   * an immediate 50 ms `factory` re-init on the next call. Holds `null` for
+   * `NEGATIVE_BACKOFF_MS` (= 2 seconds), after which the entry self-clears
+   * via `sweepStale()` and a fresh factory call is permitted. Distinct from
+   * `unavailable` (which has the full `idleTimeoutMs` TTL) so AccessLost
+   * recovery still occurs within a few seconds rather than the 20 s idle
+   * window.
+   */
+  | { kind: "negative-backoff"; recordedAt: number };
+
+/**
+ * Issue #327 item B: short-lived back-off after `sub.next()` failure to
+ * prevent a 50 ms `factory` re-init storm. 2 seconds is long enough to absorb
+ * a chained `desktop_act` x 5 sequence and short enough that AccessLost
+ * recovery still surfaces within a single user turn.
+ */
+const NEGATIVE_BACKOFF_MS = 2_000;
+
+/**
+ * Issue #327 item B instrumentation — surfaces which `acquireWithState`
+ * branch was hit so `verifyAnyChange` can populate
+ * `VisualMotionObservation.cacheState`. Kept narrow (5 values) so the
+ * cardinality stays auditable.
+ */
+export type CacheAcquireState =
+  | "hit-subscription"
+  | "hit-unavailable"
+  | "hit-negative-backoff"
+  | "miss-init"
+  | "miss-init-unavailable";
 
 /**
  * Singleton cache keyed by `outputIndex`. Lifecycle:
@@ -103,19 +135,39 @@ export class DirtyRectSubscriptionCache {
    * unsupported / unavailable for this output. Caches the failure for the
    * idle timeout window so RDP / coexistence-locked hosts don't pay the
    * init cost on every call.
+   *
+   * Back-compat wrapper around `acquireWithState` — drops the state. Used
+   * by callers that don't need the cache-state telemetry (existing tests).
    */
   acquire(outputIndex: number): SubscriptionLike | null {
+    return this.acquireWithState(outputIndex).sub;
+  }
+
+  /**
+   * Issue #327 item B instrumentation — same logic as `acquire` but also
+   * reports which cache branch was hit. Used by `verifyAnyChange` to surface
+   * `VisualMotionObservation.cacheState`.
+   */
+  acquireWithState(outputIndex: number): {
+    sub: SubscriptionLike | null;
+    state: CacheAcquireState;
+  } {
     this.sweepStale();
     const cached = this.entries.get(outputIndex);
     if (cached?.kind === "subscription") {
       if (!cached.sub.isDisposed) {
         cached.lastUsedAt = this.nowFn();
-        return cached.sub;
+        return { sub: cached.sub, state: "hit-subscription" };
       }
       // Disposed externally (AccessLost recovery) — drop and re-init.
       this.entries.delete(outputIndex);
     } else if (cached?.kind === "unavailable") {
-      return null;
+      return { sub: null, state: "hit-unavailable" };
+    } else if (cached?.kind === "negative-backoff") {
+      // Issue #327 item B: short-lived back-off after `sub.next()` failure
+      // suppresses the immediate 50 ms factory re-init. `sweepStale` clears
+      // the entry once `NEGATIVE_BACKOFF_MS` has elapsed.
+      return { sub: null, state: "hit-negative-backoff" };
     }
     try {
       const sub = this.factory(outputIndex);
@@ -124,19 +176,31 @@ export class DirtyRectSubscriptionCache {
         sub,
         lastUsedAt: this.nowFn(),
       });
-      return sub;
+      return { sub, state: "miss-init" };
     } catch {
       this.entries.set(outputIndex, {
         kind: "unavailable",
         recordedAt: this.nowFn(),
       });
-      return null;
+      return { sub: null, state: "miss-init-unavailable" };
     }
   }
 
-  /** Mark `outputIndex` as `unavailable` and dispose any live subscription
-   *  for it. Used by the orchestrator on `AccessLost` so the next call
-   *  re-initialises after the idle window. */
+  /**
+   * Mark `outputIndex` for back-off after a `sub.next()` failure and dispose
+   * any live subscription for it. The next `acquire` call within
+   * `NEGATIVE_BACKOFF_MS` returns `null` fast (state =
+   * `hit-negative-backoff`) instead of paying another factory init cost.
+   * After the back-off window expires, `sweepStale` clears the entry and a
+   * fresh factory call is permitted.
+   *
+   * Issue #327 item B: prior to this change `invalidate` deleted the entry
+   * outright, so back-to-back `desktop_act` calls hit by the same DXGI
+   * failure mode (`E_DUP_ACCESS_LOST` / `E_DUP_UNSUPPORTED`) re-paid the
+   * ~50 ms factory init on every call — the documented cache fast-path was
+   * defeated. The back-off marker fixes the cache-hit contract while keeping
+   * AccessLost recovery within a single user turn.
+   */
   invalidate(outputIndex: number): void {
     const cached = this.entries.get(outputIndex);
     if (cached?.kind === "subscription" && !cached.sub.isDisposed) {
@@ -146,7 +210,10 @@ export class DirtyRectSubscriptionCache {
         /* best-effort */
       }
     }
-    this.entries.delete(outputIndex);
+    this.entries.set(outputIndex, {
+      kind: "negative-backoff",
+      recordedAt: this.nowFn(),
+    });
   }
 
   /** Dispose every live subscription. Called by the MCP server shutdown
@@ -184,7 +251,15 @@ export class DirtyRectSubscriptionCache {
           }
           this.entries.delete(key);
         }
+      } else if (entry.kind === "negative-backoff") {
+        // Short-lived back-off TTL (separate from `idleTimeoutMs`) so
+        // AccessLost recovery still resolves within `NEGATIVE_BACKOFF_MS`
+        // rather than waiting the full 20-second idle window.
+        if (now - entry.recordedAt >= NEGATIVE_BACKOFF_MS) {
+          this.entries.delete(key);
+        }
       } else if (now - entry.recordedAt >= this.idleTimeoutMs) {
+        // `unavailable` marker reaches the full `idleTimeoutMs` TTL.
         this.entries.delete(key);
       }
     }
@@ -360,18 +435,27 @@ export async function verifyAnyChange(
 ): Promise<VisualMotionObservation> {
   const startMs = performance.now();
 
-  const degradeUnavailable = (): VisualMotionObservation => ({
+  // Issue #327 item B: `cacheState` is passed in by post-cache callers; pre-
+  // cache callers (resolver failure, cache=null) pass `undefined` so the
+  // optional field is omitted from the observation entirely.
+  const degradeUnavailable = (
+    cacheState?: CacheAcquireState,
+  ): VisualMotionObservation => ({
     motion: "indeterminate",
     source: "dxgi_dirty_rect_unavailable",
     framesSampled: 0,
     totalElapsedMs: performance.now() - startMs,
+    ...(cacheState !== undefined ? { cacheState } : {}),
   });
 
-  const degradeAccessLost = (): VisualMotionObservation => ({
+  const degradeAccessLost = (
+    cacheState?: CacheAcquireState,
+  ): VisualMotionObservation => ({
     motion: "indeterminate",
     source: "dxgi_dirty_rect",
     framesSampled: 0,
     totalElapsedMs: performance.now() - startMs,
+    ...(cacheState !== undefined ? { cacheState } : {}),
   });
 
   // Resolve target monitor first — cheaper than touching the DXGI cache when
@@ -402,10 +486,12 @@ export async function verifyAnyChange(
     return degradeUnavailable();
   }
 
-  const sub = cache.acquire(resolution.outputIndex);
-  if (sub === null) {
-    return degradeUnavailable();
+  const acquired = cache.acquireWithState(resolution.outputIndex);
+  const acquireState: CacheAcquireState = acquired.state;
+  if (acquired.sub === null) {
+    return degradeUnavailable(acquireState);
   }
+  const sub = acquired.sub;
 
   let rects: Array<{ x: number; y: number; width: number; height: number }>;
   try {
@@ -414,17 +500,18 @@ export async function verifyAnyChange(
     const msg = err instanceof Error ? err.message : String(err);
     if (msg.includes("E_DUP_ACCESS_LOST")) {
       // Thread re-creates context, but the current subscription is stale —
-      // invalidate so the next call re-acquires.
+      // invalidate (now sets negative-backoff marker per #327 item B) so the
+      // next call fast-paths instead of paying another 50 ms factory init.
       cache.invalidate(resolution.outputIndex);
-      return degradeAccessLost();
+      return degradeAccessLost(acquireState);
     }
     if (msg.includes("E_DUP_UNSUPPORTED")) {
       cache.invalidate(resolution.outputIndex);
-      return degradeUnavailable();
+      return degradeUnavailable(acquireState);
     }
     // Disposed / Other — degrade honestly without invalidating (Disposed
     // means our consumer has already torn down).
-    return degradeAccessLost();
+    return degradeAccessLost(acquireState);
   }
 
   const target = opts.region ?? opts.windowRect;
@@ -450,6 +537,7 @@ export async function verifyAnyChange(
       source: "dxgi_dirty_rect",
       framesSampled,
       totalElapsedMs,
+      cacheState: acquireState,
     };
   }
 
@@ -465,6 +553,7 @@ export async function verifyAnyChange(
       },
       framesSampled,
       totalElapsedMs,
+      cacheState: acquireState,
     };
   }
 
@@ -481,6 +570,7 @@ export async function verifyAnyChange(
     },
     framesSampled,
     totalElapsedMs,
+    cacheState: acquireState,
   };
 }
 

--- a/src/engine/any-change.ts
+++ b/src/engine/any-change.ts
@@ -147,6 +147,20 @@ export class DirtyRectSubscriptionCache {
    * Issue #327 item B instrumentation — same logic as `acquire` but also
    * reports which cache branch was hit. Used by `verifyAnyChange` to surface
    * `VisualMotionObservation.cacheState`.
+   *
+   * `state` value semantics (Opus Round 1 P2-1 — folds documented):
+   *   - `"hit-subscription"`: cached subscription returned (fast path).
+   *   - `"hit-unavailable"`: cached unavailable marker (factory previously threw).
+   *   - `"hit-negative-backoff"`: cached back-off marker set by `invalidate()`.
+   *   - `"miss-init"`: cache miss + factory succeeded. **This bucket also
+   *     absorbs the "disposed-subscription recovery" path** (entry was
+   *     `subscription` but `sub.isDisposed === true`, e.g. AccessLost
+   *     external dispose) — the disposed entry is silently dropped and a
+   *     fresh factory call paid, so both cold-start and post-dispose look
+   *     identical to dogfood logs. Do NOT add a 6th value
+   *     (`miss-after-disposed`) without a real diagnostic need; the 5-value
+   *     cardinality is intentional auditability.
+   *   - `"miss-init-unavailable"`: cache miss + factory threw; marker set.
    */
   acquireWithState(outputIndex: number): {
     sub: SubscriptionLike | null;
@@ -200,6 +214,15 @@ export class DirtyRectSubscriptionCache {
    * ~50 ms factory init on every call — the documented cache fast-path was
    * defeated. The back-off marker fixes the cache-hit contract while keeping
    * AccessLost recovery within a single user turn.
+   *
+   * Opus Round 1 P3-1: `invalidate(outputIndex)` unconditionally writes the
+   * back-off marker even when no prior entry existed (defensive — the marker
+   * self-clears in `sweepStale` after `NEGATIVE_BACKOFF_MS` regardless).
+   * Real callers only `invalidate` after a `sub.next()` failure on a
+   * previously-acquired entry, so the never-acquired case is a no-op for
+   * real workloads. Avoiding an early-return keeps the method behaviour
+   * monotone (always sets the marker on call), which simplifies callsite
+   * reasoning.
    */
   invalidate(outputIndex: number): void {
     const cached = this.entries.get(outputIndex);

--- a/src/tools/_input-pipeline.ts
+++ b/src/tools/_input-pipeline.ts
@@ -536,6 +536,31 @@ export interface VisualMotionObservation {
   };
   framesSampled: number;
   totalElapsedMs: number;
+  /**
+   * ADR-019 Stage 5 + issue #327 item B instrumentation — DXGI subscription
+   * cache state observed during this call. Helps audit the cache fast-path
+   * vs cold-path ratio for back-to-back `desktop_act` calls (the dogfood
+   * symptom that triggered #327: `totalElapsedMs ~50ms constant`). Only
+   * populated on Stage 5 paths that consult `DirtyRectSubscriptionCache`;
+   * absent on non-cache sources.
+   *
+   * Values:
+   * - `"hit-subscription"`: cached subscription returned, no init cost.
+   * - `"hit-unavailable"`: cached `unavailable` marker (factory previously
+   *   threw); fast-path negative.
+   * - `"hit-negative-backoff"`: cached `negative-backoff` marker (a recent
+   *   `sub.next()` failure triggered `invalidate`, which now sets a short
+   *   back-off instead of clearing — issue #327 item B fix).
+   * - `"miss-init"`: cache miss + factory succeeded (paid init cost).
+   * - `"miss-init-unavailable"`: cache miss + factory threw, marker now
+   *   set (paid init cost; subsequent calls fast-path on `hit-unavailable`).
+   */
+  cacheState?:
+    | "hit-subscription"
+    | "hit-unavailable"
+    | "hit-negative-backoff"
+    | "miss-init"
+    | "miss-init-unavailable";
 }
 
 // ─── Resolver ────────────────────────────────────────────────────────────────

--- a/tests/unit/any-change-orchestrator.test.ts
+++ b/tests/unit/any-change-orchestrator.test.ts
@@ -175,6 +175,81 @@ describe("verifyAnyChange orchestrator", () => {
     expect(invalidateSpy).toHaveBeenCalled();
   });
 
+  // Issue #327 item B instrumentation: cacheState should be populated on all
+  // observation paths that consulted the DXGI subscription cache, so back-to-
+  // back desktop_act calls can be audited for hit/miss ratio in dogfood logs.
+  it("cacheState='miss-init' on cold acquire, 'hit-subscription' on warm acquire (#327 item B)", async () => {
+    const sub = buildSub(async () => []);
+    const cache = cacheReturning(sub);
+
+    const first = await verifyAnyChange({
+      hwnd: 1n,
+      windowRect: WINDOW_RECT,
+      cache,
+      enumerate: () => [PRIMARY_MONITOR],
+    });
+    expect(first.cacheState).toBe("miss-init");
+
+    const second = await verifyAnyChange({
+      hwnd: 1n,
+      windowRect: WINDOW_RECT,
+      cache,
+      enumerate: () => [PRIMARY_MONITOR],
+    });
+    expect(second.cacheState).toBe("hit-subscription");
+  });
+
+  it("cacheState='hit-unavailable' after the factory has thrown once (#327 item B)", async () => {
+    const cache = cacheReturning(null); // factory throws E_DUP_UNSUPPORTED
+
+    const first = await verifyAnyChange({
+      hwnd: 1n,
+      windowRect: WINDOW_RECT,
+      cache,
+      enumerate: () => [PRIMARY_MONITOR],
+    });
+    expect(first.cacheState).toBe("miss-init-unavailable");
+
+    const second = await verifyAnyChange({
+      hwnd: 1n,
+      windowRect: WINDOW_RECT,
+      cache,
+      enumerate: () => [PRIMARY_MONITOR],
+    });
+    // Back-to-back call must NOT re-pay the 50 ms factory init —
+    // the unavailable marker fast-paths it.
+    expect(second.cacheState).toBe("hit-unavailable");
+  });
+
+  it("cacheState='hit-negative-backoff' after sub.next() E_DUP_* failure prevents 50ms re-init (#327 item B)", async () => {
+    const sub = buildSub(async () => {
+      throw new Error("E_DUP_UNSUPPORTED: vision-gpu coexistence");
+    });
+    const cache = cacheReturning(sub);
+
+    // First call: paid the factory init (miss-init), sub.next threw, invalidate
+    // set the negative-backoff marker.
+    const first = await verifyAnyChange({
+      hwnd: 1n,
+      windowRect: WINDOW_RECT,
+      cache,
+      enumerate: () => [PRIMARY_MONITOR],
+    });
+    expect(first.cacheState).toBe("miss-init");
+
+    // Second call: the negative-backoff marker fast-paths the acquire so no
+    // factory re-init is paid. THIS is the #327 item B fix — the dogfood
+    // "50ms constant" symptom is closed.
+    const second = await verifyAnyChange({
+      hwnd: 1n,
+      windowRect: WINDOW_RECT,
+      cache,
+      enumerate: () => [PRIMARY_MONITOR],
+    });
+    expect(second.cacheState).toBe("hit-negative-backoff");
+    expect(second.source).toBe("dxgi_dirty_rect_unavailable");
+  });
+
   it("off-screen window → motion: indeterminate, source: dxgi_dirty_rect_unavailable", async () => {
     const sub = buildSub(async () => []);
     const obs = await verifyAnyChange({

--- a/tests/unit/dirty-rect-subscription-cache.test.ts
+++ b/tests/unit/dirty-rect-subscription-cache.test.ts
@@ -120,15 +120,21 @@ describe("DirtyRectSubscriptionCache", () => {
     const first = cache.acquire(0)!;
     cache.invalidate(0);
     expect(first.isDisposed).toBe(true);
+    // Opus Round 1 P3-3: pin the internal contract mechanically — the
+    // marker kind must be `negative-backoff`, not a delete-and-recreate.
+    expect(cache._getEntryForTest(0)?.kind).toBe("negative-backoff");
 
     // Immediate re-acquire within the back-off window returns null fast
     // (no factory re-init — counter stays at 1).
     expect(cache.acquire(0)).toBeNull();
     expect(counter).toBe(1);
 
-    // After NEGATIVE_BACKOFF_MS (2 s), the marker is swept and a fresh
-    // factory call is permitted.
-    now = 2_000;
+    // After NEGATIVE_BACKOFF_MS (2 s) elapses, the marker is swept and a
+    // fresh factory call is permitted. Opus Round 1 P3-2: use 2_001 (= one
+    // tick past the back-off window) instead of 2_000 (= boundary exactly)
+    // for unambiguous past-window semantics matching the idleTimeout test's
+    // 2x convention.
+    now = 2_001;
     const second = cache.acquire(0)!;
     expect(second).not.toBe(first);
     expect(counter).toBe(2);

--- a/tests/unit/dirty-rect-subscription-cache.test.ts
+++ b/tests/unit/dirty-rect-subscription-cache.test.ts
@@ -104,21 +104,76 @@ describe("DirtyRectSubscriptionCache", () => {
     expect(factory).toHaveBeenCalledTimes(2);
   });
 
-  it("invalidate disposes the live subscription so the next acquire re-inits", () => {
+  // Issue #327 item B: `invalidate` now sets a 2 s `negative-backoff` marker
+  // instead of deleting the entry outright. This prevents the 50 ms factory
+  // re-init storm observed in the dogfood (back-to-back desktop_act calls
+  // hitting the same DXGI failure mode were paying init cost every call).
+  it("invalidate disposes the live subscription AND sets a negative-backoff marker (#327 item B)", () => {
     let counter = 0;
+    let now = 0;
     const factory = vi.fn(() => {
       counter += 1;
       return new StubSubscription();
     });
-    const cache = new DirtyRectSubscriptionCache(factory, () => 0);
+    const cache = new DirtyRectSubscriptionCache(factory, () => now);
 
     const first = cache.acquire(0)!;
     cache.invalidate(0);
     expect(first.isDisposed).toBe(true);
 
+    // Immediate re-acquire within the back-off window returns null fast
+    // (no factory re-init — counter stays at 1).
+    expect(cache.acquire(0)).toBeNull();
+    expect(counter).toBe(1);
+
+    // After NEGATIVE_BACKOFF_MS (2 s), the marker is swept and a fresh
+    // factory call is permitted.
+    now = 2_000;
     const second = cache.acquire(0)!;
     expect(second).not.toBe(first);
     expect(counter).toBe(2);
+  });
+
+  it("acquireWithState reports 'hit-subscription' on second acquire (cache fast-path)", () => {
+    const factory = vi.fn(() => new StubSubscription());
+    const cache = new DirtyRectSubscriptionCache(factory, () => 0);
+
+    const first = cache.acquireWithState(0);
+    expect(first.state).toBe("miss-init");
+
+    const second = cache.acquireWithState(0);
+    expect(second.state).toBe("hit-subscription");
+    expect(second.sub).toBe(first.sub);
+  });
+
+  it("acquireWithState reports 'miss-init-unavailable' then 'hit-unavailable' (factory throw path)", () => {
+    const factory = vi.fn(() => { throw new Error("factory cannot init"); });
+    const cache = new DirtyRectSubscriptionCache(factory, () => 0);
+
+    const first = cache.acquireWithState(0);
+    expect(first.sub).toBeNull();
+    expect(first.state).toBe("miss-init-unavailable");
+
+    // Second acquire fast-paths on the cached unavailable marker.
+    const second = cache.acquireWithState(0);
+    expect(second.sub).toBeNull();
+    expect(second.state).toBe("hit-unavailable");
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it("acquireWithState reports 'hit-negative-backoff' immediately after invalidate (#327 item B fast-path)", () => {
+    const factory = vi.fn(() => new StubSubscription());
+    const cache = new DirtyRectSubscriptionCache(factory, () => 0);
+
+    cache.acquire(0);
+    cache.invalidate(0);
+
+    const result = cache.acquireWithState(0);
+    expect(result.sub).toBeNull();
+    expect(result.state).toBe("hit-negative-backoff");
+    // Critical contract: invalidate must NOT trigger a 50 ms factory re-init
+    // on the immediate next call. (Pre-#327B behaviour was counter === 2.)
+    expect(factory).toHaveBeenCalledTimes(1);
   });
 
   it("STAGE5_CACHE_IDLE_TIMEOUT_MS default is 20 sec", () => {


### PR DESCRIPTION
## Summary

Issue #327 item B: back-to-back `desktop_act` calls held `totalElapsedMs ~50ms` constant despite the documented cache fast-path (`any-change.ts:81` JSDoc: "Subsequent acquire(0) within 20 sec returns the cached entry (~< 1 ms)"). Opus consultation traced the contract violation to `DirtyRectSubscriptionCache.invalidate()` deleting the entry outright, so any recurring `sub.next()` failure (`E_DUP_ACCESS_LOST` / `E_DUP_UNSUPPORTED`) re-paid the ~50 ms factory init on every call.

This PR adds:
1. A **2 s `negative-backoff` marker** set by `invalidate()` instead of clearing the entry. Fast-paths the next call (returns `null` in <1 ms) while `sweepStale` clears the marker after `NEGATIVE_BACKOFF_MS` so AccessLost recovery still resolves within a single user turn.
2. A **`VisualMotionObservation.cacheState` field** (5-value union) surfaced on every Stage 5 observation path. Dogfood logs can now audit the cache hit/miss ratio directly instead of guessing from `totalElapsedMs`.

**Item A (DXGI two-subscription coexistence with vision-gpu)** is the documented fail-soft per sub-plan §2.6 and is **formally deferred to the path-class refactor epic** (multiplex one DXGI subscription, lifecycle refactor scope). The #327 issue body has been updated with the deferral rationale: https://github.com/Harusame64/desktop-touch-mcp/issues/327#issuecomment-4468745875

## Diff

| File | Change |
|---|---|
| `src/engine/any-change.ts` | New `CacheEntry { kind: "negative-backoff" }` variant + `NEGATIVE_BACKOFF_MS = 2_000` constant + `CacheAcquireState` 5-value union + new `acquireWithState()` method + `invalidate()` sets back-off marker + `sweepStale()` separate TTL handling + `verifyAnyChange()` threads `cacheState` into every observation path |
| `src/tools/_input-pipeline.ts` | New optional `VisualMotionObservation.cacheState` field |
| `tests/unit/dirty-rect-subscription-cache.test.ts` | Existing invalidate test updated to back-off semantics + 3 new state-branch tests |
| `tests/unit/any-change-orchestrator.test.ts` | 3 new tests for `cacheState` surfacing on cold→warm / factory-throw / `sub.next()`-throw paths |

## Cache state values

| Value | Path | Cost |
|---|---|---|
| `hit-subscription` | Cached subscription returned | <1 ms |
| `hit-unavailable` | Cached unavailable marker (factory previously threw) | <1 ms |
| `hit-negative-backoff` | **NEW** — recent `sub.next()` failure marker | <1 ms (was ~50 ms before this PR) |
| `miss-init` | Cache miss + factory succeeded | ~50 ms (cold init cost) |
| `miss-init-unavailable` | Cache miss + factory threw; marker now set | ~50 ms (cold init cost) |

The canonical #327 dogfood scenario (`~50 ms constant on every call` because of vision-gpu coexistence) now reports `cacheState: "miss-init"` on the first call, then `cacheState: "hit-negative-backoff"` on every subsequent call — the documented fast-path is restored.

## Scope discipline

Per the Opus 諮問 result + `project_path_class_refactor_pending` memory:

- **Item A**: NOT addressed in this PR. The DXGI coexistence requires multiplexing, which is a larger lifecycle refactor. Documented fail-soft remains the v1.7.0 behaviour.
- **No advertised capability changes**: `AFFORDANCE_MAP` / `unsupportedExecutors` unchanged.
- **No public API breakage**: `acquire(outputIndex)` is preserved as a back-compat shim around `acquireWithState`. All 10 existing cache tests still pass (1 updated for the new back-off semantics).

## Test plan

- [x] `npm run build` clean
- [x] `npx eslint` clean on all 4 changed files
- [x] `npx vitest run` on `dirty-rect-subscription-cache` + `any-change-orchestrator` → 24 / 24 pass (6 new)
- [x] Full `npm run test:capture` → **3522 pass / 0 fail** / 32 skip / 5 todo (+6 new tests)
- [ ] Opus phase-boundary review (§3.3 Step 1)
- [ ] Codex review (`@codex review`, §3.3 Step 2 — production code change with new public API surface (`acquireWithState`, `cacheState` field, `CacheAcquireState` type))
- [ ] Dogfood re-verification: confirm back-to-back `desktop_act` reports `cacheState: "hit-negative-backoff"` on calls 2-N after the first DXGI failure

Closes #327 (B is fixed here; A is formally deferred to the path-class refactor epic per the issue body update).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
