### PR TITLE
test(_envelope): ADR-021 P1-2 — migrate lease/throw failure sites to converter

### DIFF
--- a/src/tools/_envelope.ts
+++ b/src/tools/_envelope.ts
@@ -1247,6 +1247,14 @@ export function toFailureEnvelope<Ok, Err extends HandlerError>(
     /** `buildFailureEnvelope` の `EnvelopeOptions` を pass-through
      *  (`asOfWallclockMs` 等の L1 event wallclock 経路、将来 root extras hoist 伝播)。 */
     envelopeOptions?: EnvelopeOptions;
+    /** Explicit `try_next` override (ADR-021 P1-2). When provided it is used
+     *  verbatim — **including an empty `[]`** — instead of deriving from
+     *  `getSuggestsForCode(errorName)`. Lets hand-built failure callsites that
+     *  already hold a typed/rich `try_next` (e.g. lease validation's
+     *  `{action, args, confidence}`, or a deliberately-empty list) migrate to
+     *  this single converter without changing their envelope shape (north star
+     *  1: one failure path). Absent → derive from SUGGESTS as before. */
+    tryNext?: TryNextAction[];
   },
 ): Ok | EnvelopeMinimalShape<null> | CompatRawFailureShape {
   if (result.ok) return result.value;
@@ -1255,10 +1263,17 @@ export function toFailureEnvelope<Ok, Err extends HandlerError>(
   // `_errors.ts`) は本 dict の正しい lookup API で、unknown code には汎用
   // fallback 配列を返す。empty fallback の場合は本 helper 側で再 fallback。
   const errorName = result.error.name;
-  const tryNextStrings = getSuggestsForCode(errorName);
-  const tryNext: TryNextAction[] = tryNextStrings.length > 0
-    ? tryNextStrings.map((action) => ({ action }))
-    : [{ action: "Inspect the underlying error and retry with adjusted args" }];
+  // Caller-supplied `tryNext` wins verbatim (incl. empty []); otherwise derive
+  // from SUGGESTS, falling back to a generic hint when the dict has no entry.
+  let tryNext: TryNextAction[];
+  if (options.tryNext !== undefined) {
+    tryNext = options.tryNext;
+  } else {
+    const tryNextStrings = getSuggestsForCode(errorName);
+    tryNext = tryNextStrings.length > 0
+      ? tryNextStrings.map((action) => ({ action }))
+      : [{ action: "Inspect the underlying error and retry with adjusted args" }];
+  }
   const failure = buildFailureEnvelope(errorName, tryNext, options.envelopeOptions);
   return options.optIn ? failure : compatFailureRaw(failure);
 }
@@ -2975,15 +2990,18 @@ export function makeCommitWrapper<TArgs extends Record<string, unknown>>(
       validation = await options.leaseValidator(handlerArgs);
       if (!validation.ok) {
         const { code, tryNext } = mapLeaseValidationToTypedReason(validation.reason);
-        const failure = buildFailureEnvelope(code, tryNext, envelopeOptions);
-        // Round 1 P1 (Codex + user PR review): raw-mode failures must
-        // preserve the pre-S4 `{ok:false, reason, ...}` shape; literal
-        // `null` from `compatHoist(failure, false)` would silently drop
-        // the reason + retry signal for existing positional callers.
-        // `compatFailureRaw` flattens envelope.data:null into the
-        // legacy-compatible shape AND carries `if_unexpected` so newer
-        // clients can read the typed cause without opting into envelope.
-        const finalShape = optIn ? failure : compatFailureRaw(failure);
+        // ADR-021 P1-2: unify this hand-built failure path through the central
+        // `toFailureEnvelope` converter (north star 1: one failure path). The
+        // typed/rich `tryNext` (lease-expired's {action, args, confidence}) is
+        // passed verbatim so the envelope stays bit-equal — pinned in
+        // tests/unit/path-class-contract/to-failure-envelope-shape-snapshot.test.ts
+        // (sites 5a/5b). The `optIn ? failure : compatFailureRaw` raw-mode
+        // projection (preserving the pre-S4 `{ok:false, reason, ...}` shape for
+        // positional callers) now lives inside the converter.
+        const finalShape = toFailureEnvelope(
+          Err(new CodedHandlerError(code)),
+          { optIn, envelopeOptions, tryNext },
+        );
         return {
           content: [{ type: "text", text: JSON.stringify(finalShape) }],
         };
@@ -3055,16 +3073,16 @@ export function makeCommitWrapper<TArgs extends Record<string, unknown>>(
           toolCallId,
         });
       }
-      const failure = buildFailureEnvelope(
-        "Unknown",
-        [],
-        envelopeOptions,
+      // ADR-021 P1-2: unify through `toFailureEnvelope` (north star 1). An
+      // explicit empty `tryNext` preserves the pre-migration shape bit-equal —
+      // the handler-throw fallback emits no recovery hint today (most_likely_cause
+      // "Unknown", try_next []). Adding a generic hint is the deferred hazard-B
+      // improvement (plan §3.2.1); doing it here would change the snapshot.
+      // The same legacy-compat raw projection now lives inside the converter.
+      const finalShape = toFailureEnvelope(
+        Err(new CodedHandlerError("Unknown")),
+        { optIn, envelopeOptions, tryNext: [] },
       );
-      // Round 1 P1 (Codex + user PR review): same legacy-compat raw
-      // projection as the lease-validation failure path — preserve
-      // `{ok:false, reason:"unknown", if_unexpected:{...}}` for raw
-      // clients instead of literal `null`.
-      const finalShape = optIn ? failure : compatFailureRaw(failure);
       return {
         content: [{ type: "text", text: JSON.stringify(finalShape) }],
       };

--- a/tests/unit/path-class-contract/to-failure-envelope-shape-snapshot.test.ts
+++ b/tests/unit/path-class-contract/to-failure-envelope-shape-snapshot.test.ts
@@ -10,17 +10,18 @@
  * perform that migration, this snapshot makes every output change explicit and
  * reviewable instead of silent — the whole point of the snapshot-first order.
  *
- * The 7 sites and their current construction:
- *   1-4. memory N/K bound checks — already via `toFailureEnvelope`
- *        (`src/tools/_envelope.ts:3324/3332/3340/3348`).
- *   5a.  lease validation `expired`  — `buildFailureEnvelope` direct
- *        (`src/tools/_envelope.ts:2978`, code/tryNext from
- *        `mapLeaseValidationToTypedReason`).
- *   5b.  lease validation residual reasons (collapse to `Unknown`).
- *   6.   handler throw fallback — `buildFailureEnvelope("Unknown", [], ...)`
- *        (`src/tools/_envelope.ts:3058`).
+ * The 7 sites (cited by enclosing symbol, NOT line number — line numbers drift
+ * across PRs; the @see footer lists the symbols):
+ *   1-4. memory N/K bound checks — via `toFailureEnvelope` (the 4 Working/
+ *        Episodic/Semantic/Procedural upper-bound checks in the query wrapper).
+ *   5a.  lease validation `expired` — via `toFailureEnvelope` with a verbatim
+ *        rich `tryNext` (migrated in PR-P1-2; code/tryNext from
+ *        `mapLeaseValidationToTypedReason`, lease path in `makeCommitWrapper`).
+ *   5b.  lease validation residual reasons (collapse to `Unknown`, empty tryNext).
+ *   6.   handler throw fallback — via `toFailureEnvelope` with empty `tryNext`
+ *        (migrated in PR-P1-2; handler-throw path in `makeCommitWrapper`).
  *   7.   executor_failed — DATA-level `if_unexpected` attach, pretty-printed
- *        (`src/tools/desktop-register.ts:594-604`).
+ *        (`desktopActRawHandler` in `desktop-register.ts`; NOT yet migrated, PR-P1-3).
  *
  * ── MIGRATION HAZARDS this snapshot will surface in PR-P1-2/P1-3 ──
  * (a naive swap to the CURRENT `toFailureEnvelope` is NOT bit-equal here — the
@@ -39,6 +40,12 @@
  *       (`JSON.stringify(..., null, 2)`); converter-driven paths place it at
  *       the ENVELOPE level. Normalising this asymmetry is the explicit L6
  *       goal — the diff must be deliberate.
+ *
+ * P1-2 resolution: sites 5a/5b/6 are now migrated to `toFailureEnvelope` via the
+ * verbatim `tryNext` override — hazard C avoided (rich hint preserved bit-equal),
+ * hazard B deferred (empty tryNext preserved, zero behaviour change). This
+ * snapshot stayed green through P1-2, proving the migration was shape-preserving.
+ * Site 7 (hazard A) is NOT yet migrated — that is PR-P1-3.
  *
  * Wallclock note: `as_of.wallclock_ms` is genuinely runtime-variable
  * (production passes `asOfWallclockMs: null` → `Date.now()` at these sites),
@@ -139,7 +146,7 @@ afterEach(() => {
 // Baseline for the converter's current output. These are NOT migrated in
 // Phase 1 — PR-P2-0 keeps them bit-equal (plan §3.3.2). Construction is exactly
 // `toFailureEnvelope(Err(new CodedHandlerError(code)), { optIn, envelopeOptions:
-// { viewPoisoned:false, asOfWallclockMs:null } })` (_envelope.ts:3322-3352).
+// { viewPoisoned:false, asOfWallclockMs:null } })`.
 
 describe("PR-P1-1 sites 1-4: memory bound-check converter callsites", () => {
   const MEMORY_CODES = [
@@ -187,11 +194,11 @@ describe("PR-P1-1 sites 1-4: memory bound-check converter callsites", () => {
   }
 });
 
-// ── Sites 5a/5b: lease validation failure (buildFailureEnvelope direct) ────────
+// ── Sites 5a/5b: lease validation failure (via toFailureEnvelope, migrated P1-2) ─
 //
-// makeCommitWrapper Step 2 short-circuits BEFORE the handler runs
-// (_envelope.ts:2972-2990). `getEnvValue: () => undefined` keeps the default
-// raw mode; `include:["envelope"]` opts into the full envelope.
+// makeCommitWrapper Step 2 (lease validation) short-circuits BEFORE the handler
+// runs. `getEnvValue: () => undefined` keeps the default raw mode;
+// `include:["envelope"]` opts into the full envelope.
 
 describe("PR-P1-1 site 5a: lease validation 'expired' (RICH try_next — hazard C)", () => {
   // try_next here is the rich {action, args, confidence} entry that a naive


### PR DESCRIPTION
## 概要

ADR-021 Phase 1 **PR-P1-2**。北極星 1（one failure path）: `makeCommitWrapper` 内の 2 つの hand-built failure 構築を、中央 `toFailureEnvelope` converter 経由に統一（`buildFailureEnvelope` + 手書き `optIn ? : compatFailureRaw` を廃止）。

Plan: `desktop-touch-mcp-internal@2dc7bf7:docs/adr-021-result-migration-drift-prevention-plan.md` §3.2 (PR-P1-2) + §3.2.1 (hazards)

## 変更

1. **`toFailureEnvelope` に `tryNext?` option 追加** — 与えられたら verbatim 使用（**空 `[]` 含む**）、無ければ従来通り `getSuggestsForCode` 由来 + fallback。これが **hazard C の (a) lossless 解**: lease-expired の rich `{action, args, confidence}` が migration を bit-equal で生き残る。
2. **site 5a** (lease validation, `_envelope.ts:2977`) → `toFailureEnvelope(Err(new CodedHandlerError(code)), { optIn, envelopeOptions, tryNext })`
3. **site 6** (handler throw fallback, `:3058`) → `toFailureEnvelope(Err(new CodedHandlerError("Unknown")), { optIn, envelopeOptions, tryNext: [] })`

## bit-equal 保証

**PR-P1-1 snapshot が green のまま**（sites 5a/5b/6 の出力不変）= 純粋な構造 refactor、挙動変更ゼロ。hazard B の改善（handler-throw に generic hint を付与）は **意図的に本 PR では取らず**、deferred follow-up に分離（plan §3.2.1）。

## 検証

- snapshot + logic + commit-wrapper tests **29/29** ✓、build (tsc) clean ✓
- full suite 実行中（結果追記）
- ⚠️ pre-existing unrelated lint warning `_envelope.ts:660`（main にも存在する unused eslint-disable、本 PR 非関与・stash 検証済）

## review
production code 改修のため §3.3 Step 0 に従い Opus + Codex 両方必須。