### PR TITLE
test(desktop-register): ADR-021 P1-3 — route executor_failed through converter

### DIFF
--- a/src/errors/typed-errors.ts
+++ b/src/errors/typed-errors.ts
@@ -23,11 +23,11 @@ export class HandlerError extends Error {
  * Typed error for the `executor_failed` envelope path (PR #329 carry-over,
  * ADR-020 §11 L6 closure target).
  *
- * `name === "ExecutorFailed"` matches `SUGGESTS.ExecutorFailed` key
- * (`_errors.ts:284`). `toFailureEnvelope` resolves the SUGGESTS entry at
- * runtime to produce a `most_likely_cause` + `try_next` envelope identical
- * to the one PR #329 emitted via the hand-wired
- * `buildExecutorFailedIfUnexpected()` helper in `desktop-register.ts:560-566`.
+ * `name === "ExecutorFailed"` matches the `SUGGESTS.ExecutorFailed` key, so
+ * `toFailureEnvelope` resolves the entry at runtime to produce the
+ * `most_likely_cause` + `try_next` envelope. Used by `desktopActRawHandler`
+ * via `toFailureEnvelope(Err(new ExecutorFailedError(...)))` (ADR-021 P1-3),
+ * replacing the hand-wired helper PR #329 originally emitted.
  */
 export class ExecutorFailedError extends HandlerError {
   constructor(message: string, options?: ErrorOptions) {

--- a/src/tools/desktop-register.ts
+++ b/src/tools/desktop-register.ts
@@ -36,7 +36,7 @@ import { nativeViewFocus } from "../engine/native-engine.js";
 import type { NativeLeaseTokenSummary } from "../engine/native-types.js";
 import type { ToolResult } from "./_types.js";
 import { Err } from "../types/result.js";
-import { CodedHandlerError } from "../errors/typed-errors.js";
+import { ExecutorFailedError } from "../errors/typed-errors.js";
 import type { TouchAction } from "../engine/world-graph/guarded-touch.js";
 import {
   SnapshotIngress,
@@ -583,7 +583,7 @@ export const desktopActRawHandler = async (
   // Result-returning change (ADR-021 §2.2 deferred).
   if (!result.ok && result.reason === "executor_failed") {
     const failure = toFailureEnvelope(
-      Err(new CodedHandlerError("ExecutorFailed")),
+      Err(new ExecutorFailedError("desktop_act executor failed")),
       { optIn: false },
     );
     return {

--- a/src/tools/desktop-register.ts
+++ b/src/tools/desktop-register.ts
@@ -29,12 +29,14 @@ import {
   withEnvelopeIncludeSchema,
   genericQueryCausedByProjector,
   defaultQuerySessionId,
+  toFailureEnvelope,
   type CommitWrapperOptions,
 } from "./_envelope.js";
 import { nativeViewFocus } from "../engine/native-engine.js";
 import type { NativeLeaseTokenSummary } from "../engine/native-types.js";
 import type { ToolResult } from "./_types.js";
-import { getSuggestsForCode } from "./_errors.js";
+import { Err } from "../types/result.js";
+import { CodedHandlerError } from "../errors/typed-errors.js";
 import type { TouchAction } from "../engine/world-graph/guarded-touch.js";
 import {
   SnapshotIngress,
@@ -537,34 +539,6 @@ const desktopDiscoverRawHandler = async (input: unknown): Promise<ToolResult> =>
  *  `DESKTOP_TOUCH_STAGE5_DXGI !== "0"` (default ON; opt-out by setting
  *  to `"0"`). Failures degrade silently — observation absence is
  *  bit-equal to the pre-Stage-5 envelope. */
-/**
- * Issue #327 item G: `GuardedTouchLoop.touch` returns `{ok:false, reason:"executor_failed"}`
- * on executor exception (`guarded-touch.ts:315-319`). The handler-return path bypasses
- * the L5 wrapper's `buildFailureEnvelope` typed-injection (which only fires on lease
- * validation failure or handler throw), so the envelope ships with no `if_unexpected`
- * recovery hint. We attach it here so the LLM client gets the same recovery surface
- * documented in the tool description. The advisory ↔ runtime drift is tracked for the
- * path-class refactor epic per `project_path_class_refactor_pending` memory.
- *
- * Envelope-mode position note (Opus Round 1 P2): the attach lands at the raw payload
- * level (alongside `ok` / `reason`), so in raw mode (`compatHoist` optIn=false) it
- * hoists to envelope top-level as expected. In envelope mode (`include=["envelope"]`)
- * the field surfaces at `envelope.data.if_unexpected`, **not** at `envelope.if_unexpected`
- * where `buildFailureEnvelope`-driven paths (lease validation / handler throw / typed
- * N-upper-bound paths) place it. This asymmetry is a known scope trade-off for this
- * tactical PR; the path-class refactor epic normalises both paths through a single
- * failure envelope hook.
- */
-function buildExecutorFailedIfUnexpected(): {
-  most_likely_cause: "ExecutorFailed";
-  try_next: Array<{ action: string }>;
-} {
-  return {
-    most_likely_cause: "ExecutorFailed",
-    try_next: getSuggestsForCode("ExecutorFailed").map((action) => ({ action })),
-  };
-}
-
 export const desktopActRawHandler = async (
   input: { lease: EntityLease; action?: TouchAction; text?: string },
 ): Promise<ToolResult> => {
@@ -588,19 +562,32 @@ export const desktopActRawHandler = async (
     }
   }
 
-  // Opus Round 1 P3-1: keep the TouchResult discriminated-union narrowed inside
-  // the executor_failed branch by spreading the already-narrowed `result` into
-  // the JSON payload directly, instead of widening through Record<string, unknown>.
+  // Issue #327 item G: GuardedTouchLoop.touch returns {ok:false,
+  // reason:"executor_failed", diff:[]} on executor exception. Because the handler
+  // RETURNS this (does not throw), the L5 makeCommitWrapper treats it as a normal
+  // result and would ship no if_unexpected recovery hint. We build the hint here.
+  //
+  // ADR-021 P1-3: build it through the central toFailureEnvelope converter (north
+  // star 1: one failure path) instead of the old hand-spread + local
+  // buildExecutorFailedIfUnexpected helper. This handler always returns the RAW
+  // shape (the L5 wrapper above applies envelope/optIn), so optIn:false →
+  // compatFailureRaw → {ok:false, reason:"executor_failed", diff:[], if_unexpected}.
+  // Bit-equal to the pre-migration shape (reason via pascalToSnake("ExecutorFailed"),
+  // diff:[] from compatFailureRaw, try_next via SUGGESTS) — pinned by
+  // to-failure-envelope-shape-snapshot.test.ts site 7.
+  //
+  // Scope note: the envelope-mode data->envelope asymmetry (in include=["envelope"]
+  // mode the hint surfaces at envelope.data.if_unexpected, not envelope.if_unexpected)
+  // is NOT addressed here — normalising it requires the wrapper to treat a
+  // handler-returned ok:false as a failure, which is the Phase 5 TOOL_REGISTRY
+  // Result-returning change (ADR-021 §2.2 deferred).
   if (!result.ok && result.reason === "executor_failed") {
+    const failure = toFailureEnvelope(
+      Err(new CodedHandlerError("ExecutorFailed")),
+      { optIn: false },
+    );
     return {
-      content: [{
-        type: "text" as const,
-        text: JSON.stringify(
-          { ...result, if_unexpected: buildExecutorFailedIfUnexpected() },
-          null,
-          2,
-        ),
-      }],
+      content: [{ type: "text" as const, text: JSON.stringify(failure, null, 2) }],
     };
   }
 

--- a/tests/unit/path-class-contract/to-failure-envelope-shape-snapshot.test.ts
+++ b/tests/unit/path-class-contract/to-failure-envelope-shape-snapshot.test.ts
@@ -20,8 +20,9 @@
  *   5b.  lease validation residual reasons (collapse to `Unknown`, empty tryNext).
  *   6.   handler throw fallback — via `toFailureEnvelope` with empty `tryNext`
  *        (migrated in PR-P1-2; handler-throw path in `makeCommitWrapper`).
- *   7.   executor_failed — DATA-level `if_unexpected` attach, pretty-printed
- *        (`desktopActRawHandler` in `desktop-register.ts`; NOT yet migrated, PR-P1-3).
+ *   7.   executor_failed — via `toFailureEnvelope` raw projection (migrated in
+ *        PR-P1-3, bit-equal; `desktopActRawHandler` in `desktop-register.ts`).
+ *        `if_unexpected` still serialises at the DATA level (see hazard A).
  *
  * ── MIGRATION HAZARDS this snapshot will surface in PR-P1-2/P1-3 ──
  * (a naive swap to the CURRENT `toFailureEnvelope` is NOT bit-equal here — the
@@ -36,16 +37,21 @@
  *   (B) Sites 5b/6 `try_next` is `[]` today; `toFailureEnvelope` substitutes
  *       the generic fallback `[{action:"Inspect..."}]` when SUGGESTS is empty
  *       → `[]` becomes 1 entry (an improvement, but a deliberate change).
- *   (A) Site 7 attaches `if_unexpected` at the DATA level + pretty-prints
- *       (`JSON.stringify(..., null, 2)`); converter-driven paths place it at
- *       the ENVELOPE level. Normalising this asymmetry is the explicit L6
- *       goal — the diff must be deliberate.
+ *   (A) Site 7's `if_unexpected` serialises at the DATA level (sibling of
+ *       ok/reason/diff), so in `include=["envelope"]` mode it surfaces at
+ *       `envelope.data.if_unexpected`, not `envelope.if_unexpected` like the
+ *       wrapper-driven failure paths. P1-3 unified the *construction* through
+ *       `toFailureEnvelope` (bit-equal), but the data→envelope *placement*
+ *       requires the wrapper to treat a handler-returned `ok:false` as a
+ *       failure — that is the Phase 5 TOOL_REGISTRY Result change (§2.2
+ *       deferred), NOT done here.
  *
- * P1-2 resolution: sites 5a/5b/6 are now migrated to `toFailureEnvelope` via the
- * verbatim `tryNext` override — hazard C avoided (rich hint preserved bit-equal),
- * hazard B deferred (empty tryNext preserved, zero behaviour change). This
- * snapshot stayed green through P1-2, proving the migration was shape-preserving.
- * Site 7 (hazard A) is NOT yet migrated — that is PR-P1-3.
+ * P1-2/P1-3 resolution: all 3 hand-built sites (5a/5b/6 in P1-2, 7 in P1-3) now
+ * route their failure construction through `toFailureEnvelope` — bit-equal, so
+ * this snapshot stayed green throughout (proving each migration was shape-
+ * preserving). Hazard C avoided (rich `tryNext` passed verbatim), hazard B
+ * deferred (empty `tryNext` preserved, zero behaviour change), hazard A's
+ * envelope-mode placement deferred to Phase 5 (see above).
  *
  * Wallclock note: `as_of.wallclock_ms` is genuinely runtime-variable
  * (production passes `asOfWallclockMs: null` → `Date.now()` at these sites),

--- a/tests/unit/path-class-contract/to-failure-envelope-shape-snapshot.test.ts
+++ b/tests/unit/path-class-contract/to-failure-envelope-shape-snapshot.test.ts
@@ -59,8 +59,8 @@
  *
  * @see src/tools/_envelope.ts toFailureEnvelope / buildFailureEnvelope /
  *   compatFailureRaw / makeCommitWrapper / mapLeaseValidationToTypedReason
- * @see src/tools/desktop-register.ts desktopActRawHandler /
- *   buildExecutorFailedIfUnexpected
+ * @see src/tools/desktop-register.ts desktopActRawHandler (executor_failed via
+ *   toFailureEnvelope, ADR-021 P1-3)
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";


### PR DESCRIPTION
## 概要

ADR-021 Phase 1 **PR-P1-3**（最後の L6 site）。北極星 1（one failure path）: `desktop_act` の executor_failed hint を hand-built（`{...result, if_unexpected: buildExecutorFailedIfUnexpected()}` + local helper）から中央 `toFailureEnvelope` converter 経由に統一。

Plan: `desktop-touch-mcp-internal@2dc7bf7:docs/adr-021-result-migration-drift-prevention-plan.md` §3.2 (PR-P1-3)

## 変更

- `desktopActRawHandler` は常に **RAW shape** を返す（L5 makeCommitWrapper が envelope/optIn を適用）→ `toFailureEnvelope(Err(new CodedHandlerError("ExecutorFailed")), { optIn: false })` → compatFailureRaw → `{ok:false, reason:"executor_failed", diff:[], if_unexpected:{...}}`
- **bit-equal**: reason=`pascalToSnake("ExecutorFailed")`, diff:[]=compatFailureRaw, try_next=`getSuggestsForCode("ExecutorFailed")`（converter 内で derive）
- local `buildExecutorFailedIfUnexpected` helper + `getSuggestsForCode` import 削除（converter に統合）

## scope 修正（P1-1/P1-2 docs で過大評価していた hazard A）

envelope-mode の `if_unexpected` data→envelope 位置 normalization は **本 PR では行わない**。makeCommitWrapper が handler-returned `ok:false` を failure 扱いする（現状は handler payload を `buildEnvelope()` で `data` に入れる）必要があり、これは **Phase 5（TOOL_REGISTRY Result 化、§2.2 defer）**。P1-3 は construction を bit-equal で統一、placement asymmetry は Phase 5。snapshot header の hazard A も修正。

## 検証
- snapshot 17/17（site 7 green = bit-equal）+ desktop-register 41/41（#327 executor_failed test 含む）
- build (tsc) clean、lint clean
- full suite 実行中

## review
production code 改修 → §3.3 Step 0 で Opus + Codex 両必須。**Opus には「envelope-normalization の Phase 5 defer 判断が正しいか」を明示検証依頼**。