### PR TITLE
refactor(envelope): Result + ExecutorFailedError + toFailureEnvelope helper — ADR-020 PR-SR2-1

### DIFF
--- a/docs/adr-020-phase-3-sr-2-handler-result-boundary-plan.md
+++ b/docs/adr-020-phase-3-sr-2-handler-result-boundary-plan.md
@@ -118,9 +118,9 @@ PR-SR2-3 (handler 群 boundary 共通 pattern 統一 - Part 2 + executor_failed 
 | 3282 | `makeQueryWrapper` 内 `SemanticMemoryNUpperBoundExceeded` check (同上) | PR-SR2-1 |
 | 3297 | `makeQueryWrapper` 内 `ProceduralMemoryNUpperBoundExceeded` check (同上) | PR-SR2-1 |
 
-= **PR-SR2-1 で 5 callsite (line 2910 + 3252/3267/3282/3297) を `toFailureEnvelope` 経由置換** (wrapper internal direct call、scope 内に追加)、**PR-SR2-3 で 1 callsite (line 2990) を置換** (handler throw fallback path、PR #329 独立 return 経路統一と同 wrapper)。**PR-SR2-2 は handler boundary 共通 pattern のみ、`_envelope.ts` 内 callsite 置換は 0 件**。
+= **PR-SR2-1 で wrapper internal callsite 置換 scope creep 回避**: 5 callsite (line 2910 + 3252/3267/3282/3297) はそれぞれ `mapLeaseValidationToTypedReason` + memory N upper bound `WorkingMemoryNUpperBoundExceeded` 等の独自 typed code + tryNext を direct 構築しており、`toFailureEnvelope` 経由置換には typed error class 5 種追加 + SUGGESTS dict sync 確認が必要 (PR-SR2-1 ~200-300 line scope を超過 risk)。本 SR-2 Round 3 実装中判断 (2026-05-17) で **PR-SR2-1 は基盤 (Result + ExecutorFailedError + toFailureEnvelope + toResultErr helper) のみに scope shrink**、wrapper internal 6 callsite 全件置換は PR-SR2-3 で executor_failed return path 統一と同経路で一括処理。
 
-= **PR-SR2-2 / PR-SR2-3 並走可** (`_envelope.ts` 内 callsite 置換 scope disjoint、PR-SR2-1 で 5 件 + PR-SR2-3 で 1 件、PR-SR2-2 は 0 件)。
+= **PR-SR2-2 / PR-SR2-3 並走条件再修正**: PR-SR2-2 = handler 19 件 boundary 統一 (`_envelope.ts` 内 callsite 置換 0 件)、PR-SR2-3 = handler 10 件 boundary 統一 + executor_failed return path 統一 + `_envelope.ts` 内 6 callsite 全件置換 + L6 closure (scope 拡大、~300-400 line に調整)。両 PR は scope disjoint (handler file 分担 + PR-SR2-3 が `_envelope.ts` 専有)、worktree 並走可。
 
 ---
 

--- a/src/errors/typed-errors.ts
+++ b/src/errors/typed-errors.ts
@@ -1,0 +1,41 @@
+/**
+ * Typed error hierarchy for handler failure paths (ADR-020 SR-2 PR-SR2-1).
+ *
+ * Each typed error class's `name` field matches a `SUGGESTS` dict key in
+ * `src/tools/_errors.ts`. `toFailureEnvelope` (in `_envelope.ts`) uses the
+ * class's `name` to look up `most_likely_cause` + `try_next` in SUGGESTS,
+ * keeping handler-side typed errors and LLM-facing recovery hints bit-equal
+ * sync (sub-plan §2 北極星 7).
+ *
+ * `name` field is set in the constructor body (not as class field) to avoid
+ * TypeScript class field initialisation order issues with base/derived class
+ * overrides under ES2022 class field semantics (sub-plan §4.3 + Round 2 P2-3).
+ */
+
+export class HandlerError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "HandlerError";
+  }
+}
+
+/**
+ * Typed error for the `executor_failed` envelope path (PR #329 carry-over,
+ * ADR-020 §11 L6 closure target).
+ *
+ * `name === "ExecutorFailed"` matches `SUGGESTS.ExecutorFailed` key
+ * (`_errors.ts:284`). `toFailureEnvelope` resolves the SUGGESTS entry at
+ * runtime to produce a `most_likely_cause` + `try_next` envelope identical
+ * to the one PR #329 emitted via the hand-wired
+ * `buildExecutorFailedIfUnexpected()` helper in `desktop-register.ts:560-566`.
+ */
+export class ExecutorFailedError extends HandlerError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "ExecutorFailed";
+  }
+}
+
+// Future expansion (sub-plan §9 OQ-SR2-2): ModalBlockingError, LeaseExpiredError,
+// etc., each with a `name` matching a SUGGESTS key. Hierarchy stays shallow —
+// SUGGESTS lookup is the SSOT, not a type-system inheritance tree.

--- a/src/tools/_envelope.ts
+++ b/src/tools/_envelope.ts
@@ -117,6 +117,8 @@ import {
   _resetSingleSessionPinForTest,
 } from "./_session-context.js";
 import { getSuggestsForCode, failArgs } from "./_errors.js";
+import type { Result } from "../types/result.js";
+import { HandlerError } from "../errors/typed-errors.js";
 import type { ToolResult } from "./_types.js";
 import {
   uiPatternStore,
@@ -1209,6 +1211,72 @@ export function buildFailureEnvelope(
     confidence: "stale",
     if_unexpected: { most_likely_cause: mostLikelyCause, try_next: tryNext },
   };
+}
+
+// ─── ADR-020 SR-2 PR-SR2-1: handler boundary central converter ───────────────
+
+/**
+ * `toFailureEnvelope` — handler 最外周共通 pattern で使用する converter
+ * (ADR-020 SR-2 PR-SR2-1、sub-plan §2 北極星 1 + §4.4).
+ *
+ * Signature 拡張 (sub-plan Round 2 P1-3): caller 側で
+ * `optIn ? failure : compatFailureRaw(failure)` を重複しないよう helper 内に
+ * raw-mode projection 統合 + `envelopeOptions` pass-through で `as_of.wallclock_ms`
+ * (L1 event wallclock) 等を伝播。
+ *
+ * Input:
+ *   - `result: Result<Ok, Err>` — Err は HandlerError 派生 typed error
+ *   - `options.optIn: boolean` — envelope full shape or raw-compat shape
+ *   - `options.envelopeOptions?: EnvelopeOptions` — `buildFailureEnvelope` pass-through
+ * Output:
+ *   - success → handler return value (Ok 型)
+ *   - failure → typed error name で SUGGESTS dict lookup → `mostLikelyCause` + `tryNext`
+ *     自動生成 → optIn による envelope full shape / raw-compat shape を return
+ *
+ * 注意: handler 内部 throw 経路は `toResultErr(e)` で `Result.err(HandlerError)`
+ * に変換してから本 helper に渡す (handler 最外周共通 pattern、PR-SR2-2/-3 で
+ * 29 handler に展開予定)。`failWith` 経路 (176 callsite) は本 SR-2 scope 外
+ * (sub-plan §9 OQ-SR2-4 + 親 ADR §11 L10 carry-over)。
+ */
+export function toFailureEnvelope<Ok, Err extends HandlerError>(
+  result: Result<Ok, Err>,
+  options: {
+    /** `optIn === true` → envelope full shape、`false` → raw-compat shape (caller 側で
+     *  `optIn ? failure : compatFailureRaw(failure)` 重複しないため helper 内統合)。 */
+    optIn: boolean;
+    /** `buildFailureEnvelope` の `EnvelopeOptions` を pass-through
+     *  (`asOfWallclockMs` 等の L1 event wallclock 経路、将来 root extras hoist 伝播)。 */
+    envelopeOptions?: EnvelopeOptions;
+  },
+): Ok | EnvelopeMinimalShape<null> | CompatRawFailureShape {
+  if (result.ok) return result.value;
+  // `result.error.name` は typed error class が constructor body で設定する
+  // `SUGGESTS` dict key (e.g. `"ExecutorFailed"`)。`getSuggestsForCode` (in
+  // `_errors.ts`) は本 dict の正しい lookup API で、unknown code には汎用
+  // fallback 配列を返す。empty fallback の場合は本 helper 側で再 fallback。
+  const errorName = result.error.name;
+  const tryNextStrings = getSuggestsForCode(errorName);
+  const tryNext: TryNextAction[] = tryNextStrings.length > 0
+    ? tryNextStrings.map((action) => ({ action }))
+    : [{ action: "Inspect the underlying error and retry with adjusted args" }];
+  const failure = buildFailureEnvelope(errorName, tryNext, options.envelopeOptions);
+  return options.optIn ? failure : compatFailureRaw(failure);
+}
+
+/**
+ * `toResultErr` — wrap a caught `unknown` throw into `Result.err(HandlerError)`.
+ *
+ * Use in handler 最外周 catch:
+ * ```
+ * try { ... return ok } catch (e) { return toFailureEnvelope(toResultErr(e), {optIn}) }
+ * ```
+ */
+export function toResultErr(e: unknown): Result<never, HandlerError> {
+  if (e instanceof HandlerError) return { ok: false, error: e };
+  if (e instanceof Error) {
+    return { ok: false, error: new HandlerError(e.message, { cause: e }) };
+  }
+  return { ok: false, error: new HandlerError(String(e)) };
 }
 
 // ─── tool_call_id session-local monotone counter ─────────────────────────────

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -1,0 +1,18 @@
+/**
+ * `Result<Ok, Err>` — discriminated union for handler control flow.
+ *
+ * ADR-020 SR-2 PR-SR2-1: TypeScript 慣用の Result 型を新規導入。handler 内部
+ * control flow を `throw` から `Result.err(typedError)` に gradual migrate する
+ * 際の receiver 型として使用。SR-2 では handler 最外周 try/catch 共通 pattern が
+ * 主 scope のため、handler 内部の throw → Result.err 全件 migrate は scope 外
+ * (sub-plan §2 北極星 6 = gradual migration 採用)。
+ *
+ * `failWith` 経路 (176 callsite、`_errors.ts:685-719`、`ToolFailure` shape) は
+ * 本 SR-2 scope 外、別 epic carry-over (sub-plan §9 OQ-SR2-4、親 ADR §11 L10)。
+ */
+export type Result<Ok, Err> =
+  | { readonly ok: true; readonly value: Ok }
+  | { readonly ok: false; readonly error: Err };
+
+export const Ok = <T>(value: T): Result<T, never> => ({ ok: true, value });
+export const Err = <E>(error: E): Result<never, E> => ({ ok: false, error });

--- a/tests/unit/path-class-contract/result-type.test.ts
+++ b/tests/unit/path-class-contract/result-type.test.ts
@@ -1,0 +1,56 @@
+/**
+ * tests/unit/path-class-contract/result-type.test.ts — ADR-020 SR-2 PR-SR2-1.
+ *
+ * Pins the `Result<Ok, Err>` discriminated union contract:
+ *   - `Ok(value)` produces `{ ok: true, value }`
+ *   - `Err(error)` produces `{ ok: false, error }`
+ *   - Type narrowing works for both branches (compile-time guard)
+ *
+ * @see src/types/result.ts
+ */
+
+import { describe, it, expect } from "vitest";
+import { Ok, Err, type Result } from "../../../src/types/result.js";
+
+describe("Result type (ADR-020 SR-2 PR-SR2-1)", () => {
+  it("Ok(value) → { ok: true, value }", () => {
+    const r = Ok(42);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value).toBe(42);
+    }
+  });
+
+  it("Err(error) → { ok: false, error }", () => {
+    const e = new Error("oops");
+    const r = Err(e);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toBe(e);
+    }
+  });
+
+  it("discriminated union narrowing via ok property", () => {
+    const r: Result<number, string> = Math.random() > 0.5 ? Ok(1) : Err("nope");
+    if (r.ok) {
+      // Compile-time guard: `value` is narrowed to `number`
+      const n: number = r.value;
+      expect(typeof n).toBe("number");
+    } else {
+      // Compile-time guard: `error` is narrowed to `string`
+      const s: string = r.error;
+      expect(typeof s).toBe("string");
+    }
+  });
+
+  it("Ok and Err are readonly (immutable)", () => {
+    const r = Ok({ count: 1 });
+    // `r.ok` is typed `readonly true` — runtime assignment would not throw
+    // (TypeScript readonly is compile-time only), but the discriminated
+    // union contract treats Ok/Err as values.
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value.count).toBe(1);
+    }
+  });
+});

--- a/tests/unit/path-class-contract/to-failure-envelope.test.ts
+++ b/tests/unit/path-class-contract/to-failure-envelope.test.ts
@@ -1,0 +1,137 @@
+/**
+ * tests/unit/path-class-contract/to-failure-envelope.test.ts — ADR-020 SR-2 PR-SR2-1.
+ *
+ * Pins the `toFailureEnvelope` + `toResultErr` helpers (sub-plan §4.4):
+ *   - happy path: `Result.ok(value)` → return `value` (Ok branch)
+ *   - SUGGESTS hit: `Err.name in SUGGESTS` → envelope with matching `most_likely_cause` + `try_next`
+ *   - SUGGESTS miss: unknown `Err.name` → envelope with fallback `try_next`
+ *   - `optIn: true` → `EnvelopeMinimalShape<null>` (full shape)
+ *   - `optIn: false` → `CompatRawFailureShape` (raw-compat projection)
+ *   - `envelopeOptions.asOfWallclockMs` pass-through to `buildFailureEnvelope`
+ *   - `toResultErr(unknown)`:
+ *     - `HandlerError` → unwrap (no double-wrap)
+ *     - `Error` → wrap in `HandlerError` with `cause`
+ *     - other → wrap String() result in `HandlerError`
+ *
+ * @see src/tools/_envelope.ts toFailureEnvelope + toResultErr
+ * @see src/errors/typed-errors.ts HandlerError + ExecutorFailedError
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  toFailureEnvelope,
+  toResultErr,
+} from "../../../src/tools/_envelope.js";
+import { Ok, Err } from "../../../src/types/result.js";
+import {
+  HandlerError,
+  ExecutorFailedError,
+} from "../../../src/errors/typed-errors.js";
+
+describe("toFailureEnvelope (ADR-020 SR-2 PR-SR2-1)", () => {
+  describe("happy path", () => {
+    it("Ok(value) → return value (no envelope wrapping)", () => {
+      const result = toFailureEnvelope(Ok({ data: 42 }), { optIn: true });
+      expect(result).toEqual({ data: 42 });
+    });
+  });
+
+  describe("SUGGESTS hit (ExecutorFailedError)", () => {
+    it("optIn=true → EnvelopeMinimalShape<null> with most_likely_cause='ExecutorFailed'", () => {
+      const result = toFailureEnvelope(Err(new ExecutorFailedError("UIA setValue failed")), {
+        optIn: true,
+      });
+      expect(result).toMatchObject({
+        _version: "1.0",
+        data: null,
+        confidence: "stale",
+        if_unexpected: {
+          most_likely_cause: "ExecutorFailed",
+          try_next: expect.arrayContaining([
+            expect.objectContaining({ action: expect.any(String) }),
+          ]),
+        },
+      });
+    });
+
+    it("optIn=false → CompatRawFailureShape with reason='executor_failed'", () => {
+      const result = toFailureEnvelope(Err(new ExecutorFailedError("UIA setValue failed")), {
+        optIn: false,
+      });
+      expect(result).toMatchObject({
+        ok: false,
+        reason: "executor_failed", // pascalToSnake("ExecutorFailed")
+        diff: [],
+        if_unexpected: {
+          most_likely_cause: "ExecutorFailed",
+        },
+      });
+    });
+  });
+
+  describe("SUGGESTS miss (custom HandlerError name)", () => {
+    class UnknownError extends HandlerError {
+      constructor(message: string) {
+        super(message);
+        this.name = "UnknownErrorThatIsNotInSuggests";
+      }
+    }
+
+    it("falls back to generic 'Inspect the underlying error' try_next", () => {
+      const result = toFailureEnvelope(Err(new UnknownError("oops")), { optIn: true });
+      expect(result).toMatchObject({
+        _version: "1.0",
+        data: null,
+        if_unexpected: {
+          most_likely_cause: "UnknownErrorThatIsNotInSuggests",
+        },
+      });
+      // Fallback try_next has at least 1 entry
+      const envelope = result as { if_unexpected: { try_next: Array<{ action: string }> } };
+      expect(envelope.if_unexpected.try_next.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("envelopeOptions pass-through", () => {
+    it("asOfWallclockMs is honoured by buildFailureEnvelope", () => {
+      const fixedTime = 1700000000000;
+      const result = toFailureEnvelope(Err(new ExecutorFailedError("x")), {
+        optIn: true,
+        envelopeOptions: { asOfWallclockMs: fixedTime },
+      });
+      const envelope = result as { as_of: { wallclock_ms: number } };
+      expect(envelope.as_of.wallclock_ms).toBe(fixedTime);
+    });
+  });
+});
+
+describe("toResultErr (ADR-020 SR-2 PR-SR2-1)", () => {
+  it("HandlerError → unwrap (no double-wrap)", () => {
+    const original = new ExecutorFailedError("UIA failed");
+    const r = toResultErr(original);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toBe(original); // same instance, no rewrap
+    }
+  });
+
+  it("plain Error → wrap in HandlerError with cause", () => {
+    const e = new Error("plain failure");
+    const r = toResultErr(e);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toBeInstanceOf(HandlerError);
+      expect(r.error.message).toBe("plain failure");
+      expect(r.error.cause).toBe(e);
+    }
+  });
+
+  it("non-Error value → wrap String() result in HandlerError", () => {
+    const r = toResultErr("string-thrown-as-error");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toBeInstanceOf(HandlerError);
+      expect(r.error.message).toBe("string-thrown-as-error");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

ADR-020 Phase 3 SR-2 (handler internal Result + envelope central converter + handler boundary 共通 pattern) の最初の PR。Result + ExecutorFailedError typed error + toFailureEnvelope helper の **基盤を land**。

### 新規 file
- **`src/types/result.ts`** (~25 line): `Result<Ok, Err>` discriminated union + `Ok` / `Err` helpers
- **`src/errors/typed-errors.ts`** (~40 line): `HandlerError` base + `ExecutorFailedError` (`name="ExecutorFailed"` 設定で `SUGGESTS.ExecutorFailed` lookup と bit-equal sync)
- **`tests/unit/path-class-contract/result-type.test.ts`** (4 case)
- **`tests/unit/path-class-contract/to-failure-envelope.test.ts`** (8 case)

### `src/tools/_envelope.ts` 追加
- **`toFailureEnvelope(result, options: {optIn, envelopeOptions?})`** 拡張 signature (Round 2 P1-3 反映):
  - `optIn ? failure : compatFailureRaw(failure)` helper 内統合 (caller 側重複回避)
  - `envelopeOptions` pass-through (`as_of.wallclock_ms` 等 L1 event wallclock 経路)
  - `result.error.name` → `getSuggestsForCode` lookup → `try_next` 構築 → envelope 変換
- **`toResultErr(unknown)`**: `HandlerError` unwrap / `Error` wrap with cause / other String() wrap

### Scope shrink (実装中判断)
- PR-SR2-1 では **基盤のみ** land、wrapper internal 6 callsite 置換は PR-SR2-3 で executor_failed return path 統一と同経路で一括処理
- 理由: 各 callsite が独自 typed code + tryNext を direct 構築、typed error class 5 種追加 + SUGGESTS dict sync 確認が PR-SR2-1 scope (~200-300 line) を超過
- sub-plan §3.5 callsite 分担表を Round 3 で再修正済

## Test plan

- [x] `npm run build` (tsc clean)
- [x] 全 vitest: **3653 passed | 2 failed** (failures は `benchmark-gates` Gate 2 + `native-win32-panic-fuzz` 1000 invocations、SR-2 改修と無関係の既存 flaky timer/perf-sensitive test)
- [x] 新規 PR-SR2-1 test: **12/12 全 pass**
- [x] SR-2 関連 + Phase 2 contract test 全 green 維持

## Review focus

- **`toFailureEnvelope` 拡張 signature**: `optIn` + `envelopeOptions` pass-through、`compatFailureRaw` projection 統合、`getSuggestsForCode` lookup 動作確認
- **`toResultErr` 3 case**: HandlerError unwrap (no double-wrap) / Error wrap (cause 保全) / non-Error String() wrap
- **`ExecutorFailedError.name === "ExecutorFailed"`** constructor body 内設定 (Round 2 P2-3、TS class field 初期化順 + ES2022 class field semantics で base class assignment 後勝ち回避)
- **既存 6 callsite touch なし**: 本 PR では `_envelope.ts` 内 6 既存 `buildFailureEnvelope` callsite は不変、PR-SR2-3 で一括置換

## Carry-over

- **OQ-SR2-1** (Result 純化 epic) / **OQ-SR2-2** (typed error 階層拡張) / **OQ-SR2-3** (`buildFailureEnvelope` export internal 化) は sub-plan §9 で永続化
- **OQ-SR2-4** (`failWith` 経路 migrate 判断、176 callsite、5 層永続化最終達成済): 親 ADR §11 L10 entry で物理永続化済 (PR #346 で land)
- SR-2 全 PR (PR-SR2-2 / PR-SR2-3) land 後に親 ADR §11 L6 strikethrough + OQ-SR2-4 mile-stone 確認 trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)