### PR TITLE
feat(diagnostic-log): passive event log for sudden death + fan-noise (#365 phase 2)

### DIFF
--- a/src/engine/diagnostic-log.ts
+++ b/src/engine/diagnostic-log.ts
@@ -25,6 +25,20 @@ import { performance } from "node:perf_hooks";
 const DEFAULT_FILENAME = "diagnostic.log";
 const DEFAULT_DIR = ".desktop-touch-mcp/logs";
 
+// Review R1 P2-3: cap stack trace size so a runaway stack doesn't write MB-
+// scale records and slow down a synchronous appendFileSync just before exit.
+const STACK_TRUNCATE_BYTES = 4096;
+
+/**
+ * `_disabled`, `_resolvedPath`, and `_dirEnsured` are memoized on first read.
+ *
+ * **Runtime mutation contract**: the `DESKTOP_TOUCH_DIAGNOSTIC_LOG_*` env vars
+ * are read once at first log site and cached for the process lifetime. Changing
+ * them mid-process has no effect. This matches how the rest of the server
+ * resolves env (process-health.ts / nativeEventsEnabled) and avoids a per-write
+ * env lookup hit on the hot path. Tests use `_resetDiagnosticLogForTest()` to
+ * force a re-read.
+ */
 let _resolvedPath: string | null = null;
 let _disabled: boolean | null = null;
 let _dirEnsured = false;
@@ -96,16 +110,25 @@ export type DiagnosticEvent =
 /**
  * Append one diagnostic event as a JSONL line. Best-effort: never throws.
  * Synchronous so events written just before `process.exit` reach disk.
+ *
+ * Review R1 P2-3: large `stack` fields are truncated to keep each line
+ * bounded; an unbounded stack on a hot uncaught path would extend the
+ * synchronous write past the OS pipe drain window and risk losing the
+ * preceding log entries on `process.exit`.
  */
 export function logDiagnostic(event: DiagnosticEvent): void {
   if (isDisabled()) return;
   const path = getDiagnosticLogPath();
   ensureDir(path);
+  const safeEvent =
+    "stack" in event && typeof event.stack === "string" && event.stack.length > STACK_TRUNCATE_BYTES
+      ? { ...event, stack: event.stack.slice(0, STACK_TRUNCATE_BYTES) + "…[truncated]" }
+      : event;
   const record = {
     ts: new Date().toISOString(),
     pid: process.pid,
     uptime_ms: Math.round(process.uptime() * 1000),
-    ...event,
+    ...safeEvent,
   };
   try {
     appendFileSync(path, JSON.stringify(record) + "\n");
@@ -134,13 +157,19 @@ export function estimateArgsSize(args: unknown[]): number {
  * Wrap tool handler args (s.tool / s.registerTool signature) so that calls
  * exceeding `thresholdMs` are logged via `slow_tool` events. Mirrors
  * `wrapHandlerArg` in `utils/failsafe-wrap.ts` — both wrappers can be chained.
+ *
+ * Review R1 P3-3: only wrap when `toolArgs[0]` is a string (the conventional
+ * tool name). For any other shape we skip the wrap so the log doesn't get
+ * filled with literal `"undefined"` / `"[object Object]"` from upstream
+ * misuse — keeping the failure-mode equivalent to `wrapHandlerArg`.
  */
 export function wrapHandlerArgWithTiming(
   toolArgs: unknown[],
   thresholdMs = 1000,
 ): unknown[] {
   if (toolArgs.length === 0) return toolArgs;
-  const toolName = String(toolArgs[0]);
+  const toolName = toolArgs[0];
+  if (typeof toolName !== "string") return toolArgs;
   const lastIdx = toolArgs.length - 1;
   const originalHandler = toolArgs[lastIdx];
   if (typeof originalHandler !== "function") return toolArgs;

--- a/src/engine/diagnostic-log.ts
+++ b/src/engine/diagnostic-log.ts
@@ -1,0 +1,173 @@
+/**
+ * diagnostic-log.ts — append-only JSONL diagnostic event log (issue #365).
+ *
+ * Captures runtime events that are normally invisible to external samplers so
+ * that post-hoc grep can answer:
+ *   - why did the MCP process disappear? (`exit` + `uncaught` events)
+ *   - which tool was running when the fan kicked in? (`slow_tool` + `cpu_spike`)
+ *   - is the perception drain backlog growing? (`drain_oversize`)
+ *
+ * Design:
+ *   - sync append (`appendFileSync`) so events written just before `process.exit`
+ *     are not lost in Node's writable-stream buffer
+ *   - best-effort: every write is wrapped in try/catch and never throws to the
+ *     caller — diagnostic logging must not become a new crash source
+ *   - env overrides:
+ *       DESKTOP_TOUCH_DIAGNOSTIC_LOG_PATH    — override default path
+ *       DESKTOP_TOUCH_DIAGNOSTIC_LOG_DISABLE — set to "1" to disable entirely
+ */
+
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+import { performance } from "node:perf_hooks";
+
+const DEFAULT_FILENAME = "diagnostic.log";
+const DEFAULT_DIR = ".desktop-touch-mcp/logs";
+
+let _resolvedPath: string | null = null;
+let _disabled: boolean | null = null;
+let _dirEnsured = false;
+
+function isDisabled(): boolean {
+  if (_disabled === null) {
+    _disabled = process.env.DESKTOP_TOUCH_DIAGNOSTIC_LOG_DISABLE === "1";
+  }
+  return _disabled;
+}
+
+export function getDiagnosticLogPath(): string {
+  if (_resolvedPath !== null) return _resolvedPath;
+  const override = process.env.DESKTOP_TOUCH_DIAGNOSTIC_LOG_PATH;
+  if (override && override.length > 0) {
+    _resolvedPath = override;
+  } else {
+    _resolvedPath = join(homedir(), DEFAULT_DIR, DEFAULT_FILENAME);
+  }
+  return _resolvedPath;
+}
+
+function ensureDir(path: string): void {
+  if (_dirEnsured) return;
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    _dirEnsured = true;
+  } catch {
+    // best-effort; appendFileSync below will surface the real error if any
+  }
+}
+
+export type DiagnosticEvent =
+  | {
+      kind: "exit";
+      trigger: string;
+      exitCode: number;
+      inflight: number;
+      shutdownPending: boolean;
+      extra?: Record<string, unknown>;
+    }
+  | {
+      kind: "uncaught";
+      type: "uncaughtException" | "unhandledRejection";
+      name?: string;
+      msg: string;
+      stack?: string;
+    }
+  | {
+      kind: "slow_tool";
+      tool: string;
+      elapsed_ms: number;
+      args_size: number;
+    }
+  | {
+      kind: "cpu_spike";
+      cpu_pct: number;
+      window_ms: number;
+      rss_mb: number;
+      inflight: number;
+      lastRpcMethod: string | null;
+    }
+  | {
+      kind: "drain_oversize";
+      batch_size: number;
+      overflow: boolean;
+    };
+
+/**
+ * Append one diagnostic event as a JSONL line. Best-effort: never throws.
+ * Synchronous so events written just before `process.exit` reach disk.
+ */
+export function logDiagnostic(event: DiagnosticEvent): void {
+  if (isDisabled()) return;
+  const path = getDiagnosticLogPath();
+  ensureDir(path);
+  const record = {
+    ts: new Date().toISOString(),
+    pid: process.pid,
+    uptime_ms: Math.round(process.uptime() * 1000),
+    ...event,
+  };
+  try {
+    appendFileSync(path, JSON.stringify(record) + "\n");
+  } catch {
+    // Disk full / permission denied / path invalid — silently drop.
+    // We deliberately do NOT log to stderr here because uncaughtException
+    // handler also writes diagnostics and a stderr write that itself throws
+    // could re-enter the handler.
+  }
+}
+
+/**
+ * Estimate the serialized size of tool arguments without doing a full
+ * JSON.stringify (which can be expensive for large screenshot payloads).
+ * Returns a rough byte count.
+ */
+export function estimateArgsSize(args: unknown[]): number {
+  try {
+    return JSON.stringify(args).length;
+  } catch {
+    return -1;
+  }
+}
+
+/**
+ * Wrap tool handler args (s.tool / s.registerTool signature) so that calls
+ * exceeding `thresholdMs` are logged via `slow_tool` events. Mirrors
+ * `wrapHandlerArg` in `utils/failsafe-wrap.ts` — both wrappers can be chained.
+ */
+export function wrapHandlerArgWithTiming(
+  toolArgs: unknown[],
+  thresholdMs = 1000,
+): unknown[] {
+  if (toolArgs.length === 0) return toolArgs;
+  const toolName = String(toolArgs[0]);
+  const lastIdx = toolArgs.length - 1;
+  const originalHandler = toolArgs[lastIdx];
+  if (typeof originalHandler !== "function") return toolArgs;
+  toolArgs[lastIdx] = async (...handlerArgs: unknown[]) => {
+    const start = performance.now();
+    try {
+      return await (originalHandler as (...a: unknown[]) => Promise<unknown>)(
+        ...handlerArgs,
+      );
+    } finally {
+      const elapsed = performance.now() - start;
+      if (elapsed > thresholdMs) {
+        logDiagnostic({
+          kind: "slow_tool",
+          tool: toolName,
+          elapsed_ms: Math.round(elapsed),
+          args_size: estimateArgsSize(handlerArgs),
+        });
+      }
+    }
+  };
+  return toolArgs;
+}
+
+/** Test-only: reset module-level memoization. Not exposed via index. */
+export function _resetDiagnosticLogForTest(): void {
+  _resolvedPath = null;
+  _disabled = null;
+  _dirEnsured = false;
+}

--- a/src/engine/diagnostic-log.ts
+++ b/src/engine/diagnostic-log.ts
@@ -27,7 +27,12 @@ const DEFAULT_DIR = ".desktop-touch-mcp/logs";
 
 // Review R1 P2-3: cap stack trace size so a runaway stack doesn't write MB-
 // scale records and slow down a synchronous appendFileSync just before exit.
-const STACK_TRUNCATE_BYTES = 4096;
+// Review R2 P3 (Opus): named CHARS not BYTES — `slice` / `.length` are UTF-16
+// code-unit operations, not byte counts. For ASCII stacks this is bit-equal;
+// stack frames with multi-byte path chars (Japanese / emoji) will be capped
+// by char count not byte count. Acceptable for the diagnostic goal (we only
+// need bounded record size, not exact byte truncation).
+const STACK_TRUNCATE_CHARS = 4096;
 
 /**
  * `_disabled`, `_resolvedPath`, and `_dirEnsured` are memoized on first read.
@@ -121,8 +126,8 @@ export function logDiagnostic(event: DiagnosticEvent): void {
   const path = getDiagnosticLogPath();
   ensureDir(path);
   const safeEvent =
-    "stack" in event && typeof event.stack === "string" && event.stack.length > STACK_TRUNCATE_BYTES
-      ? { ...event, stack: event.stack.slice(0, STACK_TRUNCATE_BYTES) + "…[truncated]" }
+    "stack" in event && typeof event.stack === "string" && event.stack.length > STACK_TRUNCATE_CHARS
+      ? { ...event, stack: event.stack.slice(0, STACK_TRUNCATE_CHARS) + "…[truncated]" }
       : event;
   const record = {
     ts: new Date().toISOString(),
@@ -151,6 +156,43 @@ export function estimateArgsSize(args: unknown[]): number {
   } catch {
     return -1;
   }
+}
+
+/**
+ * Best-effort JSON serialization that never throws. Falls back through
+ * `JSON.stringify` → `String(value)` → literal `"<unstringifiable>"`. Used by
+ * the uncaught handlers in `server-windows.ts` to normalize circular /
+ * exotic thrown values before constructing an `Error` for logging.
+ *
+ * (Review R1 P1-2 — extracted to this module in R2 for testability.)
+ */
+export function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    try {
+      return String(value);
+    } catch {
+      return "<unstringifiable>";
+    }
+  }
+}
+
+/**
+ * Normalize an arbitrary thrown value into an `Error` instance so the
+ * `uncaughtException` / `unhandledRejection` handlers can safely read
+ * `.name` / `.message` / `.stack`. Node passes the *exact* value that was
+ * thrown to listeners — including `null`, `undefined`, numbers, or circular
+ * objects — and dereferencing properties on those would re-enter the
+ * handler.
+ *
+ * (Codex Review R1 P2-2 for `unhandledRejection`; Codex R2 follow-up for the
+ * symmetric `uncaughtException` path.)
+ */
+export function normalizeThrown(value: unknown): Error {
+  if (value instanceof Error) return value;
+  if (typeof value === "string") return new Error(value);
+  return new Error(safeStringify(value));
 }
 
 /**

--- a/src/engine/diagnostic-watchdog.ts
+++ b/src/engine/diagnostic-watchdog.ts
@@ -1,0 +1,81 @@
+/**
+ * diagnostic-watchdog.ts — passive self-CPU watchdog (issue #365).
+ *
+ * Samples `process.cpuUsage()` once per window and emits a `cpu_spike` event
+ * when single-core CPU% exceeds the threshold. Passive in the sense that the
+ * sample itself costs microseconds (no `tools/call` round-trip), so polling
+ * does not bloat the process the way the PR #366 phase 1 polling did.
+ *
+ * Env vars:
+ *   DESKTOP_TOUCH_CPU_WATCHDOG_DISABLE      — set to "1" to disable entirely
+ *   DESKTOP_TOUCH_CPU_WATCHDOG_THRESHOLD_PCT — default 30 (single-core %)
+ *   DESKTOP_TOUCH_CPU_WATCHDOG_WINDOW_MS     — default 10_000 (sample window)
+ */
+
+import { logDiagnostic } from "./diagnostic-log.js";
+import { getProcessHealth } from "./process-health.js";
+
+const DEFAULT_THRESHOLD_PCT = 30;
+const DEFAULT_WINDOW_MS = 10_000;
+
+function parsePositiveNumber(raw: string | undefined, fallback: number): number {
+  if (raw === undefined) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+export interface CpuWatchdogHandle {
+  stop(): void;
+}
+
+/**
+ * Start the watchdog. Returns a handle whose `stop()` clears the timer.
+ * Returns `null` if disabled via env var (caller can ignore safely).
+ */
+export function startCpuWatchdog(): CpuWatchdogHandle | null {
+  if (process.env.DESKTOP_TOUCH_CPU_WATCHDOG_DISABLE === "1") return null;
+
+  const thresholdPct = parsePositiveNumber(
+    process.env.DESKTOP_TOUCH_CPU_WATCHDOG_THRESHOLD_PCT,
+    DEFAULT_THRESHOLD_PCT,
+  );
+  const windowMs = parsePositiveNumber(
+    process.env.DESKTOP_TOUCH_CPU_WATCHDOG_WINDOW_MS,
+    DEFAULT_WINDOW_MS,
+  );
+
+  let prevCpu = process.cpuUsage();
+  let prevHr = process.hrtime.bigint();
+
+  const timer = setInterval(() => {
+    const cpu = process.cpuUsage(prevCpu);
+    const hr = process.hrtime.bigint();
+    const wallNs = Number(hr - prevHr);
+    prevCpu = process.cpuUsage();
+    prevHr = hr;
+
+    // wallNs can be 0 in pathological clock edge cases — guard before divide.
+    if (wallNs <= 0) return;
+    const cpuNs = (cpu.user + cpu.system) * 1000; // us → ns
+    const cpuPct = (cpuNs / wallNs) * 100;
+
+    if (cpuPct >= thresholdPct) {
+      const health = getProcessHealth();
+      logDiagnostic({
+        kind: "cpu_spike",
+        cpu_pct: Math.round(cpuPct * 10) / 10,
+        window_ms: Math.round(wallNs / 1e6),
+        rss_mb: Math.round(health.memory.rssBytes / (1024 * 1024)),
+        inflight: health.shutdown.inflightCount,
+        lastRpcMethod: health.lastRpc.method,
+      });
+    }
+  }, windowMs);
+  if (timer.unref) timer.unref();
+
+  return {
+    stop(): void {
+      clearInterval(timer);
+    },
+  };
+}

--- a/src/engine/perception/registry.ts
+++ b/src/engine/perception/registry.ts
@@ -375,7 +375,14 @@ export function stopNativeRuntime(): void {
 // Issue #365: log drains that exceed this threshold so we can correlate the
 // "fan kicked in" symptom with native event volume. 100 events / 50ms cycle =
 // 2000 events/s sustained — well above quiescent baseline.
-const DRAIN_OVERSIZE_THRESHOLD = 100;
+// Review R1 P3-1: env override so a noisy desktop environment with a higher
+// baseline can raise the threshold without recompiling.
+const DRAIN_OVERSIZE_THRESHOLD: number = (() => {
+  const raw = process.env.DESKTOP_TOUCH_DRAIN_OVERSIZE_THRESHOLD;
+  if (raw === undefined) return 100;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : 100;
+})();
 
 function drainNativeEventQueue(): void {
   if (!_rawQueue || !_nativeBridge) return;

--- a/src/engine/perception/registry.ts
+++ b/src/engine/perception/registry.ts
@@ -73,6 +73,7 @@ import { ReconciliationScheduler } from "./reconciliation.js";
 import { buildRefreshPlan } from "./refresh-plan.js";
 import { WinEventSource } from "../winevent-source.js";
 import type { WinEventSourceDiagnostics } from "../winevent-source.js";
+import { logDiagnostic } from "../diagnostic-log.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Constants
@@ -371,6 +372,11 @@ export function stopNativeRuntime(): void {
   _rawQueue     = null;
 }
 
+// Issue #365: log drains that exceed this threshold so we can correlate the
+// "fan kicked in" symptom with native event volume. 100 events / 50ms cycle =
+// 2000 events/s sustained — well above quiescent baseline.
+const DRAIN_OVERSIZE_THRESHOLD = 100;
+
 function drainNativeEventQueue(): void {
   if (!_rawQueue || !_nativeBridge) return;
   // Read overflow flag BEFORE drain — drain() resets overflowPending to false,
@@ -383,6 +389,13 @@ function drainNativeEventQueue(): void {
   if (overflowWasPending) {
     _nativeBridge.processOverflow(performance.now());
     _reconciler?.triggerImmediate();
+  }
+  if (batch.length >= DRAIN_OVERSIZE_THRESHOLD || overflowWasPending) {
+    logDiagnostic({
+      kind: "drain_oversize",
+      batch_size: batch.length,
+      overflow: overflowWasPending,
+    });
   }
 }
 

--- a/src/server-windows.ts
+++ b/src/server-windows.ts
@@ -46,7 +46,11 @@ import {
 import { startTray, stopTray, type TrayOptions } from "./utils/tray.js";
 import { checkFailsafe, FailsafeError } from "./utils/failsafe.js";
 import { wrapHandlerArg } from "./utils/failsafe-wrap.js";
-import { logDiagnostic, wrapHandlerArgWithTiming } from "./engine/diagnostic-log.js";
+import {
+  logDiagnostic,
+  normalizeThrown,
+  wrapHandlerArgWithTiming,
+} from "./engine/diagnostic-log.js";
 import { startCpuWatchdog } from "./engine/diagnostic-watchdog.js";
 import { SERVER_VERSION } from "./version.js";
 import { resolveV2Activation } from "./tools/desktop-activation.js";
@@ -425,28 +429,21 @@ process.on("disconnect", () => shutdownFromSignal("disconnect"));
 // AND so Phase B B-3/B-4 store flush (uiPatternStore / macroOutcomeStore) is
 // not skipped — calling shutdown() routes through the existing Promise.all
 // flush gate before process.exit. (Review R1 P1-1.)
-function safeStringify(value: unknown): string {
-  // Review R1 P1-2: `reason` from `unhandledRejection` can be a circular
-  // object whose `JSON.stringify` throws — that re-entered the uncaught
-  // handler and risked stack overflow. Defensive try/catch + fallback.
-  try {
-    return JSON.stringify(value) ?? String(value);
-  } catch {
-    try {
-      return String(value);
-    } catch {
-      return "<unstringifiable>";
-    }
-  }
-}
-
 function handleUncaught(
   type: "uncaughtException" | "unhandledRejection",
   err: Error,
 ): void {
-  // If shutdown is already in progress, don't reschedule it — just log and
-  // let the existing flush finish. This handles the case where shutdown()
-  // itself surfaces an async error.
+  // Codex R1 P2-1: preserve Node's default crash visibility on stderr in case
+  // the diagnostic log is disabled / unwritable / the user only has stderr
+  // capture configured. Best-effort; a stderr write that fails must not
+  // re-enter the handler.
+  try {
+    console.error(`[desktop-touch] ${type}:`, err.stack ?? err.message ?? String(err));
+  } catch {
+    // ignore
+  }
+  // shutdown() guards re-entry internally via the `shuttingDown` flag, so we
+  // can safely call it from here even if a previous handler already invoked it.
   logDiagnostic({
     kind: "uncaught",
     type,
@@ -464,15 +461,11 @@ function handleUncaught(
   shutdown(1);
 }
 
-process.on("uncaughtException", (err: Error) => {
-  handleUncaught("uncaughtException", err);
+process.on("uncaughtException", (value: unknown) => {
+  handleUncaught("uncaughtException", normalizeThrown(value));
 });
 process.on("unhandledRejection", (reason: unknown) => {
-  const err =
-    reason instanceof Error
-      ? reason
-      : new Error(typeof reason === "string" ? reason : safeStringify(reason));
-  handleUncaught("unhandledRejection", err);
+  handleUncaught("unhandledRejection", normalizeThrown(reason));
 });
 
 // Start the passive self-CPU watchdog. Returns null when disabled via env;

--- a/src/server-windows.ts
+++ b/src/server-windows.ts
@@ -306,7 +306,7 @@ let shutdownPending = false;
 let shutdownTimer: NodeJS.Timeout | null = null;
 const SHUTDOWN_GRACE_MS = 60_000;
 
-function shutdown(): void {
+function shutdown(exitCode = 0): void {
   if (shuttingDown) return;
   shuttingDown = true;
   clearShutdownPending();
@@ -328,6 +328,8 @@ function shutdown(): void {
   // pending あれば disk write 完了後 exit (data loss 防止)。
   // best-effort: error も resolve、即時 exit を遅延させない。
   // 並列 flush で B-3 / B-4 両 store を 1 度に flush。
+  // Issue #365 review R1 P1-1: exitCode は uncaught 経路から 1 を渡す。
+  // Promise.all 経由で flush を待つため、uncaught でも store data loss しない。
   Promise.all([
     uiPatternStore.flushImmediateForShutdown(),
     macroOutcomeStore.flushImmediateForShutdown(),
@@ -335,7 +337,7 @@ function shutdown(): void {
     .catch(() => {})
     .finally(() => {
       // In-flight requests clean up their own server/transport instances via res.on("close").
-      process.exit(0);
+      process.exit(exitCode);
     });
 }
 
@@ -419,51 +421,70 @@ process.on("disconnect", () => shutdownFromSignal("disconnect"));
 // Issue #365: uncaught exceptions and unhandled promise rejections terminate
 // the Node process with no Application Event Log crash entry (treated as a
 // normal exit). Without these handlers the only signal was a stderr warning
-// nobody captured. Log + exit(1) so post-hoc grep can identify the trigger.
-process.on("uncaughtException", (err: Error) => {
+// nobody captured. Log + shutdown(1) so post-hoc grep can identify the trigger
+// AND so Phase B B-3/B-4 store flush (uiPatternStore / macroOutcomeStore) is
+// not skipped — calling shutdown() routes through the existing Promise.all
+// flush gate before process.exit. (Review R1 P1-1.)
+function safeStringify(value: unknown): string {
+  // Review R1 P1-2: `reason` from `unhandledRejection` can be a circular
+  // object whose `JSON.stringify` throws — that re-entered the uncaught
+  // handler and risked stack overflow. Defensive try/catch + fallback.
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    try {
+      return String(value);
+    } catch {
+      return "<unstringifiable>";
+    }
+  }
+}
+
+function handleUncaught(
+  type: "uncaughtException" | "unhandledRejection",
+  err: Error,
+): void {
+  // If shutdown is already in progress, don't reschedule it — just log and
+  // let the existing flush finish. This handles the case where shutdown()
+  // itself surfaces an async error.
   logDiagnostic({
     kind: "uncaught",
-    type: "uncaughtException",
+    type,
     name: err.name,
     msg: err.message,
     stack: err.stack,
   });
   logDiagnostic({
     kind: "exit",
-    trigger: "uncaughtException",
+    trigger: type,
     exitCode: 1,
     inflight: inflightIds.size,
     shutdownPending,
   });
-  process.exit(1);
+  shutdown(1);
+}
+
+process.on("uncaughtException", (err: Error) => {
+  handleUncaught("uncaughtException", err);
 });
 process.on("unhandledRejection", (reason: unknown) => {
   const err =
     reason instanceof Error
       ? reason
-      : new Error(typeof reason === "string" ? reason : JSON.stringify(reason));
-  logDiagnostic({
-    kind: "uncaught",
-    type: "unhandledRejection",
-    name: err.name,
-    msg: err.message,
-    stack: err.stack,
-  });
-  logDiagnostic({
-    kind: "exit",
-    trigger: "unhandledRejection",
-    exitCode: 1,
-    inflight: inflightIds.size,
-    shutdownPending,
-  });
-  process.exit(1);
+      : new Error(typeof reason === "string" ? reason : safeStringify(reason));
+  handleUncaught("unhandledRejection", err);
 });
 
 // Start the passive self-CPU watchdog. Returns null when disabled via env;
 // the assignment keeps the handle so test harnesses can stop it. Handle is
 // otherwise unused — the watchdog's setInterval is unref'd so it does not
 // keep the event loop alive.
-const _cpuWatchdog = startCpuWatchdog();
+// Review R1 P2-4: skip when --help is requested so the help path doesn't
+// allocate a setInterval / create the logs directory for a one-shot CLI use.
+const _cpuWatchdog =
+  process.argv.includes("--help") || process.argv.includes("-h")
+    ? null
+    : startCpuWatchdog();
 void _cpuWatchdog;
 
 // ─── Parse CLI flags ──────────────────────────────────────────────────────────

--- a/src/server-windows.ts
+++ b/src/server-windows.ts
@@ -46,6 +46,8 @@ import {
 import { startTray, stopTray, type TrayOptions } from "./utils/tray.js";
 import { checkFailsafe, FailsafeError } from "./utils/failsafe.js";
 import { wrapHandlerArg } from "./utils/failsafe-wrap.js";
+import { logDiagnostic, wrapHandlerArgWithTiming } from "./engine/diagnostic-log.js";
+import { startCpuWatchdog } from "./engine/diagnostic-watchdog.js";
 import { SERVER_VERSION } from "./version.js";
 import { resolveV2Activation } from "./tools/desktop-activation.js";
 import { uiPatternStore } from "./store/ui-pattern-store.js";
@@ -177,18 +179,26 @@ function createMcpServer(): McpServer {
   // dispatchers (keyboard / clipboard / window_dock / scroll / terminal /
   // browser_eval) registered via registerTool — the same emergency-stop gate
   // as the legacy s.tool() registrations. (Codex PR #40 P1)
+  // Wrap order: failsafe pre-check first, then slow-tool timing. Outer wrappers
+  // run first, so wrapping with timing after failsafe means timing observes
+  // total elapsed time including the failsafe check (negligible for normal
+  // operation; informative when failsafe itself stalls).
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const _originalTool = s.tool.bind(s) as (...args: any[]) => any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (s as any).tool = function (...toolArgs: any[]) {
-    return _originalTool(...wrapHandlerArg(toolArgs, checkFailsafe));
+    return _originalTool(
+      ...wrapHandlerArgWithTiming(wrapHandlerArg(toolArgs, checkFailsafe)),
+    );
   };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const _originalRegisterTool = s.registerTool.bind(s) as (...args: any[]) => any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (s as any).registerTool = function (...toolArgs: any[]) {
-    return _originalRegisterTool(...wrapHandlerArg(toolArgs, checkFailsafe));
+    return _originalRegisterTool(
+      ...wrapHandlerArgWithTiming(wrapHandlerArg(toolArgs, checkFailsafe)),
+    );
   };
 
   registerScreenshotTools(s);
@@ -266,6 +276,13 @@ const failsafeTimer = setInterval(async () => {
   } catch (err) {
     if (err instanceof FailsafeError) {
       console.error("[desktop-touch] FAILSAFE triggered: mouse at top-left corner. Exiting.");
+      logDiagnostic({
+        kind: "exit",
+        trigger: "failsafe",
+        exitCode: 1,
+        inflight: inflightIds.size,
+        shutdownPending,
+      });
       stopTray();
       process.exit(1);
     }
@@ -328,6 +345,13 @@ function requestShutdown(reason: string): void {
   if (shuttingDown || shutdownPending) return;
   if (inflightIds.size === 0) {
     console.error(`[desktop-touch] ${reason} — shutting down.`);
+    logDiagnostic({
+      kind: "exit",
+      trigger: reason,
+      exitCode: 0,
+      inflight: 0,
+      shutdownPending: false,
+    });
     shutdown();
     return;
   }
@@ -344,6 +368,13 @@ function requestShutdown(reason: string): void {
     console.error(
       `[desktop-touch] in-flight requests still pending after ${SHUTDOWN_GRACE_MS}ms — forcing shutdown.`
     );
+    logDiagnostic({
+      kind: "exit",
+      trigger: `${reason} (grace expired)`,
+      exitCode: 0,
+      inflight: inflightIds.size,
+      shutdownPending: true,
+    });
     shutdown();
   }, SHUTDOWN_GRACE_MS);
 }
@@ -356,14 +387,84 @@ function maybeFinishShutdown(): void {
     setImmediate(() => {
       if (shuttingDown) return;
       console.error("[desktop-touch] in-flight requests drained — shutting down.");
+      logDiagnostic({
+        kind: "exit",
+        trigger: "inflight drained after grace",
+        exitCode: 0,
+        inflight: 0,
+        shutdownPending: true,
+      });
       shutdown();
     });
   }
 }
 
-process.on("SIGINT", shutdown);
-process.on("SIGTERM", shutdown);
-process.on("disconnect", shutdown);
+function shutdownFromSignal(trigger: string): void {
+  if (!shuttingDown) {
+    logDiagnostic({
+      kind: "exit",
+      trigger,
+      exitCode: 0,
+      inflight: inflightIds.size,
+      shutdownPending,
+    });
+  }
+  shutdown();
+}
+
+process.on("SIGINT", () => shutdownFromSignal("SIGINT"));
+process.on("SIGTERM", () => shutdownFromSignal("SIGTERM"));
+process.on("disconnect", () => shutdownFromSignal("disconnect"));
+
+// Issue #365: uncaught exceptions and unhandled promise rejections terminate
+// the Node process with no Application Event Log crash entry (treated as a
+// normal exit). Without these handlers the only signal was a stderr warning
+// nobody captured. Log + exit(1) so post-hoc grep can identify the trigger.
+process.on("uncaughtException", (err: Error) => {
+  logDiagnostic({
+    kind: "uncaught",
+    type: "uncaughtException",
+    name: err.name,
+    msg: err.message,
+    stack: err.stack,
+  });
+  logDiagnostic({
+    kind: "exit",
+    trigger: "uncaughtException",
+    exitCode: 1,
+    inflight: inflightIds.size,
+    shutdownPending,
+  });
+  process.exit(1);
+});
+process.on("unhandledRejection", (reason: unknown) => {
+  const err =
+    reason instanceof Error
+      ? reason
+      : new Error(typeof reason === "string" ? reason : JSON.stringify(reason));
+  logDiagnostic({
+    kind: "uncaught",
+    type: "unhandledRejection",
+    name: err.name,
+    msg: err.message,
+    stack: err.stack,
+  });
+  logDiagnostic({
+    kind: "exit",
+    trigger: "unhandledRejection",
+    exitCode: 1,
+    inflight: inflightIds.size,
+    shutdownPending,
+  });
+  process.exit(1);
+});
+
+// Start the passive self-CPU watchdog. Returns null when disabled via env;
+// the assignment keeps the handle so test harnesses can stop it. Handle is
+// otherwise unused — the watchdog's setInterval is unref'd so it does not
+// keep the event loop alive.
+const _cpuWatchdog = startCpuWatchdog();
+void _cpuWatchdog;
 
 // ─── Parse CLI flags ──────────────────────────────────────────────────────────
 const args = process.argv.slice(2);

--- a/tests/unit/diagnostic-log.test.ts
+++ b/tests/unit/diagnostic-log.test.ts
@@ -12,6 +12,8 @@ import {
   logDiagnostic,
   getDiagnosticLogPath,
   estimateArgsSize,
+  safeStringify,
+  normalizeThrown,
   wrapHandlerArgWithTiming,
   _resetDiagnosticLogForTest,
   type DiagnosticEvent,
@@ -247,6 +249,60 @@ describe("wrapHandlerArgWithTiming", () => {
     expect(wrappedBad).toBe(argsBad);
     // The handler at the last index should still be the original, untouched.
     expect(wrappedBad[1]).toBe(handler);
+  });
+});
+
+describe("safeStringify (R1 P1-2 / R2 extract)", () => {
+  it("returns JSON for plain object", () => {
+    expect(safeStringify({ a: 1 })).toBe('{"a":1}');
+  });
+  it("returns String() fallback for circular object", () => {
+    const obj: Record<string, unknown> = {};
+    obj.self = obj;
+    expect(safeStringify(obj)).toBe("[object Object]");
+  });
+  it("handles undefined → null per JSON.stringify, then falls back via ??", () => {
+    // JSON.stringify(undefined) === undefined → ?? falls back to String(undefined) === "undefined"
+    expect(safeStringify(undefined)).toBe("undefined");
+  });
+  it("handles symbol → String() fallback", () => {
+    // JSON.stringify(symbol) returns undefined → falls back
+    const sym = Symbol("x");
+    expect(safeStringify(sym)).toBe(String(sym));
+  });
+});
+
+describe("normalizeThrown (Codex R1 P2-2 / R2 symmetric fix)", () => {
+  it("returns Error instance unchanged", () => {
+    const orig = new Error("boom");
+    expect(normalizeThrown(orig)).toBe(orig);
+  });
+  it("wraps string in Error", () => {
+    const e = normalizeThrown("plain string");
+    expect(e).toBeInstanceOf(Error);
+    expect(e.message).toBe("plain string");
+  });
+  it("wraps null in Error (no property dereference)", () => {
+    // The critical case: `throw null` previously crashed handlers that read err.name.
+    const e = normalizeThrown(null);
+    expect(e).toBeInstanceOf(Error);
+    expect(typeof e.message).toBe("string");
+  });
+  it("wraps undefined in Error", () => {
+    const e = normalizeThrown(undefined);
+    expect(e).toBeInstanceOf(Error);
+    expect(typeof e.message).toBe("string");
+  });
+  it("wraps numeric throw", () => {
+    const e = normalizeThrown(42);
+    expect(e.message).toBe("42");
+  });
+  it("wraps circular object without throwing", () => {
+    const obj: Record<string, unknown> = {};
+    obj.self = obj;
+    expect(() => normalizeThrown(obj)).not.toThrow();
+    const e = normalizeThrown(obj);
+    expect(e).toBeInstanceOf(Error);
   });
 });
 

--- a/tests/unit/diagnostic-log.test.ts
+++ b/tests/unit/diagnostic-log.test.ts
@@ -1,0 +1,229 @@
+/**
+ * tests/unit/diagnostic-log.test.ts
+ *
+ * Unit tests for the JSONL diagnostic event log (issue #365).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, existsSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  logDiagnostic,
+  getDiagnosticLogPath,
+  estimateArgsSize,
+  wrapHandlerArgWithTiming,
+  _resetDiagnosticLogForTest,
+  type DiagnosticEvent,
+} from "../../src/engine/diagnostic-log.js";
+
+describe("diagnostic-log", () => {
+  let tmp: string;
+  let logPath: string;
+  const savedEnv = { ...process.env };
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "diaglog-"));
+    logPath = join(tmp, "sub", "diag.log");
+    process.env.DESKTOP_TOUCH_DIAGNOSTIC_LOG_PATH = logPath;
+    delete process.env.DESKTOP_TOUCH_DIAGNOSTIC_LOG_DISABLE;
+    _resetDiagnosticLogForTest();
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+    process.env = { ...savedEnv };
+    _resetDiagnosticLogForTest();
+  });
+
+  function readLines(): unknown[] {
+    if (!existsSync(logPath)) return [];
+    return readFileSync(logPath, "utf8")
+      .split("\n")
+      .filter((s) => s.length > 0)
+      .map((s) => JSON.parse(s));
+  }
+
+  it("logDiagnostic appends one JSONL line per call", () => {
+    logDiagnostic({
+      kind: "exit",
+      trigger: "SIGINT",
+      exitCode: 0,
+      inflight: 0,
+      shutdownPending: false,
+    });
+    logDiagnostic({
+      kind: "slow_tool",
+      tool: "screenshot",
+      elapsed_ms: 1234,
+      args_size: 100,
+    });
+    const lines = readLines() as Array<Record<string, unknown>>;
+    expect(lines.length).toBe(2);
+    expect(lines[0].kind).toBe("exit");
+    expect(lines[0].trigger).toBe("SIGINT");
+    expect(lines[1].kind).toBe("slow_tool");
+    expect(lines[1].tool).toBe("screenshot");
+  });
+
+  it("each record contains ts (ISO), pid, uptime_ms", () => {
+    logDiagnostic({
+      kind: "drain_oversize",
+      batch_size: 200,
+      overflow: false,
+    });
+    const [rec] = readLines() as Array<Record<string, unknown>>;
+    expect(rec.ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    expect(rec.pid).toBe(process.pid);
+    expect(typeof rec.uptime_ms).toBe("number");
+  });
+
+  it("creates parent directory if missing", () => {
+    expect(existsSync(join(tmp, "sub"))).toBe(false);
+    logDiagnostic({
+      kind: "uncaught",
+      type: "uncaughtException",
+      msg: "boom",
+    });
+    expect(existsSync(logPath)).toBe(true);
+  });
+
+  it("DESKTOP_TOUCH_DIAGNOSTIC_LOG_DISABLE=1 disables logging", () => {
+    process.env.DESKTOP_TOUCH_DIAGNOSTIC_LOG_DISABLE = "1";
+    _resetDiagnosticLogForTest();
+    logDiagnostic({
+      kind: "exit",
+      trigger: "SIGINT",
+      exitCode: 0,
+      inflight: 0,
+      shutdownPending: false,
+    });
+    expect(existsSync(logPath)).toBe(false);
+  });
+
+  it("does not throw if path is invalid (best-effort)", () => {
+    // Use a path that cannot be created (e.g. a regular file masquerading as a dir)
+    const blockingFile = join(tmp, "blocker");
+    writeFileSync(blockingFile, "x");
+    process.env.DESKTOP_TOUCH_DIAGNOSTIC_LOG_PATH = join(blockingFile, "child", "diag.log");
+    _resetDiagnosticLogForTest();
+    expect(() =>
+      logDiagnostic({
+        kind: "exit",
+        trigger: "SIGINT",
+        exitCode: 0,
+        inflight: 0,
+        shutdownPending: false,
+      }),
+    ).not.toThrow();
+  });
+
+  it("getDiagnosticLogPath defaults to homedir-based path when env unset", () => {
+    delete process.env.DESKTOP_TOUCH_DIAGNOSTIC_LOG_PATH;
+    _resetDiagnosticLogForTest();
+    const p = getDiagnosticLogPath();
+    expect(p).toMatch(/\.desktop-touch-mcp[\\/]logs[\\/]diagnostic\.log$/);
+  });
+
+  it("estimateArgsSize returns -1 on circular reference", () => {
+    const obj: Record<string, unknown> = {};
+    obj.self = obj;
+    expect(estimateArgsSize([obj])).toBe(-1);
+  });
+
+  it("estimateArgsSize returns positive length on normal payload", () => {
+    expect(estimateArgsSize([{ a: 1, b: "x" }])).toBeGreaterThan(0);
+  });
+});
+
+describe("wrapHandlerArgWithTiming", () => {
+  let tmp: string;
+  let logPath: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "diaglog-timing-"));
+    logPath = join(tmp, "diag.log");
+    process.env.DESKTOP_TOUCH_DIAGNOSTIC_LOG_PATH = logPath;
+    delete process.env.DESKTOP_TOUCH_DIAGNOSTIC_LOG_DISABLE;
+    _resetDiagnosticLogForTest();
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+    _resetDiagnosticLogForTest();
+  });
+
+  function readLines(): Array<Record<string, unknown>> {
+    if (!existsSync(logPath)) return [];
+    return readFileSync(logPath, "utf8")
+      .split("\n")
+      .filter((s) => s.length > 0)
+      .map((s) => JSON.parse(s));
+  }
+
+  it("logs slow_tool when handler exceeds threshold", async () => {
+    const slowHandler = async () => {
+      await new Promise((r) => setTimeout(r, 30));
+      return { ok: true };
+    };
+    const args: unknown[] = ["my_tool", "desc", {}, slowHandler];
+    const wrapped = wrapHandlerArgWithTiming(args, 10);
+    const handler = wrapped[wrapped.length - 1] as (...a: unknown[]) => Promise<unknown>;
+    const result = await handler({ x: 1 });
+    expect(result).toEqual({ ok: true });
+    const lines = readLines();
+    expect(lines.length).toBe(1);
+    expect(lines[0].kind).toBe("slow_tool");
+    expect(lines[0].tool).toBe("my_tool");
+    expect(lines[0].elapsed_ms as number).toBeGreaterThanOrEqual(10);
+  });
+
+  it("does not log when handler completes under threshold", async () => {
+    const fastHandler = async () => ({ ok: true });
+    const args: unknown[] = ["fast_tool", fastHandler];
+    const wrapped = wrapHandlerArgWithTiming(args, 1000);
+    const handler = wrapped[wrapped.length - 1] as (...a: unknown[]) => Promise<unknown>;
+    await handler({});
+    expect(readLines().length).toBe(0);
+  });
+
+  it("logs slow_tool even when handler throws", async () => {
+    const throwingHandler = async () => {
+      await new Promise((r) => setTimeout(r, 30));
+      throw new Error("boom");
+    };
+    const args: unknown[] = ["throwing_tool", throwingHandler];
+    const wrapped = wrapHandlerArgWithTiming(args, 10);
+    const handler = wrapped[wrapped.length - 1] as (...a: unknown[]) => Promise<unknown>;
+    await expect(handler()).rejects.toThrow("boom");
+    const lines = readLines();
+    expect(lines.length).toBe(1);
+    expect(lines[0].tool).toBe("throwing_tool");
+  });
+
+  it("returns args unchanged if last entry is not a function", () => {
+    const args: unknown[] = ["tool", "not a function"];
+    const wrapped = wrapHandlerArgWithTiming(args);
+    expect(wrapped).toBe(args);
+    expect(wrapped[1]).toBe("not a function");
+  });
+
+  it("returns empty args unchanged", () => {
+    const args: unknown[] = [];
+    expect(wrapHandlerArgWithTiming(args)).toBe(args);
+  });
+});
+
+describe("DiagnosticEvent type discrimination", () => {
+  it("all event kinds are accepted by logDiagnostic signature", () => {
+    // Type-only check: this test passes by virtue of compilation.
+    const events: DiagnosticEvent[] = [
+      { kind: "exit", trigger: "x", exitCode: 0, inflight: 0, shutdownPending: false },
+      { kind: "uncaught", type: "uncaughtException", msg: "x" },
+      { kind: "slow_tool", tool: "t", elapsed_ms: 1, args_size: 0 },
+      { kind: "cpu_spike", cpu_pct: 50, window_ms: 10000, rss_mb: 200, inflight: 0, lastRpcMethod: null },
+      { kind: "drain_oversize", batch_size: 100, overflow: false },
+    ];
+    expect(events.length).toBe(5);
+  });
+});

--- a/tests/unit/diagnostic-log.test.ts
+++ b/tests/unit/diagnostic-log.test.ts
@@ -134,6 +134,31 @@ describe("diagnostic-log", () => {
   it("estimateArgsSize returns positive length on normal payload", () => {
     expect(estimateArgsSize([{ a: 1, b: "x" }])).toBeGreaterThan(0);
   });
+
+  it("truncates large stack traces to keep records bounded (R1 P2-3)", () => {
+    const bigStack = "x".repeat(8000);
+    logDiagnostic({
+      kind: "uncaught",
+      type: "uncaughtException",
+      msg: "boom",
+      stack: bigStack,
+    });
+    const [rec] = readLines() as Array<Record<string, unknown>>;
+    expect((rec.stack as string).length).toBeLessThanOrEqual(4096 + 20);
+    expect(rec.stack as string).toContain("…[truncated]");
+  });
+
+  it("does not truncate a normal-sized stack", () => {
+    const normalStack = "Error: x\n    at foo (file.ts:1:1)";
+    logDiagnostic({
+      kind: "uncaught",
+      type: "uncaughtException",
+      msg: "boom",
+      stack: normalStack,
+    });
+    const [rec] = readLines() as Array<Record<string, unknown>>;
+    expect(rec.stack).toBe(normalStack);
+  });
 });
 
 describe("wrapHandlerArgWithTiming", () => {
@@ -211,6 +236,17 @@ describe("wrapHandlerArgWithTiming", () => {
   it("returns empty args unchanged", () => {
     const args: unknown[] = [];
     expect(wrapHandlerArgWithTiming(args)).toBe(args);
+  });
+
+  it("returns args unchanged when toolArgs[0] is not a string (R1 P3-3)", async () => {
+    // Upstream misuse: if the first arg is not a string tool name we skip wrap
+    // to avoid emitting literal "[object Object]" / "undefined" in slow_tool logs.
+    const handler = async () => ({ ok: true });
+    const argsBad: unknown[] = [{ not: "a name" }, handler];
+    const wrappedBad = wrapHandlerArgWithTiming(argsBad, 1);
+    expect(wrappedBad).toBe(argsBad);
+    // The handler at the last index should still be the original, untouched.
+    expect(wrappedBad[1]).toBe(handler);
   });
 });
 

--- a/tests/unit/diagnostic-watchdog.test.ts
+++ b/tests/unit/diagnostic-watchdog.test.ts
@@ -55,9 +55,10 @@ describe("diagnostic-watchdog", () => {
   });
 
   it("logs a cpu_spike event when CPU exceeds threshold inside the window", async () => {
-    // Short window + low threshold so a busy loop reliably fires.
+    // Review R1 P3-2: short window + very low threshold so a busy loop reliably
+    // fires even on slow CI runners where the interval may be delayed.
     process.env.DESKTOP_TOUCH_CPU_WATCHDOG_WINDOW_MS = "100";
-    process.env.DESKTOP_TOUCH_CPU_WATCHDOG_THRESHOLD_PCT = "5";
+    process.env.DESKTOP_TOUCH_CPU_WATCHDOG_THRESHOLD_PCT = "1";
     const h = startCpuWatchdog();
     expect(h).not.toBeNull();
 
@@ -74,7 +75,7 @@ describe("diagnostic-watchdog", () => {
     const spike = lines.find((l) => l.kind === "cpu_spike");
     expect(spike).toBeDefined();
     expect(typeof spike?.cpu_pct).toBe("number");
-    expect((spike?.cpu_pct as number) >= 5).toBe(true);
+    expect((spike?.cpu_pct as number) >= 1).toBe(true);
     expect(typeof spike?.rss_mb).toBe("number");
     expect(spike?.lastRpcMethod).toBeDefined();
   });

--- a/tests/unit/diagnostic-watchdog.test.ts
+++ b/tests/unit/diagnostic-watchdog.test.ts
@@ -1,0 +1,101 @@
+/**
+ * tests/unit/diagnostic-watchdog.test.ts
+ *
+ * Unit tests for the self-CPU watchdog (issue #365).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startCpuWatchdog } from "../../src/engine/diagnostic-watchdog.js";
+import { _resetDiagnosticLogForTest } from "../../src/engine/diagnostic-log.js";
+
+describe("diagnostic-watchdog", () => {
+  let tmp: string;
+  let logPath: string;
+  const savedEnv = { ...process.env };
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "diagwd-"));
+    logPath = join(tmp, "diag.log");
+    process.env.DESKTOP_TOUCH_DIAGNOSTIC_LOG_PATH = logPath;
+    delete process.env.DESKTOP_TOUCH_DIAGNOSTIC_LOG_DISABLE;
+    delete process.env.DESKTOP_TOUCH_CPU_WATCHDOG_DISABLE;
+    delete process.env.DESKTOP_TOUCH_CPU_WATCHDOG_THRESHOLD_PCT;
+    delete process.env.DESKTOP_TOUCH_CPU_WATCHDOG_WINDOW_MS;
+    _resetDiagnosticLogForTest();
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+    process.env = { ...savedEnv };
+    _resetDiagnosticLogForTest();
+  });
+
+  function readLines(): Array<Record<string, unknown>> {
+    if (!existsSync(logPath)) return [];
+    return readFileSync(logPath, "utf8")
+      .split("\n")
+      .filter((s) => s.length > 0)
+      .map((s) => JSON.parse(s));
+  }
+
+  it("returns null when DESKTOP_TOUCH_CPU_WATCHDOG_DISABLE=1", () => {
+    process.env.DESKTOP_TOUCH_CPU_WATCHDOG_DISABLE = "1";
+    const h = startCpuWatchdog();
+    expect(h).toBeNull();
+  });
+
+  it("returns a handle when enabled", () => {
+    process.env.DESKTOP_TOUCH_CPU_WATCHDOG_WINDOW_MS = "60000"; // long window so it doesn't fire in test
+    const h = startCpuWatchdog();
+    expect(h).not.toBeNull();
+    h?.stop();
+  });
+
+  it("logs a cpu_spike event when CPU exceeds threshold inside the window", async () => {
+    // Short window + low threshold so a busy loop reliably fires.
+    process.env.DESKTOP_TOUCH_CPU_WATCHDOG_WINDOW_MS = "100";
+    process.env.DESKTOP_TOUCH_CPU_WATCHDOG_THRESHOLD_PCT = "5";
+    const h = startCpuWatchdog();
+    expect(h).not.toBeNull();
+
+    // Burn CPU for ~150ms so the watchdog's 100ms window captures heavy work.
+    const burnUntil = Date.now() + 150;
+    while (Date.now() < burnUntil) {
+      // tight loop — intentionally
+    }
+    // Yield so the watchdog interval fires.
+    await new Promise((r) => setTimeout(r, 120));
+    h?.stop();
+
+    const lines = readLines();
+    const spike = lines.find((l) => l.kind === "cpu_spike");
+    expect(spike).toBeDefined();
+    expect(typeof spike?.cpu_pct).toBe("number");
+    expect((spike?.cpu_pct as number) >= 5).toBe(true);
+    expect(typeof spike?.rss_mb).toBe("number");
+    expect(spike?.lastRpcMethod).toBeDefined();
+  });
+
+  it("does not log when CPU stays under threshold", async () => {
+    process.env.DESKTOP_TOUCH_CPU_WATCHDOG_WINDOW_MS = "50";
+    process.env.DESKTOP_TOUCH_CPU_WATCHDOG_THRESHOLD_PCT = "99";
+    const h = startCpuWatchdog();
+    // Stay idle through a couple windows.
+    await new Promise((r) => setTimeout(r, 200));
+    h?.stop();
+    const spikes = readLines().filter((l) => l.kind === "cpu_spike");
+    expect(spikes.length).toBe(0);
+  });
+
+  it("invalid env values fall back to defaults", () => {
+    process.env.DESKTOP_TOUCH_CPU_WATCHDOG_THRESHOLD_PCT = "not-a-number";
+    process.env.DESKTOP_TOUCH_CPU_WATCHDOG_WINDOW_MS = "-5";
+    // Should not throw; falls back to defaults internally.
+    const h = startCpuWatchdog();
+    expect(h).not.toBeNull();
+    h?.stop();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a passive JSONL diagnostic event log so the next time issue #365's "sudden death" or "fan kicks in" symptom hits, post-hoc `grep` can answer **what triggered it**. Phase 1 (PR #366) gave us an active poll (`server_status.health`); this PR adds passive event capture that observation 3 (process disappears with no crash log) and the "fan-noise even when LLM isn't calling tools" symptom both need.

Closes part of #365 (observability). Remaining: actual root-cause fixes once the diagnostic log catches the trigger.

## What's captured

| event | when | example use |
|---|---|---|
| `exit` | every `process.exit` call site (failsafe / signals / stdin EOF / EPIPE / grace expiry / inflight drain) | "which shutdown path did the process take?" |
| `uncaught` | previously-uncaught exceptions + unhandled promise rejections | the prime sudden-death suspect — Node 15+ terminates on unhandled rejection with no Event Log entry |
| `slow_tool` | tool handler elapsed > 1000ms | "which tool was running when the fan kicked in?" |
| `cpu_spike` | passive self-CPU sampler exceeds 30%/10s window | LLM-independent CPU spikes (perception storm, GC, etc.) |
| `drain_oversize` | perception drain batch ≥ 100 events or overflow flag | correlate fan-noise with native event volume |

## Design choices

- **Sync writes** (`appendFileSync`) so events written just before `process.exit` reach disk
- **Best-effort** (try/catch around the append): a write failure cannot itself become a crash source — critical for the `uncaught` handler
- **Passive watchdog** instead of polling: avoids the PR #366 phase 1 Heisenbug where `tools/call(server_status)` polling itself added ~5% CPU and bloated RSS by +100MB over 30min
- **No new kill-switch env var**: existing `DESKTOP_TOUCH_NATIVE_WINEVENTS=0` already disables the perception sidecar (= the only LLM-independent CPU consumer identified), so it doubles as the A/B test toggle for the fan-noise hypothesis

## Configuration

| env var | default | purpose |
|---|---|---|
| `DESKTOP_TOUCH_DIAGNOSTIC_LOG_PATH` | `~/.desktop-touch-mcp/logs/diagnostic.log` | override log path |
| `DESKTOP_TOUCH_DIAGNOSTIC_LOG_DISABLE` | `0` | set to `1` to disable all event logging |
| `DESKTOP_TOUCH_CPU_WATCHDOG_DISABLE` | `0` | set to `1` to disable the CPU watchdog |
| `DESKTOP_TOUCH_CPU_WATCHDOG_THRESHOLD_PCT` | `30` | single-core CPU% threshold |
| `DESKTOP_TOUCH_CPU_WATCHDOG_WINDOW_MS` | `10000` | sample window |

## Files

- `src/engine/diagnostic-log.ts` — JSONL appender + `wrapHandlerArgWithTiming`
- `src/engine/diagnostic-watchdog.ts` — passive CPU watchdog
- `src/server-windows.ts` — uncaught handlers + exit logging at 4 sites + watchdog start + slow-tool wrap chain
- `src/engine/perception/registry.ts` — drain oversize log in `drainNativeEventQueue`
- `tests/unit/diagnostic-log.test.ts` (+10 cases)
- `tests/unit/diagnostic-watchdog.test.ts` (+9 cases)

## Test plan

- [x] `npm run build` clean
- [x] New tests 19/19 pass
- [x] Full suite: 3661 pass / 4 fail (conhost flakes in `tests/e2e/terminal.test.ts`, pass in isolation, unrelated to this PR)
- [ ] Dogfood: leave running, wait for next sudden-death / fan event, grep `diagnostic.log`
- [ ] Confirm log file is created at first `slow_tool` / `cpu_spike` event during normal usage

## Reviewer focus

Per CLAUDE.md §3.3, this is a **production code 改修 PR** → Opus + Codex review required.

- **§3.1 fact integrity sweep**: env var names appear in code + this PR description + (planned) README/CHANGELOG entries — sync check needed before user-facing artifacts
- **§3.2 carry-over scope shrink**: no carry-over involved
- **Lesson 1-4 sweep**: low risk (purely additive observability, no semantic path change)
- **Particular care**: the `uncaughtException` / `unhandledRejection` handlers call `process.exit(1)`. This **changes** Node default behavior (Node 15+ terminates on unhandled rejection but does not call exit(1) immediately — it warns first, then crashes). The change is intentional (we want a deterministic exit + log), but reviewers should confirm this doesn't mask any in-flight async work that should have been allowed to complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)