### PR TITLE
feat(server-status): expose process health counters (#365 phase 1)

### DIFF
--- a/src/engine/process-health.ts
+++ b/src/engine/process-health.ts
@@ -1,0 +1,99 @@
+/**
+ * process-health.ts — diagnostic snapshot of the MCP process internals.
+ *
+ * Surfaced through `server_status` so external samplers can observe dormant /
+ * shutdown progression that is otherwise invisible (issue #365):
+ *   - dormant: thread/handle/WS shrinks but no log signal — needs poll path
+ *   - shutdown: stdin EOF deferred grace (60s) is silent unless caller asks
+ *
+ * server-windows.ts is the source of truth for shutdown / inflight state and
+ * pushes updates via the setters below. This module never reads server-windows
+ * state directly (avoids a cycle and keeps tool layer testable).
+ */
+
+let _lastRpcReceivedAt: number | null = null;
+let _lastRpcMethod: string | null = null;
+let _shutdownPending = false;
+let _shutdownGraceMs: number | null = null;
+let _inflightCount = 0;
+
+const _initialCpu = process.cpuUsage();
+
+export function recordRpcReceived(method: string): void {
+  _lastRpcReceivedAt = Date.now();
+  _lastRpcMethod = method;
+}
+
+export function setInflightCount(n: number): void {
+  _inflightCount = n;
+}
+
+export function setShutdownPending(graceMs: number): void {
+  _shutdownPending = true;
+  _shutdownGraceMs = graceMs;
+}
+
+export function clearShutdownPending(): void {
+  _shutdownPending = false;
+  _shutdownGraceMs = null;
+}
+
+export interface ProcessHealth {
+  uptimeSec: number;
+  memory: {
+    rssBytes: number;
+    heapUsedBytes: number;
+    heapTotalBytes: number;
+  };
+  cpu: {
+    userUs: number;
+    systemUs: number;
+  };
+  shutdown: {
+    pending: boolean;
+    graceMs: number | null;
+    inflightCount: number;
+  };
+  lastRpc: {
+    receivedAt: string | null;
+    method: string | null;
+  };
+}
+
+export function getProcessHealth(): ProcessHealth {
+  const mem = process.memoryUsage();
+  const cpu = process.cpuUsage(_initialCpu);
+  return {
+    uptimeSec: Math.floor(process.uptime()),
+    memory: {
+      rssBytes: mem.rss,
+      heapUsedBytes: mem.heapUsed,
+      heapTotalBytes: mem.heapTotal,
+    },
+    cpu: {
+      userUs: cpu.user,
+      systemUs: cpu.system,
+    },
+    shutdown: {
+      pending: _shutdownPending,
+      graceMs: _shutdownGraceMs,
+      inflightCount: _inflightCount,
+    },
+    lastRpc: {
+      receivedAt:
+        _lastRpcReceivedAt !== null
+          ? new Date(_lastRpcReceivedAt).toISOString()
+          : null,
+      method: _lastRpcMethod,
+    },
+  };
+}
+
+/** Test-only: reset module-level state. Not exposed via index. */
+export function _resetProcessHealthForTest(): void {
+  _lastRpcReceivedAt = null;
+  _lastRpcMethod = null;
+  _shutdownPending = false;
+  _shutdownGraceMs = null;
+  _inflightCount = 0;
+}

--- a/src/server-windows.ts
+++ b/src/server-windows.ts
@@ -37,6 +37,12 @@ import { registerServerStatusTool } from "./tools/server-status.js";
 import { logAutoGuardStartup } from "./tools/_action-guard.js";
 import { stopNativeRuntime } from "./engine/perception/registry.js";
 import { disposeSharedDirtyRectBroker } from "./engine/dxgi-broker.js";
+import {
+  recordRpcReceived,
+  setInflightCount,
+  setShutdownPending,
+  clearShutdownPending,
+} from "./engine/process-health.js";
 import { startTray, stopTray, type TrayOptions } from "./utils/tray.js";
 import { checkFailsafe, FailsafeError } from "./utils/failsafe.js";
 import { wrapHandlerArg } from "./utils/failsafe-wrap.js";
@@ -286,6 +292,7 @@ const SHUTDOWN_GRACE_MS = 60_000;
 function shutdown(): void {
   if (shuttingDown) return;
   shuttingDown = true;
+  clearShutdownPending();
   if (shutdownTimer) {
     clearTimeout(shutdownTimer);
     shutdownTimer = null;
@@ -325,6 +332,7 @@ function requestShutdown(reason: string): void {
     return;
   }
   shutdownPending = true;
+  setShutdownPending(SHUTDOWN_GRACE_MS);
   console.error(
     `[desktop-touch] ${reason} — deferring shutdown for ${inflightIds.size} in-flight request(s) (grace ${SHUTDOWN_GRACE_MS}ms).`
   );
@@ -515,12 +523,17 @@ if (useHttp) {
     const m = msg as { id?: string | number; method?: string };
     const isRequest = !!m && m.id !== undefined && typeof m.method === "string";
     const id = isRequest ? (m.id as string | number) : undefined;
-    if (id !== undefined) inflightIds.add(id);
+    if (isRequest) recordRpcReceived(m.method as string);
+    if (id !== undefined) {
+      inflightIds.add(id);
+      setInflightCount(inflightIds.size);
+    }
     try {
       origOnmessage?.(msg, ...rest);
     } catch (err) {
       if (id !== undefined) {
         inflightIds.delete(id);
+        setInflightCount(inflightIds.size);
         maybeFinishShutdown();
       }
       throw err;
@@ -534,6 +547,7 @@ if (useHttp) {
       const m = msg as { id?: string | number; method?: string };
       if (m && m.id !== undefined && m.method === undefined) {
         inflightIds.delete(m.id);
+        setInflightCount(inflightIds.size);
         maybeFinishShutdown();
       }
     }

--- a/src/stub-tool-catalog.ts
+++ b/src/stub-tool-catalog.ts
@@ -1555,7 +1555,7 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
   },
   {
     "name": "server_status",
-    "description": "Return MCP server status: version / native engine availability / Auto Perception state / v2 activation. uia: 'native' = Rust UIA addon (fast, ~2 ms focus / ~100 ms tree); 'powershell' = PS fallback (~366 ms focus). imageDiff: 'native' = Rust SSE2 SIMD (0.26 ms @ 1080p); 'typescript' = TS fallback (~3.8 ms). Diagnostic metadata — do not surface these values to the user unless they ask about performance or troubleshooting. Call once per session if you need to know which path is active; the result is stable for the lifetime of the server process.",
+    "description": "Return MCP server status. engine: native engine availability — uia: 'native' = Rust UIA addon (~2 ms focus / ~100 ms tree); 'powershell' = PS fallback (~366 ms focus). imageDiff: 'native' = Rust SSE2 SIMD (0.26 ms @ 1080p); 'typescript' = TS fallback (~3.8 ms). health: process diagnostic snapshot (issue #365) — uptimeSec, memory.{rssBytes,heapUsedBytes,heapTotalBytes}, cpu.{userUs,systemUs} (cumulative since startup), shutdown.{pending,graceMs,inflightCount} (pending=true means stdin EOF received and grace timer is running), lastRpc.{receivedAt(ISO),method} (last JSON-RPC request observed on stdio transport; HTTP transport is not tracked). Diagnostic metadata — do not surface unless the user asks about performance/troubleshooting. engine values are stable for the process lifetime; health values change per call.",
     "inputSchema": {
       "type": "object",
       "properties": {

--- a/src/tools/server-status.ts
+++ b/src/tools/server-status.ts
@@ -3,6 +3,7 @@ import { ok } from "./_types.js";
 import type { ToolResult } from "./_types.js";
 import { failWith } from "./_errors.js";
 import { getEngineStatus } from "../engine/status.js";
+import { getProcessHealth } from "../engine/process-health.js";
 import { makeQueryWrapper, withEnvelopeIncludeSchema, genericQueryCausedByProjector, defaultQuerySessionId } from "./_envelope.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -18,7 +19,8 @@ export const serverStatusSchema = {};
 export const serverStatusHandler = async (): Promise<ToolResult> => {
   try {
     const status = getEngineStatus();
-    return ok({ engine: status });
+    const health = getProcessHealth();
+    return ok({ engine: status, health });
   } catch (err) {
     return failWith(err, "server_status");
   }
@@ -50,7 +52,7 @@ export const serverStatusRegistrationHandler = makeQueryWrapper(
 export function registerServerStatusTool(server: McpServer): void {
   server.tool(
     "server_status",
-    "Return MCP server status: version / native engine availability / Auto Perception state / v2 activation. uia: 'native' = Rust UIA addon (fast, ~2 ms focus / ~100 ms tree); 'powershell' = PS fallback (~366 ms focus). imageDiff: 'native' = Rust SSE2 SIMD (0.26 ms @ 1080p); 'typescript' = TS fallback (~3.8 ms). Diagnostic metadata — do not surface these values to the user unless they ask about performance or troubleshooting. Call once per session if you need to know which path is active; the result is stable for the lifetime of the server process.",
+    "Return MCP server status. engine: native engine availability — uia: 'native' = Rust UIA addon (~2 ms focus / ~100 ms tree); 'powershell' = PS fallback (~366 ms focus). imageDiff: 'native' = Rust SSE2 SIMD (0.26 ms @ 1080p); 'typescript' = TS fallback (~3.8 ms). health: process diagnostic snapshot (issue #365) — uptimeSec, memory.{rssBytes,heapUsedBytes,heapTotalBytes}, cpu.{userUs,systemUs} (cumulative since startup), shutdown.{pending,graceMs,inflightCount} (pending=true means stdin EOF received and grace timer is running), lastRpc.{receivedAt(ISO),method} (last JSON-RPC request observed on stdio transport; HTTP transport is not tracked). Diagnostic metadata — do not surface unless the user asks about performance/troubleshooting. engine values are stable for the process lifetime; health values change per call.",
     serverStatusRegistrationSchema,
     serverStatusRegistrationHandler as typeof serverStatusHandler
   );

--- a/tests/unit/process-health.test.ts
+++ b/tests/unit/process-health.test.ts
@@ -1,0 +1,81 @@
+/**
+ * tests/unit/process-health.test.ts
+ *
+ * Unit tests for the diagnostic snapshot module exposed via server_status (issue #365).
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  recordRpcReceived,
+  setInflightCount,
+  setShutdownPending,
+  clearShutdownPending,
+  getProcessHealth,
+  _resetProcessHealthForTest,
+} from "../../src/engine/process-health.js";
+
+describe("process-health", () => {
+  beforeEach(() => {
+    _resetProcessHealthForTest();
+  });
+
+  it("initial snapshot has null lastRpc and zero/false shutdown state", () => {
+    const h = getProcessHealth();
+    expect(h.lastRpc.receivedAt).toBeNull();
+    expect(h.lastRpc.method).toBeNull();
+    expect(h.shutdown.pending).toBe(false);
+    expect(h.shutdown.graceMs).toBeNull();
+    expect(h.shutdown.inflightCount).toBe(0);
+  });
+
+  it("snapshot exposes process-level fields with sane types/ranges", () => {
+    const h = getProcessHealth();
+    expect(h.uptimeSec).toBeGreaterThanOrEqual(0);
+    expect(h.memory.rssBytes).toBeGreaterThan(0);
+    expect(h.memory.heapUsedBytes).toBeGreaterThan(0);
+    expect(h.memory.heapTotalBytes).toBeGreaterThanOrEqual(h.memory.heapUsedBytes);
+    expect(h.cpu.userUs).toBeGreaterThanOrEqual(0);
+    expect(h.cpu.systemUs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("recordRpcReceived updates lastRpc and uses ISO timestamp", () => {
+    recordRpcReceived("tools/call");
+    const h = getProcessHealth();
+    expect(h.lastRpc.method).toBe("tools/call");
+    expect(h.lastRpc.receivedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+  });
+
+  it("recordRpcReceived overwrites previous record", () => {
+    recordRpcReceived("initialize");
+    recordRpcReceived("tools/list");
+    const h = getProcessHealth();
+    expect(h.lastRpc.method).toBe("tools/list");
+  });
+
+  it("setInflightCount reflects in shutdown.inflightCount", () => {
+    setInflightCount(3);
+    expect(getProcessHealth().shutdown.inflightCount).toBe(3);
+    setInflightCount(0);
+    expect(getProcessHealth().shutdown.inflightCount).toBe(0);
+  });
+
+  it("setShutdownPending sets pending=true and records graceMs", () => {
+    setShutdownPending(60_000);
+    const h = getProcessHealth();
+    expect(h.shutdown.pending).toBe(true);
+    expect(h.shutdown.graceMs).toBe(60_000);
+  });
+
+  it("clearShutdownPending resets pending state without touching inflight/lastRpc", () => {
+    recordRpcReceived("ping");
+    setInflightCount(2);
+    setShutdownPending(60_000);
+    clearShutdownPending();
+    const h = getProcessHealth();
+    expect(h.shutdown.pending).toBe(false);
+    expect(h.shutdown.graceMs).toBeNull();
+    // inflight and lastRpc untouched
+    expect(h.shutdown.inflightCount).toBe(2);
+    expect(h.lastRpc.method).toBe("ping");
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of the observability bundle in #365 — option (b): extend `server_status` so external samplers / dogfood polling can observe MCP process internals without depending on stderr capture.

New module `src/engine/process-health.ts` records:
- `lastRpc.{receivedAt, method}` — populated from the stdio transport `onmessage` wrapper
- `shutdown.{pending, graceMs, inflightCount}` — populated from `requestShutdown` / `inflightIds` add+delete sites
- `uptimeSec`, `memory.{rssBytes, heapUsedBytes, heapTotalBytes}`, `cpu.{userUs, systemUs}` — pulled live from `process.*` on each call

`server-windows.ts` is the source of truth for shutdown / inflight state and pushes updates via setters. `process-health.ts` never reads `server-windows` directly, keeping the tool layer testable.

`server_status` response now returns `{ engine, health }`. Tool description updated to document each field.

## Scope (deliberately small)

- HTTP transport (stateless, short-lived) is **not** tracked — documented on the tool description.
- (a) stderr log path inventory and (c) `DESKTOP_TOUCH_TRACE_TIMERS` env-gated periodic-timer labels — **deferred to follow-up PRs** under #365.

## Test plan

- [x] `vitest tests/unit/process-health.test.ts` — 7 tests covering initial state / range invariants / each setter
- [x] `tsc --noEmit` — clean
- [x] `npm run check:stub-catalog` — regen diff limited to `server_status` description
- [x] Live MCP reload + `server_status` call — returns the new `health` field with the expected shape (uptimeSec, memory bytes, cpu µs, shutdown flags, lastRpc ISO + method)
- [ ] Opus review loop per CLAUDE.md — Opus P1/P2 = 0
- [ ] Codex auto-review — P1 = 0

Closes part of #365 (phase 1 only).