### PR TITLE
refactor(executor): 5th keyboard block + CHANGELOG entry — ADR-020 PR-SR5-2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **`keyboard` executor as a first-class advertised executor option.**
+  When a text input exposes UIA `ValuePattern`, `entities[].capabilities.preferredExecutors` now lists `["uia", "keyboard"]` instead of `["uia"]`, so the LLM can opt to bypass UIA's name-filter requery and inject WM_CHAR directly via `keyboardTypeBg`. Useful for RichEdit / Document controls (e.g. Notepad's RichEditD2DPT) where UIA `setValue` fails because the entity's name/automationId cannot be re-found.
+
+  The `keyboard` executor:
+  - Sends WM_CHAR to the focused child of the target window (no focus-steal, same primitive as `terminal({action:'send'})`)
+  - Returns `executor: "keyboard"` (bare string, no downgrade marker — internal UIA→keyboard recovery uses the same return shape, preserving the existing bare-string contract for the `desktop_act` text fallback)
+  - **Fail-soft on unsupported windows**: Chromium / WT-XAML / UWP hosts surface `ok:false reason:"executor_failed"`, and the existing `desktop_act` `if_unexpected.try_next` recovery hint applies (typically suggesting `keyboard({action:'type', text, method:'foreground'})` which uses FG SendInput instead of background WM_CHAR injection)
+
+  How to use: include `"keyboard"` in your tool call's intended executor preference, or rely on the `desktop_discover` advisory (`capabilities.preferredExecutors[1]` is now often `"keyboard"` for text inputs).
+
 ## [1.6.1] - 2026-05-17 — `desktop_act` reliability + observability sweep (Notepad type, lease TTL, modal classification, executor downgrade marker, cache marker storm)
 
 ### Fixed

--- a/docs/adr-020-phase-3-sr-5-keyboard-promotion-plan.md
+++ b/docs/adr-020-phase-3-sr-5-keyboard-promotion-plan.md
@@ -244,9 +244,19 @@ const ADVISORY_TEXT =
 // ... 既存 logic (line 260-264)
 
 // ── ★ 新規 keyboard block (PR-SR5-2 で追加、mouse block の直前) ─────────────
-// preferredAllows("keyboard") check で entry gate
+// 北極星 9 (1) baseline 完全同一動作維持: `entity.preferredExecutors === undefined`
+// (test 直 invoke / legacy path) の case で新 keyboard block を entry させないため、
+// `preferredAllows("keyboard")` (undefined 時 true 返却) ではなく explicit な
+// `entity.preferredExecutors !== undefined && includes("keyboard")` で gate する
+// (Round 3 実装中追加発見、preferredAllows semantic との組合せ sweep miss を修正)。
 // 注意: text 必須 (keyboard は WM_CHAR injection 専用、click action では入れない)
-if (!blocked.includes("keyboard") && preferredAllows("keyboard") && text !== undefined && (action === "type" || action === "setValue")) {
+if (
+  entity.preferredExecutors !== undefined &&
+  entity.preferredExecutors.includes("keyboard") &&
+  !blocked.includes("keyboard") &&
+  text !== undefined &&
+  (action === "type" || action === "setValue")
+) {
   // UIA route 内 fallback の keyboardTypeBg を direct invoke
   // 失敗時は throw 直伝播 (CDP/terminal と同 pattern、generic mouse rescue しない、北極星 9 (3) の延長)
   await d.keyboardTypeBg(resolveWindowTitle(target), text);

--- a/src/tools/desktop-executor.ts
+++ b/src/tools/desktop-executor.ts
@@ -263,6 +263,40 @@ export function createDesktopExecutor(
       return "terminal";
     }
 
+    // ── Keyboard route (ADR-020 SR-5 PR-SR5-2、北極星 9 (4) + 5 block sequential) ──
+    // `preferredExecutors` に `"keyboard"` が含まれ、UIA / CDP / terminal の
+    // どれも entry しなかった場合に到達する direct keyboard 経路。`keyboardTypeBg`
+    // (UIA route 内 recovery と同 primitive、`bg-input.ts::postCharsToHwnd` 経由
+    // WM_CHAR injection) を呼び出し、bare `"keyboard"` return (PR #330 contract 維持、
+    // OQ-SR5-1 exit condition (1))。失敗時は throw 直伝播 (CDP/terminal と同 pattern、
+    // mouse rescue しない、北極星 9 (3) 整合)。
+    //
+    // 到達条件 (sub-plan §5.2 末尾):
+    //   - `preferredExecutors=["keyboard"]` 単独 set で UIA-排除 + (a) `sources` に
+    //     "uia" 含まない or (b) `unsupportedExecutors.includes("uia")` で uiaBlocked、
+    //     かつ CDP / terminal eligibility なし
+    //   - text 必須 + (action === "type" | "setValue") のみ entry (click は keyboard で意味なし)
+    // 典型 ValuePattern entity (`preferredExecutors=["uia","keyboard"]`) は UIA block
+    // で entry → UIA setValue → keyboardTypeBg 内部 ladder で bare "keyboard" return
+    // (新 block は到達せず、北極星 2 = PR #330 contract bit-equal 維持)。
+    // 北極星 9 (1) baseline 完全同一動作維持: entity.preferredExecutors が undefined
+    // (registry lookup 不在 = test 直 invoke / legacy path) の case で新 keyboard block
+    // を entry させないため、`preferredAllows("keyboard")` (undefined 時 true 返却) では
+    // なく、explicit な `entity.preferredExecutors !== undefined && includes("keyboard")`
+    // で gate する。これで preferredExecutors を明示 advertise していない baseline 経路
+    // (e.g. unsupportedExecutors:["uia"] 単独 + text な test case) で text drop 防止 throw
+    // への到達経路が baseline と bit-equal 維持される。
+    if (
+      entity.preferredExecutors !== undefined &&
+      entity.preferredExecutors.includes("keyboard") &&
+      !blocked.includes("keyboard") &&
+      text !== undefined &&
+      (action === "type" || action === "setValue")
+    ) {
+      await d.keyboardTypeBg(winTitle, text);
+      return "keyboard";
+    }
+
     // ── Mouse fallback ───────────────────────────────────────────────────────
     // Opus PR #302 P2 #2 — when the caller supplied `text` (action='type'/
     // 'setValue', or action='auto' with text) and every text-capable executor
@@ -273,9 +307,12 @@ export function createDesktopExecutor(
     // wrapper surfaces `ok:false reason:'executor_failed'` and the caller can
     // diagnose the dropped payload rather than chasing a phantom-typed bug.
     if (text !== undefined && (action === "type" || action === "setValue")) {
+      // ADR-020 SR-5 PR-SR5-2: keyboard executor が advertised に昇格したので
+      // diagnostic string にも keyboard 経路の skip 理由を含める。
+      const keyboardBlocked = blocked.includes("keyboard");
       throw new Error(
         `setValue/type requested for "${entity.label ?? entity.entityId}" but no text-capable executor available ` +
-        `(uia${uiaBlocked ? "=blocked" : "=no-source"}, cdp${cdpBlocked ? "=blocked" : "=no-selector"}, terminal${terminalBlocked ? "=blocked" : "=no-source-or-text"}) — mouse fallback would drop the text payload`
+        `(uia${uiaBlocked ? "=blocked" : "=no-source"}, cdp${cdpBlocked ? "=blocked" : "=no-selector"}, terminal${terminalBlocked ? "=blocked" : "=no-source-or-text"}, keyboard${keyboardBlocked ? "=blocked" : "=not-in-preferred"}) — mouse fallback would drop the text payload`
       );
     }
     if (mouseBlocked) {

--- a/tests/unit/desktop-executor-keyboard-block.test.ts
+++ b/tests/unit/desktop-executor-keyboard-block.test.ts
@@ -1,0 +1,184 @@
+/**
+ * desktop-executor-keyboard-block.test.ts — ADR-020 SR-5 PR-SR5-2.
+ *
+ * Pins the new 5th `keyboard` block in `createDesktopExecutor` (sub-plan §5.2 +
+ * §5.4 acceptance). 5 軸 cover:
+ *
+ *   (1) `preferredExecutors === undefined` → 新 block 不 entry (baseline 完全同一、北極星 9 (1))
+ *   (2) `preferredExecutors=["keyboard"]` 単独 set + text + setValue → 新 block entry、bare "keyboard"
+ *   (3) `preferredExecutors=["uia","keyboard"]` + UIA succeeds → UIA block entry、bare "uia" (新 block 到達せず)
+ *   (4) `preferredExecutors=["uia","keyboard"]` + UIA setValue throws → UIA route 内 keyboardTypeBg recovery で bare "keyboard" (新 block 到達せず、PR #330 contract 維持)
+ *   (5) `preferredExecutors=["keyboard"]` + click action → 新 block skip (text + setValue/type gate)、mouse 直行
+ *
+ * 北極星 (sub-plan §2):
+ *   2 = PR #330 bare "keyboard" return contract 維持
+ *   3 = 5 block sequential で baseline 4 block + UIA route 内 keyboardTypeBg recovery bit-equal
+ *   9 (1) = preferredExecutors undefined → baseline 完全同一動作
+ *   9 (3) = 新 block throw 直伝播、mouse rescue しない (CDP/terminal と同 pattern)
+ *
+ * @see docs/adr-020-phase-3-sr-5-keyboard-promotion-plan.md §5.2 / §5.4
+ * @see src/tools/desktop-executor.ts ── Keyboard route ── block
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  createDesktopExecutor,
+  type ExecutorDeps,
+} from "../../src/tools/desktop-executor.js";
+import type { UiEntity } from "../../src/engine/world-graph/types.js";
+
+function entity(overrides: Partial<UiEntity> = {}): UiEntity {
+  return {
+    entityId: "e1",
+    role: "textbox",
+    label: "TextInput",
+    confidence: 0.9,
+    sources: ["uia"],
+    affordances: [],
+    generation: "gen-1",
+    evidenceDigest: "d-e1",
+    rect: { x: 100, y: 200, width: 200, height: 30 },
+    ...overrides,
+  };
+}
+
+function mockDeps(overrides: Partial<ExecutorDeps> = {}): ExecutorDeps {
+  return {
+    uiaClick:       vi.fn(async () => {}),
+    uiaSetValue:    vi.fn(async () => {}),
+    cdpClick:       vi.fn(async () => {}),
+    cdpFill:        vi.fn(async () => {}),
+    terminalSend:   vi.fn(async () => {}),
+    keyboardTypeBg: vi.fn(async () => {}),
+    mouseClick:     vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+describe("5th keyboard block (ADR-020 SR-5 PR-SR5-2)", () => {
+  describe("(1) preferredExecutors undefined → 新 block 不 entry (北極星 9 (1) baseline 完全同一)", () => {
+    it("UIA-blocked entity + setValue + text + preferredExecutors undefined → throws (text drop 防止、新 block skip)", async () => {
+      const deps = mockDeps();
+      const exec = createDesktopExecutor({ hwnd: "h" }, deps);
+      // sources=["uia"] + unsupportedExecutors=["uia"] + setValue + text + preferredExecutors undefined
+      // → UIA block skip (blocked) + CDP/terminal eligibility なし + 新 keyboard block skip
+      //   (preferredExecutors undefined のため) → text drop 防止 throw
+      await expect(
+        exec(
+          entity({ sources: ["uia"], unsupportedExecutors: ["uia"] }),
+          "setValue",
+          "hello",
+        ),
+      ).rejects.toThrow(/no text-capable executor available/i);
+      expect(deps.keyboardTypeBg).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("(2) preferredExecutors=['keyboard'] 単独 set → 新 block entry", () => {
+    it("UIA-blocked entity + preferredExecutors=['keyboard'] + setValue + text → keyboardTypeBg direct, bare 'keyboard'", async () => {
+      const deps = mockDeps();
+      const exec = createDesktopExecutor({ hwnd: "h" }, deps);
+      const result = await exec(
+        entity({
+          sources: ["uia"],
+          unsupportedExecutors: ["uia"],
+          preferredExecutors: ["keyboard"],
+        }),
+        "setValue",
+        "hello",
+      );
+      expect(result).toBe("keyboard"); // bare ExecutorKind (PR #330 contract、OQ-SR5-1 (1))
+      expect(deps.keyboardTypeBg).toHaveBeenCalledOnce();
+      expect(deps.keyboardTypeBg).toHaveBeenCalledWith("h", "hello");
+      expect(deps.uiaSetValue).not.toHaveBeenCalled();
+      expect(deps.mouseClick).not.toHaveBeenCalled();
+    });
+
+    it("preferredExecutors=['keyboard'] + click action → 新 block skip (text + setValue/type gate)、mouse 直行 (北極星 9 (5))", async () => {
+      const deps = mockDeps();
+      const exec = createDesktopExecutor({ hwnd: "h" }, deps);
+      const result = await exec(
+        entity({
+          sources: ["uia"],
+          unsupportedExecutors: ["uia"],
+          preferredExecutors: ["keyboard", "mouse"],
+        }),
+        "click",
+      );
+      // click action は keyboard で意味なし → 新 keyboard block skip (text + setValue/type gate)
+      // → mouse block entry (preferredAllows("mouse") true) → bare "mouse"
+      expect(result).toBe("mouse");
+      expect(deps.keyboardTypeBg).not.toHaveBeenCalled();
+      expect(deps.mouseClick).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("(3) preferredExecutors=['uia','keyboard'] + UIA succeeds → UIA block 先 entry (北極星 2 維持)", () => {
+    it("preferredExecutors=['uia','keyboard'] + UIA setValue succeeds → bare 'uia' (新 block 到達せず)", async () => {
+      const deps = mockDeps();
+      const exec = createDesktopExecutor({ hwnd: "h" }, deps);
+      const result = await exec(
+        entity({
+          sources: ["uia"],
+          patterns: ["ValuePattern"],
+          preferredExecutors: ["uia", "keyboard"],
+        }),
+        "setValue",
+        "hello",
+      );
+      expect(result).toBe("uia");
+      expect(deps.uiaSetValue).toHaveBeenCalledOnce();
+      expect(deps.keyboardTypeBg).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("(4) preferredExecutors=['uia','keyboard'] + UIA setValue throws → UIA route 内 keyboardTypeBg recovery (PR #330 contract 維持、新 block 到達せず)", () => {
+    it("UIA setValue throws + keyboardTypeBg succeeds → bare 'keyboard' (UIA route 内 fallback、北極星 2)", async () => {
+      const deps = mockDeps({
+        uiaSetValue: vi.fn(async () => {
+          throw new Error("UIA setValue failed");
+        }),
+      });
+      const exec = createDesktopExecutor({ hwnd: "h" }, deps);
+      const result = await exec(
+        entity({
+          sources: ["uia"],
+          patterns: ["ValuePattern"],
+          preferredExecutors: ["uia", "keyboard"],
+        }),
+        "setValue",
+        "hello",
+      );
+      // PR #330 contract: UIA route 内 keyboardTypeBg recovery で bare "keyboard"
+      // 新 block (top-level) は到達せず、UIA block 内 fallback で完結
+      expect(result).toBe("keyboard");
+      expect(deps.uiaSetValue).toHaveBeenCalledOnce();
+      expect(deps.keyboardTypeBg).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("(5) keyboardTypeBg failure 時 throw 直伝播 → guarded-touch 経由 executor_failed (北極星 9 (3)、R-SR5-2-c)", () => {
+    it("preferredExecutors=['keyboard'] + keyboardTypeBg throws → throws directly (no mouse rescue)", async () => {
+      const kbErr = new Error("Background keyboard type not supported for WT-XAML host");
+      const deps = mockDeps({
+        keyboardTypeBg: vi.fn(async () => {
+          throw kbErr;
+        }),
+      });
+      const exec = createDesktopExecutor({ hwnd: "h" }, deps);
+      await expect(
+        exec(
+          entity({
+            sources: ["uia"],
+            unsupportedExecutors: ["uia"],
+            preferredExecutors: ["keyboard"],
+          }),
+          "type",
+          "hello",
+        ),
+      ).rejects.toThrow(/Background keyboard type not supported/);
+      // mouse rescue しない (CDP/terminal と同 pattern、北極星 9 (3) 整合)
+      expect(deps.mouseClick).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

ADR-020 Phase 3 SR-5 (`"keyboard"` first-class promotion) の 2 番目の PR。`createDesktopExecutor` に **5 番目 keyboard block** を mouse fallback の直前に追加、`"keyboard"` advertised executor の direct 経路を opening。baseline 4 block + UIA route 内 keyboardTypeBg recovery は **bit-equal 維持** (北極星 2 + 3)。

### Entry 条件 (Round 3 実装中追加発見の sweep miss 修正反映)

```ts
if (
  entity.preferredExecutors !== undefined &&   // ← undefined 時 baseline 完全同一 (北極星 9 (1))
  entity.preferredExecutors.includes("keyboard") &&
  !blocked.includes("keyboard") &&
  text !== undefined &&
  (action === "type" || action === "setValue")
) {
  await d.keyboardTypeBg(winTitle, text);
  return "keyboard";  // bare ExecutorKind (PR #330 contract、OQ-SR5-1 exit (1))
}
```

`preferredAllows("keyboard")` helper は `entity.preferredExecutors === undefined` 時に true を返すため、explicit な `!== undefined && includes("keyboard")` で gate して baseline 完全同一動作 (北極星 9 (1)) を維持。

### OQ-SR5-1 closure (sub-plan §5.3、本 PR で確定)

**Exit condition (1) keep bare keyboard as final contract** 採用:
- PR #330 で確立した bare `"keyboard"` return contract を本 PR で維持
- 5 番目 keyboard block 追加で advertise 経路は別途実現 (direct 経路、`preferredExecutors=["keyboard"]` 単独 set 限定)
- 内部 UIA→keyboard recovery (UIA route 内 keyboardTypeBg fallback) は **bit-equal 維持** (新 block 到達せず、典型 `["uia","keyboard"]` entity は UIA block 内 fallback で完結)

## Changes

- **`src/tools/desktop-executor.ts`**: 5 番目 keyboard block 追加 (Terminal block 直後 + mouse 直前) + mouse fallback text drop 防止 throw 文言を keyboard 経路含む 5 executor 形に拡張
- **`tests/unit/desktop-executor-keyboard-block.test.ts`** 新設 (5 軸 6 case):
  - (1) `preferredExecutors === undefined` → 新 block 不 entry (北極星 9 (1) 維持)
  - (2) `preferredExecutors=["keyboard"]` 単独 set → 新 block entry, bare `"keyboard"` + click action で skip (text + setValue/type gate)、mouse 直行
  - (3) `preferredExecutors=["uia","keyboard"]` + UIA succeeds → bare `"uia"` (新 block 到達せず)
  - (4) `preferredExecutors=["uia","keyboard"]` + UIA setValue throws → UIA route 内 keyboardTypeBg recovery で bare `"keyboard"` (PR #330 contract、北極星 2)
  - (5) keyboardTypeBg failure 時 throw 直伝播 → mouse rescue しない (北極星 9 (3))
- **`CHANGELOG.md`** `[Unreleased]` entry (CLAUDE.md 強制命令 10 準拠、user-facing 英語、内部 PR # 削除、WT-XAML fail-soft + `if_unexpected.try_next` 連動明記)
- **`docs/adr-020-phase-3-sr-5-keyboard-promotion-plan.md`** §5.2 outline で entry 条件を explicit に修正

## Test plan

- [x] `npm run build` (tsc clean)
- [x] 全 vitest: **3642 passed | 1 failed** (failed = `PERSIST-10` 既存 flaky timer test、SR-5 改修と無関係)
- [x] SR-5 関連 + Phase 2 contract test 全 green:
  - `desktop-executor-keyboard-block.test.ts` 6/6 (新設、5 軸 cover)
  - `desktop-executor.test.ts` 46 case 無変更 (北極星 9 (1) baseline 完全同一動作 pin)
  - `desktop-executor-preferred-eligibility.test.ts` 10 case 無変更 (SR-1 contract bit-equal)
  - `desktop-capabilities.test.ts` 14 case (PR-SR5-1 で 1 case 意図的更新済)
  - `capabilities-registry-invariant.test.ts` 17 case (PR-SR5-1 で 1 case 意図的更新済)
  - Phase 2 contract: c/d/e/f/b 全 green
- [ ] **dogfood 実機 smoke** (R-SR5-2-a 対策、PR-SR5-2 merge 前に user 確認、ValuePattern entity (Edit / ComboBox) で `preferredExecutors=["uia","keyboard"]` が advertised + UIA setValue throw → keyboardTypeBg recovery で bare "keyboard" return が正常動作するか)

## Review focus

- **北極星 2 PR #330 contract 維持**: 内部 UIA→keyboard recovery で bare `"keyboard"` return (UIA route 内 line 198-215)、新 block も bare return で一貫
- **北極星 3 baseline 4 block bit-equal**: UIA / CDP / terminal / mouse の 4 block + UIA route 内 keyboardTypeBg recovery 完全保全
- **北極星 9 (1) baseline 完全同一動作**: `entity.preferredExecutors === undefined` で新 block 不 entry (`!== undefined && includes("keyboard")` explicit gate)
- **北極星 9 (3) throw 直伝播**: keyboard block 失敗時 mouse rescue しない (CDP/terminal と同 pattern)
- **OQ-SR5-1 closure**: bare keyboard final contract 維持、SR-1 sub-plan §9 への post-merge strikethrough 予定

## Carry-over

- **OQ-SR5-1 closure** (本 PR で完全 closure 予定): SR-1 sub-plan §9 OQ-SR5-1 entry を本 PR merge 後 post-merge strikethrough
- **ADR-020 §11 L4 (E 軸) strikethrough**: 本 PR merge 後 親 ADR §11 ledger L4 を SR-5 構造除去達成 pin
- **OQ-SR5-2** (KeyboardWritable 単体 case、2 軸 dependency 明示): SR-5 完了後 dogfood 観察 → 必要なら別 epic / 後続 SR

🤖 Generated with [Claude Code](https://claude.com/claude-code)