### PR TITLE
feat(failsafe): dwell-based trigger — require continuous 500ms in zone (#365)

### DIFF
--- a/src/utils/failsafe.ts
+++ b/src/utils/failsafe.ts
@@ -1,29 +1,77 @@
 import { mouse } from "../engine/nutjs.js";
 
 const FAILSAFE_RADIUS = 10;
+const DEFAULT_HOLD_MS = 500;
+
+function readHoldMs(): number {
+  const raw = process.env.DESKTOP_TOUCH_FAILSAFE_HOLD_MS;
+  if (raw === undefined) return DEFAULT_HOLD_MS;
+  const n = Number(raw);
+  // `n >= 0` lets the user opt back into the immediate-trigger behaviour
+  // (HOLD_MS=0) without re-introducing the bug that motivated the redesign.
+  return Number.isFinite(n) && n >= 0 ? n : DEFAULT_HOLD_MS;
+}
 
 export class FailsafeError extends Error {
   constructor() {
     super(
-      "FAILSAFE triggered: mouse is at top-left corner (0,0). " +
-      "Operation aborted for safety. Move mouse away from corner to resume."
+      "FAILSAFE triggered: mouse has been at top-left corner (within " +
+        FAILSAFE_RADIUS +
+        "px of 0,0) continuously. " +
+        "Operation aborted for safety. Move mouse away from corner to resume."
     );
     this.name = "FailsafeError";
   }
 }
 
+// Module-level state — when did the cursor first enter the failsafe zone?
+// Reset to null on the first check that finds the cursor outside the zone.
+let _enteredAt: number | null = null;
+
 /**
- * Check mouse position and throw FailsafeError if at top-left corner.
- * Call this before every tool execution.
+ * Check mouse position. Throws `FailsafeError` only after the cursor has been
+ * inside the failsafe zone (≤ `FAILSAFE_RADIUS` px from top-left) continuously
+ * for `DESKTOP_TOUCH_FAILSAFE_HOLD_MS` milliseconds (default 500).
+ *
+ * Drive-by cursor movements through (0,0) — common during window drag, dock
+ * gestures, automated E2E tests, accidental flicks — no longer trigger the
+ * emergency stop. The 500 ms hold requirement is short enough that a
+ * deliberate "park the cursor in the corner" gesture still feels immediate to
+ * a human, but long enough that no normal usage will hit it by accident.
+ *
+ * `DESKTOP_TOUCH_FAILSAFE_HOLD_MS=0` restores the original immediate-trigger
+ * behaviour for callers who depend on it (kill-switch escape hatch).
+ *
+ * Call this before every tool execution AND from the 500 ms background
+ * watcher. The dwell timer is shared across both call sites.
  */
 export async function checkFailsafe(): Promise<void> {
   try {
     const pos = await mouse.getPosition();
-    if (pos.x <= FAILSAFE_RADIUS && pos.y <= FAILSAFE_RADIUS) {
-      throw new FailsafeError();
+    const inZone =
+      pos.x <= FAILSAFE_RADIUS && pos.y <= FAILSAFE_RADIUS;
+    if (inZone) {
+      const holdMs = readHoldMs();
+      if (_enteredAt === null) {
+        _enteredAt = Date.now();
+      }
+      if (Date.now() - _enteredAt >= holdMs) {
+        throw new FailsafeError();
+      }
+      // Inside the zone but not yet dwelled long enough — no-op.
+    } else {
+      // Cursor left the zone — clear the dwell timestamp so the next entry
+      // starts the hold counter fresh.
+      _enteredAt = null;
     }
   } catch (err) {
     if (err instanceof FailsafeError) throw err;
-    // Transient mouse query error — don't block tools
+    // Transient mouse query error — don't block tools.
+    // Also do not clear _enteredAt here — we don't know cursor state.
   }
+}
+
+/** Test-only: reset the dwell timestamp. Not exposed via the public index. */
+export function _resetFailsafeForTest(): void {
+  _enteredAt = null;
 }

--- a/src/utils/failsafe.ts
+++ b/src/utils/failsafe.ts
@@ -3,10 +3,25 @@ import { mouse } from "../engine/nutjs.js";
 const FAILSAFE_RADIUS = 10;
 const DEFAULT_HOLD_MS = 500;
 
+// The 500 ms background watcher in server-windows.ts polls at fixed cadence;
+// per-tool pre-checks may fire at any moment. If the gap between two
+// consecutive in-zone observations is larger than this, we assume the cursor
+// may have left and returned within the unsampled window and restart the
+// dwell timer (Codex review R1 P2-2). 1500 ms = 3x watcher tick, generous
+// enough to tolerate setInterval slip without re-introducing the
+// in-zone → out → in drive-by failure mode.
+const MAX_INTRA_DWELL_GAP_MS = 1500;
+
 function readHoldMs(): number {
   const raw = process.env.DESKTOP_TOUCH_FAILSAFE_HOLD_MS;
   if (raw === undefined) return DEFAULT_HOLD_MS;
-  const n = Number(raw);
+  // Codex review R1 P2-1: a blank / whitespace-only env value would coerce
+  // to 0 via Number("") and silently restore the immediate-trigger behaviour
+  // we're trying to remove. Treat blank as "unset" and fall back to default.
+  // `"0"` (explicit numeric zero) remains a valid opt-out.
+  const trimmed = raw.trim();
+  if (trimmed === "") return DEFAULT_HOLD_MS;
+  const n = Number(trimmed);
   // `n >= 0` lets the user opt back into the immediate-trigger behaviour
   // (HOLD_MS=0) without re-introducing the bug that motivated the redesign.
   return Number.isFinite(n) && n >= 0 ? n : DEFAULT_HOLD_MS;
@@ -25,8 +40,12 @@ export class FailsafeError extends Error {
 }
 
 // Module-level state — when did the cursor first enter the failsafe zone?
-// Reset to null on the first check that finds the cursor outside the zone.
+// `_lastInZoneAt` is the most recent in-zone sample; we use it to detect a
+// large gap between samples (cursor may have left and returned unobserved)
+// and restart the dwell timer in that case. Reset to null on the first check
+// that finds the cursor outside the zone.
 let _enteredAt: number | null = null;
+let _lastInZoneAt: number | null = null;
 
 /**
  * Check mouse position. Throws `FailsafeError` only after the cursor has been
@@ -38,6 +57,13 @@ let _enteredAt: number | null = null;
  * emergency stop. The 500 ms hold requirement is short enough that a
  * deliberate "park the cursor in the corner" gesture still feels immediate to
  * a human, but long enough that no normal usage will hit it by accident.
+ *
+ * Sampling caveat: detection is poll-based (500 ms watcher tick + per-tool
+ * pre-checks). A cursor that leaves and re-enters the zone entirely between
+ * two samples is not directly observable. We mitigate by restarting the
+ * dwell timer whenever consecutive in-zone samples are separated by more
+ * than `MAX_INTRA_DWELL_GAP_MS` (3x the watcher tick), so a long unsampled
+ * gap is treated as if the cursor may have left.
  *
  * `DESKTOP_TOUCH_FAILSAFE_HOLD_MS=0` restores the original immediate-trigger
  * behaviour for callers who depend on it (kill-switch escape hatch).
@@ -52,10 +78,20 @@ export async function checkFailsafe(): Promise<void> {
       pos.x <= FAILSAFE_RADIUS && pos.y <= FAILSAFE_RADIUS;
     if (inZone) {
       const holdMs = readHoldMs();
-      if (_enteredAt === null) {
-        _enteredAt = Date.now();
+      const now = Date.now();
+      // Codex review R1 P2-2: if the gap since the last in-zone sample is
+      // large enough that the cursor could have left and returned without
+      // being observed, restart the dwell timer.
+      if (
+        _lastInZoneAt !== null &&
+        now - _lastInZoneAt > MAX_INTRA_DWELL_GAP_MS
+      ) {
+        _enteredAt = now;
+      } else if (_enteredAt === null) {
+        _enteredAt = now;
       }
-      if (Date.now() - _enteredAt >= holdMs) {
+      _lastInZoneAt = now;
+      if (now - _enteredAt >= holdMs) {
         throw new FailsafeError();
       }
       // Inside the zone but not yet dwelled long enough — no-op.
@@ -63,6 +99,7 @@ export async function checkFailsafe(): Promise<void> {
       // Cursor left the zone — clear the dwell timestamp so the next entry
       // starts the hold counter fresh.
       _enteredAt = null;
+      _lastInZoneAt = null;
     }
   } catch (err) {
     if (err instanceof FailsafeError) throw err;
@@ -74,4 +111,5 @@ export async function checkFailsafe(): Promise<void> {
 /** Test-only: reset the dwell timestamp. Not exposed via the public index. */
 export function _resetFailsafeForTest(): void {
   _enteredAt = null;
+  _lastInZoneAt = null;
 }

--- a/tests/unit/failsafe-hold.test.ts
+++ b/tests/unit/failsafe-hold.test.ts
@@ -1,0 +1,139 @@
+/**
+ * tests/unit/failsafe-hold.test.ts
+ *
+ * Issue #365 follow-up — dwell-based failsafe trigger. The original
+ * `pos.x <= 10 && pos.y <= 10 → throw` design fired on any drive-by cursor
+ * movement through the top-left corner (E2E tests at (1,1), window drags
+ * ending at (0,0), accidental flicks) and routinely killed live MCP servers
+ * during dogfood. The new design requires the cursor to dwell in the zone
+ * for `DESKTOP_TOUCH_FAILSAFE_HOLD_MS` (default 500 ms) continuously.
+ *
+ * `mouse.getPosition` is mocked because we want to control the cursor state
+ * at sub-ms granularity to verify the dwell timer.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("../../src/engine/nutjs.js", () => ({
+  mouse: {
+    getPosition: vi.fn(),
+  },
+}));
+
+import { mouse } from "../../src/engine/nutjs.js";
+import {
+  checkFailsafe,
+  FailsafeError,
+  _resetFailsafeForTest,
+} from "../../src/utils/failsafe.js";
+
+const getPositionMock = mouse.getPosition as unknown as ReturnType<typeof vi.fn>;
+
+function setCursor(x: number, y: number): void {
+  getPositionMock.mockResolvedValue({ x, y });
+}
+
+describe("checkFailsafe — dwell-based trigger", () => {
+  const savedEnv = { ...process.env };
+
+  beforeEach(() => {
+    getPositionMock.mockReset();
+    _resetFailsafeForTest();
+    delete process.env.DESKTOP_TOUCH_FAILSAFE_HOLD_MS;
+    vi.useFakeTimers({ shouldAdvanceTime: false });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    process.env = { ...savedEnv };
+    _resetFailsafeForTest();
+  });
+
+  it("does not throw on a single check inside the zone (no dwell yet)", async () => {
+    setCursor(5, 5);
+    await expect(checkFailsafe()).resolves.toBeUndefined();
+  });
+
+  it("does not throw when cursor is far from the corner", async () => {
+    setCursor(500, 500);
+    await expect(checkFailsafe()).resolves.toBeUndefined();
+  });
+
+  it("throws after dwell threshold elapses with cursor still in zone", async () => {
+    setCursor(2, 2);
+    // First check arms the timer.
+    await checkFailsafe();
+    // Advance just under the default 500 ms threshold.
+    vi.setSystemTime(new Date(Date.now() + 499));
+    await expect(checkFailsafe()).resolves.toBeUndefined();
+    // Cross the threshold.
+    vi.setSystemTime(new Date(Date.now() + 2));
+    await expect(checkFailsafe()).rejects.toBeInstanceOf(FailsafeError);
+  });
+
+  it("resets the dwell timer when cursor leaves the zone", async () => {
+    setCursor(1, 1);
+    await checkFailsafe(); // arm
+    vi.setSystemTime(new Date(Date.now() + 300));
+    setCursor(500, 500);
+    await checkFailsafe(); // reset
+    vi.setSystemTime(new Date(Date.now() + 300));
+    setCursor(1, 1);
+    await checkFailsafe(); // re-arm (NOT throw — total wall time 600ms but dwell was reset)
+    // Even though wallclock has crossed 500ms total, the continuous-dwell
+    // requirement is not yet met because we left the zone in the middle.
+    vi.setSystemTime(new Date(Date.now() + 200));
+    await expect(checkFailsafe()).resolves.toBeUndefined();
+  });
+
+  it("DESKTOP_TOUCH_FAILSAFE_HOLD_MS=0 restores immediate-trigger behaviour", async () => {
+    process.env.DESKTOP_TOUCH_FAILSAFE_HOLD_MS = "0";
+    setCursor(0, 0);
+    await expect(checkFailsafe()).rejects.toBeInstanceOf(FailsafeError);
+  });
+
+  it("custom hold threshold via env var", async () => {
+    process.env.DESKTOP_TOUCH_FAILSAFE_HOLD_MS = "2000";
+    setCursor(3, 3);
+    await checkFailsafe(); // arm
+    vi.setSystemTime(new Date(Date.now() + 1000));
+    await expect(checkFailsafe()).resolves.toBeUndefined();
+    vi.setSystemTime(new Date(Date.now() + 1001));
+    await expect(checkFailsafe()).rejects.toBeInstanceOf(FailsafeError);
+  });
+
+  it("invalid env value falls back to default 500 ms", async () => {
+    process.env.DESKTOP_TOUCH_FAILSAFE_HOLD_MS = "not-a-number";
+    setCursor(5, 5);
+    await checkFailsafe();
+    vi.setSystemTime(new Date(Date.now() + 600));
+    await expect(checkFailsafe()).rejects.toBeInstanceOf(FailsafeError);
+  });
+
+  it("negative env value falls back to default 500 ms", async () => {
+    process.env.DESKTOP_TOUCH_FAILSAFE_HOLD_MS = "-100";
+    setCursor(5, 5);
+    await checkFailsafe();
+    vi.setSystemTime(new Date(Date.now() + 600));
+    await expect(checkFailsafe()).rejects.toBeInstanceOf(FailsafeError);
+  });
+
+  it("(1, 1) — the historic E2E click coordinate — does not trigger on a single check", async () => {
+    // Regression test for the issue #365 root cause. The old immediate-trigger
+    // semantics would throw here; the new dwell-based design must not.
+    setCursor(1, 1);
+    await expect(checkFailsafe()).resolves.toBeUndefined();
+  });
+
+  it("transient mouse.getPosition error does not throw or reset state", async () => {
+    setCursor(1, 1);
+    await checkFailsafe(); // arm
+    getPositionMock.mockRejectedValueOnce(new Error("transient"));
+    await expect(checkFailsafe()).resolves.toBeUndefined();
+    // After transient error, dwell counter should NOT have been cleared —
+    // we resume from where we were when the next real reading comes in.
+    setCursor(1, 1);
+    vi.setSystemTime(new Date(Date.now() + 600));
+    await expect(checkFailsafe()).rejects.toBeInstanceOf(FailsafeError);
+  });
+});

--- a/tests/unit/failsafe-hold.test.ts
+++ b/tests/unit/failsafe-hold.test.ts
@@ -125,6 +125,58 @@ describe("checkFailsafe — dwell-based trigger", () => {
     await expect(checkFailsafe()).resolves.toBeUndefined();
   });
 
+  it("blank env value falls back to default 500 ms (Codex R1 P2-1)", async () => {
+    // `DESKTOP_TOUCH_FAILSAFE_HOLD_MS=` (empty) used to coerce to 0 via
+    // Number(""), silently restoring the immediate-trigger behaviour.
+    process.env.DESKTOP_TOUCH_FAILSAFE_HOLD_MS = "";
+    setCursor(5, 5);
+    await expect(checkFailsafe()).resolves.toBeUndefined();
+    vi.setSystemTime(new Date(Date.now() + 600));
+    await expect(checkFailsafe()).rejects.toBeInstanceOf(FailsafeError);
+  });
+
+  it("whitespace-only env value falls back to default 500 ms (Codex R1 P2-1)", async () => {
+    process.env.DESKTOP_TOUCH_FAILSAFE_HOLD_MS = "   ";
+    setCursor(5, 5);
+    await expect(checkFailsafe()).resolves.toBeUndefined();
+    vi.setSystemTime(new Date(Date.now() + 600));
+    await expect(checkFailsafe()).rejects.toBeInstanceOf(FailsafeError);
+  });
+
+  it("env value with surrounding whitespace is trimmed (e.g., ' 100 ' → 100)", async () => {
+    process.env.DESKTOP_TOUCH_FAILSAFE_HOLD_MS = "  100  ";
+    setCursor(5, 5);
+    await checkFailsafe(); // arm
+    vi.setSystemTime(new Date(Date.now() + 80));
+    await expect(checkFailsafe()).resolves.toBeUndefined();
+    vi.setSystemTime(new Date(Date.now() + 30));
+    await expect(checkFailsafe()).rejects.toBeInstanceOf(FailsafeError);
+  });
+
+  it("dwell timer restarts when consecutive in-zone samples are >1500 ms apart (Codex R1 P2-2)", async () => {
+    // Sampling caveat: if two in-zone samples are separated by a long
+    // unsampled gap, the cursor may have left and returned within that
+    // window. We restart the dwell to avoid a drive-by trigger.
+    setCursor(5, 5);
+    await checkFailsafe(); // arm at t=0
+    vi.setSystemTime(new Date(Date.now() + 2000)); // large gap (cursor may have left)
+    await checkFailsafe(); // dwell restarts (now t=2000 as the new entered_at)
+    // Even though wallclock elapsed = 2000 ms total, we restarted the
+    // dwell at t=2000, so we need another 500 ms to trigger.
+    vi.setSystemTime(new Date(Date.now() + 100));
+    await expect(checkFailsafe()).resolves.toBeUndefined();
+    vi.setSystemTime(new Date(Date.now() + 500));
+    await expect(checkFailsafe()).rejects.toBeInstanceOf(FailsafeError);
+  });
+
+  it("normal-cadence in-zone samples (well under 1500 ms gap) accumulate dwell", async () => {
+    // Watcher-tick scenario: 500 ms gap < 1500 ms threshold, dwell continues.
+    setCursor(5, 5);
+    await checkFailsafe(); // t=0
+    vi.setSystemTime(new Date(Date.now() + 500));
+    await expect(checkFailsafe()).rejects.toBeInstanceOf(FailsafeError);
+  });
+
   it("transient mouse.getPosition error does not throw or reset state", async () => {
     setCursor(1, 1);
     await checkFailsafe(); // arm


### PR DESCRIPTION
## Summary

Issue #365 dogfood discovery. The original failsafe (`pos.x ≤ 10 && pos.y ≤ 10 → process.exit(1)`) fired on **any drive-by cursor movement** through the top-left corner, killing live MCP servers during normal work. The diagnostic event log added in PR #367 captured this as repeated `kind:"exit" trigger:"failsafe"` entries.

Sources of accidental triggers we observed:
- E2E tests calling `mouseClickHandler({x:1, y:1})` (fixed coords in PR #371)
- Window drag operations ending near (0,0)
- Dock gestures, accidental mouse flicks, multi-monitor virtual edges
- Any tool internally moving the cursor close to the corner before the actual action

## Design

Cursor must remain inside the 10 px corner radius **continuously for `DESKTOP_TOUCH_FAILSAFE_HOLD_MS` ms (default 500)** before the process exits. Drive-by movements reset the dwell timer; only a deliberate "park and wait" gesture triggers the stop.

| Cursor sequence | Old behaviour | New behaviour |
|---|---|---|
| (1, 1) for one check | exit(1) | armed, no throw |
| (1, 1) continuously ≥ 500 ms | exit(1) | exit(1) |
| (1, 1) → (500, 500) → (1, 1) (drive-by) | exit(1) | dwell reset, no throw |
| (1, 1) → (500, 500) (transient) | exit(1) | no throw |

## Env var

- `DESKTOP_TOUCH_FAILSAFE_HOLD_MS` (default `500`): tune the dwell threshold. `0` restores the immediate-trigger behaviour (escape hatch). Invalid / negative values fall back to default.

## Files

- `src/utils/failsafe.ts` — module-level `_enteredAt` timestamp + dwell check
- `tests/unit/failsafe-hold.test.ts` — 10 new unit cases (in-zone single check / far / dwell elapsed / dwell reset on leave / env=0 immediate / custom env / invalid env / negative env / historic (1,1) regression / transient error)

## Test plan

- [x] `tsc` clean
- [x] New tests 10/10 pass
- [ ] CI green on this branch
- [ ] Post-merge dogfood: no more spurious `trigger: "failsafe"` events in `diagnostic.log` during routine work

## Reviewer focus

Per CLAUDE.md §3.3 — production code 改修 PR, Opus + Codex review required.

- **§3.1 fact integrity**: new env name `DESKTOP_TOUCH_FAILSAFE_HOLD_MS` and the constant `FAILSAFE_RADIUS = 10` (unchanged) appear in code, tests, CHANGELOG (in v1.7.2 prep, separate commit), and the FailsafeError message string.
- **§3.2 carry-over scope shrink**: existing public API (`checkFailsafe` async function) and existing semantics for `DESKTOP_TOUCH_FAILSAFE_HOLD_MS=0` (immediate-trigger). Verify the dwell-state module variable does not leak across test isolation.
- **Lesson 1-4 sweep**:
  - Causal window: 500ms dwell vs. 500ms watcher interval — the watcher tick is what advances the dwell check, so a single tick at exactly t=500ms inside the zone is sufficient.
  - Transient error: `mouse.getPosition` rejection deliberately does NOT clear `_enteredAt` (we don't know cursor state). Verify this is the intended semantics.
  - Compile-time guard: `_enteredAt = null` initialization is the only mutation path; check there's no stale state leak across separate Claude Code sessions (process-level state, fine for stdio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)