### PR TITLE
fix(e2e): move mouse-verify-delivery clicks outside failsafe radius (#365)

### DIFF
--- a/tests/e2e/mouse-verify-delivery.test.ts
+++ b/tests/e2e/mouse-verify-delivery.test.ts
@@ -38,8 +38,13 @@ describe("mouse_click verifyDelivery hint (issue #178)", () => {
 
   it("returns hints.verifyDelivery when verifyDelivery=true (default)", async () => {
     const result = await mouseClickHandler({
-      x: 1,
-      y: 1,
+      // Outside the failsafe radius (10px from top-left), but still on the
+      // desktop / extreme top-left so there's typically no actionable target.
+      // Using (1, 1) triggered the running MCP server's failsafe (issue #365
+      // Phase 2 caught this) and killed it mid-test — false-positive sudden
+      // death symptom in dogfood logs.
+      x: 50,
+      y: 50,
       button: "left",
       doubleClick: false,
       tripleClick: false,
@@ -63,8 +68,13 @@ describe("mouse_click verifyDelivery hint (issue #178)", () => {
 
   it("does NOT include verifyDelivery hint when verifyDelivery=false", async () => {
     const result = await mouseClickHandler({
-      x: 1,
-      y: 1,
+      // Outside the failsafe radius (10px from top-left), but still on the
+      // desktop / extreme top-left so there's typically no actionable target.
+      // Using (1, 1) triggered the running MCP server's failsafe (issue #365
+      // Phase 2 caught this) and killed it mid-test — false-positive sudden
+      // death symptom in dogfood logs.
+      x: 50,
+      y: 50,
       button: "left",
       doubleClick: false,
       tripleClick: false,
@@ -81,18 +91,27 @@ describe("mouse_click verifyDelivery hint (issue #178)", () => {
   }, 10_000);
 
   it("blank-area click returns 'focus_only' or 'unverifiable' (silent fail pin)", async () => {
-    // Click at (1,1) which is the desktop / extreme top-left — there's
-    // typically no actionable target there. Pre/post UIA observations
-    // should be identical (stable desktop element), giving 'focus_only'
-    // when UIA is available. On hosts without UIA the snapshot returns
-    // null and we expect 'unverifiable'.
+    // Click in the extreme top-left desktop area — there's typically no
+    // actionable target there. Pre/post UIA observations should be identical
+    // (stable desktop element), giving 'focus_only' when UIA is available.
+    // On hosts without UIA the snapshot returns null and we expect
+    // 'unverifiable'.
     //
     // This is the "intentional silent fail" pin from the issue
     // acceptance criteria: a click that doesn't hit anything must NOT
     // return verifyDelivery:'delivered'.
+    //
+    // (Avoid coordinates inside the 10px failsafe radius — that triggers
+    // the host MCP server's emergency-stop on real Windows hardware and
+    // kills it mid-test. See issue #365.)
     const result = await mouseClickHandler({
-      x: 1,
-      y: 1,
+      // Outside the failsafe radius (10px from top-left), but still on the
+      // desktop / extreme top-left so there's typically no actionable target.
+      // Using (1, 1) triggered the running MCP server's failsafe (issue #365
+      // Phase 2 caught this) and killed it mid-test — false-positive sudden
+      // death symptom in dogfood logs.
+      x: 50,
+      y: 50,
       button: "left",
       doubleClick: false,
       tripleClick: false,


### PR DESCRIPTION
## Summary

**Live-discovered bug from issue #365 Phase 2 dogfood**: `tests/e2e/mouse-verify-delivery.test.ts` clicks at `(x:1, y:1)` — inside the 10 px failsafe radius (`src/utils/failsafe.ts: FAILSAFE_RADIUS = 10`). Whenever the E2E suite ran on a host with the Claude Code MCP server live, that server's 500 ms failsafe interval observed the cursor at (1, 1) on its next poll and called `process.exit(1)`.

Visible symptom: MCP server "suddenly disappears" mid-dogfood, every time the E2E suite touches `mouse_click`. The Phase 2 diagnostic log (PR #367) caught the exit event with `trigger: "failsafe"` — that is how the root cause was confirmed (full timeline in #365).

## Fix

Move all three clicks from (1, 1) → (50, 50). Still in the desktop top-left blank area, still validates the "no actionable target / silent fail" intent, but well clear of the 10 px failsafe zone.

| Before | After |
|---|---|
| `x: 1, y: 1` × 3 spots | `x: 50, y: 50` × 3 spots |

Updated comments explain the rationale so a future test author knows not to creep the coordinates back into the failsafe zone.

## Test plan

- [x] `tsc` clean
- [ ] CI green on this branch
- [ ] Next E2E suite run does not kill the host MCP server
- [ ] PR #367's `diagnostic.log` no longer accumulates `trigger: "failsafe"` exits during routine dogfood

🤖 Generated with [Claude Code](https://claude.com/claude-code)