### PR TITLE
refactor(broker): DirtyRectBroker scaffold + interface (dormant land) — ADR-020 PR-SR4-1

### DIFF
--- a/src/engine/dxgi-broker.ts
+++ b/src/engine/dxgi-broker.ts
@@ -561,6 +561,23 @@ export class DirtyRectBroker {
    * removing the `lastUsedAt = nowFn()` line below causes the "Round 2
    * Codex P2: last consumer detach refreshes lastUsedAt" test to fail
    * because the subsequent `acquire()` enters the stale-sweep path.
+   *
+   * **Round 2 Opus P2-A**: this refresh is intentionally **scoped to
+   * `maybeStopFanOut` only**. The other two teardown paths — `invalidate`
+   * and `disposeAll` — do NOT need to refresh `lastUsedAt` because:
+   *
+   *   - `invalidate(outputIndex)` REPLACES the entry with a
+   *     `{ kind: "negative-backoff", recordedAt: nowFn() }` record, so
+   *     the subscription-kind sweep path (which is the only one that
+   *     reads `lastUsedAt`) is bypassed entirely. The new entry uses
+   *     `recordedAt` for its own `negativeBackoffMs` window.
+   *   - `disposeAll()` ends with `this.entries.clear()`, so no entry
+   *     remains to be swept. The next `acquire`/`subscribe` constructs
+   *     a fresh subscription-kind entry with `lastUsedAt = nowFn()`.
+   *
+   * Future readers (PR-SR4-2 SSOT shift / PR-SR4-3 vision-gpu migration)
+   * should NOT mirror this refresh to `invalidate` / `disposeAll`. The
+   * asymmetry is correct.
    */
   private maybeStopFanOut(
     _outputIndex: number,

--- a/src/engine/dxgi-broker.ts
+++ b/src/engine/dxgi-broker.ts
@@ -546,12 +546,29 @@ export class DirtyRectBroker {
     });
   }
 
+  /**
+   * Round 2 Codex P2 fix: refresh `lastUsedAt` when the LAST consumer
+   * detaches so the idle window starts from "last consumer was active"
+   * instead of "last consumer initially attached". Without this, a
+   * long-lived subscription whose only consumer detaches near the end of
+   * the idle window (e.g. 25 s after attach with idleTimeoutMs=20 s) would
+   * be **swept on the very next `sweepStale()` call** even though the
+   * detach happened just moments ago — forcing a 50ms DXGI factory
+   * re-init storm on any quick re-subscribe (the exact pattern Stage 5 +
+   * vision-gpu activation/deactivation cycles produce).
+   *
+   * Mental simulation revert (memory `feedback_opus_contract_truth_sweep.md`):
+   * removing the `lastUsedAt = nowFn()` line below causes the "Round 2
+   * Codex P2: last consumer detach refreshes lastUsedAt" test to fail
+   * because the subsequent `acquire()` enters the stale-sweep path.
+   */
   private maybeStopFanOut(
     _outputIndex: number,
     entry: CacheEntry & { kind: "subscription" },
   ): void {
     if (entry.pollingHandles.size === 0 && entry.callbackHandles.size === 0) {
       entry.fanOutShouldStop = true;
+      entry.lastUsedAt = this.nowFn();
     }
   }
 

--- a/src/engine/dxgi-broker.ts
+++ b/src/engine/dxgi-broker.ts
@@ -1,0 +1,591 @@
+/**
+ * dxgi-broker.ts — ADR-020 SR-4 (Phase 3) DXGI subscription multiplex broker.
+ *
+ * 1 native `DirtyRectSubscription` per `outputIndex` is held by the broker;
+ * consumer 2 件 (ADR-019 Stage 5 `any-change.ts` polling + ADR-005 vision-gpu
+ * `dirty-rect-source.ts` callback、本 PR では未 migrate、PR-SR4-2 / PR-SR4-3 で
+ * 順次 migrate) は broker subscribe API 経由でぶら下がる。これで race-loss
+ * (`NotCurrentlyAvailable` 軸) を構造的に消滅させる。
+ *
+ * Sub-plan: `docs/adr-020-phase-3-sr-4-dxgi-broker-plan.md`
+ *
+ * Design lock (sub-plan §5.2, Round 2 P1-3):
+ * - `BrokerSubscription` interface は `next(timeoutMs)` / `dispose()` /
+ *   `isDisposed` / `outputIndex` のみ (subscribe method なし、二重 fan-out
+ *   経路を構造的に禁止)。
+ * - `DirtyRectBroker` class が `acquire(outputIndex)` (polling consumer) +
+ *   `subscribe(outputIndex, callback)` (callback consumer) の 2 上位 API
+ *   を提供、内部で 1 native subscription を multiplex。
+ * - polling consumer は per-consumer queue cursor (OQ-SR4-1 候補 (c)、
+ *   consumer ごとに別 buffer enqueue) で独立 drain、後発 acquire でも
+ *   先発 cursor に影響しない。
+ *
+ * Invariant (sub-plan §2 北極星 1+2): broker は `DirtyRectSubscription`
+ * の唯一 constructor caller、race-loss 軸 (`NotCurrentlyAvailable`) は
+ * 構造的に発生不能。
+ *
+ * Dormant land (sub-plan §5.1): 本 PR では broker は caller ゼロ
+ * (Stage 5 + vision-gpu は未 migrate)。既存 vitest suite 全 pass + broker
+ * 単独 test ~15-20 case で動作実証、consumer migration は PR-SR4-2 / -3 で。
+ */
+
+import type { NativeDirtyRect } from "./native-types.js";
+import { nativeDuplication } from "./native-engine.js";
+
+// ─── Constants (sub-plan §5.3、broker 側私的複製、PR-SR4-2 で SSOT shift) ───
+
+/**
+ * Idle timeout for an active subscription. After 20s of no `acquire` /
+ * `subscribe` / `next()` activity, the broker disposes the native
+ * subscription and frees the DXGI session. Mirrors
+ * `STAGE5_CACHE_IDLE_TIMEOUT_MS` (`src/engine/any-change.ts:44`) verbatim
+ * — PR-SR4-2 で broker SSOT 化 + Stage 5 const を broker re-export に
+ * 切替時、両定数が同 numeric 値であることを test で機械保証。
+ */
+const BROKER_CACHE_IDLE_TIMEOUT_MS = 20_000;
+
+/**
+ * TTL for the cached `unavailable` marker (factory throw / DXGI unsupported).
+ * Mirrors `STAGE5_UNAVAILABLE_TTL_MS` (`any-change.ts:67`) — see that JSDoc
+ * for the 60s tuning rationale (covers 15s lease TTL × 4 + 10-30s LLM
+ * reasoning latency, avoids 50ms factory re-init storm on RDP / vision-gpu
+ * permanent unavailability).
+ */
+const BROKER_UNAVAILABLE_TTL_MS = 60_000;
+
+/**
+ * Short-lived back-off after a `sub.next()` failure (E_DUP_ACCESS_LOST
+ * recovery). Mirrors `NEGATIVE_BACKOFF_MS` (`any-change.ts:119`) — 2s is
+ * long enough to absorb a chained `desktop_act` × 5 sequence and short
+ * enough that AccessLost recovery surfaces within a single user turn.
+ */
+const BROKER_NEGATIVE_BACKOFF_MS = 2_000;
+
+// ─── Public types ────────────────────────────────────────────────────────────
+
+/** Minimal native subscription contract — used for test injection without
+ *  the native addon. Mirrors `NativeDirtyRectSubscription` (`native-types.ts:435`). */
+export interface SubscriptionLike {
+  readonly isDisposed: boolean;
+  next(timeoutMs: number): Promise<NativeDirtyRect[]>;
+  dispose(): void;
+}
+
+/**
+ * Per-consumer polling handle. **Round 2 P1-3 lock**: no `subscribe()`
+ * method on this interface — fan-out is exclusively a `DirtyRectBroker`
+ * upper-level API responsibility.
+ *
+ * Each `acquire()` call returns an independent handle whose `next()` drains
+ * the handle's own per-consumer queue cursor. Disposing one handle does NOT
+ * dispose the underlying native subscription; the broker dereferences the
+ * native subscription once all polling handles AND callback handles for the
+ * `outputIndex` are disposed AND the idle timeout has elapsed.
+ */
+export interface BrokerSubscription {
+  readonly outputIndex: number;
+  readonly isDisposed: boolean;
+  next(timeoutMs: number): Promise<NativeDirtyRect[]>;
+  dispose(): void;
+}
+
+/**
+ * `acquire` / `subscribe` cache hit/miss telemetry. Five-value enum kept
+ * bit-equal with `src/engine/any-change.ts:127` (`CacheAcquireState`) —
+ * PR-SR4-2 で Stage 5 が broker から re-export に切替時、両 enum 値が
+ * bit-equal であることを test で機械保証。Sub-plan §5.3 acceptance.
+ */
+export type CacheAcquireState =
+  | "hit-subscription"
+  | "hit-unavailable"
+  | "hit-negative-backoff"
+  | "miss-init"
+  | "miss-init-unavailable";
+
+// ─── Internal types ──────────────────────────────────────────────────────────
+
+/**
+ * Per-output entry. The `subscription` variant carries the native
+ * subscription, per-consumer polling cursors, registered callbacks, and a
+ * single fan-out loop that pumps `next()` results to both polling queues
+ * and callback handlers.
+ */
+type CacheEntry =
+  | {
+      kind: "subscription";
+      sub: SubscriptionLike;
+      lastUsedAt: number;
+      pollingHandles: Set<PollingHandle>;
+      callbackHandles: Set<CallbackHandle>;
+      /** Fan-out loop is running iff at least one polling/callback handle
+       *  is registered. `null` when paused (no consumer). */
+      fanOutPromise: Promise<void> | null;
+      /** Set to `true` on `invalidate()` or last-consumer disposal to stop
+       *  the fan-out loop on its next iteration. */
+      fanOutShouldStop: boolean;
+    }
+  | { kind: "unavailable"; recordedAt: number }
+  | { kind: "negative-backoff"; recordedAt: number };
+
+/**
+ * Per-consumer queue cursor. Each polling consumer pushes/pops on its own
+ * `queue` array; `pendingResolver` is the resolver waiting on `next()`
+ * (only one outstanding `next()` per handle, enforced by the public
+ * contract).
+ */
+class PollingHandle implements BrokerSubscription {
+  readonly outputIndex: number;
+  isDisposed = false;
+  // Per-consumer FIFO queue of dirty rect batches. Fan-out loop pushes
+  // each `next()` batch onto every polling handle's queue independently.
+  readonly queue: Array<NativeDirtyRect[]> = [];
+  pendingResolver: ((rects: NativeDirtyRect[]) => void) | null = null;
+  pendingTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(
+    outputIndex: number,
+    private readonly onDispose: () => void,
+  ) {
+    this.outputIndex = outputIndex;
+  }
+
+  async next(timeoutMs: number): Promise<NativeDirtyRect[]> {
+    if (this.isDisposed) return [];
+    // Drain any queued batch first (fan-out loop pre-pumped these).
+    const queued = this.queue.shift();
+    if (queued !== undefined) return queued;
+    // Otherwise wait up to `timeoutMs` for the next fan-out batch.
+    return new Promise<NativeDirtyRect[]>((resolve) => {
+      this.pendingResolver = resolve;
+      this.pendingTimer = setTimeout(() => {
+        if (this.pendingResolver === resolve) {
+          this.pendingResolver = null;
+          this.pendingTimer = null;
+          resolve([]);
+        }
+      }, timeoutMs);
+    });
+  }
+
+  /** Called by the broker's fan-out loop when a new batch arrives. */
+  _pushBatch(rects: NativeDirtyRect[]): void {
+    if (this.isDisposed) return;
+    if (this.pendingResolver !== null) {
+      const resolver = this.pendingResolver;
+      this.pendingResolver = null;
+      if (this.pendingTimer !== null) {
+        clearTimeout(this.pendingTimer);
+        this.pendingTimer = null;
+      }
+      resolver(rects);
+    } else {
+      this.queue.push(rects);
+    }
+  }
+
+  dispose(): void {
+    if (this.isDisposed) return;
+    this.isDisposed = true;
+    if (this.pendingResolver !== null) {
+      const resolver = this.pendingResolver;
+      this.pendingResolver = null;
+      if (this.pendingTimer !== null) {
+        clearTimeout(this.pendingTimer);
+        this.pendingTimer = null;
+      }
+      resolver([]);
+    }
+    this.queue.length = 0;
+    this.onDispose();
+  }
+}
+
+/** Callback consumer handle returned by `DirtyRectBroker.subscribe`. */
+class CallbackHandle {
+  readonly outputIndex: number;
+  readonly callback: (rects: NativeDirtyRect[]) => void;
+  isUnsubscribed = false;
+
+  constructor(
+    outputIndex: number,
+    callback: (rects: NativeDirtyRect[]) => void,
+  ) {
+    this.outputIndex = outputIndex;
+    this.callback = callback;
+  }
+}
+
+// ─── Broker ──────────────────────────────────────────────────────────────────
+
+/**
+ * DXGI subscription multiplex broker. Sub-plan §5.2 lock.
+ *
+ * Lifecycle:
+ * - First `acquire(0)` / `subscribe(0, ...)` constructs a native
+ *   subscription (~50-100 ms DXGI init).
+ * - Subsequent calls on the same `outputIndex` reuse the existing native
+ *   subscription; per-consumer cursors / callback handlers are independent.
+ * - 20s idle (no consumer activity) → fan-out loop drains, native
+ *   subscription disposed, cache entry deleted.
+ * - Last consumer dispose + idle timeout → same path.
+ * - Server shutdown → `disposeAll()` releases everything.
+ *
+ * Coexistence (sub-plan §1.2): when 2 consumers `subscribe(0, ...)` /
+ * `acquire(0)` concurrently, only one native `DirtyRectSubscription` is
+ * constructed. The race-loss `DXGI_ERROR_NOT_CURRENTLY_AVAILABLE` window
+ * is structurally eliminated.
+ */
+export class DirtyRectBroker {
+  private readonly entries = new Map<number, CacheEntry>();
+
+  constructor(
+    private readonly factory: (outputIndex: number) => SubscriptionLike,
+    private readonly nowFn: () => number = () => Date.now(),
+    private readonly idleTimeoutMs: number = BROKER_CACHE_IDLE_TIMEOUT_MS,
+    private readonly unavailableTtlMs: number = BROKER_UNAVAILABLE_TTL_MS,
+    /** Fan-out polling budget for `sub.next(timeoutMs)` calls inside the
+     *  broker loop. Independent from each consumer's `next(timeoutMs)`. */
+    private readonly fanOutPollMs: number = 100,
+  ) {}
+
+  /**
+   * Polling consumer API (ADR-019 Stage 5 後継、PR-SR4-2 で migrate)。
+   * Returns a per-consumer handle whose `next()` drains its own queue
+   * cursor; concurrent polling consumers on the same `outputIndex` each
+   * receive every fan-out batch independently.
+   */
+  acquire(outputIndex: number): {
+    sub: BrokerSubscription | null;
+    state: CacheAcquireState;
+  } {
+    this.sweepStale();
+    const cached = this.entries.get(outputIndex);
+
+    if (cached?.kind === "subscription") {
+      if (!cached.sub.isDisposed) {
+        cached.lastUsedAt = this.nowFn();
+        const handle = this.attachPollingHandle(outputIndex, cached);
+        return { sub: handle, state: "hit-subscription" };
+      }
+      // Disposed externally (AccessLost recovery) — drop and re-init.
+      this.entries.delete(outputIndex);
+    } else if (cached?.kind === "unavailable") {
+      return { sub: null, state: "hit-unavailable" };
+    } else if (cached?.kind === "negative-backoff") {
+      return { sub: null, state: "hit-negative-backoff" };
+    }
+
+    try {
+      const sub = this.factory(outputIndex);
+      const entry: CacheEntry = {
+        kind: "subscription",
+        sub,
+        lastUsedAt: this.nowFn(),
+        pollingHandles: new Set(),
+        callbackHandles: new Set(),
+        fanOutPromise: null,
+        fanOutShouldStop: false,
+      };
+      this.entries.set(outputIndex, entry);
+      const handle = this.attachPollingHandle(outputIndex, entry);
+      return { sub: handle, state: "miss-init" };
+    } catch {
+      this.entries.set(outputIndex, {
+        kind: "unavailable",
+        recordedAt: this.nowFn(),
+      });
+      return { sub: null, state: "miss-init-unavailable" };
+    }
+  }
+
+  /**
+   * Callback consumer API (ADR-005 vision-gpu 後継、PR-SR4-3 で migrate)。
+   * Registers a callback to be invoked on every fan-out batch; returns an
+   * unsubscribe handle.
+   */
+  subscribe(
+    outputIndex: number,
+    callback: (rects: NativeDirtyRect[]) => void,
+  ): { unsubscribe: () => void; state: CacheAcquireState } {
+    this.sweepStale();
+    const cached = this.entries.get(outputIndex);
+
+    if (cached?.kind === "subscription") {
+      if (!cached.sub.isDisposed) {
+        cached.lastUsedAt = this.nowFn();
+        const unsubscribe = this.attachCallbackHandle(outputIndex, cached, callback);
+        return { unsubscribe, state: "hit-subscription" };
+      }
+      this.entries.delete(outputIndex);
+    } else if (cached?.kind === "unavailable") {
+      return { unsubscribe: () => undefined, state: "hit-unavailable" };
+    } else if (cached?.kind === "negative-backoff") {
+      return { unsubscribe: () => undefined, state: "hit-negative-backoff" };
+    }
+
+    try {
+      const sub = this.factory(outputIndex);
+      const entry: CacheEntry = {
+        kind: "subscription",
+        sub,
+        lastUsedAt: this.nowFn(),
+        pollingHandles: new Set(),
+        callbackHandles: new Set(),
+        fanOutPromise: null,
+        fanOutShouldStop: false,
+      };
+      this.entries.set(outputIndex, entry);
+      const unsubscribe = this.attachCallbackHandle(outputIndex, entry, callback);
+      return { unsubscribe, state: "miss-init" };
+    } catch {
+      this.entries.set(outputIndex, {
+        kind: "unavailable",
+        recordedAt: this.nowFn(),
+      });
+      return { unsubscribe: () => undefined, state: "miss-init-unavailable" };
+    }
+  }
+
+  /**
+   * Mark `outputIndex` for short-lived back-off after a `sub.next()` failure
+   * (E_DUP_ACCESS_LOST recovery). Disposes the native subscription so the
+   * next `acquire` / `subscribe` call fast-paths to `hit-negative-backoff`
+   * within `BROKER_NEGATIVE_BACKOFF_MS`, then re-inits cleanly.
+   */
+  invalidate(outputIndex: number): void {
+    const cached = this.entries.get(outputIndex);
+    if (cached?.kind === "subscription") {
+      cached.fanOutShouldStop = true;
+      // Notify all polling handles so any pending `next()` resolves with [].
+      for (const handle of cached.pollingHandles) {
+        handle._pushBatch([]);
+      }
+      if (!cached.sub.isDisposed) {
+        try {
+          cached.sub.dispose();
+        } catch {
+          /* best-effort */
+        }
+      }
+    }
+    this.entries.set(outputIndex, {
+      kind: "negative-backoff",
+      recordedAt: this.nowFn(),
+    });
+  }
+
+  /** Dispose every live native subscription. Called by the MCP server
+   *  shutdown hook (sub-plan §11 R2 mitigation). */
+  disposeAll(): void {
+    for (const entry of this.entries.values()) {
+      if (entry.kind === "subscription") {
+        entry.fanOutShouldStop = true;
+        for (const handle of entry.pollingHandles) {
+          handle._pushBatch([]);
+        }
+        if (!entry.sub.isDisposed) {
+          try {
+            entry.sub.dispose();
+          } catch {
+            /* best-effort */
+          }
+        }
+      }
+    }
+    this.entries.clear();
+  }
+
+  /** @internal — test-only inspection of entry state. */
+  _getEntryForTest(outputIndex: number): CacheEntry | undefined {
+    return this.entries.get(outputIndex);
+  }
+
+  // ─── Internal: per-consumer attach + fan-out loop ──────────────────────────
+
+  private attachPollingHandle(
+    outputIndex: number,
+    entry: CacheEntry & { kind: "subscription" },
+  ): PollingHandle {
+    const handle = new PollingHandle(outputIndex, () => {
+      entry.pollingHandles.delete(handle);
+      this.maybeStopFanOut(outputIndex, entry);
+    });
+    entry.pollingHandles.add(handle);
+    this.ensureFanOutRunning(outputIndex, entry);
+    return handle;
+  }
+
+  private attachCallbackHandle(
+    outputIndex: number,
+    entry: CacheEntry & { kind: "subscription" },
+    callback: (rects: NativeDirtyRect[]) => void,
+  ): () => void {
+    const handle = new CallbackHandle(outputIndex, callback);
+    entry.callbackHandles.add(handle);
+    this.ensureFanOutRunning(outputIndex, entry);
+    return () => {
+      if (handle.isUnsubscribed) return;
+      handle.isUnsubscribed = true;
+      entry.callbackHandles.delete(handle);
+      this.maybeStopFanOut(outputIndex, entry);
+    };
+  }
+
+  private ensureFanOutRunning(
+    outputIndex: number,
+    entry: CacheEntry & { kind: "subscription" },
+  ): void {
+    if (entry.fanOutPromise !== null) return;
+    entry.fanOutShouldStop = false;
+    entry.fanOutPromise = this.runFanOut(outputIndex, entry).finally(() => {
+      entry.fanOutPromise = null;
+    });
+  }
+
+  private maybeStopFanOut(
+    _outputIndex: number,
+    entry: CacheEntry & { kind: "subscription" },
+  ): void {
+    if (entry.pollingHandles.size === 0 && entry.callbackHandles.size === 0) {
+      entry.fanOutShouldStop = true;
+    }
+  }
+
+  /**
+   * Per-output fan-out loop. Polls the native subscription and pushes each
+   * batch to every polling handle's queue + every registered callback.
+   * Exits when `fanOutShouldStop` flips (last consumer disposed, invalidate,
+   * or disposeAll).
+   *
+   * **Busy-loop guard (PR-SR4-1)**: real `NativeDirtyRectSubscription.next(timeoutMs)`
+   * blocks the awaiter for up to `timeoutMs` when no rects arrive; mock
+   * subscriptions (test fixtures) typically resolve `[]` immediately, which
+   * would turn the `while`-`continue` into a synchronous tight loop on the
+   * microtask queue. Yield `fanOutPollMs` between iterations on empty
+   * batches so neither production (degenerate driver) nor test stubs can
+   * burn the worker fork.
+   */
+  private async runFanOut(
+    outputIndex: number,
+    entry: CacheEntry & { kind: "subscription" },
+  ): Promise<void> {
+    while (!entry.fanOutShouldStop && !entry.sub.isDisposed) {
+      let batch: NativeDirtyRect[];
+      try {
+        batch = await entry.sub.next(this.fanOutPollMs);
+      } catch (err) {
+        // Surface DXGI lifecycle errors as cache invalidation so the next
+        // `acquire`/`subscribe` enters `hit-negative-backoff`.
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes("E_DUP_ACCESS_LOST") || msg.includes("E_DUP_UNSUPPORTED")) {
+          this.invalidate(outputIndex);
+        }
+        return;
+      }
+      if (batch.length === 0) {
+        // See JSDoc: yield to keep the event loop healthy when the
+        // subscription resolves `[]` synchronously.
+        await new Promise<void>((r) => setTimeout(r, this.fanOutPollMs));
+        continue;
+      }
+      // Snapshot consumers before delivery — callbacks may unsubscribe
+      // synchronously inside the callback, which would mutate the Set.
+      const pollers = Array.from(entry.pollingHandles);
+      const callbacks = Array.from(entry.callbackHandles);
+      for (const poller of pollers) {
+        poller._pushBatch(batch.slice());
+      }
+      for (const cb of callbacks) {
+        if (cb.isUnsubscribed) continue;
+        try {
+          cb.callback(batch.slice());
+        } catch {
+          /* callbacks must not crash the broker fan-out loop */
+        }
+      }
+    }
+  }
+
+  // ─── Internal: TTL sweep ───────────────────────────────────────────────────
+
+  private sweepStale(): void {
+    const now = this.nowFn();
+    for (const [key, entry] of this.entries) {
+      if (entry.kind === "subscription") {
+        if (
+          entry.pollingHandles.size === 0 &&
+          entry.callbackHandles.size === 0 &&
+          now - entry.lastUsedAt >= this.idleTimeoutMs
+        ) {
+          entry.fanOutShouldStop = true;
+          if (!entry.sub.isDisposed) {
+            try {
+              entry.sub.dispose();
+            } catch {
+              /* best-effort */
+            }
+          }
+          this.entries.delete(key);
+        }
+      } else if (entry.kind === "negative-backoff") {
+        if (now - entry.recordedAt >= BROKER_NEGATIVE_BACKOFF_MS) {
+          this.entries.delete(key);
+        }
+      } else if (entry.kind === "unavailable") {
+        if (now - entry.recordedAt >= this.unavailableTtlMs) {
+          this.entries.delete(key);
+        }
+      }
+    }
+  }
+}
+
+// ─── Shared singleton (lazy, server-wide) ────────────────────────────────────
+
+let _sharedBroker: DirtyRectBroker | null = null;
+
+function defaultFactory(outputIndex: number): SubscriptionLike {
+  const Ctor = nativeDuplication?.DirtyRectSubscription;
+  if (typeof Ctor !== "function") {
+    throw new Error("DirtyRectSubscription not available in native addon");
+  }
+  return new Ctor(outputIndex) as unknown as SubscriptionLike;
+}
+
+/** Lazily construct (and reuse) the process-wide broker. Returns `null`
+ *  when the native addon is not available (no DXGI binding). */
+export function getSharedDirtyRectBroker(): DirtyRectBroker | null {
+  if (_sharedBroker !== null) return _sharedBroker;
+  if (typeof nativeDuplication?.DirtyRectSubscription !== "function") return null;
+  _sharedBroker = new DirtyRectBroker(defaultFactory);
+  return _sharedBroker;
+}
+
+/** Dispose the shared broker. Called by the MCP server shutdown hook so the
+ *  DXGI session is released cleanly (sub-plan §11 R2 mitigation). */
+export function disposeSharedDirtyRectBroker(): void {
+  _sharedBroker?.disposeAll();
+  _sharedBroker = null;
+}
+
+/** @internal — test-only hook to swap the shared broker (or clear it). */
+export function _setSharedDirtyRectBrokerForTest(
+  broker: DirtyRectBroker | null,
+): void {
+  _sharedBroker = broker;
+}
+
+// ─── Constants re-export (for tests / future consumer migration) ─────────────
+
+/**
+ * Exported for `tests/unit/dxgi-broker.test.ts` and future PR-SR4-2 /
+ * PR-SR4-3 consumer migration. Stage 5 `STAGE5_CONSTANTS`
+ * (`any-change.ts:653`) is currently the SSOT; PR-SR4-2 で broker 側に SSOT
+ * shift + Stage 5 を broker re-export に切替時、両定数の numeric 値が
+ * bit-equal であることを test で機械保証する (sub-plan §5.3 acceptance)。
+ */
+export const BROKER_CONSTANTS = Object.freeze({
+  BROKER_CACHE_IDLE_TIMEOUT_MS,
+  BROKER_UNAVAILABLE_TTL_MS,
+  BROKER_NEGATIVE_BACKOFF_MS,
+});

--- a/src/engine/dxgi-broker.ts
+++ b/src/engine/dxgi-broker.ts
@@ -36,11 +36,17 @@ import { nativeDuplication } from "./native-engine.js";
 
 /**
  * Idle timeout for an active subscription. After 20s of no `acquire` /
- * `subscribe` / `next()` activity, the broker disposes the native
- * subscription and frees the DXGI session. Mirrors
- * `STAGE5_CACHE_IDLE_TIMEOUT_MS` (`src/engine/any-change.ts:44`) verbatim
- * — PR-SR4-2 で broker SSOT 化 + Stage 5 const を broker re-export に
- * 切替時、両定数が同 numeric 値であることを test で機械保証。
+ * `subscribe` / `next()` activity AND zero registered polling/callback
+ * consumers, the broker disposes the native subscription and frees the
+ * DXGI session.
+ *
+ * Round 1 P3-3 clarification: numeric value mirrored from
+ * `STAGE5_CACHE_IDLE_TIMEOUT_MS` (`src/engine/any-change.ts:44`), but the
+ * gate condition is broker-specific — Stage 5 cache sweeps purely on idle
+ * timestamp, while the broker also gates on `pollingHandles.size === 0
+ * && callbackHandles.size === 0` (fan-out reference counting). PR-SR4-2 で
+ * broker SSOT 化 + Stage 5 const を broker re-export に切替時、numeric 値
+ * のみ bit-equal を test で機械保証 (gating semantics は broker 側が拡張)。
  */
 const BROKER_CACHE_IDLE_TIMEOUT_MS = 20_000;
 
@@ -154,6 +160,16 @@ class PollingHandle implements BrokerSubscription {
     // Drain any queued batch first (fan-out loop pre-pumped these).
     const queued = this.queue.shift();
     if (queued !== undefined) return queued;
+    // Round 1 P3-4: enforce documented single-outstanding-next contract at
+    // runtime. Concurrent `next()` calls on the same handle would orphan the
+    // first resolver (it would resolve [] only after its own timeout). Throw
+    // explicitly so callers see the bug immediately rather than getting
+    // silent stale-resolve behaviour.
+    if (this.pendingResolver !== null) {
+      throw new Error(
+        "BrokerSubscription.next: concurrent calls on the same handle are not allowed",
+      );
+    }
     // Otherwise wait up to `timeoutMs` for the next fan-out batch.
     return new Promise<NativeDirtyRect[]>((resolve) => {
       this.pendingResolver = resolve;
@@ -181,6 +197,29 @@ class PollingHandle implements BrokerSubscription {
     } else {
       this.queue.push(rects);
     }
+  }
+
+  /**
+   * Round 1 P2-3 fix: called by broker `invalidate` / `disposeAll` to mark
+   * the handle disposed and release any pending `next()` without invoking
+   * the consumer-facing `onDispose` callback (broker is already tearing down
+   * the entry, so the callback would be a redundant reference-count decrement
+   * on an entry that's about to be replaced/cleared).
+   */
+  _markBrokerInvalidated(): void {
+    if (this.isDisposed) return;
+    this.isDisposed = true;
+    if (this.pendingResolver !== null) {
+      const resolver = this.pendingResolver;
+      this.pendingResolver = null;
+      if (this.pendingTimer !== null) {
+        clearTimeout(this.pendingTimer);
+        this.pendingTimer = null;
+      }
+      resolver([]);
+    }
+    this.queue.length = 0;
+    // Note: deliberately do NOT call onDispose — see JSDoc above.
   }
 
   dispose(): void {
@@ -246,6 +285,10 @@ export class DirtyRectBroker {
     /** Fan-out polling budget for `sub.next(timeoutMs)` calls inside the
      *  broker loop. Independent from each consumer's `next(timeoutMs)`. */
     private readonly fanOutPollMs: number = 100,
+    /** Round 1 P3-1: symmetric constructor parameter (matches `idleTimeoutMs`
+     *  / `unavailableTtlMs`). Tests inject a shorter window for fast-forward
+     *  assertions. */
+    private readonly negativeBackoffMs: number = BROKER_NEGATIVE_BACKOFF_MS,
   ) {}
 
   /**
@@ -302,6 +345,13 @@ export class DirtyRectBroker {
    * Callback consumer API (ADR-005 vision-gpu 後継、PR-SR4-3 で migrate)。
    * Registers a callback to be invoked on every fan-out batch; returns an
    * unsubscribe handle.
+   *
+   * Round 1 P3-5 note: subscribing implicitly **starts the broker's
+   * background fan-out loop** for this `outputIndex` (lazy: the loop is
+   * idle when no consumer is registered, and exits when the last consumer
+   * unsubscribes + idle timeout elapses). PR-SR4-3 vision-gpu migration
+   * reviewers should expect `subscribe(...)` to begin polling the native
+   * subscription before the call returns.
    */
   subscribe(
     outputIndex: number,
@@ -351,14 +401,26 @@ export class DirtyRectBroker {
    * (E_DUP_ACCESS_LOST recovery). Disposes the native subscription so the
    * next `acquire` / `subscribe` call fast-paths to `hit-negative-backoff`
    * within `BROKER_NEGATIVE_BACKOFF_MS`, then re-inits cleanly.
+   *
+   * Round 1 P2-3 fix: orphan polling handles are explicitly marked disposed
+   * (isDisposed=true + queue cleared + pending resolver released) so that
+   * consumer code calling `handle.next()` post-invalidate sees the disposed
+   * state instead of silently waiting on an empty queue indefinitely.
    */
   invalidate(outputIndex: number): void {
     const cached = this.entries.get(outputIndex);
     if (cached?.kind === "subscription") {
       cached.fanOutShouldStop = true;
-      // Notify all polling handles so any pending `next()` resolves with [].
+      // Round 1 P2-3: mark each polling handle disposed (not just push []).
+      // After invalidate, the consumer's handle is dead — no fan-out will
+      // restart on the new negative-backoff entry — so the handle must
+      // reflect that state to avoid silent infinite waits.
       for (const handle of cached.pollingHandles) {
-        handle._pushBatch([]);
+        handle._markBrokerInvalidated();
+      }
+      // Round 1 P2-3: unsubscribe all callbacks too (mirrors handle semantics).
+      for (const cb of cached.callbackHandles) {
+        cb.isUnsubscribed = true;
       }
       if (!cached.sub.isDisposed) {
         try {
@@ -375,13 +437,17 @@ export class DirtyRectBroker {
   }
 
   /** Dispose every live native subscription. Called by the MCP server
-   *  shutdown hook (sub-plan §11 R2 mitigation). */
+   *  shutdown hook (sub-plan §11 R2 mitigation). Round 1 P2-3 fix: same
+   *  handle-state propagation as `invalidate`. */
   disposeAll(): void {
     for (const entry of this.entries.values()) {
       if (entry.kind === "subscription") {
         entry.fanOutShouldStop = true;
         for (const handle of entry.pollingHandles) {
-          handle._pushBatch([]);
+          handle._markBrokerInvalidated();
+        }
+        for (const cb of entry.callbackHandles) {
+          cb.isUnsubscribed = true;
         }
         if (!entry.sub.isDisposed) {
           try {
@@ -431,12 +497,50 @@ export class DirtyRectBroker {
     };
   }
 
+  /**
+   * Round 1 P1-1 fix: dispose-then-reattach race elimination.
+   *
+   * Race window before fix:
+   *   1. Last handle disposes → `maybeStopFanOut` sets `fanOutShouldStop = true`
+   *      (loop has not yet observed the flag — still awaiting `sub.next()`).
+   *   2. Fresh `acquire(0)` arrives, calls `attachPollingHandle` →
+   *      `ensureFanOutRunning`.
+   *   3. Old code: `if (fanOutPromise !== null) return;` early-returned WITHOUT
+   *      resetting `fanOutShouldStop` → loop exits on next iteration, leaving
+   *      the freshly attached handle orphaned (queue never fed).
+   *
+   * Fix: always reset `fanOutShouldStop = false` (so a still-running loop
+   * notices the new consumer and keeps going), AND if the loop already
+   * exited / is exiting, chain a restart attempt via `.finally(...)` so a
+   * dispose-reattach-during-exit sequence still resumes fan-out for the new
+   * consumer. Regression test: "dispose then immediate re-acquire restarts
+   * fan-out for the new consumer".
+   */
   private ensureFanOutRunning(
     outputIndex: number,
     entry: CacheEntry & { kind: "subscription" },
   ): void {
-    if (entry.fanOutPromise !== null) return;
     entry.fanOutShouldStop = false;
+    if (entry.fanOutPromise !== null) {
+      // Loop is currently running (or in its finally trampoline). Chain a
+      // post-completion check so an exiting loop can be restarted for the
+      // newly attached consumer.
+      const existing = entry.fanOutPromise;
+      void existing.finally(() => {
+        const current = this.entries.get(outputIndex);
+        if (
+          current === entry &&
+          current.kind === "subscription" &&
+          !current.sub.isDisposed &&
+          (current.pollingHandles.size > 0 ||
+            current.callbackHandles.size > 0) &&
+          current.fanOutPromise === null
+        ) {
+          this.ensureFanOutRunning(outputIndex, current);
+        }
+      });
+      return;
+    }
     entry.fanOutPromise = this.runFanOut(outputIndex, entry).finally(() => {
       entry.fanOutPromise = null;
     });
@@ -474,12 +578,16 @@ export class DirtyRectBroker {
       try {
         batch = await entry.sub.next(this.fanOutPollMs);
       } catch (err) {
-        // Surface DXGI lifecycle errors as cache invalidation so the next
-        // `acquire`/`subscribe` enters `hit-negative-backoff`.
-        const msg = err instanceof Error ? err.message : String(err);
-        if (msg.includes("E_DUP_ACCESS_LOST") || msg.includes("E_DUP_UNSUPPORTED")) {
-          this.invalidate(outputIndex);
-        }
+        // Round 1 P2-1 fix: ANY exception from `sub.next()` must invalidate
+        // the entry. Previously only DXGI substrings (`E_DUP_ACCESS_LOST` /
+        // `E_DUP_UNSUPPORTED`) triggered invalidate; transient native errors,
+        // mock test failures, and unexpected `Error` types silently exited
+        // the fan-out loop, leaving the entry stuck as `kind:"subscription"`
+        // with no fan-out → orphaned consumers. Invalidate uniformly so the
+        // next `acquire`/`subscribe` hits `hit-negative-backoff` and recovery
+        // is bounded by `BROKER_NEGATIVE_BACKOFF_MS`.
+        void err;
+        this.invalidate(outputIndex);
         return;
       }
       if (batch.length === 0) {
@@ -528,7 +636,10 @@ export class DirtyRectBroker {
           this.entries.delete(key);
         }
       } else if (entry.kind === "negative-backoff") {
-        if (now - entry.recordedAt >= BROKER_NEGATIVE_BACKOFF_MS) {
+        // Round 1 P3-1: use the constructor parameter instead of the module
+        // constant so tests can inject a shorter window symmetrically with
+        // `idleTimeoutMs` / `unavailableTtlMs`.
+        if (now - entry.recordedAt >= this.negativeBackoffMs) {
           this.entries.delete(key);
         }
       } else if (entry.kind === "unavailable") {

--- a/src/engine/native-types.ts
+++ b/src/engine/native-types.ts
@@ -439,6 +439,22 @@ export interface NativeDirtyRectSubscription {
   dispose(): void
 }
 
+/**
+ * ADR-020 SR-4 PR-SR4-1 — re-export of the broker handle interface so
+ * downstream consumers (Stage 5 in PR-SR4-2, vision-gpu in PR-SR4-3) can
+ * reference the typed handle from a single SSOT (`native-types.ts`).
+ *
+ * The actual interface definition lives in `src/engine/dxgi-broker.ts`
+ * (where the broker class also lives). This file re-exports the type so
+ * sub-plan §5.2's "BrokerSubscription re-exported interface" SSOT row
+ * is satisfied without duplicating the declaration.
+ *
+ * Per Round 2 P1-3 lock: this interface has no `subscribe()` method —
+ * fan-out is exclusively a `DirtyRectBroker.subscribe()` upper-level API
+ * responsibility.
+ */
+export type { BrokerSubscription } from "./dxgi-broker.js"
+
 // ── Visual GPU Phase 4 (ADR-005) ─────────────────────────────────────────────
 
 /** Rust src/vision_backend/types.rs::Rect */

--- a/tests/unit/dxgi-broker.test.ts
+++ b/tests/unit/dxgi-broker.test.ts
@@ -458,6 +458,40 @@ describe("DirtyRectBroker", () => {
     await first;
   });
 
+  /**
+   * Round 2 Codex P2 regression test: detaching the last consumer must
+   * reset the idle window so a quick re-subscribe doesn't trigger an
+   * immediate native subscription dispose + re-init.
+   *
+   * Pre-fix: lastUsedAt stays at attach-time → sweepStale on the
+   * resubscribe sees `now - lastUsedAt >= idleTimeoutMs` → entry deleted
+   * → factory called again.
+   * Post-fix: lastUsedAt refreshed at detach → sweepStale on the
+   * resubscribe sees `now - lastUsedAt < idleTimeoutMs` → entry retained
+   * → `hit-subscription` state, no factory re-init.
+   */
+  it("Round 2 Codex P2: last consumer detach refreshes lastUsedAt (idle window restart)", () => {
+    let now = 0;
+    const factory = vi.fn(() => new StubSubscription());
+    // idleTimeoutMs = 100, unavailableTtlMs = 500.
+    const broker = makeBroker(factory, () => now, 100, 500);
+
+    // T=0: acquire — lastUsedAt = 0.
+    const a = broker.acquire(0);
+    expect(factory).toHaveBeenCalledTimes(1);
+
+    // T=99: handle disposed (last consumer) — lastUsedAt MUST refresh to 99.
+    now = 99;
+    a.sub!.dispose();
+
+    // T=150: re-acquire. Pre-fix: now - lastUsedAt (=0) = 150 > 100 → swept.
+    // Post-fix: now - lastUsedAt (=99) = 51 < 100 → entry retained.
+    now = 150;
+    const b = broker.acquire(0);
+    expect(b.state).toBe("hit-subscription");
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
   it("BROKER_CONSTANTS values are bit-equal with STAGE5_CONSTANTS (PR-SR4-2 SSOT shift prerequisite)", () => {
     // Sub-plan §5.3 acceptance: PR-SR4-1 holds private duplicates; PR-SR4-2
     // shifts SSOT to broker side + Stage 5 re-exports. The numeric values

--- a/tests/unit/dxgi-broker.test.ts
+++ b/tests/unit/dxgi-broker.test.ts
@@ -24,7 +24,7 @@
  *   i. const bit-equal with Stage 5 SSOT ✓
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 
 import {
   DirtyRectBroker,
@@ -32,6 +32,24 @@ import {
   type SubscriptionLike,
 } from "../../src/engine/dxgi-broker.js";
 import { STAGE5_CONSTANTS } from "../../src/engine/any-change.js";
+
+// Round 1 P2-4: shared registration helper + afterEach cleanup so each test's
+// fan-out loop is reliably stopped before the next test starts. Avoids
+// dangling `setTimeout` handles + `runFanOut` promises piling up under
+// parallel/pool reuse (no flake observed today; this is preventive hygiene
+// per memory `feedback_sub_plan_full_reread.md`).
+const _activeBrokers: DirtyRectBroker[] = [];
+function makeBroker(...args: ConstructorParameters<typeof DirtyRectBroker>): DirtyRectBroker {
+  const broker = new DirtyRectBroker(...args);
+  _activeBrokers.push(broker);
+  return broker;
+}
+afterEach(() => {
+  while (_activeBrokers.length > 0) {
+    const b = _activeBrokers.pop();
+    b?.disposeAll();
+  }
+});
 
 /** Test-only mock of `NativeDirtyRectSubscription`. The `next()` body
  *  is replaced per-test so each case can simulate empty / non-empty
@@ -54,7 +72,7 @@ describe("DirtyRectBroker", () => {
 
   it("acquire returns a handle and constructs one native subscription", () => {
     const factory = vi.fn(() => new StubSubscription());
-    const broker = new DirtyRectBroker(factory, () => 0);
+    const broker = makeBroker(factory, () => 0);
 
     const result = broker.acquire(0);
     expect(result.sub).not.toBeNull();
@@ -64,7 +82,7 @@ describe("DirtyRectBroker", () => {
 
   it("second acquire on same outputIndex reuses the native subscription (state=hit-subscription)", () => {
     const factory = vi.fn(() => new StubSubscription());
-    const broker = new DirtyRectBroker(factory, () => 0);
+    const broker = makeBroker(factory, () => 0);
 
     const first = broker.acquire(0);
     const second = broker.acquire(0);
@@ -81,7 +99,7 @@ describe("DirtyRectBroker", () => {
   it("2 polling consumers on same outputIndex share exactly one native subscription (race-loss eliminated)", () => {
     const stub = new StubSubscription();
     const factory = vi.fn(() => stub);
-    const broker = new DirtyRectBroker(factory, () => 0);
+    const broker = makeBroker(factory, () => 0);
 
     const a = broker.acquire(0);
     const b = broker.acquire(0);
@@ -97,7 +115,7 @@ describe("DirtyRectBroker", () => {
 
   it("polling + callback consumer on same outputIndex share one native subscription", () => {
     const factory = vi.fn(() => new StubSubscription());
-    const broker = new DirtyRectBroker(factory, () => 0);
+    const broker = makeBroker(factory, () => 0);
 
     broker.acquire(0);
     broker.subscribe(0, () => undefined);
@@ -106,7 +124,7 @@ describe("DirtyRectBroker", () => {
 
   it("different outputIndex values get separate native subscriptions", () => {
     const factory = vi.fn(() => new StubSubscription());
-    const broker = new DirtyRectBroker(factory, () => 0);
+    const broker = makeBroker(factory, () => 0);
 
     broker.acquire(0);
     broker.acquire(1);
@@ -123,7 +141,7 @@ describe("DirtyRectBroker", () => {
       ).mockImplementation(async () => []),
       dispose: vi.fn(),
     };
-    const broker = new DirtyRectBroker(() => stub, () => 0, 20_000, 60_000, 5);
+    const broker = makeBroker(() => stub, () => 0, 20_000, 60_000, 5);
 
     const a = broker.acquire(0);
     const b = broker.acquire(0);
@@ -148,7 +166,7 @@ describe("DirtyRectBroker", () => {
       ).mockImplementation(async () => []),
       dispose: vi.fn(),
     };
-    const broker = new DirtyRectBroker(() => stub, () => 0, 20_000, 60_000, 5);
+    const broker = makeBroker(() => stub, () => 0, 20_000, 60_000, 5);
 
     const callbacks: { x: number; y: number; width: number; height: number }[][] = [];
     broker.subscribe(0, (batch) => callbacks.push(batch));
@@ -167,7 +185,7 @@ describe("DirtyRectBroker", () => {
     let now = 0;
     const stub = new StubSubscription();
     const factory = vi.fn(() => stub);
-    const broker = new DirtyRectBroker(factory, () => now, 100, 500);
+    const broker = makeBroker(factory, () => now, 100, 500);
 
     const result = broker.acquire(0);
     result.sub!.dispose(); // last consumer leaves
@@ -187,7 +205,7 @@ describe("DirtyRectBroker", () => {
     const factory = vi.fn(() => {
       throw new Error("E_DUP_UNSUPPORTED");
     });
-    const broker = new DirtyRectBroker(factory, () => now, 100, 500);
+    const broker = makeBroker(factory, () => now, 100, 500);
 
     expect(broker.acquire(0).sub).toBeNull();
     expect(factory).toHaveBeenCalledTimes(1);
@@ -212,7 +230,7 @@ describe("DirtyRectBroker", () => {
       counter += 1;
       return new StubSubscription();
     });
-    const broker = new DirtyRectBroker(factory, () => now);
+    const broker = makeBroker(factory, () => now);
 
     broker.acquire(0);
     broker.invalidate(0);
@@ -240,7 +258,7 @@ describe("DirtyRectBroker", () => {
       if (mode === "throw") throw new Error("E_DUP_UNSUPPORTED");
       return new StubSubscription();
     });
-    const broker = new DirtyRectBroker(factory, () => now, 1_000, 5_000);
+    const broker = makeBroker(factory, () => now, 1_000, 5_000);
 
     // 1. miss-init (cold start, factory ok)
     expect(broker.acquire(0).state).toBe("miss-init");
@@ -266,7 +284,7 @@ describe("DirtyRectBroker", () => {
       next: vi.fn().mockRejectedValueOnce(new Error("E_DUP_ACCESS_LOST")),
       dispose: vi.fn(),
     };
-    const broker = new DirtyRectBroker(() => stub, () => 0, 20_000, 60_000, 5);
+    const broker = makeBroker(() => stub, () => 0, 20_000, 60_000, 5);
 
     broker.acquire(0);
     // Allow fan-out loop one tick to surface the exception → invalidate.
@@ -284,7 +302,7 @@ describe("DirtyRectBroker", () => {
     const b = new StubSubscription();
     const queue: StubSubscription[] = [a, b];
     const factory = vi.fn(() => queue.shift()!);
-    const broker = new DirtyRectBroker(factory, () => 0);
+    const broker = makeBroker(factory, () => 0);
 
     broker.acquire(0);
     broker.acquire(1);
@@ -300,7 +318,7 @@ describe("DirtyRectBroker", () => {
 
   it("BrokerSubscription handle exposes no `subscribe()` (Round 2 P1-3 interface lock)", () => {
     const factory = vi.fn(() => new StubSubscription());
-    const broker = new DirtyRectBroker(factory, () => 0);
+    const broker = makeBroker(factory, () => 0);
 
     const { sub } = broker.acquire(0);
     expect(sub).not.toBeNull();
@@ -312,6 +330,134 @@ describe("DirtyRectBroker", () => {
 
   // ─── i. const bit-equal with Stage 5 SSOT ─────────────────────────────────
 
+  // ─── j. Round 1 regression tests (P1-1 / P2-1 / P2-3) ────────────────────
+
+  /**
+   * Round 1 P1-1 regression test: dispose-then-immediate-reattach must
+   * restart the fan-out loop for the newly attached consumer instead of
+   * leaving them orphaned. Pre-fix sequence:
+   *   1. handle A dispose → `maybeStopFanOut` sets `fanOutShouldStop=true`
+   *   2. immediate `acquire(0)` returns handle B
+   *   3. old `ensureFanOutRunning` early-returned because `fanOutPromise !== null`
+   *      without resetting `fanOutShouldStop` → loop exited → handle B's
+   *      `next()` waited forever (no fan-out feeding the queue).
+   * Post-fix: `fanOutShouldStop = false` is always reset, AND a chained
+   * `.finally(...)` post-completion restart catches the exit window.
+   */
+  it("Round 1 P1-1: dispose then immediate re-acquire resets fanOutShouldStop to false (internal state pin)", () => {
+    // End-to-end batch arrival assertion is flaky in mock-stub form because
+    // the fan-out loop's poll-and-distribute timing relative to A.dispose() +
+    // B.acquire() can interleave many ways. The load-bearing invariant the
+    // fix needs to pin is: **after `acquire()` reattaches a consumer, the
+    // entry's `fanOutShouldStop` flag is back to `false`**. Without the
+    // P1-1 fix that flag stayed `true` after the early `ensureFanOutRunning`
+    // return, causing the fan-out loop to exit on its next iteration check
+    // and leaving handle B orphaned. The internal-state assertion below
+    // would fail under the pre-fix code (would observe `fanOutShouldStop:
+    // true` after the re-acquire) and pass post-fix.
+    const broker = makeBroker(() => new StubSubscription(), () => 0, 20_000, 60_000, 5);
+
+    const a = broker.acquire(0);
+    expect(a.sub).not.toBeNull();
+    a.sub!.dispose();
+
+    // After last consumer leaves: maybeStopFanOut sets fanOutShouldStop=true.
+    const beforeReacquire = broker._getEntryForTest(0);
+    expect(beforeReacquire?.kind).toBe("subscription");
+    if (beforeReacquire?.kind === "subscription") {
+      expect(beforeReacquire.fanOutShouldStop).toBe(true);
+    }
+
+    // Immediate re-acquire — P1-1 fix must reset fanOutShouldStop to false
+    // so the (potentially still-running) loop continues serving the new
+    // consumer, and the chained restart trampoline catches the
+    // already-exited case.
+    const b = broker.acquire(0);
+    expect(b.state).toBe("hit-subscription");
+    const afterReacquire = broker._getEntryForTest(0);
+    if (afterReacquire?.kind === "subscription") {
+      expect(afterReacquire.fanOutShouldStop).toBe(false);
+      expect(afterReacquire.pollingHandles.size).toBe(1);
+    }
+  });
+
+  /**
+   * Round 1 P2-1 regression test: a non-DXGI exception from `sub.next()`
+   * must invalidate the entry (transitioning to `negative-backoff`) so the
+   * next `acquire`/`subscribe` recovers via the bounded back-off window
+   * instead of returning `hit-subscription` on an entry whose fan-out has
+   * silently died.
+   */
+  it("Round 1 P2-1: non-DXGI exception in fan-out invalidates the entry (no silent fan-out death)", async () => {
+    const stub: SubscriptionLike = {
+      isDisposed: false,
+      next: vi.fn().mockRejectedValueOnce(new Error("totally unexpected error type")),
+      dispose: vi.fn(),
+    };
+    const broker = makeBroker(() => stub, () => 0, 20_000, 60_000, 5);
+
+    broker.acquire(0);
+    await new Promise((r) => setTimeout(r, 30));
+
+    const entry = broker._getEntryForTest(0);
+    expect(entry?.kind).toBe("negative-backoff");
+    expect(broker.acquire(0).state).toBe("hit-negative-backoff");
+  });
+
+  /**
+   * Round 1 P2-3 regression test: after `invalidate(outputIndex)`,
+   * pre-existing polling handles must report `isDisposed === true` so
+   * consumer code calling `handle.next()` sees the disposed state
+   * immediately instead of silently waiting on an empty queue.
+   */
+  it("Round 1 P2-3: invalidate marks pre-existing polling handles as disposed", async () => {
+    const stub = new StubSubscription();
+    const broker = makeBroker(() => stub, () => 0, 20_000, 60_000, 5);
+
+    const { sub } = broker.acquire(0);
+    expect(sub).not.toBeNull();
+    expect(sub!.isDisposed).toBe(false);
+
+    broker.invalidate(0);
+    expect(sub!.isDisposed).toBe(true);
+    // `next()` on a disposed handle resolves to [] immediately (not after
+    // the timeout — verified via the absence of a sleep before assertion).
+    const batch = await sub!.next(10_000);
+    expect(batch).toEqual([]);
+  });
+
+  /** Round 1 P2-3 regression test (same fix for disposeAll). */
+  it("Round 1 P2-3: disposeAll marks pre-existing polling handles as disposed", async () => {
+    const stub = new StubSubscription();
+    const broker = makeBroker(() => stub, () => 0, 20_000, 60_000, 5);
+    const { sub } = broker.acquire(0);
+    broker.disposeAll();
+    expect(sub!.isDisposed).toBe(true);
+    expect(await sub!.next(10_000)).toEqual([]);
+  });
+
+  /**
+   * Round 1 P3-4 regression test: concurrent `next()` calls on the same
+   * handle must throw (instead of silently orphaning the first resolver).
+   */
+  it("Round 1 P3-4: concurrent next() on the same handle rejects", async () => {
+    const stub: SubscriptionLike = {
+      isDisposed: false,
+      next: vi.fn().mockImplementation(async () => []),
+      dispose: vi.fn(),
+    };
+    const broker = makeBroker(() => stub, () => 0, 20_000, 60_000, 5);
+    const { sub } = broker.acquire(0);
+
+    // First call starts waiting (no batch in queue, no fan-out batch yet).
+    const first = sub!.next(50);
+    // `PollingHandle.next` is `async`, so the contract violation surfaces
+    // as a promise rejection (not a synchronous throw).
+    await expect(sub!.next(50)).rejects.toThrow(/concurrent/);
+    // First call resolves on timeout (cleanup).
+    await first;
+  });
+
   it("BROKER_CONSTANTS values are bit-equal with STAGE5_CONSTANTS (PR-SR4-2 SSOT shift prerequisite)", () => {
     // Sub-plan §5.3 acceptance: PR-SR4-1 holds private duplicates; PR-SR4-2
     // shifts SSOT to broker side + Stage 5 re-exports. The numeric values
@@ -320,8 +466,10 @@ describe("DirtyRectBroker", () => {
     expect(BROKER_CONSTANTS.BROKER_CACHE_IDLE_TIMEOUT_MS).toBe(
       STAGE5_CONSTANTS.STAGE5_CACHE_IDLE_TIMEOUT_MS,
     );
+    // Round 1 P3-2: cast removed — `STAGE5_UNAVAILABLE_TTL_MS` is already
+    // part of `STAGE5_CONSTANTS`'s `Object.freeze` payload.
     expect(BROKER_CONSTANTS.BROKER_UNAVAILABLE_TTL_MS).toBe(
-      (STAGE5_CONSTANTS as { STAGE5_UNAVAILABLE_TTL_MS: number }).STAGE5_UNAVAILABLE_TTL_MS,
+      STAGE5_CONSTANTS.STAGE5_UNAVAILABLE_TTL_MS,
     );
     // NEGATIVE_BACKOFF_MS is not in STAGE5_CONSTANTS (any-change.ts uses
     // a module-private const). The numeric value 2_000 is documented in

--- a/tests/unit/dxgi-broker.test.ts
+++ b/tests/unit/dxgi-broker.test.ts
@@ -1,0 +1,334 @@
+/**
+ * ADR-020 SR-4 (Phase 3) — `DirtyRectBroker` lifecycle + multiplex tests.
+ *
+ * Sub-plan: `docs/adr-020-phase-3-sr-4-dxgi-broker-plan.md` §5 (PR-SR4-1).
+ *
+ * Sub-plan §5.3 acceptance requires production-path real-invoke design:
+ * each case constructs a real `DirtyRectBroker` with `factory` mock injection
+ * and exercises the broker's actual logic. **No hand-built fixture forms**
+ * — every assertion follows a state transition reachable through the public
+ * API (`acquire` / `subscribe` / `invalidate` / `disposeAll`). Mental
+ * simulation: if the broker's internal reference-count logic were
+ * intentionally broken (`count++` → `count--`), each multiplex test
+ * (e.g. "1 native subscription across 2 polling consumers") would fail.
+ *
+ * Coverage map vs sub-plan §5.2 草案:
+ *   a. acquire / unsubscribe single consumer ✓
+ *   b. multi-consumer multiplex (race-loss elimination) ✓
+ *   c. callback fan-out + polling fan-out independence ✓
+ *   d. 3-TTL state machine (idle / unavailable / negative-backoff) ✓
+ *   e. factory failure → unavailable marker ✓
+ *   f. AccessLost (fan-out exception) → negative-backoff ✓
+ *   g. disposeAll teardown ✓
+ *   h. 5-value CacheAcquireState all branches ✓
+ *   i. const bit-equal with Stage 5 SSOT ✓
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  DirtyRectBroker,
+  BROKER_CONSTANTS,
+  type SubscriptionLike,
+} from "../../src/engine/dxgi-broker.js";
+import { STAGE5_CONSTANTS } from "../../src/engine/any-change.js";
+
+/** Test-only mock of `NativeDirtyRectSubscription`. The `next()` body
+ *  is replaced per-test so each case can simulate empty / non-empty
+ *  batches / AccessLost without scheduling real timers. */
+class StubSubscription implements SubscriptionLike {
+  isDisposed = false;
+  readonly disposeMock = vi.fn();
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async next(_timeoutMs: number): Promise<Array<{ x: number; y: number; width: number; height: number }>> {
+    return [];
+  }
+  dispose(): void {
+    this.disposeMock();
+    this.isDisposed = true;
+  }
+}
+
+describe("DirtyRectBroker", () => {
+  // ─── a. single consumer acquire / dispose ──────────────────────────────────
+
+  it("acquire returns a handle and constructs one native subscription", () => {
+    const factory = vi.fn(() => new StubSubscription());
+    const broker = new DirtyRectBroker(factory, () => 0);
+
+    const result = broker.acquire(0);
+    expect(result.sub).not.toBeNull();
+    expect(result.state).toBe("miss-init");
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it("second acquire on same outputIndex reuses the native subscription (state=hit-subscription)", () => {
+    const factory = vi.fn(() => new StubSubscription());
+    const broker = new DirtyRectBroker(factory, () => 0);
+
+    const first = broker.acquire(0);
+    const second = broker.acquire(0);
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(first.state).toBe("miss-init");
+    expect(second.state).toBe("hit-subscription");
+    // Handles are independent (per-consumer queue cursor) but back the
+    // same native subscription (verified via factory call count above).
+    expect(first.sub).not.toBe(second.sub);
+  });
+
+  // ─── b. multi-consumer multiplex (race-loss elimination, 北極星 2) ────────
+
+  it("2 polling consumers on same outputIndex share exactly one native subscription (race-loss eliminated)", () => {
+    const stub = new StubSubscription();
+    const factory = vi.fn(() => stub);
+    const broker = new DirtyRectBroker(factory, () => 0);
+
+    const a = broker.acquire(0);
+    const b = broker.acquire(0);
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(a.sub).not.toBeNull();
+    expect(b.sub).not.toBeNull();
+    // Disposing one handle does NOT dispose the native subscription —
+    // the other consumer is still active. (北極星 5: ≥1 consumer active.)
+    a.sub!.dispose();
+    expect(stub.disposeMock).not.toHaveBeenCalled();
+    expect(stub.isDisposed).toBe(false);
+  });
+
+  it("polling + callback consumer on same outputIndex share one native subscription", () => {
+    const factory = vi.fn(() => new StubSubscription());
+    const broker = new DirtyRectBroker(factory, () => 0);
+
+    broker.acquire(0);
+    broker.subscribe(0, () => undefined);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it("different outputIndex values get separate native subscriptions", () => {
+    const factory = vi.fn(() => new StubSubscription());
+    const broker = new DirtyRectBroker(factory, () => 0);
+
+    broker.acquire(0);
+    broker.acquire(1);
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+
+  // ─── c. callback fan-out + polling fan-out independence ────────────────────
+
+  it("fan-out delivers batches to every polling consumer's queue independently", async () => {
+    const stub: SubscriptionLike & { isDisposed: boolean; _pump?: (rects: { x: number; y: number; width: number; height: number }[]) => void } = {
+      isDisposed: false,
+      next: vi.fn().mockImplementationOnce(async () =>
+        [{ x: 1, y: 2, width: 3, height: 4 }],
+      ).mockImplementation(async () => []),
+      dispose: vi.fn(),
+    };
+    const broker = new DirtyRectBroker(() => stub, () => 0, 20_000, 60_000, 5);
+
+    const a = broker.acquire(0);
+    const b = broker.acquire(0);
+
+    // Both pollers receive the SAME batch (multiplexed fan-out, not
+    // first-come-first-served).
+    const [aBatch, bBatch] = await Promise.all([
+      a.sub!.next(200),
+      b.sub!.next(200),
+    ]);
+    expect(aBatch).toEqual([{ x: 1, y: 2, width: 3, height: 4 }]);
+    expect(bBatch).toEqual([{ x: 1, y: 2, width: 3, height: 4 }]);
+
+    broker.disposeAll();
+  });
+
+  it("callback consumer receives fan-out batches", async () => {
+    const stub: SubscriptionLike = {
+      isDisposed: false,
+      next: vi.fn().mockImplementationOnce(async () =>
+        [{ x: 10, y: 20, width: 30, height: 40 }],
+      ).mockImplementation(async () => []),
+      dispose: vi.fn(),
+    };
+    const broker = new DirtyRectBroker(() => stub, () => 0, 20_000, 60_000, 5);
+
+    const callbacks: { x: number; y: number; width: number; height: number }[][] = [];
+    broker.subscribe(0, (batch) => callbacks.push(batch));
+
+    // Allow the fan-out loop one microtask cycle to drain the queued batch.
+    await new Promise((r) => setTimeout(r, 30));
+    expect(callbacks.length).toBeGreaterThanOrEqual(1);
+    expect(callbacks[0]).toEqual([{ x: 10, y: 20, width: 30, height: 40 }]);
+
+    broker.disposeAll();
+  });
+
+  // ─── d. 3-TTL state machine ────────────────────────────────────────────────
+
+  it("idle timeout disposes the native subscription on next sweepStale (no live consumers)", () => {
+    let now = 0;
+    const stub = new StubSubscription();
+    const factory = vi.fn(() => stub);
+    const broker = new DirtyRectBroker(factory, () => now, 100, 500);
+
+    const result = broker.acquire(0);
+    result.sub!.dispose(); // last consumer leaves
+    expect(stub.disposeMock).not.toHaveBeenCalled(); // still within idle window
+    expect(stub.isDisposed).toBe(false);
+
+    now = 200; // past idle timeout
+    const fresh = new StubSubscription();
+    factory.mockImplementationOnce(() => fresh);
+    const second = broker.acquire(0);
+    expect(second.sub).not.toBeNull();
+    expect(stub.disposeMock).toHaveBeenCalledOnce();
+  });
+
+  it("unavailable marker survives the idle window but expires at unavailable-TTL", () => {
+    let now = 0;
+    const factory = vi.fn(() => {
+      throw new Error("E_DUP_UNSUPPORTED");
+    });
+    const broker = new DirtyRectBroker(factory, () => now, 100, 500);
+
+    expect(broker.acquire(0).sub).toBeNull();
+    expect(factory).toHaveBeenCalledTimes(1);
+
+    // After idle window (100 ms) but before unavailable TTL (500 ms) —
+    // marker still active.
+    now = 200;
+    expect(broker.acquire(0).sub).toBeNull();
+    expect(broker.acquire(0).state).toBe("hit-unavailable");
+    expect(factory).toHaveBeenCalledTimes(1);
+
+    // After unavailable TTL — marker swept, factory re-tries.
+    now = 501;
+    expect(broker.acquire(0).sub).toBeNull();
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+
+  it("negative-backoff marker fast-paths to hit-negative-backoff within 2 s window", () => {
+    let now = 0;
+    let counter = 0;
+    const factory = vi.fn(() => {
+      counter += 1;
+      return new StubSubscription();
+    });
+    const broker = new DirtyRectBroker(factory, () => now);
+
+    broker.acquire(0);
+    broker.invalidate(0);
+    expect(broker._getEntryForTest(0)?.kind).toBe("negative-backoff");
+
+    // Immediate re-acquire within 2 s → fast path, no factory re-init.
+    const result = broker.acquire(0);
+    expect(result.sub).toBeNull();
+    expect(result.state).toBe("hit-negative-backoff");
+    expect(counter).toBe(1);
+
+    // After 2 s — marker swept, fresh factory call permitted.
+    now = 2_001;
+    const fresh = broker.acquire(0);
+    expect(fresh.sub).not.toBeNull();
+    expect(counter).toBe(2);
+  });
+
+  // ─── e. 5-value CacheAcquireState all branches ─────────────────────────────
+
+  it("all 5 CacheAcquireState branches are reachable through the public API", () => {
+    let now = 0;
+    let mode: "ok" | "throw" = "ok";
+    const factory = vi.fn(() => {
+      if (mode === "throw") throw new Error("E_DUP_UNSUPPORTED");
+      return new StubSubscription();
+    });
+    const broker = new DirtyRectBroker(factory, () => now, 1_000, 5_000);
+
+    // 1. miss-init (cold start, factory ok)
+    expect(broker.acquire(0).state).toBe("miss-init");
+    // 2. hit-subscription (second acquire, same outputIndex)
+    expect(broker.acquire(0).state).toBe("hit-subscription");
+
+    // 3. hit-negative-backoff (after invalidate)
+    broker.invalidate(0);
+    expect(broker.acquire(0).state).toBe("hit-negative-backoff");
+
+    // 4. miss-init-unavailable (cold start, factory throw on outputIndex 1)
+    mode = "throw";
+    expect(broker.acquire(1).state).toBe("miss-init-unavailable");
+    // 5. hit-unavailable (second acquire on outputIndex 1, cached marker)
+    expect(broker.acquire(1).state).toBe("hit-unavailable");
+  });
+
+  // ─── f. AccessLost recovery via fan-out exception → negative-backoff ──────
+
+  it("fan-out exception triggers invalidate → next acquire fast-paths to negative-backoff", async () => {
+    const stub: SubscriptionLike = {
+      isDisposed: false,
+      next: vi.fn().mockRejectedValueOnce(new Error("E_DUP_ACCESS_LOST")),
+      dispose: vi.fn(),
+    };
+    const broker = new DirtyRectBroker(() => stub, () => 0, 20_000, 60_000, 5);
+
+    broker.acquire(0);
+    // Allow fan-out loop one tick to surface the exception → invalidate.
+    await new Promise((r) => setTimeout(r, 30));
+
+    const entry = broker._getEntryForTest(0);
+    expect(entry?.kind).toBe("negative-backoff");
+    expect(broker.acquire(0).state).toBe("hit-negative-backoff");
+  });
+
+  // ─── g. disposeAll teardown ────────────────────────────────────────────────
+
+  it("disposeAll releases every live subscription and clears entries", () => {
+    const a = new StubSubscription();
+    const b = new StubSubscription();
+    const queue: StubSubscription[] = [a, b];
+    const factory = vi.fn(() => queue.shift()!);
+    const broker = new DirtyRectBroker(factory, () => 0);
+
+    broker.acquire(0);
+    broker.acquire(1);
+    broker.disposeAll();
+
+    expect(a.disposeMock).toHaveBeenCalledOnce();
+    expect(b.disposeMock).toHaveBeenCalledOnce();
+    expect(broker._getEntryForTest(0)).toBeUndefined();
+    expect(broker._getEntryForTest(1)).toBeUndefined();
+  });
+
+  // ─── h. interface lock: BrokerSubscription has no `subscribe()` method ────
+
+  it("BrokerSubscription handle exposes no `subscribe()` (Round 2 P1-3 interface lock)", () => {
+    const factory = vi.fn(() => new StubSubscription());
+    const broker = new DirtyRectBroker(factory, () => 0);
+
+    const { sub } = broker.acquire(0);
+    expect(sub).not.toBeNull();
+    // Compile-time guard would normally catch this; runtime check pins the
+    // contract for documentation purposes (memory feedback_sub_plan_full_reread.md
+    // pattern: claim documentation must match runtime).
+    expect((sub as unknown as { subscribe?: unknown }).subscribe).toBeUndefined();
+  });
+
+  // ─── i. const bit-equal with Stage 5 SSOT ─────────────────────────────────
+
+  it("BROKER_CONSTANTS values are bit-equal with STAGE5_CONSTANTS (PR-SR4-2 SSOT shift prerequisite)", () => {
+    // Sub-plan §5.3 acceptance: PR-SR4-1 holds private duplicates; PR-SR4-2
+    // shifts SSOT to broker side + Stage 5 re-exports. The numeric values
+    // MUST match before that shift can happen — this is the mechanical
+    // guarantee.
+    expect(BROKER_CONSTANTS.BROKER_CACHE_IDLE_TIMEOUT_MS).toBe(
+      STAGE5_CONSTANTS.STAGE5_CACHE_IDLE_TIMEOUT_MS,
+    );
+    expect(BROKER_CONSTANTS.BROKER_UNAVAILABLE_TTL_MS).toBe(
+      (STAGE5_CONSTANTS as { STAGE5_UNAVAILABLE_TTL_MS: number }).STAGE5_UNAVAILABLE_TTL_MS,
+    );
+    // NEGATIVE_BACKOFF_MS is not in STAGE5_CONSTANTS (any-change.ts uses
+    // a module-private const). The numeric value 2_000 is documented in
+    // dxgi-broker.ts JSDoc and mirrored from any-change.ts:119 — pin
+    // here so a Stage 5 side bump triggers a broker test fail.
+    expect(BROKER_CONSTANTS.BROKER_NEGATIVE_BACKOFF_MS).toBe(2_000);
+    expect(BROKER_CONSTANTS.BROKER_CACHE_IDLE_TIMEOUT_MS).toBe(20_000);
+    expect(BROKER_CONSTANTS.BROKER_UNAVAILABLE_TTL_MS).toBe(60_000);
+  });
+});


### PR DESCRIPTION
## Summary

ADR-020 SR-4 (Phase 3) PR-SR4-1: `src/engine/dxgi-broker.ts` 新規 + `tests/unit/dxgi-broker.test.ts` 新規。DXGI subscription multiplex broker を **dormant land** (caller ゼロで main 入り) し、後続 PR-SR4-2 (Stage 5 migrate) / PR-SR4-3 (vision-gpu migrate) で consumer migrate する scaffold + interface land。

## 主要構造

- **broker interface lock** (sub-plan §5.2 Round 2 P1-3): `BrokerSubscription` に `subscribe()` method **なし**、fan-out は `DirtyRectBroker.subscribe()` 上位 API のみ (二重 fan-out 経路を構造的に禁止)
- **race-loss 軸消滅** (sub-plan §1.2 北極星 2): 同 output index に N consumer subscribe しても broker 内 native subscription 1 つだけ、`DXGI_ERROR_NOT_CURRENTLY_AVAILABLE` race 構造的に発生不能 (test \"2 polling consumers on same outputIndex share exactly one native subscription\" で機械保証)
- **3-TTL state machine + 5-value CacheAcquireState** (sub-plan §5.3): Stage 5 既存 cache から bit-equal 移植、test \"all 5 CacheAcquireState branches\" で全 branch reachable + test \"BROKER_CONSTANTS values are bit-equal with STAGE5_CONSTANTS\" で numeric 値同値機械保証
- **per-consumer queue cursor** (OQ-SR4-1 候補 (c) 採用): polling consumer ごとに独立 queue、fan-out loop で N consumer 分 enqueue、後発 acquire でも先発 cursor に影響しない
- **Busy-loop guard**: fan-out loop 空 batch 時に `fanOutPollMs` setTimeout で yield (test stub の即 resolve に対する safety、real native sub では `timeoutMs` block で問題なし)

## Acceptance (sub-plan §5.3 全件達成)

- [x] broker single subscription per output index (test \"b\" 群、4 case)
- [x] 3-TTL state machine bit-equal (test \"d\" 群、3 case)
- [x] 5-value CacheAcquireState 全 reachable (test \"e\")
- [x] broker test **production path 実 invoke 設計** (公開 factory + injection mock、mental simulation で revert/diff 検出力、memory `feedback_opus_contract_truth_sweep.md` 整合)
- [x] const bit-equal with `STAGE5_CONSTANTS` (test \"i\"、PR-SR4-2 SSOT shift prerequisite)
- [x] 既存 vitest suite 全 pass (any-change-orchestrator + dirty-rect-subscription-cache + resolve-output-index 計 31 case 全 green、broker test 15 case 全 green)

## Test plan

- [x] `npm run build` (tsc) 全 pass
- [x] `npx vitest run tests/unit/dxgi-broker.test.ts` 15 case 全 pass (372 ms)
- [x] `npx vitest run tests/unit/any-change-orchestrator.test.ts tests/unit/dirty-rect-subscription-cache.test.ts tests/unit/resolve-output-index.test.ts` 31 case 全 pass (regression check)
- [ ] Opus phase-boundary review Round 1 (本 PR 作成直後 trigger)
- [ ] Codex review (`@codex review`、API contract surface + lifecycle 軸で必須)

## Dormant land 確認

本 PR で broker は caller ゼロ (Stage 5 + vision-gpu は未 migrate)。`grep "DirtyRectBroker\|getSharedDirtyRectBroker" src/` 結果は `src/engine/dxgi-broker.ts` 内 self-reference のみ、外部 caller なし。**runtime 影響ゼロ**で main 入り、PR-SR4-2 (Stage 5 migrate) 着手時に caller 追加。

## 関連

- 親 sub-plan: `docs/adr-020-phase-3-sr-4-dxgi-broker-plan.md` (PR #349 merged `a8668ba`)
- 次 PR-SR4-2: Stage 5 `any-change.ts` を broker subscribe 経路に置換 + ADR-019 §2.6 文言 sync
- 次々 PR-SR4-3: vision-gpu `dirty-rect-source.ts` を broker subscribe + `addon[\"DirtyRectSubscription\"]` untyped escape hatch 完全削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)