### PR TITLE
feat(_errors): ADR-021 P2-0 — error-model + flat-failure presenter family

### DIFF
--- a/src/errors/typed-errors.ts
+++ b/src/errors/typed-errors.ts
@@ -118,6 +118,10 @@ export class ToolFailureError extends HandlerError {
   readonly rootExtras?: Record<string, unknown>;
 
   constructor(code: string, payload?: ToolFailurePayload, options?: ErrorOptions) {
+    // `??` (not `||`) is load-bearing: an empty `displayMessage` ("") must be
+    // preserved, not coalesced to `code`, so a thrown empty message stays
+    // bit-equal with `failWith`. The presenter's `err.displayMessage ?? code`
+    // relies on the same `??` semantics.
     super(payload?.displayMessage ?? code, options);
     this.name = code;
     this.toolName = payload?.toolName;

--- a/src/errors/typed-errors.ts
+++ b/src/errors/typed-errors.ts
@@ -131,8 +131,10 @@ export class ToolFailureError extends HandlerError {
     // long-lived value (carried through `Result.err`), so holding the shared
     // reference would let any downstream mutation (sort/push while enriching or
     // logging) corrupt global suggestion state across requests. `failWith` was
-    // safe only because it serialised the array immediately; the typed model is
-    // not, so it owns an independent copy (Round 1 Codex P2). `context` /
+    // safe only because it spread the reference into a throwaway object and
+    // `JSON.stringify`d it without ever retaining a live reference; the typed
+    // model retains one, so it owns an independent copy (Round 1 Codex P2).
+    // `context` /
     // `rootExtras` are caller-owned fresh containers (same as failWith) — no
     // shared global state, so no clone needed.
     this.suggest = payload?.suggest ? [...payload.suggest] : undefined;

--- a/src/errors/typed-errors.ts
+++ b/src/errors/typed-errors.ts
@@ -60,6 +60,74 @@ export class CodedHandlerError extends HandlerError {
   }
 }
 
+/**
+ * Optional payload carried by {@link ToolFailureError} — the fields the flat
+ * `ToolFailure` presenter (`toToolFailure` in `src/tools/_errors.ts`) renders.
+ *
+ * ADR-021 Phase 2 PR-P2-0 (B′: error-model-as-SSOT + presenter family). The
+ * typed error is the single source of truth for a handler failure (≒ RFC 9457
+ * problem-detail object / Effect `Data.TaggedError` / a Rust error enum);
+ * rendering it into the flat `{ok:false, code, error, ...}` wire shape is a
+ * separate concern done by a narrow presenter, NOT by hand-built object
+ * literals (Phase 4 ESLint `no-tool-failure-shape-direct-construct` enforces
+ * this). This is why the envelope family converter (`toFailureEnvelope`) stays
+ * untouched: the two shapes are different render targets of one error model.
+ *
+ * Field → rendered output (`toToolFailure`, bit-equal with today's `failWith`):
+ *   - `toolName` + `displayMessage` → `error: "${toolName} failed: ${displayMessage}"`
+ *   - `suggest`    → `suggest` (omitted when empty — matches `failWith`)
+ *   - `context`    → nested `context` (the non-hoisted half of `failWith`'s context arg)
+ *   - `rootExtras` → spread onto the failure root (the ROOT_HOISTED_KEYS half:
+ *     `_perceptionForPost` / `_richForPost` / `hints`, read by `_post.ts`)
+ *
+ * The plan §3.3.2 listed the suggest field as `suggestOverride`; under B′ the
+ * model carries an already-resolved `suggest` array — the `errorFromMessage`
+ * factory fills it from `classify(message)`, and an explicit caller may override
+ * by constructing with a different `suggest`. Either way the presenter only
+ * renders; it never re-classifies.
+ */
+export interface ToolFailurePayload {
+  toolName?: string;
+  displayMessage?: string;
+  suggest?: string[];
+  context?: Record<string, unknown>;
+  rootExtras?: Record<string, unknown>;
+}
+
+/**
+ * Canonical typed model for a handler failure that renders to the flat
+ * `ToolFailure` shape — the `failWith` family (175 callsites, migrated to
+ * `Result.err` + presenter across PR-P2-2 … P2-4, OQ-1(a) full removal).
+ *
+ * `name === code` (same convention as {@link CodedHandlerError}) so the SUGGESTS
+ * dict / envelope family can resolve it too if ever rendered that way — both
+ * failure families consume `HandlerError` descendants, keeping a single typed
+ * boundary. Constructed via the `errorFromMessage(message, toolName, context)`
+ * factory (`src/tools/_errors.ts`, OQ-7(c)), which centralises `classify`
+ * so this class stays thin (no message dispatch in the constructor).
+ *
+ * Extra payload fields are assigned in the constructor BODY (after `super`),
+ * the same defensive ordering the module header documents for `name` under
+ * ES2022 class-field semantics.
+ */
+export class ToolFailureError extends HandlerError {
+  readonly toolName?: string;
+  readonly displayMessage?: string;
+  readonly suggest?: string[];
+  readonly context?: Record<string, unknown>;
+  readonly rootExtras?: Record<string, unknown>;
+
+  constructor(code: string, payload?: ToolFailurePayload, options?: ErrorOptions) {
+    super(payload?.displayMessage ?? code, options);
+    this.name = code;
+    this.toolName = payload?.toolName;
+    this.displayMessage = payload?.displayMessage;
+    this.suggest = payload?.suggest;
+    this.context = payload?.context;
+    this.rootExtras = payload?.rootExtras;
+  }
+}
+
 // Future expansion (sub-plan §9 OQ-SR2-2): ModalBlockingError, LeaseExpiredError,
 // etc., each with a `name` matching a SUGGESTS key. Hierarchy stays shallow —
 // SUGGESTS lookup is the SSOT, not a type-system inheritance tree.

--- a/src/errors/typed-errors.ts
+++ b/src/errors/typed-errors.ts
@@ -126,7 +126,16 @@ export class ToolFailureError extends HandlerError {
     this.name = code;
     this.toolName = payload?.toolName;
     this.displayMessage = payload?.displayMessage;
-    this.suggest = payload?.suggest;
+    // Clone `suggest`: `errorFromMessage` forwards the array straight from the
+    // shared `SUGGESTS` dictionary (`classify`'s return). The model is a
+    // long-lived value (carried through `Result.err`), so holding the shared
+    // reference would let any downstream mutation (sort/push while enriching or
+    // logging) corrupt global suggestion state across requests. `failWith` was
+    // safe only because it serialised the array immediately; the typed model is
+    // not, so it owns an independent copy (Round 1 Codex P2). `context` /
+    // `rootExtras` are caller-owned fresh containers (same as failWith) — no
+    // shared global state, so no clone needed.
+    this.suggest = payload?.suggest ? [...payload.suggest] : undefined;
     this.context = payload?.context;
     this.rootExtras = payload?.rootExtras;
   }

--- a/src/tools/_errors.ts
+++ b/src/tools/_errors.ts
@@ -679,8 +679,15 @@ function classify(message: string): { code: string; suggest: string[] } {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * `errorFromMessage` — factory that turns a raw failure `message` into the
- * canonical {@link ToolFailureError} model (ADR-021 Phase 2 PR-P2-0, OQ-7(c)).
+ * `errorFromMessage` — factory that turns a thrown value into the canonical
+ * {@link ToolFailureError} model (ADR-021 Phase 2 PR-P2-0, OQ-7(c)).
+ *
+ * The first arg is `unknown` (a true superset of `failWith`'s first arg) and is
+ * normalized to a message string with the SAME rule `failWith` uses today —
+ * production callsites throw / pass non-Error values (bare strings, `??`-
+ * coalesced strings, raw caught values), so the factory, not the callsite, owns
+ * that normalization. This is what lets the PR-P2-2 flip stay bit-equal for any
+ * input (pinned by the equivalence test's non-Error cases).
  *
  * This is the ONE place that runs `classify(message)` for the flat-failure
  * family, and the ONE place that splits a caller's `context` into the two
@@ -698,10 +705,11 @@ function classify(message: string): { code: string; suggest: string[] } {
  * flip, mirroring the snapshot-first discipline that de-risked Phase 1.
  */
 export function errorFromMessage(
-  message: string,
+  err: unknown,
   toolName: string,
   context?: Record<string, unknown>,
 ): ToolFailureError {
+  const message = err instanceof Error ? err.message : String(err);
   const { code, suggest } = classify(message);
 
   // Same split `failWith` performs today: hoisted keys go to the failure root

--- a/src/tools/_errors.ts
+++ b/src/tools/_errors.ts
@@ -1,4 +1,5 @@
 import { fail, type ToolFailure, type ToolResult } from "./_types.js";
+import { ToolFailureError } from "../errors/typed-errors.js";
 
 // Context keys that must be hoisted to the root of the failure JSON so that
 // _post.ts (withPostState) can find them. `_post.ts` reads obj._perceptionForPost /
@@ -676,6 +677,92 @@ function classify(message: string): { code: string; suggest: string[] } {
 // ─────────────────────────────────────────────────────────────────────────────
 // Public API
 // ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * `errorFromMessage` — factory that turns a raw failure `message` into the
+ * canonical {@link ToolFailureError} model (ADR-021 Phase 2 PR-P2-0, OQ-7(c)).
+ *
+ * This is the ONE place that runs `classify(message)` for the flat-failure
+ * family, and the ONE place that splits a caller's `context` into the two
+ * halves the flat shape needs:
+ *   - root-hoisted keys (`_perceptionForPost` / `_richForPost` / `hints`) →
+ *     `rootExtras`, spread onto the failure root so `_post.ts` can find them;
+ *   - everything else → nested `context` (the LLM-facing detail).
+ *
+ * The returned error is a pure value; rendering it to the flat wire shape is
+ * `toToolFailure`'s job (separation of concerns — the model is the SSOT, the
+ * presenter is replaceable). `failWith` becomes a thin wrapper over
+ * `fail(toToolFailure(errorFromMessage(...)))` in PR-P2-2 — kept untouched here
+ * so PR-P2-0 only ADDS the model + factory + presenter and proves bit-equality
+ * (tests/unit/path-class-contract/to-tool-failure-payload.test.ts) before the
+ * flip, mirroring the snapshot-first discipline that de-risked Phase 1.
+ */
+export function errorFromMessage(
+  message: string,
+  toolName: string,
+  context?: Record<string, unknown>,
+): ToolFailureError {
+  const { code, suggest } = classify(message);
+
+  // Same split `failWith` performs today: hoisted keys go to the failure root
+  // (so `_post.ts` can attach post-perception), the rest stays nested under
+  // `context`. Both halves preserve `Object.entries(context)` iteration order
+  // so the rendered JSON is byte-for-byte identical to `failWith`'s.
+  let rootExtras: Record<string, unknown> | undefined;
+  let nestedContext: Record<string, unknown> | undefined;
+  if (context) {
+    for (const [k, v] of Object.entries(context)) {
+      if (ROOT_HOISTED_KEYS.has(k)) {
+        (rootExtras ??= {})[k] = v;
+      } else {
+        (nestedContext ??= {})[k] = v;
+      }
+    }
+  }
+
+  return new ToolFailureError(code, {
+    toolName,
+    displayMessage: message,
+    suggest,
+    context: nestedContext,
+    rootExtras,
+  });
+}
+
+/**
+ * `toToolFailure` — presenter that renders a {@link ToolFailureError} into the
+ * flat `ToolFailure` wire shape (ADR-021 Phase 2 PR-P2-0, B′ presenter family).
+ *
+ * Sibling of `toFailureEnvelope` (the envelope-family presenter in
+ * `_envelope.ts`): both consume a typed error, neither re-classifies, and each
+ * has a single narrow return type — one error model, two render targets. The
+ * key order / omission rules match today's `failWith` output byte-for-byte so
+ * PR-P2-2 can route `failWith` through this presenter with zero shape change
+ * (codemod fixtures + the equivalence test pin it):
+ *
+ *   { ok:false, code, error, [suggest], [context], ...rootExtras }
+ *
+ * `error` is total over the payload: with both `toolName` and `displayMessage`
+ * it is `"${toolName} failed: ${displayMessage}"` (the canonical failWith
+ * string); the partial-payload fallbacks are pinned in the matrix test. An
+ * empty `displayMessage` (`""`) is preserved (not coalesced to `code`) so an
+ * empty thrown message stays bit-equal with `failWith`.
+ */
+export function toToolFailure(err: ToolFailureError): ToolFailure & Record<string, unknown> {
+  const code = err.name;
+  const displayMessage = err.displayMessage ?? code;
+  const error =
+    err.toolName !== undefined ? `${err.toolName} failed: ${displayMessage}` : displayMessage;
+
+  return {
+    ok: false,
+    code,
+    error,
+    ...(err.suggest && err.suggest.length > 0 && { suggest: err.suggest }),
+    ...(err.context && { context: err.context }),
+    ...(err.rootExtras ?? {}),
+  };
+}
 
 /**
  * Normalize any thrown value into a structured ToolFailure and return it

--- a/tests/unit/path-class-contract/to-tool-failure-payload.test.ts
+++ b/tests/unit/path-class-contract/to-tool-failure-payload.test.ts
@@ -1,0 +1,269 @@
+/**
+ * tests/unit/path-class-contract/to-tool-failure-payload.test.ts
+ * — ADR-021 Phase 2 PR-P2-0 (Plan: desktop-touch-mcp-internal §3.3.2 PR-P2-0).
+ *
+ * Establishes the flat-failure PRESENTER FAMILY (design B′):
+ *
+ *   errorFromMessage(message, toolName, context) → ToolFailureError   (model / SSOT)
+ *   toToolFailure(err)                           → ToolFailure        (flat presenter)
+ *
+ * `toFailureEnvelope` (the envelope-family presenter) is intentionally NOT
+ * touched — the two failure shapes are different render targets of one error
+ * model, so each presenter keeps a single narrow return type (one error model,
+ * two presenters; cf. RFC 9457 problem-detail object + Effect Data.TaggedError +
+ * Rust error-enum-vs-Display). PR-P2-2 routes `failWith` through this presenter;
+ * `failWith` itself is unchanged in PR-P2-0.
+ *
+ * Three layers of pinning:
+ *   1. MATRIX — the presenter's flat shape over the 4 payload axes
+ *      (toolName / displayMessage / context / rootExtras presence) + suggest
+ *      presence + key-order, with FROZEN literals built from explicit
+ *      ToolFailureError construction (decoupled from classify()/SUGGESTS, so a
+ *      dictionary edit cannot silently move both sides — PR #373 Codex P2).
+ *   2. FACTORY — errorFromMessage's classify() code + context split
+ *      (root-hoisted keys → rootExtras, rest → nested context).
+ *   3. EQUIVALENCE (safety net for the PR-P2-2 flip) — the new path
+ *      `fail(toToolFailure(errorFromMessage(m,t,c)))` is byte-for-byte identical
+ *      to today's `failWith(new Error(m), t, c)`. This assertion is deliberately
+ *      COUPLED to the two production paths (it proves they agree); it is the
+ *      opposite role from the frozen-literal matrix above.
+ *
+ * @see src/errors/typed-errors.ts ToolFailureError / ToolFailurePayload
+ * @see src/tools/_errors.ts errorFromMessage / toToolFailure / failWith / classify
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  errorFromMessage,
+  toToolFailure,
+  failWith,
+} from "../../../src/tools/_errors.js";
+import { ToolFailureError } from "../../../src/errors/typed-errors.js";
+
+/** Parse the JSON text block a tool/wrapper returns. */
+function parseContent(content: ReadonlyArray<{ type: string; text?: string }>): unknown {
+  const block = content[0];
+  if (!block || block.type !== "text" || typeof block.text !== "string") {
+    throw new Error("expected a text content block");
+  }
+  return JSON.parse(block.text);
+}
+
+// ── Layer 1: presenter shape matrix (frozen literals) ─────────────────────────
+//
+// `code` is fixed to a neutral "ToolError" and `suggest` is an explicit literal
+// so nothing here depends on classify()/SUGGESTS — the matrix pins ONLY the
+// presenter's field-presence + key-order behaviour.
+
+describe("PR-P2-0 layer 1: toToolFailure shape matrix (4 payload axes)", () => {
+  it("1. code only (no toolName / displayMessage) → error falls back to code", () => {
+    expect(toToolFailure(new ToolFailureError("ToolError"))).toEqual({
+      ok: false,
+      code: "ToolError",
+      error: "ToolError",
+    });
+  });
+
+  it("2. toolName only → 'tool failed: <code>' (displayMessage falls back to code)", () => {
+    expect(toToolFailure(new ToolFailureError("ToolError", { toolName: "keyboard" }))).toEqual({
+      ok: false,
+      code: "ToolError",
+      error: "keyboard failed: ToolError",
+    });
+  });
+
+  it("3. displayMessage only → bare message (no toolName prefix)", () => {
+    expect(toToolFailure(new ToolFailureError("ToolError", { displayMessage: "boom" }))).toEqual({
+      ok: false,
+      code: "ToolError",
+      error: "boom",
+    });
+  });
+
+  it("4. toolName + displayMessage → canonical 'tool failed: message' string", () => {
+    expect(
+      toToolFailure(new ToolFailureError("ToolError", { toolName: "keyboard", displayMessage: "boom" })),
+    ).toEqual({
+      ok: false,
+      code: "ToolError",
+      error: "keyboard failed: boom",
+    });
+  });
+
+  it("5. + non-empty suggest → suggest present", () => {
+    expect(
+      toToolFailure(
+        new ToolFailureError("ToolError", {
+          toolName: "keyboard",
+          displayMessage: "boom",
+          suggest: ["try A", "try B"],
+        }),
+      ),
+    ).toEqual({
+      ok: false,
+      code: "ToolError",
+      error: "keyboard failed: boom",
+      suggest: ["try A", "try B"],
+    });
+  });
+
+  it("6. + empty suggest → suggest OMITTED (matches failWith's `length > 0` guard)", () => {
+    expect(
+      toToolFailure(
+        new ToolFailureError("ToolError", { toolName: "keyboard", displayMessage: "boom", suggest: [] }),
+      ),
+    ).toEqual({
+      ok: false,
+      code: "ToolError",
+      error: "keyboard failed: boom",
+    });
+  });
+
+  it("7. + nested context → context present", () => {
+    expect(
+      toToolFailure(
+        new ToolFailureError("ToolError", {
+          toolName: "keyboard",
+          displayMessage: "boom",
+          context: { selector: "#x", attempt: 2 },
+        }),
+      ),
+    ).toEqual({
+      ok: false,
+      code: "ToolError",
+      error: "keyboard failed: boom",
+      context: { selector: "#x", attempt: 2 },
+    });
+  });
+
+  it("8. full payload → rootExtras spread at root + key order pinned", () => {
+    const full = new ToolFailureError("ToolError", {
+      toolName: "keyboard",
+      displayMessage: "boom",
+      suggest: ["s1"],
+      context: { k: "v" },
+      rootExtras: { hints: { h: 1 } },
+    });
+    expect(toToolFailure(full)).toEqual({
+      ok: false,
+      code: "ToolError",
+      error: "keyboard failed: boom",
+      suggest: ["s1"],
+      context: { k: "v" },
+      hints: { h: 1 },
+    });
+    // Key ORDER is wire-significant (JSON.stringify is order-sensitive) — pin it
+    // explicitly because toEqual ignores key order.
+    expect(JSON.stringify(toToolFailure(full))).toBe(
+      '{"ok":false,"code":"ToolError","error":"keyboard failed: boom","suggest":["s1"],"context":{"k":"v"},"hints":{"h":1}}',
+    );
+  });
+
+  it("preserves an empty displayMessage ('') instead of coalescing to code", () => {
+    expect(
+      toToolFailure(new ToolFailureError("ToolError", { toolName: "scroll", displayMessage: "" })),
+    ).toEqual({
+      ok: false,
+      code: "ToolError",
+      error: "scroll failed: ",
+    });
+  });
+});
+
+// ── Layer 2: errorFromMessage factory (classify + context split) ──────────────
+
+describe("PR-P2-0 layer 2: errorFromMessage factory", () => {
+  it("classifies the message into the typed code (name)", () => {
+    const err = errorFromMessage("window not found", "focus_window");
+    expect(err).toBeInstanceOf(ToolFailureError);
+    expect(err.name).toBe("WindowNotFound");
+    expect(err.displayMessage).toBe("window not found");
+    expect(err.toolName).toBe("focus_window");
+    expect(err.suggest).toBeInstanceOf(Array);
+    expect(err.suggest!.length).toBeGreaterThan(0); // WindowNotFound has SUGGESTS entries
+  });
+
+  it("falls back to ToolError + empty suggest for an unclassifiable message", () => {
+    const err = errorFromMessage("unexpected internal state xyzzy", "keyboard");
+    expect(err.name).toBe("ToolError");
+    expect(err.suggest).toEqual([]);
+  });
+
+  it("splits context: ROOT_HOISTED_KEYS → rootExtras, rest → nested context", () => {
+    const err = errorFromMessage("element not found", "click_element", {
+      _richForPost: { a: 1 },
+      _perceptionForPost: { p: 1 },
+      hints: { verifyDelivery: true },
+      selector: "#x",
+      attempt: 2,
+    });
+    expect(err.rootExtras).toEqual({
+      _richForPost: { a: 1 },
+      _perceptionForPost: { p: 1 },
+      hints: { verifyDelivery: true },
+    });
+    expect(err.context).toEqual({ selector: "#x", attempt: 2 });
+  });
+
+  it("leaves rootExtras / context undefined when no such keys are present", () => {
+    const err = errorFromMessage("boom", "keyboard", { onlyNested: 1 });
+    expect(err.rootExtras).toBeUndefined();
+    expect(err.context).toEqual({ onlyNested: 1 });
+
+    const err2 = errorFromMessage("boom", "keyboard");
+    expect(err2.rootExtras).toBeUndefined();
+    expect(err2.context).toBeUndefined();
+  });
+});
+
+// ── Layer 3: failWith equivalence (safety net for the PR-P2-2 flip) ───────────
+//
+// Proves `fail(toToolFailure(errorFromMessage(m,t,c)))` is byte-for-byte equal
+// to today's `failWith(new Error(m), t, c)`. Coupled to both production paths on
+// purpose — this is the invariant PR-P2-2 must preserve when it rewrites
+// failWith as a thin wrapper.
+
+describe("PR-P2-0 layer 3: failWith ⇔ toToolFailure∘errorFromMessage equivalence", () => {
+  const CASES: Array<{ name: string; message: string; tool: string; context?: Record<string, unknown> }> = [
+    { name: "classified code, no context", message: "window not found", tool: "focus_window" },
+    {
+      name: "classified code, nested context only",
+      message: "element not found",
+      tool: "click_element",
+      context: { selector: "#x", attempt: 2 },
+    },
+    {
+      name: "unclassifiable (ToolError + empty suggest), root-hoisted + nested mix",
+      message: "unexpected internal state xyzzy",
+      tool: "keyboard",
+      context: { _richForPost: { a: 1 }, detail: "d" },
+    },
+    {
+      name: "classified code with suggest, all three root-hoisted keys + nested",
+      message: "guard failed: zone",
+      tool: "mouse_click",
+      context: {
+        hints: { verifyDelivery: true },
+        _perceptionForPost: { p: 1 },
+        _richForPost: { r: 1 },
+        note: "n",
+      },
+    },
+    { name: "empty thrown message", message: "", tool: "scroll" },
+  ];
+
+  for (const c of CASES) {
+    it(`${c.name}`, () => {
+      const legacy = failWith(new Error(c.message), c.tool, c.context);
+      const viaModel = toToolFailure(errorFromMessage(c.message, c.tool, c.context));
+
+      // Structural equality.
+      expect(viaModel).toEqual(parseContent(legacy.content));
+
+      // Byte-for-byte JSON equality (key order + omission) — `failWith` wraps via
+      // `fail()` which is `JSON.stringify(failure)`, so compare the same way.
+      const legacyText = (legacy.content[0] as { text: string }).text;
+      expect(JSON.stringify(viaModel)).toBe(legacyText);
+    });
+  }
+});

--- a/tests/unit/path-class-contract/to-tool-failure-payload.test.ts
+++ b/tests/unit/path-class-contract/to-tool-failure-payload.test.ts
@@ -55,7 +55,7 @@ function parseContent(content: ReadonlyArray<{ type: string; text?: string }>): 
 // so nothing here depends on classify()/SUGGESTS — the matrix pins ONLY the
 // presenter's field-presence + key-order behaviour.
 
-describe("PR-P2-0 layer 1: toToolFailure shape matrix (4 payload axes)", () => {
+describe("PR-P2-0 layer 1: toToolFailure shape matrix (8 combos over 4 payload axes + edge pins)", () => {
   it("1. code only (no toolName / displayMessage) → error falls back to code", () => {
     expect(toToolFailure(new ToolFailureError("ToolError"))).toEqual({
       ok: false,
@@ -174,13 +174,22 @@ describe("PR-P2-0 layer 1: toToolFailure shape matrix (4 payload axes)", () => {
 
 describe("PR-P2-0 layer 2: errorFromMessage factory", () => {
   it("classifies the message into the typed code (name)", () => {
-    const err = errorFromMessage("window not found", "focus_window");
+    const err = errorFromMessage(new Error("window not found"), "focus_window");
     expect(err).toBeInstanceOf(ToolFailureError);
     expect(err.name).toBe("WindowNotFound");
     expect(err.displayMessage).toBe("window not found");
     expect(err.toolName).toBe("focus_window");
     expect(err.suggest).toBeInstanceOf(Array);
     expect(err.suggest!.length).toBeGreaterThan(0); // WindowNotFound has SUGGESTS entries
+  });
+
+  it("normalizes the thrown value exactly as failWith (Error.message vs String(err))", () => {
+    expect(errorFromMessage(new Error("boom"), "keyboard").displayMessage).toBe("boom");
+    expect(errorFromMessage("bare string", "keyboard").displayMessage).toBe("bare string");
+    expect(errorFromMessage({ weird: true }, "desktop_act").displayMessage).toBe("[object Object]");
+    expect(errorFromMessage(undefined, "keyboard").displayMessage).toBe("undefined");
+    expect(errorFromMessage(null, "keyboard").displayMessage).toBe("null");
+    expect(errorFromMessage(42, "scroll").displayMessage).toBe("42");
   });
 
   it("falls back to ToolError + empty suggest for an unclassifiable message", () => {
@@ -224,23 +233,30 @@ describe("PR-P2-0 layer 2: errorFromMessage factory", () => {
 // failWith as a thin wrapper.
 
 describe("PR-P2-0 layer 3: failWith ⇔ toToolFailure∘errorFromMessage equivalence", () => {
-  const CASES: Array<{ name: string; message: string; tool: string; context?: Record<string, unknown> }> = [
-    { name: "classified code, no context", message: "window not found", tool: "focus_window" },
+  // The SAME raw thrown value feeds both paths. This is what pins P1-1: the
+  // factory must normalize non-Error inputs (bare strings / objects / undefined /
+  // null / numbers) exactly as failWith's `instanceof Error ? .message :
+  // String(err)` does — not just `new Error(...)`. Production callsites pass all
+  // of these (e.g. failWith("Element not found", ...),
+  // failWith(focusResult.error ?? "...", ...), failWith(caughtUnknown, ...)).
+  const CASES: Array<{ name: string; thrown: unknown; tool: string; context?: Record<string, unknown> }> = [
+    { name: "Error instance, no context", thrown: new Error("window not found"), tool: "focus_window" },
+    { name: "bare string (non-Error) — common failWith callsite shape", thrown: "Element not found", tool: "browser_form" },
     {
-      name: "classified code, nested context only",
-      message: "element not found",
+      name: "Error instance, nested context only",
+      thrown: new Error("element not found"),
       tool: "click_element",
       context: { selector: "#x", attempt: 2 },
     },
     {
       name: "unclassifiable (ToolError + empty suggest), root-hoisted + nested mix",
-      message: "unexpected internal state xyzzy",
+      thrown: new Error("unexpected internal state xyzzy"),
       tool: "keyboard",
       context: { _richForPost: { a: 1 }, detail: "d" },
     },
     {
       name: "classified code with suggest, all three root-hoisted keys + nested",
-      message: "guard failed: zone",
+      thrown: new Error("guard failed: zone"),
       tool: "mouse_click",
       context: {
         hints: { verifyDelivery: true },
@@ -249,13 +265,17 @@ describe("PR-P2-0 layer 3: failWith ⇔ toToolFailure∘errorFromMessage equival
         note: "n",
       },
     },
-    { name: "empty thrown message", message: "", tool: "scroll" },
+    { name: "empty thrown message", thrown: new Error(""), tool: "scroll" },
+    { name: "non-Error object value (String() coercion)", thrown: { weird: true }, tool: "desktop_act" },
+    { name: "undefined caught value", thrown: undefined, tool: "keyboard" },
+    { name: "null caught value", thrown: null, tool: "keyboard" },
+    { name: "numeric caught value", thrown: 42, tool: "scroll" },
   ];
 
   for (const c of CASES) {
     it(`${c.name}`, () => {
-      const legacy = failWith(new Error(c.message), c.tool, c.context);
-      const viaModel = toToolFailure(errorFromMessage(c.message, c.tool, c.context));
+      const legacy = failWith(c.thrown, c.tool, c.context);
+      const viaModel = toToolFailure(errorFromMessage(c.thrown, c.tool, c.context));
 
       // Structural equality.
       expect(viaModel).toEqual(parseContent(legacy.content));

--- a/tests/unit/path-class-contract/to-tool-failure-payload.test.ts
+++ b/tests/unit/path-class-contract/to-tool-failure-payload.test.ts
@@ -37,6 +37,7 @@ import {
   errorFromMessage,
   toToolFailure,
   failWith,
+  getSuggestsForCode,
 } from "../../../src/tools/_errors.js";
 import { ToolFailureError } from "../../../src/errors/typed-errors.js";
 
@@ -212,6 +213,18 @@ describe("PR-P2-0 layer 2: errorFromMessage factory", () => {
       hints: { verifyDelivery: true },
     });
     expect(err.context).toEqual({ selector: "#x", attempt: 2 });
+  });
+
+  it("does not alias the shared SUGGESTS dictionary — mutating model.suggest is isolated (Codex P2)", () => {
+    const before = [...getSuggestsForCode("WindowNotFound")];
+    expect(before.length).toBeGreaterThan(0);
+
+    const err = errorFromMessage(new Error("window not found"), "focus_window");
+    (err.suggest as string[]).push("MUTATED"); // would corrupt the global dict without the clone
+
+    expect(getSuggestsForCode("WindowNotFound")).toEqual(before); // dict untouched
+    const err2 = errorFromMessage(new Error("window not found"), "focus_window");
+    expect(err2.suggest).toEqual(before); // a later failure for the same code is unaffected
   });
 
   it("leaves rootExtras / context undefined when no such keys are present", () => {


### PR DESCRIPTION
## What

ADR-021 **Phase 2 PR-P2-0** — the prerequisite for migrating `failWith` (175 callsites) to a converter-based failure path. Establishes design **B′: error-model-as-SSOT + presenter family**.

- **`src/errors/typed-errors.ts`** — `ToolFailureError` model (+ `ToolFailurePayload`) carrying optional `toolName` / `displayMessage` / `suggest` / `context` / `rootExtras`; `name === code` (same convention as `CodedHandlerError`).
- **`src/tools/_errors.ts`** —
  - `errorFromMessage(message, toolName, context): ToolFailureError` factory (**OQ-7(c)**): the one place that runs `classify(message)` and splits `context` into the `ROOT_HOISTED_KEYS` half (`_perceptionForPost` / `_richForPost` / `hints` → `rootExtras`) vs the nested half.
  - `toToolFailure(err): ToolFailure` presenter: renders the flat `{ ok:false, code, error, [suggest], [context], ...rootExtras }` shape, **byte-for-byte equal to today's `failWith`**.
- **`failWith` and `toFailureEnvelope` are both untouched** in this PR. The new functions are dormant scaffolding; the P2-2 flip is pre-validated by a `failWith`-equivalence safety net.

## Why B′ (not the plan-literal "extend `toFailureEnvelope`")

The flat `ToolFailure` shape (`code`/`error`/`suggest`, what 175 `failWith` callsites emit) and the envelope/compat-raw shapes (`if_unexpected`/`_version`, what `toFailureEnvelope` emits) are **structurally disjoint, permanent output families** serving disjoint consumers (§2.2 keeps the `ToolFailure` shape 100% backward-compatible). Extending one converter to emit both would give it a **4-way union return switched by an option flag** — the boolean-return-type anti-pattern, itself a "繋ぐと破綻" surface.

Cross-ecosystem research converged on the same principle: the error is **one pure typed value (the SSOT)** and rendering it to a wire shape is a **separate, narrow, per-format concern** — RFC 9457 problem-detail object, Effect `Data.TaggedError`, neverthrow `mapErr`/`match` at boundaries, Rust error-enum vs `Display`/`Serialize`. So: one model, two narrow presenters. This makes the typed boundary **stronger** than a polymorphic converter (technical north star: write drift out at the type level), and leaves the envelope-family snapshot trivially bit-equal because that path is not touched. Same scope; downstream PR structure (P2-2 flip, P2-3 codemod) unchanged.

## MCP protocol

Protocol-neutral. All tool failures serialize to a text content block (`{content:[{type:"text",text:"<json>"}]}`); MCP never inspects the JSON internals. B′ changes only **construction**, not the resulting JSON (bit-equal) nor the wrapping. Bonus: centralising failure construction makes a future `isError` / `structuredContent` adoption a one-place change.

## Tests

`tests/unit/path-class-contract/to-tool-failure-payload.test.ts` (18 cases, all green):
1. **Matrix** — presenter flat shape over the 4 payload axes + suggest presence + key-order, frozen literals **decoupled from `classify()`/SUGGESTS** (PR #373 Codex P2 discipline).
2. **Factory** — `errorFromMessage` code classification + context split.
3. **Equivalence (safety net)** — `fail(toToolFailure(errorFromMessage(m,t,c)))` is **byte-for-byte equal** to `failWith(new Error(m), t, c)` across representative inputs (incl. root-hoisted keys + empty message). This is the invariant P2-2 must preserve.

`npm run build` clean.

## Test suite

`3 failed | 3783 passed | 32 skipped` — the **3 failures are pre-existing & environmental, unrelated to this diff**:
- `tests/unit/benchmark-gates.test.ts > Gate 2 — idle cost` (timing measurement, flaky under parallel load)
- `tests/e2e/keyboard-bg-verification.test.ts` (e2e, needs real conhost)
- `tests/e2e/mouse-verify-delivery.test.ts` (e2e, needs real mouse / failsafe-collateral)

The new functions are dormant (not wired into any runtime path) and touch none of keyboard/mouse/benchmark/visual code. The bit-equal envelope-family safety net (`to-failure-envelope-shape-snapshot.test.ts`) **passes**, confirming the envelope path is intact.

## Plan

`desktop-touch-mcp-internal@4ae0c26:docs/adr-021-result-migration-drift-prevention-plan.md` §3.3.2 PR-P2-0 — [permalink](https://github.com/Harusame64/desktop-touch-mcp-internal/blob/4ae0c262377fb0d6f36bf584be919ad36800a793/docs/adr-021-result-migration-drift-prevention-plan.md) (private repo; logged-in reviewers only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)