### PR TITLE
refactor(modal): classifyModal(entity, context) unify — ADR-020 PR-P2-1 (D fix)

### DIFF
--- a/docs/adr-020-phase-2-p2-1-modal-refactor-plan.md
+++ b/docs/adr-020-phase-2-p2-1-modal-refactor-plan.md
@@ -1,0 +1,231 @@
+# ADR-020 Phase 2 PR-P2-1 — D refactor: classifyModal 切り出し sub-plan
+
+- Status: **Drafted (2026-05-17)**
+- 親 ADR: `docs/adr-020-path-class-refactor-plan.md` (epic plan、merged 2026-05-17 PR #335)
+- 該当 Phase / 軸: Phase 2 PR-P2-1 (D refactor、scope §4.4 D bullet)
+- 関連 issue: #327 item D (closed by PR #331、本 sub-plan で構造除去完了)
+- 関連 PR (baseline): #331 (`isChromeControlType` 共有 helper 抽出 + `isModalLike` 同期 = D tactical fix)
+
+---
+
+## 0. 親 ADR + user 判断引き継ぎ (2026-05-17 session で先取り確定)
+
+本 sub-plan は ADR-020 land 直後の user judgment session (2026-05-17) で以下が確定済:
+
+**auto-mode 運用パラメータ**:
+- PR 分割粒度: 都度判断
+- production code 改修 PR の merge: Opus + Codex 両 Approved で AI merge OK
+- release timing: Phase 3 完了で一括 v1.7.0 minor (本 PR-P2-1 は no release、CHANGELOG entry 不要)
+- branch 削除: PR merged 直後 auto
+
+**Phase 2 design 判断 (本 sub-plan に直接影響)**:
+- D refactor: `classifyModal(entity, context)` 切り出し方針 (ADR-020 §4.4)、本 sub-plan で signature 詳細確定
+- 既存 helper export 整理: minimum、production callsite から consume される形を pin (ADR-020 §4.6 acceptance)
+
+**Phase 3 design 判断 (本 sub-plan の範囲外、参考)**:
+- SR-1 CapabilityRegistry: 新規 module `src/capabilities/registry.ts` 新設
+- SR-4 DXGI broker: subscription handle pattern
+- PR-P2-2 (F refactor) の `observedRoundTripMs` 計測: act→next see() wallclock 差
+
+---
+
+## 1. Scope (本 PR の範囲)
+
+### 1.1 [in scope] 本 PR-P2-1 で扱う
+
+A. **`classifyModal(entity, context, options?)` 新規 export** (`src/engine/world-graph/session-registry.ts` 内、既存 `isChromeControlType` の近傍):
+   - signature: `classifyModal(entity: UiEntity, context: "pre-touch" | "post-touch-diff", options?: { excludeSelf?: UiEntity }): boolean`
+   - core 判定ロジック: `entity.sources.includes("uia") && entity.role === "unknown" && !isChromeControlType(entity.controlType)`
+   - context = "pre-touch" + `options.excludeSelf` 指定時: `entity.entityId !== options.excludeSelf.entityId` を追加判定
+   - context = "post-touch-diff": self-exclusion 不要 (post snapshot は touched 自身を別 layer で扱うため)
+
+B. **`isModalCandidate(target, candidate)` の deprecate 化**:
+   - 内部実装を `classifyModal(candidate, "pre-touch", { excludeSelf: target })` へ delegate
+   - export 維持 (内部 callsite から `isModalCandidate` を呼んでいる箇所 = `session-registry.ts:313, 318` を `classifyModal` 経由に移行する PR scope に含む)
+   - JSDoc に `@deprecated Use classifyModal(candidate, "pre-touch", { excludeSelf: target }) directly` 追記、Phase 3 SR-3 で削除 (= ADR-020 §5.1 で SR-3 削除済のため、deprecate のまま完了)
+
+C. **`isModalLike(e)` (guarded-touch.ts 内 private function) の deprecate 化**:
+   - 内部実装を `classifyModal(e, "post-touch-diff")` へ delegate
+   - `function` → `const` に変換 (export しないため deprecate 注釈のみ)
+   - 内部 callsite (`guarded-touch.ts:260, 261, 267`) を直接 `classifyModal(e, "post-touch-diff")` に移行
+
+D. **既存 callsite 移行**:
+   - `session-registry.ts:313`: `s.entities.some((e) => isModalCandidate(entity, e))` → `s.entities.some((e) => classifyModal(e, "pre-touch", { excludeSelf: entity }))`
+   - `session-registry.ts:318`: `s.entities.find((e) => isModalCandidate(entity, e))` → 同上
+   - `guarded-touch.ts:260, 261`: `appeared.filter(isModalLike)` / `removed.filter(isModalLike)` → `appeared.filter((e) => classifyModal(e, "post-touch-diff"))` / 同上
+   - `guarded-touch.ts:267`: `appeared.filter((e) => !isModalLike(e))` → `appeared.filter((e) => !classifyModal(e, "post-touch-diff"))`
+
+E. **既存 test の維持 + 新規 test 追加**:
+   - 既存 `tests/unit/modal-candidate.test.ts` + `tests/unit/guarded-touch.test.ts` は全 pass 維持 (BC 確認)
+   - 新規 `tests/unit/classify-modal.test.ts`: `classifyModal` の 2 context × core 判定 4 軸 (UIA / role unknown / non-chrome / self-exclusion) 直接 unit test
+
+### 1.2 [out of scope] 本 PR で扱わない
+
+- `classifyModal` を export する `_helpers.ts` barrel: ADR-020 §4.4 で「observable marker public export 整理のみ」と書いたが、`classifyModal` は production API でありかつ既存 `session-registry.ts` export 規約に乗るため barrel 不要
+- Phase 2 contract test (`tests/unit/path-class-contract/`): PR-P2-3 で land、本 PR-P2-1 は `classifyModal` API surface を確立するのみ
+- F refactor (`computeLeaseTtlMs` input 拡張): PR-P2-2 で land
+- Phase 3 SR-1〜SR-4: 各 SR sub-plan で
+
+---
+
+## 2. 北極星 (本 sub-plan)
+
+ADR-020 §2 全 4 項目を継承 + 本 PR 固有:
+
+1. **`classifyModal` 1 関数化により modal 判定の 2 関数分裂 (D drift) を構造的に解消** (= ADR-020 §1.1 D 軸の根本対策)
+2. **既存 `isModalCandidate` / `isModalLike` の挙動を bit-equal で維持** (BC、ADR-020 §2 #3): deprecate wrapper が完全に既存挙動と一致することを既存 test (modal-candidate / guarded-touch) で機械保証
+3. **`isChromeControlType` 共有 helper を `classifyModal` 内 private 化しない** (= PR #331 で確立済の export を維持、SR-1 でも consume される可能性、ADR-020 §5.1 SR-1 参照)
+
+---
+
+## 3. 既存コード状況 (grep 確認済)
+
+### 3.1 既存 export / helper
+
+- `isChromeControlType(controlType)` — `session-registry.ts:51-53` で定義、`guarded-touch.ts:4` import + 両 file で使用 (PR #331 で共有抽出済)
+- `NON_MODAL_CHROME_CONTROL_TYPES` — `session-registry.ts:28-37` で private 定数 (export なし)
+- `isModalCandidate(target, candidate)` — `session-registry.ts:93-99` で export
+- `isModalLike(e)` — `guarded-touch.ts:194-199` で private function (export なし)
+
+### 3.2 既存 callsite
+
+| caller | line | 現コード |
+|--------|------|---------|
+| `session-registry.ts` | 313 | `s.entities.some((e) => isModalCandidate(entity, e))` |
+| `session-registry.ts` | 318 | `s.entities.find((e) => isModalCandidate(entity, e)) ?? null` |
+| `guarded-touch.ts` | 260 | `appeared.filter(isModalLike)` |
+| `guarded-touch.ts` | 261 | `removed.filter(isModalLike)` |
+| `guarded-touch.ts` | 267 | `appeared.filter((e) => !isModalLike(e))` |
+
+### 3.3 既存 test
+
+- `tests/unit/modal-candidate.test.ts` — `isModalCandidate` の unit test
+- `tests/unit/guarded-touch.test.ts` — `guarded-touch` 経由の `isModalLike` 振る舞いを統合的に test
+
+---
+
+## 4. 統合戦略 (案 A 採用、案 B/C 不採用論拠)
+
+### 4.1 案 A (採用): `classifyModal(entity, context, options?)` 3 引数 unified API
+
+```ts
+export function classifyModal(
+  entity: UiEntity,
+  context: "pre-touch" | "post-touch-diff",
+  options?: { excludeSelf?: UiEntity }
+): boolean {
+  // Core: UIA-sourced + unknown role + non-chrome
+  if (!entity.sources.includes("uia")) return false;
+  if (entity.role !== "unknown") return false;
+  if (isChromeControlType(entity.controlType)) return false;
+  // Pre-touch context only: exclude self (target entity itself)
+  if (context === "pre-touch" && options?.excludeSelf?.entityId === entity.entityId) return false;
+  return true;
+}
+```
+
+**論拠**:
+- ADR-020 §4.4 の `classifyModal(entity, context)` 文言と整合 (options 引数は補助、core signature は (entity, context) 2 引数)
+- pre-touch / post-touch の文脈差分を **context 引数で明示**、core 判定は共有 (drift 構造的不能)
+- self-exclusion は **pre-touch 固有の要件**を options で表現、post-touch では使わない (post snapshot は touched 自身を別 layer で扱うため不要)
+- 既存 `isModalCandidate(target, candidate)` は thin wrapper として deprecate (= delegate)、`isModalLike(e)` は private function なので直接 callsite 移行
+
+### 4.2 案 B (不採用): signature 別、共通 core helper のみ統合
+
+```ts
+function isModalEntity(e: UiEntity): boolean { /* core 共通 */ }
+export function isModalCandidate(target, candidate) { return candidate.entityId !== target.entityId && isModalEntity(candidate); }
+function isModalLike(e) { return isModalEntity(e); }
+```
+
+**不採用論拠**:
+- ADR-020 §4.4 「`classifyModal(entity, context)` 1 関数化」と矛盾 (案 B は 2 関数のまま、core helper 抽出のみ)
+- 「2 関数分裂 (D drift) を構造的に解消」(本 sub-plan §2 北極星 #1) を達成しない、core 共通化は **再分裂を許す構造** (新規 context 拡張時に case-by-case で再分裂し得る)
+
+### 4.3 案 C (不採用): context 引数 + `isModalCandidate` を composition
+
+```ts
+classifyModalEntity(e, context: "pre-touch-candidate" | "post-touch-diff"): boolean
+isModalCandidate(target, candidate) = candidate.entityId !== target.entityId && classifyModalEntity(candidate, "pre-touch-candidate")
+```
+
+**不採用論拠**:
+- context 値が `"pre-touch-candidate"` という long string + `isModalCandidate` の composition が冗長
+- 案 A の `options.excludeSelf` 方式が同等表現力 + より読みやすい
+
+---
+
+## 5. 実装内訳 (PR 単一、推定 ~150-250 line)
+
+### 5.1 新規追加
+
+- `session-registry.ts`: `classifyModal(entity, context, options?)` export 追加 (line ~100 周辺、`isModalCandidate` の直前)、JSDoc 完備 (3 contexts / options / core 判定 4 軸 / D drift 教訓)
+
+### 5.2 既存改修
+
+- `session-registry.ts:93-99`: `isModalCandidate(target, candidate)` 内部を `classifyModal(candidate, "pre-touch", { excludeSelf: target })` へ delegate、`@deprecated` JSDoc 追記
+- `session-registry.ts:313, 318`: 既存 callsite を `classifyModal` 直接 call に移行
+- `guarded-touch.ts:194-199`: `isModalLike(e)` 内部を `classifyModal(e, "post-touch-diff")` へ delegate、`function` 宣言維持 (private なので export なし、JSDoc に `@deprecated, use classifyModal directly` 追記)
+- `guarded-touch.ts:260, 261, 267`: 既存 callsite を `classifyModal(e, "post-touch-diff")` に移行
+
+### 5.3 test 追加
+
+- `tests/unit/classify-modal.test.ts` 新規:
+  - 2 context × 4 core 判定軸 = 8 case + self-exclusion 2 case = 計 10 case
+  - 既存 `modal-candidate.test.ts` の test fixture を再利用可能
+
+### 5.4 既存 test pass 維持 (BC 機械保証)
+
+- `tests/unit/modal-candidate.test.ts`: `isModalCandidate(target, candidate)` の挙動が deprecate wrapper 経由でも 100% 同一 → 全 pass 維持で BC 保証
+- `tests/unit/guarded-touch.test.ts`: `guarded-touch` 経由の `isModalLike` 振る舞いが `classifyModal` 経由でも 100% 同一 → 全 pass 維持で BC 保証
+
+---
+
+## 6. BC (Backward Compatibility) 維持確認
+
+- `isModalCandidate` export 維持 (deprecate wrapper)、外部 import 経路は不変
+- `isChromeControlType` export 不変 (PR #331 確立済 SSOT)
+- `NON_MODAL_CHROME_CONTROL_TYPES` private 維持 (export なし)
+- `isModalLike` は元から private function なので外部影響なし
+- 新規 export `classifyModal` 追加のみ、既存 export 削除なし
+
+---
+
+## 7. Risks
+
+| R# | risk | 対策 |
+|----|------|------|
+| R1 | `classifyModal` の signature design が後続 Phase 3 (SR-1 CapabilityRegistry) と矛盾する API shape で固まる | ADR-020 §8 R7 で fact 整合 sweep を SR-1 sub-plan 起草時に明示済、本 sub-plan の signature は ADR-020 §4.4 と bit-equal sync 確認済 |
+| R2 | `isModalCandidate` deprecate wrapper の挙動が既存と微妙にズレ (e.g. options.excludeSelf undefined 時の挙動) | 既存 `modal-candidate.test.ts` 全 pass を merge ブロッカー化 (Phase 2 §4.6 同型 acceptance) |
+| R3 | `classifyModal` を export する場所 (`session-registry.ts` vs 新規 `modal-classifier.ts`) で迷い | 本 sub-plan §1.1 で `session-registry.ts` 内 export 確定 (既存 `isChromeControlType` と同居が natural、新 file 作成は YAGNI) |
+
+---
+
+## 8. Acceptance criteria
+
+- `classifyModal(entity, context, options?)` が `session-registry.ts` から export され、JSDoc 完備
+- `isModalCandidate` / `isModalLike` 内部実装が `classifyModal` へ delegate、`@deprecated` JSDoc 追記
+- 既存 5 callsite (§3.2) 全て `classifyModal` 直接 call に移行
+- 新規 `tests/unit/classify-modal.test.ts` 10 case 全 pass
+- 既存 `tests/unit/modal-candidate.test.ts` + `tests/unit/guarded-touch.test.ts` 全 pass 維持 (BC 機械保証)
+- 既存 vitest suite 全 pass + tsc build pass
+- Opus + Codex 各 1+ round Approved (production code 改修 PR、CLAUDE.md §3.3 Step 0)
+- ADR-020 carry-over ledger L3 (D) を sub-plan land 後の commit message で strikethrough 候補化 (実際の strikethrough は PR-P2-3 contract test land 時 = D drift 構造除去完了 trigger)
+
+---
+
+## 9. Open Questions
+
+### 残存
+
+- **OQ #1**: `isModalCandidate` の deprecate を「内部 re-export 残し + JSDoc deprecated」止めで完了するか、それとも本 PR-P2-1 で完全削除するか? 内部 callsite を全て `classifyModal` 直接 call に移行するため、export 削除 = breaking change にはならない (外部 import がない前提、grep 確認: src 外で `isModalCandidate` import している file はテスト 1 件のみ = `tests/unit/modal-candidate.test.ts`)。判断: deprecate 維持で Phase 3 完了時に再諮問 (SR-3 削除済のため永続 deprecate も option)、本 PR では deprecate のみ
+- **OQ #2**: `tests/unit/modal-candidate.test.ts` を `tests/unit/classify-modal.test.ts` 内に merge するか、別 file 維持か? 判断: 別 file 維持 (deprecated API の test も残しておく、BC pin として)
+
+---
+
+## 10. 起草 metadata
+
+- 起草日: 2026-05-17
+- 起草 session: ADR-020 land 直後の Phase 2 PR-P2-1 起動 (auto-mode、user 指示「本 session で PR-P2-1 起動、auto-mode で land まで」)
+- 起草前 read 済: ADR-020 全体 + `src/engine/world-graph/session-registry.ts` + `src/engine/world-graph/guarded-touch.ts` + grep 確認 (`isModalCandidate` / `isModalLike` / `NON_MODAL_CHROME_CONTROL_TYPES` / `isChromeControlType` の caller / test)
+- 次のステップ: 本 sub-plan を chat 表示 → user 目視確認 → 修正なければ feature branch + impl + commit + PR + Opus/Codex 並列 review + auto-mode merge

--- a/docs/adr-020-phase-2-p2-1-modal-refactor-plan.md
+++ b/docs/adr-020-phase-2-p2-1-modal-refactor-plan.md
@@ -114,12 +114,14 @@ export function classifyModal(
   context: "pre-touch" | "post-touch-diff",
   options?: { excludeSelf?: UiEntity }
 ): boolean {
+  // Pre-touch self-exclusion FIRST (load-bearing per-clause order — preserves
+  // legacy isModalCandidate ordering where `entityId === target.entityId` is
+  // the first early-return). Keep this clause at line 1 of the body.
+  if (context === "pre-touch" && options?.excludeSelf?.entityId === entity.entityId) return false;
   // Core: UIA-sourced + unknown role + non-chrome
   if (!entity.sources.includes("uia")) return false;
   if (entity.role !== "unknown") return false;
   if (isChromeControlType(entity.controlType)) return false;
-  // Pre-touch context only: exclude self (target entity itself)
-  if (context === "pre-touch" && options?.excludeSelf?.entityId === entity.entityId) return false;
   return true;
 }
 ```

--- a/src/engine/world-graph/guarded-touch.ts
+++ b/src/engine/world-graph/guarded-touch.ts
@@ -1,7 +1,7 @@
 import type { UiEntity, EntityLease, ExecutorKind, ExecutorOutcome, UiAffordance } from "./types.js";
 import type { LeaseStore } from "./lease-store.js";
 import type { VisualMotionObservation } from "../../tools/_input-pipeline.js";
-import { isChromeControlType } from "./session-registry.js";
+import { classifyModal } from "./session-registry.js";
 
 export type TouchAction = "auto" | "invoke" | "click" | "type" | "setValue" | "select";
 
@@ -177,26 +177,6 @@ function hasEntityMoved(pre: UiEntity, post: UiEntity): boolean {
   );
 }
 
-/**
- * Modal heuristic: UIA-sourced entity with role "unknown" is likely an overlay/dialog.
- * Conservative — plain toolbar buttons have specific roles and are excluded.
- * A richer heuristic (ControlType=Dialog, IsModal=true) requires UIA property access
- * not yet wired.
- *
- * Issue #327 item D / Issue #297 closure completion: UI chrome
- * (MenuBar / TitleBar / StatusBar / ToolBar / ScrollBar / Tab / Menu / MenuItem)
- * also surfaces as `role: "unknown"` on UIA, so without a controlType check
- * Notepad's TitleBar / MenuBar / StatusBar fire `modal_appeared` every time the
- * UIA snapshot re-keys those entities. The shared `isChromeControlType` helper
- * from `session-registry.ts` keeps this predicate bit-equal with the pre-touch
- * `isModalCandidate` path so the two modal detectors cannot diverge again.
- */
-function isModalLike(e: UiEntity): boolean {
-  if (!e.sources.includes("uia")) return false;
-  if (e.role !== "unknown") return false;
-  if (isChromeControlType(e.controlType)) return false;
-  return true;
-}
 
 /**
  * Value fingerprint for an entity — what counts as "the value" varies by source:
@@ -257,14 +237,16 @@ function computeDiff(ctx: DiffContext): SemanticDiff {
   const removed  = preEntities.filter((e) => !postIds.has(e.entityId));
 
   // modal_appeared / modal_dismissed take priority for modal entities.
-  const modalAppeared   = appeared.filter(isModalLike);
-  const modalDismissed  = removed.filter(isModalLike);
+  // ADR-020 PR-P2-1: unified classifier (post-touch-diff context, no self-exclusion;
+  // the `touched` entity is handled separately above).
+  const modalAppeared   = appeared.filter((e) => classifyModal(e, "post-touch-diff"));
+  const modalDismissed  = removed.filter((e) => classifyModal(e, "post-touch-diff"));
   if (modalAppeared.length   > 0) diff.push("modal_appeared");
   if (modalDismissed.length  > 0) diff.push("modal_dismissed");
 
   // entity_appeared: non-modal entities that are new in the post snapshot.
   // Suppressed for entities already covered by modal_appeared.
-  const nonModalAppeared = appeared.filter((e) => !isModalLike(e));
+  const nonModalAppeared = appeared.filter((e) => !classifyModal(e, "post-touch-diff"));
   if (nonModalAppeared.length > 0) diff.push("entity_appeared");
 
   // ── Focus shift ───────────────────────────────────────────────────────────

--- a/src/engine/world-graph/session-registry.ts
+++ b/src/engine/world-graph/session-registry.ts
@@ -53,49 +53,63 @@ export function isChromeControlType(controlType: string | undefined): boolean {
 }
 
 /**
- * Shared predicate used by the default `isModalBlocking` and `findBlockingModal`
- * implementations so they cannot diverge. UIA exposes system dialogs and
- * overlays as `role: "unknown"` elements; the self-exclusion (entityId !==)
- * keeps a dialog from blocking actions on its own children. Issue #63.
+ * ADR-020 Phase 2 PR-P2-1 — unified modal classifier (issue #327 item D
+ * structural fix). Replaces the historical 2-function split (`isModalCandidate`
+ * pre-touch UIA-tree path / `isModalLike` post-touch diff path) that drifted
+ * silently when the chrome-exclusion clause was added to one side only
+ * (#297 closure was incomplete until PR #331). Single source of truth so the
+ * two paths cannot diverge again.
  *
- * Issue #297: UI chrome (MenuBar / TitleBar / StatusBar / ToolBar) is also
- * `role:"unknown"` in the UIA tree but is never a modal blocker. The
- * `controlType` field carried through by Issue #296 lets the predicate
- * distinguish dialog overlays (no `controlType` or `Pane` / `Window`) from
- * UI chrome (`MenuBar` etc.). Entities lacking `controlType` (legacy /
- * non-UIA-fronted producers) fall through to the prior behaviour for
- * back-compat.
+ * Core predicate (both contexts): UIA-sourced + `role:"unknown"` + non-chrome
+ * controlType. Entities lacking `controlType` fall through to the prior
+ * "trust the role:'unknown' signal" behaviour for back-compat with pre-#296
+ * producers.
  *
- * Exported for direct unit testing of the truth table (the per-clause
- * negation order is load-bearing — Codex / Opus reviewers historically
- * read this code line-by-line).
+ * Context-specific clauses:
+ *   - `"pre-touch"` with `options.excludeSelf` set: excludes the focus target
+ *     from its own blocking-modal search (a dialog cannot block actions on
+ *     its own children, Issue #63).
+ *   - `"post-touch-diff"`: no self-exclusion; the post snapshot's `touched`
+ *     entity is handled by a separate layer (see `guarded-touch.ts`
+ *     `computeDiff`).
  *
- * Cross-signal consistency note (Issue #297): the three modal-detection
- * APIs in this codebase serve different layers and intentionally use
- * different signals:
+ * Cross-signal consistency note (Issue #297): the three modal-detection APIs
+ * in this codebase serve different layers and intentionally use different
+ * signals:
  *
  *   - `desktop-state.ts::MODAL_RE` — window-title regex; surface-level
  *     "is there a window with 'dialog' / 'confirm' / '警告' in its title".
- *     Cheap, top-of-window flag for orientation.
- *   - `isModalCandidate` (this function) — UIA-tree based; resolves
- *     `blockingElement` for `desktop_act` so the LLM can dismiss the
- *     specific element. Requires Issue #296's `controlType` to exclude
- *     UI chrome.
+ *   - `classifyModal` (this function) — UIA-tree based; both pre-touch
+ *     `blockingElement` resolution and post-touch `modal_appeared` /
+ *     `modal_dismissed` diff detection. Requires Issue #296's `controlType`
+ *     to exclude UI chrome.
  *   - `evaluateModalAbove` (`sensors-win32.ts`) — Win32-Z-order based
- *     confidence score (owner chain + className `#32770` + target
- *     disabled). Used for perception-layer attention scoring.
+ *     confidence score (owner chain + className `#32770` + target disabled).
  *
  * The three are NOT expected to converge on every state — they answer
- * different questions and target different layers. The chrome exclusion
- * here is the minimum change needed so they no longer **disagree** in
- * the common false-positive case (MenuBar on a non-modal main window).
+ * different questions and target different layers. The chrome exclusion here
+ * is the minimum change needed so they no longer **disagree** in the common
+ * false-positive case (MenuBar on a non-modal main window).
+ */
+export function classifyModal(
+  entity: UiEntity,
+  context: "pre-touch" | "post-touch-diff",
+  options?: { excludeSelf?: UiEntity },
+): boolean {
+  if (context === "pre-touch" && options?.excludeSelf?.entityId === entity.entityId) return false;
+  if (!entity.sources.includes("uia")) return false;
+  if (entity.role !== "unknown") return false;
+  if (isChromeControlType(entity.controlType)) return false;
+  return true;
+}
+
+/**
+ * @deprecated ADR-020 Phase 2 PR-P2-1 — call `classifyModal(candidate, "pre-touch", { excludeSelf: target })` directly.
+ * Retained as a thin wrapper for backward compatibility (existing tests +
+ * external callers). Internal callsites in this file already migrated.
  */
 export function isModalCandidate(target: UiEntity, candidate: UiEntity): boolean {
-  if (candidate.entityId === target.entityId) return false;
-  if (!candidate.sources.includes("uia")) return false;
-  if (candidate.role !== "unknown") return false;
-  if (isChromeControlType(candidate.controlType)) return false;
-  return true;
+  return classifyModal(candidate, "pre-touch", { excludeSelf: target });
 }
 
 export type TargetSessionKey =
@@ -301,7 +315,7 @@ export class SessionRegistry {
       // Issue #63 (Codex P1): when the user overrides exactly one of the pair, we derive
       // the other to keep predicate ↔ blockingElement consistent — never surface a default
       // UIA-unknown blocker alongside an unrelated custom predicate.
-      //   both default      → shared isModalCandidate predicate (consistent)
+      //   both default      → shared classifyModal predicate (consistent, ADR-020 PR-P2-1)
       //   both overridden   → caller's responsibility (no derivation)
       //   only isModalBlocking overridden → findBlockingModal returns null (blockingElement omitted,
       //                                     so the LLM is never told to dismiss the wrong element)
@@ -310,12 +324,12 @@ export class SessionRegistry {
         opts.isModalBlocking ??
         (opts.findBlockingModal
           ? (entity: UiEntity) => opts.findBlockingModal!(entity) !== null
-          : (entity: UiEntity) => s.entities.some((e) => isModalCandidate(entity, e))),
+          : (entity: UiEntity) => s.entities.some((e) => classifyModal(e, "pre-touch", { excludeSelf: entity }))),
       findBlockingModal:
         opts.findBlockingModal ??
         (opts.isModalBlocking
           ? () => null
-          : (entity: UiEntity) => s.entities.find((e) => isModalCandidate(entity, e)) ?? null),
+          : (entity: UiEntity) => s.entities.find((e) => classifyModal(e, "pre-touch", { excludeSelf: entity })) ?? null),
       isInViewport: opts.isInViewport ?? (() => true),
       // G1-C: Focus fingerprint for focus_shifted detection.
       // Only wired when opts.getFocusedEntityId is provided (e.g. production desktop-register.ts).

--- a/tests/unit/classify-modal.test.ts
+++ b/tests/unit/classify-modal.test.ts
@@ -1,0 +1,106 @@
+/**
+ * tests/unit/classify-modal.test.ts — ADR-020 Phase 2 PR-P2-1.
+ *
+ * Pins the unified `classifyModal(entity, context, options?)` truth table
+ * directly (the historical 2-function split `isModalCandidate` / `isModalLike`
+ * silently drifted on the chrome-exclusion clause until PR #331; this test
+ * pins the merged classifier so the same drift cannot reappear under a new
+ * context expansion).
+ *
+ * Context coverage:
+ *   - pre-touch + excludeSelf: self-exclusion clause active
+ *   - pre-touch without excludeSelf: core predicate only
+ *   - post-touch-diff: core predicate only (no self-exclusion)
+ *
+ * The legacy `isModalCandidate` / `isModalLike` behaviours are pinned by their
+ * own tests (`modal-candidate.test.ts` + `guarded-touch.test.ts`) which now
+ * route through this classifier — keeping both layers guarantees BC.
+ */
+
+import { describe, it, expect } from "vitest";
+import { classifyModal } from "../../src/engine/world-graph/session-registry.js";
+import type { UiEntity } from "../../src/engine/world-graph/types.js";
+
+function makeEntity(overrides: Partial<UiEntity> = {}): UiEntity {
+  return {
+    entityId: "ent-default",
+    role: "unknown",
+    confidence: 1,
+    sources: ["uia"],
+    affordances: [],
+    generation: "g0",
+    evidenceDigest: "d0",
+    ...overrides,
+  };
+}
+
+describe("classifyModal — ADR-020 PR-P2-1 unified classifier", () => {
+  describe("core predicate (both contexts share)", () => {
+    it("returns true for a UIA unknown-role overlay (canonical dialog) in pre-touch", () => {
+      const overlay = makeEntity({ entityId: "overlay" });
+      expect(classifyModal(overlay, "pre-touch")).toBe(true);
+    });
+
+    it("returns true for a UIA unknown-role overlay in post-touch-diff", () => {
+      const overlay = makeEntity({ entityId: "overlay" });
+      expect(classifyModal(overlay, "post-touch-diff")).toBe(true);
+    });
+
+    it("returns false when sources lacks 'uia' (cdp-only / visual-only)", () => {
+      const cdp = makeEntity({ entityId: "cdp", sources: ["cdp"] });
+      expect(classifyModal(cdp, "pre-touch")).toBe(false);
+      expect(classifyModal(cdp, "post-touch-diff")).toBe(false);
+    });
+
+    it("returns false when role is NOT 'unknown' (e.g. button)", () => {
+      const btn = makeEntity({ entityId: "btn", role: "button" });
+      expect(classifyModal(btn, "pre-touch")).toBe(false);
+      expect(classifyModal(btn, "post-touch-diff")).toBe(false);
+    });
+
+    it.each([
+      "MenuBar", "Menu", "MenuItem", "TitleBar",
+      "StatusBar", "ToolBar", "ScrollBar", "Tab",
+    ])("returns false for chrome controlType=%s in both contexts", (chromeCt) => {
+      const chrome = makeEntity({ entityId: "chrome", controlType: chromeCt });
+      expect(classifyModal(chrome, "pre-touch")).toBe(false);
+      expect(classifyModal(chrome, "post-touch-diff")).toBe(false);
+    });
+
+    it("returns true for non-chrome controlType (e.g. Pane) in both contexts", () => {
+      const pane = makeEntity({ entityId: "pane", controlType: "Pane" });
+      expect(classifyModal(pane, "pre-touch")).toBe(true);
+      expect(classifyModal(pane, "post-touch-diff")).toBe(true);
+    });
+
+    it("returns true when controlType is undefined (pre-#296 producer back-compat)", () => {
+      const legacy = makeEntity({ entityId: "legacy" });
+      expect(classifyModal(legacy, "pre-touch")).toBe(true);
+      expect(classifyModal(legacy, "post-touch-diff")).toBe(true);
+    });
+  });
+
+  describe("self-exclusion clause (pre-touch + excludeSelf only)", () => {
+    const target = makeEntity({ entityId: "target", role: "button" });
+
+    it("returns false for the target itself when excludeSelf is provided (pre-touch)", () => {
+      // Even when the candidate would otherwise satisfy the core predicate,
+      // self-exclusion wins to keep a dialog from blocking its own children (Issue #63).
+      const selfWithModalShape = makeEntity({ entityId: "target" });
+      expect(classifyModal(selfWithModalShape, "pre-touch", { excludeSelf: target })).toBe(false);
+    });
+
+    it("returns true for a non-self entity even when excludeSelf is provided (pre-touch)", () => {
+      const other = makeEntity({ entityId: "other" });
+      expect(classifyModal(other, "pre-touch", { excludeSelf: target })).toBe(true);
+    });
+
+    it("ignores excludeSelf in post-touch-diff context (no self-exclusion)", () => {
+      // post-touch-diff context: the `touched` entity is handled by a separate layer
+      // in computeDiff, so self-exclusion must not leak here. A modal-shaped entity
+      // matching target.entityId must still classify as modal in post-touch context.
+      const selfWithModalShape = makeEntity({ entityId: "target" });
+      expect(classifyModal(selfWithModalShape, "post-touch-diff", { excludeSelf: target })).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

ADR-020 Phase 2 PR-P2-1 — structurally eliminates the 2-function split (`isModalCandidate` pre-touch / `isModalLike` post-touch-diff) that silently drifted on the chrome-exclusion clause until PR #331 (issue #327 item D). Now a single `classifyModal(entity, context, options?)` classifier in `session-registry.ts` is the source of truth for both contexts.

## Design (sub-plan §4.1 case A)

\`\`\`ts
classifyModal(
  entity: UiEntity,
  context: \"pre-touch\" | \"post-touch-diff\",
  options?: { excludeSelf?: UiEntity },
): boolean
\`\`\`

Core predicate (both contexts): UIA-sourced + `role:\"unknown\"` + non-chrome controlType. Context-specific clauses: pre-touch + `options.excludeSelf` adds self-exclusion (Issue #63); post-touch-diff omits it (the `touched` entity is handled by a separate layer in `computeDiff`).

## Changes

- **`classifyModal`** new export in `session-registry.ts`
- **`isModalCandidate(target, candidate)`** now a thin deprecated wrapper delegating to `classifyModal(candidate, \"pre-touch\", { excludeSelf: target })`
- **`isModalLike(e)`** private function **fully removed** (sub-plan §1.1 C said \"deprecate wrapper\" but private function has no external BC surface → CLAUDE.md \"unused = delete\" applies, cleaner than dead wrapper)
- 5 callsites migrated: `session-registry.ts:327,332` + `guarded-touch.ts:260,261,267`
- `guarded-touch.ts` `isChromeControlType` import removed (unused after delegation)

## Tests

- **New**: `tests/unit/classify-modal.test.ts` (10 cases: core × 2 contexts + self-exclusion × 3)
- **Unchanged BC pins**: `tests/unit/modal-candidate.test.ts` (pins `isModalCandidate` through delegate wrapper) + `tests/unit/guarded-touch.test.ts` (pins post-touch-diff through migrated callsites)
- **Full suite**: 3540 passed | 32 skipped | 5 todo (zero regression)
- **tsc build**: clean

## Sub-plan / parent ADR

- Sub-plan: `docs/adr-020-phase-2-p2-1-modal-refactor-plan.md` (bundled in this PR)
- Parent ADR: `docs/adr-020-path-class-refactor-plan.md` (merged PR #335)
- ADR-020 ledger L3 (D drift) → struct-removed by this PR; final strike-through deferred to PR-P2-3 (contract test land, ledger close trigger)

## Test plan

- [ ] Opus phase-boundary review (CLAUDE.md §3.3 Step 1)
- [ ] Codex review (production code change, §3.3 Step 0 mandatory)
- [ ] Round iteration until P1 zero
- [ ] auto-mode merge per `feedback_auto_mode_merge_opus_judgment.md` (production code OK with both reviewers Approved, per 2026-05-17 user direction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)