### PR TITLE
refactor(capabilities): CapabilityRegistry SSOT + entity bake helper — ADR-020 PR-SR1-1

### DIFF
--- a/src/capabilities/registry.ts
+++ b/src/capabilities/registry.ts
@@ -1,0 +1,255 @@
+/**
+ * CapabilityRegistry — capability rule SSOT for ADR-020 SR-1 (PR-SR1-1).
+ *
+ * Three consumers (`deriveEntityCapabilities` advisory wrapper,
+ * `createDesktopExecutor` execution route order, `desktop-register.ts` tool
+ * description) all derive capability semantics from this registry exclusively
+ * (北極星 1, registry SSOT 1 箇所). Rule table re-implementation or
+ * re-declaration in consumer modules is forbidden — `deriveEntityCapabilities`
+ * is a thin wrapper around `registry.lookup` for backward compatibility only.
+ *
+ * Pure lookup invariant (北極星 1 + sub-plan §4.2): the registry has no
+ * internal state. The `defaultRegistry` module-level singleton is safe for
+ * concurrent / parallel test execution (no race possible). Constant data is
+ * held in module-level `const` declarations (string primitives benefit from
+ * TypeScript's `const` guard; object caches, if added later, must be wrapped
+ * with `Object.freeze({...})` — note that `Object.freeze` on a string
+ * primitive is a no-op).
+ */
+
+import type { UiEntity } from "../engine/world-graph/types.js";
+import type {
+  EntityCapabilities,
+  ViewConstraints,
+} from "../tools/desktop-constraints.js";
+
+/**
+ * Advertised executor kinds — the narrow union of executors that the
+ * capability registry surfaces to the LLM and that `createDesktopExecutor`
+ * consumes as a route order. Distinct from `ExecutorKind` (in
+ * `src/engine/world-graph/types.ts:36`) which additionally includes
+ * `"keyboard"` as an internal fallback executor used only inside the UIA
+ * `setValue` ladder (`keyboardTypeBg`).
+ *
+ * SR-5 (`"keyboard"` first-class promotion) extends this alias to include
+ * `"keyboard"` when the registry begins advertising that executor; the
+ * single change to this type propagates the narrow widening to every
+ * consumer via the TypeScript compiler.
+ */
+export type AdvertisedExecutorKind = "uia" | "cdp" | "terminal" | "mouse";
+
+/** Runtime defense-in-depth — every emitted `preferredExecutor` must belong
+ *  to this set. Catches rule-table edits that accidentally introduce
+ *  `"keyboard"` or other non-advertised values that the TS narrow type would
+ *  otherwise miss in dynamic / unsoundly-cast contexts. */
+const ALLOWED_EXECUTORS: ReadonlySet<AdvertisedExecutorKind> = new Set<AdvertisedExecutorKind>([
+  "uia",
+  "cdp",
+  "terminal",
+  "mouse",
+]);
+
+export interface CapabilityRegistry {
+  /**
+   * Pure derivation of `EntityCapabilities` from a `UiEntity` + optional
+   * `ViewConstraints`. Returns `undefined` when the entity exposes no
+   * actionable signal (e.g. UIA-only entity with no rect and no pattern).
+   *
+   * Invariant on a defined return value (北極星 7):
+   *   (a) `preferredExecutors.length >= 1`
+   *   (b) `preferredExecutors ∩ unsupportedExecutors = ∅`
+   *   (c) `preferredExecutors ⊆ Array<AdvertisedExecutorKind>` (no `"keyboard"`)
+   *
+   * Bit-equal output guarantee with the pre-SR-1 `deriveEntityCapabilities`
+   * implementation — pinned by the existing
+   * `tests/unit/desktop-capabilities.test.ts` 14 cases and the new
+   * `tests/unit/capabilities-registry-invariant.test.ts` cases.
+   */
+  lookup(
+    entity: UiEntity,
+    viewConstraints?: ViewConstraints,
+  ): EntityCapabilities | undefined;
+
+  /**
+   * LLM-facing tool description advisory text generated from the rule
+   * table. PR-SR1-3 will derive this from the registry rule shape; in the
+   * current PR-SR1-1 land it returns a hand-written `ADVISORY_TEXT` constant
+   * that is bit-equal to the existing static string at
+   * `src/tools/desktop-register.ts:800`.
+   */
+  toolDescriptionAdvisory(): string;
+}
+
+/** Construct the production registry (singleton-friendly, no internal state). */
+export function createDefaultCapabilityRegistry(): CapabilityRegistry {
+  return {
+    lookup: lookupDefault,
+    toolDescriptionAdvisory: toolDescriptionAdvisoryDefault,
+  };
+}
+
+// ── rule table (migrated bit-equal from desktop-capabilities.ts:64) ─────────
+
+/**
+ * UIA pattern names this rule table recognises. Strings are the wire-form
+ * values emitted by both the Rust native path and the PowerShell fallback
+ * (canonicalised upstream by `uia-provider.ts::normalizeUiaPatternNames`).
+ */
+const INVOKE_PATTERN = "InvokePattern";
+const VALUE_PATTERN = "ValuePattern";
+const TOGGLE_PATTERN = "TogglePattern";
+
+/**
+ * UIA control types that historically refuse `Invoke` even though the LLM
+ * tends to treat them as clickable (Issue #296 user report). Selection
+ * happens via `SelectionItemPattern`, not `Invoke`.
+ */
+const SELECTION_ONLY_CONTROLS = new Set(["ListItem", "TabItem", "TreeItem"]);
+
+function lookupDefault(
+  entity: UiEntity,
+  viewConstraints?: ViewConstraints,
+): EntityCapabilities | undefined {
+  const isUiaSource = entity.sources.includes("uia");
+  const hasRect = entity.rect !== undefined;
+  const patterns = entity.patterns ?? [];
+  const controlType = entity.controlType;
+
+  const uiaProviderFailed = viewConstraints?.uia === "provider_failed";
+
+  let cap: EntityCapabilities | undefined;
+
+  if (!isUiaSource) {
+    if (!hasRect) cap = undefined;
+    else
+      cap = {
+        preferredExecutors: ["mouse"],
+        unsupportedExecutors: ["uia"],
+      };
+  } else {
+    const hasInvoke = patterns.includes(INVOKE_PATTERN);
+    const hasToggle = patterns.includes(TOGGLE_PATTERN);
+    const hasValue = patterns.includes(VALUE_PATTERN);
+    const isSelectionOnly =
+      controlType !== undefined && SELECTION_ONLY_CONTROLS.has(controlType);
+
+    if (uiaProviderFailed) {
+      if (!hasRect) cap = undefined;
+      else
+        cap = {
+          preferredExecutors: ["mouse"],
+          unsupportedExecutors: ["uia"],
+          fallbackHint: "use mouse_click — UIA provider failed for this view",
+        };
+    } else if (hasInvoke) {
+      cap = { preferredExecutors: ["uia", "mouse"] };
+    } else if (isSelectionOnly && hasRect) {
+      cap = {
+        preferredExecutors: ["mouse"],
+        unsupportedExecutors: ["uia"],
+        fallbackHint: `use mouse_click — UIA InvokePattern not exposed on ${controlType ?? "this control"}`,
+      };
+    } else if (hasToggle && hasRect) {
+      cap = {
+        preferredExecutors: ["mouse"],
+        unsupportedExecutors: ["uia"],
+        fallbackHint:
+          "use mouse_click — UIA executor does not yet implement TogglePattern",
+      };
+    } else if (hasValue) {
+      cap = { preferredExecutors: ["uia"] };
+    } else if (hasRect) {
+      cap = {
+        preferredExecutors: ["mouse"],
+        unsupportedExecutors: ["uia"],
+      };
+    } else {
+      cap = undefined;
+    }
+  }
+
+  if (cap !== undefined) assertCapabilitiesInvariant(cap);
+  return cap;
+}
+
+// ── invariant guard (北極星 7 defense-in-depth) ─────────────────────────────
+
+/**
+ * Defensive check enforcing the three registry invariants (北極星 7) at
+ * runtime. Wired into `lookupDefault` so any rule-table edit that violates
+ * the invariants throws at production runtime rather than silently emitting
+ * a broken capability shape. The check is cheap (O(n) over a 1-4 element
+ * array) and runs on every `see()` call.
+ */
+export function assertCapabilitiesInvariant(cap: EntityCapabilities): void {
+  const preferred = cap.preferredExecutors ?? [];
+  const unsupported = cap.unsupportedExecutors ?? [];
+
+  if (preferred.length === 0) {
+    throw new Error(
+      "CapabilityRegistry invariant violation: preferredExecutors.length === 0",
+    );
+  }
+
+  for (const e of preferred) {
+    if (!ALLOWED_EXECUTORS.has(e as AdvertisedExecutorKind)) {
+      throw new Error(
+        `CapabilityRegistry invariant violation: "${e}" ∉ ALLOWED_EXECUTORS (narrow type breach, e.g. "keyboard" misplaced into advertised set)`,
+      );
+    }
+    if (unsupported.includes(e)) {
+      throw new Error(
+        `CapabilityRegistry invariant violation: overlap "${e}" in preferred ∩ unsupported`,
+      );
+    }
+  }
+}
+
+// ── entity bake helper (北極星 8) ────────────────────────────────────────────
+
+/**
+ * Bake the registry-derived `EntityCapabilities` onto a `UiEntity` so the
+ * executor can consume `preferredExecutors / unsupportedExecutors /
+ * fallbackHint` without invoking the registry itself (case β, sub-plan
+ * §1.5). Writes all three fields in a single batch — partial bakes would
+ * re-introduce the `provider_failed` view bias loss bug that the SR-1
+ * design specifically eliminates.
+ *
+ * Safe to call with `cap === undefined` (no-op).
+ */
+export function bakeEntityCapabilities(
+  entity: UiEntity,
+  cap: EntityCapabilities | undefined,
+): void {
+  if (cap === undefined) return;
+  if (cap.preferredExecutors && cap.preferredExecutors.length > 0) {
+    entity.preferredExecutors = [...cap.preferredExecutors];
+  }
+  if (cap.unsupportedExecutors && cap.unsupportedExecutors.length > 0) {
+    entity.unsupportedExecutors = [...cap.unsupportedExecutors];
+  }
+  if (cap.fallbackHint !== undefined) {
+    entity.fallbackHint = cap.fallbackHint;
+  }
+}
+
+// ── tool description (PR-SR1-1 stub, PR-SR1-3 will derive from rule shape) ──
+
+/**
+ * PR-SR1-3 will replace this hand-written constant with text generated from
+ * the rule table shape. The current value is bit-equal to the existing
+ * static string at `src/tools/desktop-register.ts:800` so the PR-SR1-3
+ * switch-over is a snapshot-safe drop-in.
+ *
+ * Note: `Object.freeze` on a string primitive is a no-op, so the `const`
+ * keyword is the relevant mutation guard here.
+ */
+const ADVISORY_TEXT =
+  "Issue #296: entities[].capabilities (when present) advises executor selection. " +
+  "preferredExecutors[0] is the executor most likely to succeed; " +
+  "if unsupportedExecutors contains 'uia', go straight to mouse_click instead of click_element " +
+  "(saves a InvokePatternNotSupported round-trip on ListItem / TabItem / custom-drawn controls).";
+
+function toolDescriptionAdvisoryDefault(): string {
+  return ADVISORY_TEXT;
+}

--- a/src/engine/world-graph/types.ts
+++ b/src/engine/world-graph/types.ts
@@ -130,6 +130,31 @@ export interface UiEntity {
    * the field from a full `EntityCapabilities` value without a cast.
    */
   unsupportedExecutors?: Array<"uia" | "cdp" | "terminal" | "mouse">;
+  /**
+   * ADR-020 SR-1 PR-SR1-1 (北極星 8, case β entity bake): executor route
+   * order baked from the registry-derived `EntityCapabilities` during
+   * `DesktopFacade.see()` via `bakeEntityCapabilities`. The executor
+   * (`createDesktopExecutor`) consumes this array directly instead of
+   * re-invoking the registry, keeping `createDesktopExecutor`'s signature
+   * unchanged and avoiding the `_sessionOpts()` executorFactory lifetime
+   * mismatch that a `viewConstraints` runtime parameter would otherwise
+   * impose.
+   *
+   * Inline string-union shape mirrors `unsupportedExecutors` above (same
+   * advisory-free engine-layer convention). Absent when no registry lookup
+   * was performed (test direct invoke / legacy path) — `createDesktopExecutor`
+   * falls back to the hardcoded `["uia","cdp","terminal","mouse"]` ladder.
+   */
+  preferredExecutors?: Array<"uia" | "cdp" | "terminal" | "mouse">;
+  /**
+   * ADR-020 SR-1 PR-SR1-1 (case β entity bake): human-readable recovery
+   * hint baked from the registry-derived `EntityCapabilities.fallbackHint`
+   * during `DesktopFacade.see()`. Currently unused by the engine layer
+   * (the LLM consumes it via `EntityView.capabilities.fallbackHint`); held
+   * here so the bake remains a single batch and so the field is available
+   * to executor-side diagnostics in future PRs.
+   */
+  fallbackHint?: string;
 }
 
 export interface EntityLease {

--- a/src/tools/desktop-capabilities.ts
+++ b/src/tools/desktop-capabilities.ts
@@ -1,160 +1,31 @@
 /**
- * desktop-capabilities.ts — Issue #296.
+ * desktop-capabilities.ts — backward-compatible thin wrapper.
  *
- * Pure derivation of `EntityCapabilities` from a `UiEntity`. Reads UIA
- * `controlType` + `patterns` (carried through the candidate → resolver →
- * entity chain) and emits executor preferences so the LLM does not waste a
- * round-trip on `click_element` against a target that does not expose
- * `InvokePattern` (ListItem / TabItem / TreeItem / custom-drawn checkbox /
- * custom-drawn button — Issue #296 user report).
+ * ADR-020 SR-1 PR-SR1-1: the rule table previously hosted here has moved to
+ * `src/capabilities/registry.ts` as the single source of truth for capability
+ * derivation. This module is retained as a thin re-export wrapper so the
+ * existing `desktop.ts:466` callsite and the existing
+ * `tests/unit/desktop-capabilities.test.ts` 14 cases continue to operate
+ * without modification.
  *
- * No I/O, no extra UIA round-trips — the pattern set was already collected
- * at discover time by `getUiElements`'s underlying `GetSupportedPatterns()`
- * call (Rust native path: `src/uia/tree.rs`; PowerShell fallback:
- * `makeGetElementsScript` in `uia-bridge.ts`).
- *
- * **Pattern-name canonicalisation lives upstream** in
- * `uia-provider.ts::normalizeUiaPatternNames` (Issue #296 / Opus R1 P1) —
- * the Rust path emits the short form (`"Invoke"`) while the PowerShell path
- * emits the suffixed form (`"InvokePattern"`). The provider normalises both
- * to the `*Pattern`-suffixed form before they reach this module, so the rule
- * table below can match by exact string equality without case-folding or
- * suffix probing.
+ * New callsites should import `createDefaultCapabilityRegistry().lookup`
+ * directly from `src/capabilities/registry.ts`. Final removal of this
+ * wrapper is tracked as `L9-a` carry-over in the parent ADR §11 (deferred
+ * until all ADR-020 SRs land).
  */
 
 import type { UiEntity } from "../engine/world-graph/types.js";
 import type { EntityCapabilities, ViewConstraints } from "./desktop-constraints.js";
+import { createDefaultCapabilityRegistry } from "../capabilities/registry.js";
 
-// NB: `UiEntityCandidate.actionability` (set by `uia-provider.ts::uiaActionability`)
-// is a legacy controlType-based hint about what verbs the resolver may expand
-// into affordances. It is NOT the same signal as `EntityCapabilities` — when
-// the two disagree, `EntityCapabilities` is authoritative for executor
-// selection (it is derived from actual `GetSupportedPatterns()` data, not
-// just controlType heuristics). Future PR may collapse the two surfaces.
+const defaultRegistry = createDefaultCapabilityRegistry();
 
-/**
- * UIA pattern names this rule table recognises. Strings are the wire-form
- * values emitted by both the Rust native path and the PowerShell fallback.
- */
-const INVOKE_PATTERN = "InvokePattern";
-const VALUE_PATTERN = "ValuePattern";
-const TOGGLE_PATTERN = "TogglePattern";
-
-/**
- * UIA control types that historically refuse `Invoke` even though the LLM
- * tends to treat them as clickable — TabItem / TreeItem / ListItem (Issue
- * #296 user report). Selection happens via `SelectionItemPattern`, not
- * `Invoke`, and the UIA executor in this codebase only routes the `click`
- * verb through `InvokePattern` today. Keep this list conservative — expanding
- * it should require a fresh dogfood report rather than speculation.
- */
-const SELECTION_ONLY_CONTROLS = new Set(["ListItem", "TabItem", "TreeItem"]);
-
-/**
- * Derive entity capabilities. Returns `undefined` when no signal is available
- * (e.g. CDP-only entity, visual-only entity with no rect, UIA entity with
- * neither Invoke nor a known fallback) — the existing default-dispatch path
- * is then the correct response.
- *
- * Optional `viewConstraints` argument lets the caller propagate view-level
- * UIA failure state (`constraints.uia === "provider_failed"`) so UIA-sourced
- * entities in a UIA-blind view bias toward mouse even when their pattern set
- * looks fine.
- */
+/** @deprecated SR-1 PR-SR1-1 — use `createDefaultCapabilityRegistry().lookup`
+ *  directly. Retained as thin wrapper for the existing `desktop.ts:466`
+ *  callsite and existing unit tests. */
 export function deriveEntityCapabilities(
   entity: UiEntity,
   viewConstraints?: ViewConstraints,
 ): EntityCapabilities | undefined {
-  const isUiaSource = entity.sources.includes("uia");
-  const hasRect = entity.rect !== undefined;
-  const patterns = entity.patterns ?? [];
-  const controlType = entity.controlType;
-
-  const uiaProviderFailed = viewConstraints?.uia === "provider_failed";
-
-  // Visual-only entity (SOM / GPU lane found a rect but no UIA element).
-  // Mouse is the only viable executor.
-  if (!isUiaSource) {
-    if (!hasRect) return undefined;
-    return {
-      preferredExecutors: ["mouse"],
-      unsupportedExecutors: ["uia"],
-    };
-  }
-
-  // From here the entity is UIA-sourced.
-  const hasInvoke = patterns.includes(INVOKE_PATTERN);
-  const hasToggle = patterns.includes(TOGGLE_PATTERN);
-  const hasValue = patterns.includes(VALUE_PATTERN);
-  const isSelectionOnly =
-    controlType !== undefined && SELECTION_ONLY_CONTROLS.has(controlType);
-
-  // Provider-level UIA failure (warnings emitted `uia_provider_failed` etc.).
-  // Bias every UIA-sourced entity in this view toward mouse — the UIA
-  // executor will likely hit the same failure the provider already saw.
-  if (uiaProviderFailed) {
-    if (!hasRect) return undefined;
-    return {
-      preferredExecutors: ["mouse"],
-      unsupportedExecutors: ["uia"],
-      fallbackHint: "use mouse_click — UIA provider failed for this view",
-    };
-  }
-
-  // Case 1: InvokePattern available → standard happy path. UIA `click` verb
-  // succeeds (Invoke); mouse is the natural fallback if the visible region
-  // shifts after focus.
-  if (hasInvoke) {
-    return {
-      preferredExecutors: ["uia", "mouse"],
-    };
-  }
-
-  // Case 2: SelectionItem-style controls (ListItem / TabItem / TreeItem)
-  // without Invoke. The UIA executor's `click` verb maps to Invoke, which
-  // fails with `InvokePatternNotSupported`. Steer to mouse_click directly so
-  // the LLM does not pay a round-trip discovering this.
-  if (isSelectionOnly && hasRect) {
-    return {
-      preferredExecutors: ["mouse"],
-      unsupportedExecutors: ["uia"],
-      fallbackHint: `use mouse_click — UIA InvokePattern not exposed on ${controlType ?? "this control"}`,
-    };
-  }
-
-  // Case 3: TogglePattern-only entity (custom checkboxes without Invoke).
-  // The current UIA executor does not yet implement Toggle, so until that
-  // lands (ADR-018 Phase 5 carry-over) the truthful recommendation is mouse.
-  // We deliberately do NOT advertise `preferredExecutors:['uia']` here —
-  // that would lie to the LLM about today's executor surface.
-  if (hasToggle && hasRect) {
-    return {
-      preferredExecutors: ["mouse"],
-      unsupportedExecutors: ["uia"],
-      fallbackHint: "use mouse_click — UIA executor does not yet implement TogglePattern",
-    };
-  }
-
-  // Case 4: ValuePattern-bearing entity (Edit / ComboBox / Document) with
-  // no Invoke. UIA `setValue` is the right path for value updates; we steer
-  // typing toward UIA. The mouse stays available as a `click`/focus fallback
-  // via default dispatch (no `unsupportedExecutors`).
-  if (hasValue) {
-    return {
-      preferredExecutors: ["uia"],
-    };
-  }
-
-  // Case 5: UIA-sourced but no actionable pattern (Text / Image labels,
-  // ScreenReader-only entities). Mouse may still hit the rect if it
-  // represents a visible widget.
-  if (hasRect) {
-    return {
-      preferredExecutors: ["mouse"],
-      unsupportedExecutors: ["uia"],
-    };
-  }
-
-  // No rect, no patterns → nothing actionable.
-  return undefined;
+  return defaultRegistry.lookup(entity, viewConstraints);
 }

--- a/src/tools/desktop-constraints.ts
+++ b/src/tools/desktop-constraints.ts
@@ -6,6 +6,8 @@
  * Returns undefined when no constraint-relevant warnings are present (field stays absent from JSON).
  */
 
+import type { AdvertisedExecutorKind } from "../capabilities/registry.js";
+
 /**
  * View-level negative capability hints.
  * Derived deterministically from warnings[]. Absent field = no constraint known for that provider.
@@ -77,10 +79,16 @@ export interface EntityCapabilities {
    */
   canType?: false;
   canClick?: false;
-  /** Executor kinds expected to succeed (derived from entity sources + provider constraints). */
-  preferredExecutors?: Array<"uia" | "cdp" | "terminal" | "mouse">;
-  /** Executor kinds observed/predicted to fail for this target class. */
-  unsupportedExecutors?: Array<"uia" | "cdp" | "terminal" | "mouse">;
+  /** Executor kinds expected to succeed (derived from entity sources + provider constraints).
+   *  ADR-020 SR-1: type narrowed to `AdvertisedExecutorKind[]` (single SSOT in
+   *  `src/capabilities/registry.ts`). The previous inline string-union
+   *  (`Array<"uia"|"cdp"|"terminal"|"mouse">`) was structurally identical;
+   *  the alias makes the compile-time guard explicit. */
+  preferredExecutors?: AdvertisedExecutorKind[];
+  /** Executor kinds observed/predicted to fail for this target class.
+   *  ADR-020 SR-1: narrowed to `AdvertisedExecutorKind[]` for the same
+   *  reason as `preferredExecutors`. */
+  unsupportedExecutors?: AdvertisedExecutorKind[];
   /** Human-readable recovery hint, e.g. "use terminal(action='send') V1 tool". */
   fallbackHint?: string;
 }

--- a/src/tools/desktop.ts
+++ b/src/tools/desktop.ts
@@ -17,6 +17,7 @@ import { createDesktopExecutor, type ExecutorDeps } from "./desktop-executor.js"
 import type { TouchAction, TouchResult } from "../engine/world-graph/guarded-touch.js";
 import { deriveViewConstraints, type ViewConstraints, type EntityCapabilities } from "./desktop-constraints.js";
 import { deriveEntityCapabilities } from "./desktop-capabilities.js";
+import { bakeEntityCapabilities } from "../capabilities/registry.js";
 import { isUiaCacheStale } from "../engine/identity-tracker.js";
 import type { AttentionState } from "../engine/perception/types.js";
 
@@ -460,15 +461,21 @@ export class DesktopFacade {
     // paying the `InvokePatternNotSupported` round-trip. `resolved` and
     // `session.entities` alias the same array, so the touch path picks this
     // up automatically.
+    // ADR-020 SR-1 PR-SR1-1 (case β entity bake、北極星 8): the registry
+    // lookup result is baked onto the engine `UiEntity` in a single batch
+    // (`preferredExecutors / unsupportedExecutors / fallbackHint`) via
+    // `bakeEntityCapabilities`. The previous inline writeback handled only
+    // `unsupportedExecutors`; SR-1 extends this to all three advisory fields
+    // so `createDesktopExecutor` can consume them via `entity.*` without
+    // re-invoking the registry (which would conflict with the session-bound
+    // `executorFactory` lifetime).
     for (let i = 0; i < entityViews.length; i++) {
       const entity = resolved[i];
       if (entity === undefined) continue;
       const cap = deriveEntityCapabilities(entity, constraints);
       if (cap) {
         entityViews[i]!.capabilities = cap;
-        if (cap.unsupportedExecutors && cap.unsupportedExecutors.length > 0) {
-          entity.unsupportedExecutors = [...cap.unsupportedExecutors];
-        }
+        bakeEntityCapabilities(entity, cap);
       }
     }
 

--- a/tests/unit/capabilities-registry-invariant.test.ts
+++ b/tests/unit/capabilities-registry-invariant.test.ts
@@ -1,0 +1,188 @@
+/**
+ * capabilities-registry-invariant.test.ts — ADR-020 SR-1 PR-SR1-1.
+ *
+ * Pins the three registry invariants (北極星 7) for the production
+ * `lookupDefault` output plus the `assertCapabilitiesInvariant` defensive
+ * guard. Existing rule-table behaviour is covered separately by
+ * `tests/unit/desktop-capabilities.test.ts` (14 cases, bit-equal pin); this
+ * file targets the invariants themselves:
+ *
+ *   (a) preferredExecutors.length >= 1                   (non-empty)
+ *   (b) preferredExecutors ∩ unsupportedExecutors = ∅    (disjoint)
+ *   (c) preferredExecutors ⊆ AdvertisedExecutorKind set  (narrow type)
+ *
+ * The narrow-type runtime check guards against rule-table edits that
+ * accidentally introduce `"keyboard"` (or other non-advertised values) into
+ * `preferredExecutors`. This is defense-in-depth — the TypeScript compiler
+ * also guards (c) via the `AdvertisedExecutorKind` alias.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  createDefaultCapabilityRegistry,
+  assertCapabilitiesInvariant,
+  bakeEntityCapabilities,
+  type AdvertisedExecutorKind,
+} from "../../src/capabilities/registry.js";
+import type { UiEntity } from "../../src/engine/world-graph/types.js";
+import type { EntityCapabilities } from "../../src/tools/desktop-constraints.js";
+
+const registry = createDefaultCapabilityRegistry();
+
+function makeEntity(overrides: Partial<UiEntity> = {}): UiEntity {
+  return {
+    entityId: "e",
+    role: "button",
+    confidence: 1,
+    sources: ["uia"],
+    affordances: [],
+    generation: "g0",
+    evidenceDigest: "d0",
+    ...overrides,
+  };
+}
+
+describe("CapabilityRegistry invariant — sub-plan §4.5 acceptance", () => {
+  describe("lookupDefault output (production rule table) satisfies invariants", () => {
+    // Each rule branch from `lookupDefault` is exercised with a representative
+    // entity; the registry's internal `assertCapabilitiesInvariant` call would
+    // throw on any rule-table edit that violates (a), (b), or (c).
+    const cases: Array<{ name: string; entity: UiEntity; constraints?: Parameters<typeof registry.lookup>[1] }> = [
+      {
+        name: "UIA + InvokePattern (Case Invoke happy path)",
+        entity: makeEntity({ controlType: "Button", patterns: ["InvokePattern"], rect: { x: 0, y: 0, width: 10, height: 10 } }),
+      },
+      {
+        name: "UIA + SelectionOnly (ListItem) without Invoke",
+        entity: makeEntity({ controlType: "ListItem", patterns: [], rect: { x: 0, y: 0, width: 10, height: 10 } }),
+      },
+      {
+        name: "UIA + TogglePattern (CheckBox) without Invoke",
+        entity: makeEntity({ controlType: "CheckBox", patterns: ["TogglePattern"], rect: { x: 0, y: 0, width: 10, height: 10 } }),
+      },
+      {
+        name: "UIA + ValuePattern (Edit)",
+        entity: makeEntity({ controlType: "Edit", patterns: ["ValuePattern"], rect: { x: 0, y: 0, width: 10, height: 10 } }),
+      },
+      {
+        name: "UIA + no-actionable-pattern + rect (Text label)",
+        entity: makeEntity({ controlType: "Text", patterns: [], rect: { x: 0, y: 0, width: 10, height: 10 } }),
+      },
+      {
+        name: "Visual-only with rect",
+        entity: makeEntity({ sources: ["visual_gpu"], rect: { x: 0, y: 0, width: 10, height: 10 } }),
+      },
+      {
+        name: "UIA provider_failed view with InvokePattern",
+        entity: makeEntity({ controlType: "Button", patterns: ["InvokePattern"], rect: { x: 0, y: 0, width: 10, height: 10 } }),
+        constraints: { uia: "provider_failed" },
+      },
+    ];
+
+    it.each(cases)("$name → invariants hold", ({ entity, constraints }) => {
+      const cap = registry.lookup(entity, constraints);
+      // `undefined` is allowed (no actionable signal); when defined the
+      // invariants must hold.
+      if (cap === undefined) return;
+      expect(cap.preferredExecutors).toBeDefined();
+      expect(cap.preferredExecutors!.length).toBeGreaterThanOrEqual(1);
+      // Disjoint
+      const unsupported = cap.unsupportedExecutors ?? [];
+      for (const p of cap.preferredExecutors!) {
+        expect(unsupported).not.toContain(p);
+      }
+      // Narrow type (re-run assertion for explicit pin)
+      expect(() => assertCapabilitiesInvariant(cap)).not.toThrow();
+    });
+  });
+
+  describe("assertCapabilitiesInvariant defensive guard", () => {
+    it("rejects empty preferredExecutors (a)", () => {
+      const bad: EntityCapabilities = { preferredExecutors: [] };
+      expect(() => assertCapabilitiesInvariant(bad)).toThrow(/length === 0/);
+    });
+
+    it("rejects preferred ∩ unsupported overlap (b)", () => {
+      const bad: EntityCapabilities = {
+        preferredExecutors: ["uia"],
+        unsupportedExecutors: ["uia"],
+      };
+      expect(() => assertCapabilitiesInvariant(bad)).toThrow(/overlap "uia"/);
+    });
+
+    it('rejects "keyboard" smuggled into preferredExecutors via unsound cast (c)', () => {
+      // The TS narrow type would normally prevent this; the cast simulates
+      // a rule-table edit that bypasses the compile-time guard.
+      const bad = {
+        preferredExecutors: ["keyboard" as unknown as AdvertisedExecutorKind],
+      } as EntityCapabilities;
+      expect(() => assertCapabilitiesInvariant(bad)).toThrow(
+        /ALLOWED_EXECUTORS|narrow type breach/,
+      );
+    });
+
+    it("accepts a well-formed capability shape", () => {
+      const ok: EntityCapabilities = {
+        preferredExecutors: ["uia", "mouse"],
+        unsupportedExecutors: ["cdp"],
+      };
+      expect(() => assertCapabilitiesInvariant(ok)).not.toThrow();
+    });
+  });
+
+  describe("bakeEntityCapabilities (case β entity bake、北極星 8)", () => {
+    it("bakes all three fields (preferredExecutors / unsupportedExecutors / fallbackHint) in one batch", () => {
+      const entity = makeEntity();
+      const cap: EntityCapabilities = {
+        preferredExecutors: ["mouse"],
+        unsupportedExecutors: ["uia"],
+        fallbackHint: "use mouse_click",
+      };
+      bakeEntityCapabilities(entity, cap);
+      expect(entity.preferredExecutors).toEqual(["mouse"]);
+      expect(entity.unsupportedExecutors).toEqual(["uia"]);
+      expect(entity.fallbackHint).toBe("use mouse_click");
+    });
+
+    it("is a no-op when cap is undefined (test direct invoke / legacy path safe)", () => {
+      const entity = makeEntity();
+      bakeEntityCapabilities(entity, undefined);
+      expect(entity.preferredExecutors).toBeUndefined();
+      expect(entity.unsupportedExecutors).toBeUndefined();
+      expect(entity.fallbackHint).toBeUndefined();
+    });
+
+    it("does not bake empty preferredExecutors array (matches pre-SR-1 behaviour)", () => {
+      const entity = makeEntity();
+      // Synthesise a degenerate shape that bypassed the invariant guard.
+      const cap = { preferredExecutors: [] } as EntityCapabilities;
+      bakeEntityCapabilities(entity, cap);
+      expect(entity.preferredExecutors).toBeUndefined();
+    });
+
+    it("copies arrays defensively (caller cannot mutate registry output via entity)", () => {
+      const entity = makeEntity();
+      const cap: EntityCapabilities = { preferredExecutors: ["mouse"] };
+      bakeEntityCapabilities(entity, cap);
+      entity.preferredExecutors!.push("uia");
+      expect(cap.preferredExecutors).toEqual(["mouse"]); // original untouched
+    });
+  });
+
+  describe("registry singleton purity (副作用波 6 防止)", () => {
+    it("two independent registry instances produce identical output for the same entity", () => {
+      const r1 = createDefaultCapabilityRegistry();
+      const r2 = createDefaultCapabilityRegistry();
+      const entity = makeEntity({ controlType: "Button", patterns: ["InvokePattern"], rect: { x: 0, y: 0, width: 10, height: 10 } });
+      expect(r1.lookup(entity)).toEqual(r2.lookup(entity));
+    });
+
+    it("toolDescriptionAdvisory returns a non-empty stable string (PR-SR1-3 will derive from rule shape)", () => {
+      const r = createDefaultCapabilityRegistry();
+      const a = r.toolDescriptionAdvisory();
+      const b = r.toolDescriptionAdvisory();
+      expect(a.length).toBeGreaterThan(0);
+      expect(a).toBe(b);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

ADR-020 Phase 3 SR-1 (CapabilityRegistry SSOT 一本化) の最初の PR。`docs/adr-020-phase-3-sr-1-capability-registry-plan.md` §4 を厳密遵守して registry interface + rule table 移管 + AdvertisedExecutorKind type alias single SSOT 化 + assertCapabilitiesInvariant defense-in-depth + bakeEntityCapabilities helper + UiEntity engine field 拡張を実装。

- **`createDesktopExecutor` signature 不変** (case β、北極星 6) — `_sessionOpts() executorFactory` 固定 lifetime と整合
- **3 consumer (`deriveEntityCapabilities` thin wrapper / `desktop.ts` bake 経路 / 将来の `desktop-register.ts` description) は全て registry 経由** (北極星 1)
- **北極星 7 invariant 3 件** (disjoint + 非空 + narrow type) を `lookupDefault` 出力 + `assertCapabilitiesInvariant` production defensive check で機械保証
- **北極星 8 entity bake invariant**: `bakeEntityCapabilities(entity, cap)` 共通 helper で `preferredExecutors / unsupportedExecutors / fallbackHint` 3 field 1 batch bake (partial bake による `provider_failed` view bias loss 構造的不能化)

## Changes

- `src/capabilities/registry.ts` 新設 (~250 line)
- `src/tools/desktop-capabilities.ts` thin wrapper 化 (153 → 32 line に縮約)
- `src/tools/desktop-constraints.ts:81` `EntityCapabilities.preferredExecutors` / `unsupportedExecutors` を `AdvertisedExecutorKind[]` に narrow 化 (既存 inline shape と等価で wire shape 不変)
- `src/engine/world-graph/types.ts` `UiEntity` に `preferredExecutors?` + `fallbackHint?` engine internal field 追加 (既存 `unsupportedExecutors` inline shape pattern と整合)
- `src/tools/desktop.ts:466-473` inline 書き戻しを `bakeEntityCapabilities(entity, cap)` 呼出に置換
- `tests/unit/capabilities-registry-invariant.test.ts` 新設 17 case

## Test plan

- [x] `npm run build` (tsc clean)
- [x] `npm test` で **3622 passed | 0 failed** (baseline と完全同等、SR-1 改修済再実行で確認)
- [x] SR-1 関連 test 全 green:
  - `tests/unit/desktop-capabilities.test.ts` 14 case (既存、無変更で全 pass — bit-equal 出力 pin)
  - `tests/unit/capabilities-registry-invariant.test.ts` 17 case (新設、北極星 7 + bakeEntityCapabilities + singleton purity)
  - `tests/unit/path-class-contract/c-executor-downgrade.test.ts` 7 case (Phase 2 C contract test、PR #332 downgrade marker wire-level pin 維持)
  - `tests/unit/path-class-contract/e-uia-fallback-ladder.test.ts` 6 case (Phase 2 E contract test、preferredExecutors[0] == "uia" 固定保証維持)
- [x] LLM-facing wire shape 不変 (`entityView.capabilities` 全 field shape 維持)

## Review focus (sub-plan §5.6 Codex prompt 雛形)

- **rule table 移管の bit-equal 性**: `src/capabilities/registry.ts::lookupDefault` が元 `desktop-capabilities.ts:64-160` のロジックを 1 case でも入れ替えなく完全移管しているか (Case 1-5 + uiaProviderFailed + visual-only + no-rect 全分岐)
- **北極星 7 invariant 機械保証**: `assertCapabilitiesInvariant` が disjoint + 非空 + narrow type 3 条件を全て確実に検出するか、`ALLOWED_EXECUTORS` ReadonlySet が `"keyboard"` 等の混入を runtime throw するか
- **北極星 8 entity bake invariant**: `bakeEntityCapabilities` が 3 field を 1 batch で書き戻し、partial bake (例: `preferredExecutors` だけ書いて `fallbackHint` 忘れる) を構造的に発生不能化しているか、`provider_failed` view bias が executor まで届くか
- **case β signature 不変保証**: `createDesktopExecutor(target, deps?)` の第 3/4 引数 (registry? / viewConstraints?) 追加なし、`_sessionOpts() executorFactory` lifetime と矛盾なし
- **副作用波 6 (singleton state race)**: `defaultRegistry` module-level singleton が pure lookup invariant 維持 (internal state なし)、`ADVISORY_TEXT` module-level const で string primitive 直接 mutation 不能

## Carry-over

- 親 ADR §11 **L9-a** (UiEntity engine field collapse): 本 PR で追加した `preferredExecutors?` / `fallbackHint?` 含めて `EntityCapabilities` 直参照へ collapse は ADR-020 全 SR 完了後判断
- 親 ADR §11 **L9-b** (ADVISORY_TEXT rule-shape derive 化): PR-SR1-3 で stub → const 実装、rule table 文章自動生成は本 SR-1 全 PR land 後判断

## 次の PR

PR-SR1-2 (executor entity.preferredExecutors 直接 consume + routeExecutor observed kind return + downgrade marker [from → to] 一般化、~250-350 line) ‖ PR-SR1-3 (tool description registry derive、~100-200 line) を **worktree 並走** で着手 (sub-plan §3 並走条件: PR-SR1-1 land 前提、scope disjoint)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)