### PR TITLE
refactor(tools): ADR-021 P2-3a — un-deprecate failWith (canonical) + sweep (C) hand-built failure literals via failCode

### DIFF
--- a/src/errors/typed-errors.ts
+++ b/src/errors/typed-errors.ts
@@ -96,11 +96,14 @@ export interface ToolFailurePayload {
 
 /**
  * Canonical typed model for a handler failure that renders to the flat
- * `ToolFailure` shape — the `failWith` family (171 migratable callsites under
- * `src/tools/**`; 176 grep hits minus the 5 self-references in `_errors.ts`,
- * machine-counted by scripts/extract-failwith-shape-fixtures.mjs). PR-P2-2 made
- * `failWith` a thin wrapper over this model; PR-P2-3 migrates the callsites and
- * PR-P2-4 removes the wrapper (OQ-1(a) full removal).
+ * `ToolFailure` shape. PR-P2-2 made `failWith` a thin wrapper over this model
+ * (`failWith = fail(toToolFailure(errorFromMessage(...)))`), so `failWith` is the
+ * canonical single window for flat failures and this class is its SSOT error
+ * value. ADR-021 OQ-1 RE-DECISION (Round 6): `failWith` is KEPT (not deleted) —
+ * once the wrapper unified the path, removing it would only churn the ~171
+ * already-sanctioned callsites. PR-P2-3 instead routes the remaining hand-built
+ * `{ ok:false, ... }` literals through `failWith`, and Phase 4 ESLint bans new
+ * ones (`no-tool-failure-shape-direct-construct`).
  *
  * `name === code` (same convention as {@link CodedHandlerError}) so the SUGGESTS
  * dict / envelope family can resolve it too if ever rendered that way — both

--- a/src/tools/_envelope.ts
+++ b/src/tools/_envelope.ts
@@ -1235,9 +1235,9 @@ export function buildFailureEnvelope(
  *
  * 注意: handler 内部 throw 経路は `toResultErr(e)` で `Result.err(HandlerError)`
  * に変換してから本 helper に渡す (handler 最外周共通 pattern、PR-SR2-2/-3 で
- * 29 handler に展開予定)。`failWith` 経路 (171 migratable callsite) は本 SR-2
- * scope 外、ADR-021 Phase 2 で migrate (canonical count は
- * `errors/typed-errors.ts` ToolFailureError doc 参照)。
+ * 29 handler に展開予定)。`failWith` 経路 (flat `ToolFailure` shape) は本 SR-2
+ * scope 外、ADR-021 Phase 2 で B′ presenter family の thin wrapper 化 + canonical
+ * 化 (OQ-1 RE-DECISION で keep、`errors/typed-errors.ts` ToolFailureError doc 参照)。
  */
 export function toFailureEnvelope<Ok, Err extends HandlerError>(
   result: Result<Ok, Err>,

--- a/src/tools/_errors.ts
+++ b/src/tools/_errors.ts
@@ -803,6 +803,44 @@ export function failWith(
 }
 
 /**
+ * `failCode` — flat failure for handlers that already KNOW the typed `code`
+ * (no message classification needed). The explicit-code sibling of `failWith`
+ * (code derived via `classify`) and `failArgs` (fixed `InvalidArgs`).
+ *
+ * Routes through the B′ presenter (`toToolFailure(new ToolFailureError(...))`) so
+ * the wire shape stays bit-equal with a hand-built literal — use this instead of
+ * `fail({ ok:false, code, ... })` (ADR-021 PR-P2-3; Phase 4 ESLint
+ * `no-tool-failure-shape-direct-construct` bans the literal). Emitted shape:
+ *
+ *   { ok:false, code, error, [suggest], [context], ...rootExtras }
+ *
+ * `error` is emitted VERBATIM — no `${toolName} failed:` prefix (the caller owns
+ * the full string, unlike `failWith`), matching the bespoke error strings the
+ * replaced literals carry. `suggest` is omitted when empty / absent (same guard
+ * as `failWith`). `rootExtras` (e.g. `_perceptionForPost`) spread onto the root.
+ */
+export function failCode(
+  code: string,
+  error: string,
+  extra?: {
+    suggest?: string[];
+    context?: Record<string, unknown>;
+    rootExtras?: Record<string, unknown>;
+  }
+): ToolResult {
+  return fail(
+    toToolFailure(
+      new ToolFailureError(code, {
+        displayMessage: error,
+        suggest: extra?.suggest,
+        context: extra?.context,
+        rootExtras: extra?.rootExtras,
+      })
+    )
+  );
+}
+
+/**
  * Return a structured ToolFailure for invalid / missing input arguments.
  * Use this instead of failWith() for validation errors so they get the
  * dedicated InvalidArgs code rather than the generic ToolError fallback.

--- a/src/tools/_errors.ts
+++ b/src/tools/_errors.ts
@@ -773,22 +773,26 @@ export function toToolFailure(err: ToolFailureError): ToolFailure & Record<strin
 }
 
 /**
- * Normalize any thrown value into a structured ToolFailure and return it as a
- * ToolResult, with recovery suggestions derived from the message.
+ * `failWith` — the canonical entry point for a flat handler failure
+ * (`{ ok:false, code, error, suggest?, context?, ...rootExtras }`). Normalizes
+ * any thrown value, classifies it to a typed `code` with recovery `suggest`,
+ * and renders the flat wire shape, returning it as a `ToolResult`.
  *
- * @deprecated ADR-021 Phase 2 — `failWith` is now a thin wrapper over the B′
- * presenter family and is being removed callsite-by-callsite (PR-P2-3) ahead of
- * full deletion (PR-P2-4, OQ-1(a)). Do NOT add new callers. Construct the typed
- * error model directly instead:
+ * Implemented as a thin wrapper over the B′ presenter family (ADR-021 Phase 2):
+ * `errorFromMessage` owns the `unknown` → message normalization + `classify`
+ * (the typed error model is the SSOT); `toToolFailure` renders the flat shape
+ * (the presenter). `failWith` composes them so handlers have ONE concise,
+ * lint-enforceable failure path. Do NOT hand-build `{ ok:false, ... }` literals
+ * (or wire failures through `ok()`) — route them here instead; Phase 4 ESLint
+ * (`no-tool-failure-shape-direct-construct`) bans the former.
  *
- *   return fail(toToolFailure(errorFromMessage(err, toolName, context)));
+ * Output is byte-for-byte stable (pinned by
+ * tests/unit/path-class-contract/failwith-thin-wrapper.test.ts layer A).
  *
- * `errorFromMessage` owns the `unknown` → message normalization and `classify`;
- * `toToolFailure` renders the flat wire shape — one error model (SSOT), one
- * presenter. The wrapper below delegates to exactly that, so its output stays
- * byte-for-byte identical to the historical hand-built object (pinned by
- * tests/unit/path-class-contract/failwith-thin-wrapper.test.ts layer A — a
- * revert of this delegation fails those frozen goldens).
+ * ADR-021 OQ-1 RE-DECISION (Round 6, 2026-05-21): kept as the canonical window —
+ * full removal (old OQ-1(a)) was superseded once B′ + PR-P2-2 collapsed the dual
+ * failure system (failWith now delegates to the presenter; the typed error model
+ * is the SSOT). Deleting it would only churn the 171 already-sanctioned callsites.
  */
 export function failWith(
   err: unknown,

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -5,7 +5,7 @@ import { enumWindowsInZOrder, restoreAndFocusWindow } from "../engine/win32.js";
 import { updateWindowCache } from "../engine/window-cache.js";
 import { ok, buildDesc } from "./_types.js";
 import type { ToolResult } from "./_types.js";
-import { failWith } from "./_errors.js";
+import { failWith, failCode } from "./_errors.js";
 import { coercedBoolean } from "./_coerce.js";
 import { pollUntil } from "../engine/poll.js";
 import {
@@ -1007,13 +1007,14 @@ export const browserClickElementHandler = async ({
       const coordsForGuard = await getElementScreenCoords(effectiveSelector, effectiveTabId ?? null, port);
       if (!coordsForGuard.inViewport) {
         // Element not in viewport — fail before running guard
-        return fail({
-          ok: false,
-          code: "ElementNotInViewport",
-          error: `browser_click: element "${effectiveSelector}" is outside the visible viewport.`,
-          suggest: ["Element is outside the visible viewport. Scroll it into view first using browser_eval with element.scrollIntoView(), then retry browser_click."],
-          context: { selector: effectiveSelector },
-        });
+        return failCode(
+          "ElementNotInViewport",
+          `browser_click: element "${effectiveSelector}" is outside the visible viewport.`,
+          {
+            suggest: ["Element is outside the visible viewport. Scroll it into view first using browser_eval with element.scrollIntoView(), then retry browser_click."],
+            context: { selector: effectiveSelector },
+          },
+        );
       }
       const descriptor: import("./_action-guard.js").ActionTargetDescriptor = {
         kind: "browserTab", port, tabId: effectiveTabId, urlIncludes: undefined,
@@ -1045,13 +1046,14 @@ export const browserClickElementHandler = async ({
       port
     );
     if (!coords.inViewport) {
-      return fail({
-        ok: false,
-        code: "ElementNotInViewport",
-        error: `browser_click: element "${effectiveSelector}" is outside the visible viewport.`,
-        suggest: ["Element is outside the visible viewport. Scroll it into view first using browser_eval with element.scrollIntoView(), then retry browser_click."],
-        context: { selector: effectiveSelector },
-      });
+      return failCode(
+        "ElementNotInViewport",
+        `browser_click: element "${effectiveSelector}" is outside the visible viewport.`,
+        {
+          suggest: ["Element is outside the visible viewport. Scroll it into view first using browser_eval with element.scrollIntoView(), then retry browser_click."],
+          context: { selector: effectiveSelector },
+        },
+      );
     }
     // Ensure browser window is focused so click events reach the page
     await ensureBrowserFocused(port);
@@ -1444,16 +1446,17 @@ export const browserNavigateHandler = async ({
 
     // Surface CDP navigation errors (DNS failure etc.)
     if (navResult.errorText) {
-      return fail({
-        ok: false,
-        code: "NavigateFailed",
-        error: `browser_navigate failed: ${navResult.errorText}`,
-        suggest: [
-          "Check the URL is correct and reachable",
-          "Verify network connectivity",
-        ],
-        context: { url, errorText: navResult.errorText },
-      });
+      return failCode(
+        "NavigateFailed",
+        `browser_navigate failed: ${navResult.errorText}`,
+        {
+          suggest: [
+            "Check the URL is correct and reachable",
+            "Verify network connectivity",
+          ],
+          context: { url, errorText: navResult.errorText },
+        },
+      );
     }
 
     if (!waitForLoad) {
@@ -2156,29 +2159,29 @@ export const browserSearchHandler = async ({
         : code === "BrowserSearchTimeout"
         ? ["Reduce maxResults", "Narrow scope via CSS selector", "Try by:'selector' if you know the element"]
         : ["Verify your regex syntax", "Try a literal pattern with by:'text'"];
-      return fail({
-        ok: false, code,
-        error: `browser_search: ${r.__error}${r.message ? " — " + r.message : ""}`,
-        suggest,
-        context: { by, pattern, scope },
-      });
+      return failCode(
+        code,
+        `browser_search: ${r.__error}${r.message ? " — " + r.message : ""}`,
+        { suggest, context: { by, pattern, scope } },
+      );
     }
     const payload = result as {
       total: number; returned: number; truncated: boolean;
       results: Array<{ confidence: number; selector: string; text: string }>;
     };
     if (payload.total === 0) {
-      return fail({
-        ok: false,
-        code: "BrowserSearchNoResults",
-        error: `browser_search(${by}, ${JSON.stringify(pattern)}) returned 0 results`,
-        suggest: [
-          "Try a different 'by' axis",
-          "Remove scope or set visibleOnly:false",
-          "Toggle caseSensitive:false",
-        ],
-        context: { by, pattern, scope, visibleOnly, inViewportOnly },
-      });
+      return failCode(
+        "BrowserSearchNoResults",
+        `browser_search(${by}, ${JSON.stringify(pattern)}) returned 0 results`,
+        {
+          suggest: [
+            "Try a different 'by' axis",
+            "Remove scope or set visibleOnly:false",
+            "Toggle caseSensitive:false",
+          ],
+          context: { by, pattern, scope, visibleOnly, inViewportOnly },
+        },
+      );
     }
     const tabCtx = await getTabContext(tabId ?? null, port);
     return ok({ ...payload, activeTab: { id: tabCtx.id, title: tabCtx.title, url: tabCtx.url }, readyState: tabCtx.readyState });

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -20,7 +20,6 @@ import {
 } from "../engine/cdp-bridge.js";
 import { resolveWellKnownPath, spawnDetached, killProcessesByName } from "../utils/launch.js";
 import { getCdpPort } from "../utils/desktop-config.js";
-import { fail } from "./_types.js";
 import { setBrowserSearchHook } from "./wait-until.js";
 import { narrateParam, withRichNarration } from "./_narration.js";
 import { makeCommitWrapper, makeQueryWrapper, withEnvelopeIncludeSchema, withEnvelopeIncludeForUnion, flattenUnionToObjectSchema, parseActionArgsOrFail, genericQueryCausedByProjector, defaultQuerySessionId } from "./_envelope.js";

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { createHash } from "node:crypto";
-import { ok, fail, buildDesc } from "./_types.js";
+import { ok, buildDesc } from "./_types.js";
 import type { ToolResult } from "./_types.js";
 import { failWith, failCode } from "./_errors.js";
 import { coercedBoolean } from "./_coerce.js";
@@ -1267,11 +1267,11 @@ export const terminalRunHandler = async ({
   // Reject invalid sendOptions/readOptions BEFORE doing any I/O so unbounded
   // values (e.g. chunkSize:0 hanging the background loop, source:'uia' on a
   // non-TextPattern terminal) cannot bypass the public schema bounds.
-  // Use fail() directly (not failWith) so we get code:"InvalidArgs" and the
-  // suggest[] array stays at the top level. failWith would classify "Invalid
-  // sendOptions" as the generic "ToolError" code and bury our custom suggest
-  // strings under context.suggest, which mis-classifies argument errors as
-  // internal errors and hides actionable remediation guidance from callers.
+  // Use failCode("InvalidArgs", ...) (the explicit-code presenter) so we get
+  // code:"InvalidArgs" and the suggest[] array stays at the top level. failWith
+  // would classify "Invalid sendOptions" as the generic "ToolError" code and
+  // bury our custom suggest strings under context.suggest, which mis-classifies
+  // argument errors as internal errors and hides actionable remediation guidance.
   let validatedSendOptions: Partial<z.infer<typeof TERMINAL_RUN_SEND_OPTIONS_SCHEMA>> = {};
   if (sendOptions !== undefined) {
     const parsed = TERMINAL_RUN_SEND_OPTIONS_SCHEMA.safeParse(sendOptions);

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { createHash } from "node:crypto";
 import { ok, fail, buildDesc } from "./_types.js";
 import type { ToolResult } from "./_types.js";
-import { failWith } from "./_errors.js";
+import { failWith, failCode } from "./_errors.js";
 import { coercedBoolean } from "./_coerce.js";
 import {
   enumWindowsInZOrder,
@@ -315,16 +315,17 @@ export const terminalReadHandler = async ({
       }
     }
     if (raw === null) {
-      return fail({
-        ok: false,
-        code: "TerminalTextPatternUnavailable",
-        error: "TextPattern not available and no OCR fallback usable",
-        suggest: [
-          "Retry with source:'ocr' to force OCR",
-          "Verify the window is actually a terminal (Windows Terminal, conhost, PowerShell)",
-        ],
-        context: { windowTitle: win.title },
-      });
+      return failCode(
+        "TerminalTextPatternUnavailable",
+        "TextPattern not available and no OCR fallback usable",
+        {
+          suggest: [
+            "Retry with source:'ocr' to force OCR",
+            "Verify the window is actually a terminal (Windows Terminal, conhost, PowerShell)",
+          ],
+          context: { windowTitle: win.title },
+        },
+      );
     }
 
     const cleaned = doStripAnsi ? stripAnsi(raw) : raw;
@@ -1275,16 +1276,17 @@ export const terminalRunHandler = async ({
   if (sendOptions !== undefined) {
     const parsed = TERMINAL_RUN_SEND_OPTIONS_SCHEMA.safeParse(sendOptions);
     if (!parsed.success) {
-      return fail({
-        ok: false,
-        code: "InvalidArgs",
-        error: `terminal:run: Invalid sendOptions: ${describeZodIssues(parsed.error)}`,
-        suggest: [
-          "Refer to terminal(action='send') schema for valid keys/types",
-          "windowTitle, input, and sinceMarker cannot be overridden via sendOptions",
-        ],
-        context: { windowTitle },
-      });
+      return failCode(
+        "InvalidArgs",
+        `terminal:run: Invalid sendOptions: ${describeZodIssues(parsed.error)}`,
+        {
+          suggest: [
+            "Refer to terminal(action='send') schema for valid keys/types",
+            "windowTitle, input, and sinceMarker cannot be overridden via sendOptions",
+          ],
+          context: { windowTitle },
+        },
+      );
     }
     validatedSendOptions = keepOnlyProvidedKeys(parsed.data, sendOptions);
   }
@@ -1292,16 +1294,17 @@ export const terminalRunHandler = async ({
   if (readOptions !== undefined) {
     const parsed = TERMINAL_RUN_READ_OPTIONS_SCHEMA.safeParse(readOptions);
     if (!parsed.success) {
-      return fail({
-        ok: false,
-        code: "InvalidArgs",
-        error: `terminal:run: Invalid readOptions: ${describeZodIssues(parsed.error)}`,
-        suggest: [
-          "Refer to terminal(action='read') schema for valid keys/types",
-          "windowTitle and sinceMarker cannot be overridden via readOptions",
-        ],
-        context: { windowTitle },
-      });
+      return failCode(
+        "InvalidArgs",
+        `terminal:run: Invalid readOptions: ${describeZodIssues(parsed.error)}`,
+        {
+          suggest: [
+            "Refer to terminal(action='read') schema for valid keys/types",
+            "windowTitle and sinceMarker cannot be overridden via readOptions",
+          ],
+          context: { windowTitle },
+        },
+      );
     }
     validatedReadOptions = keepOnlyProvidedKeys(parsed.data, readOptions);
   }

--- a/src/tools/wait-until.ts
+++ b/src/tools/wait-until.ts
@@ -2,7 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { ok, fail, buildDesc } from "./_types.js";
 import type { ToolResult } from "./_types.js";
-import { failWith } from "./_errors.js";
+import { failWith, failCode } from "./_errors.js";
 import { coercedBoolean, coercedJsonObject } from "./_coerce.js";
 import { pollUntil } from "../engine/poll.js";
 import { makeQueryWrapper, withEnvelopeIncludeSchema, genericQueryCausedByProjector, defaultQuerySessionId } from "./_envelope.js";
@@ -364,17 +364,18 @@ export const waitUntilHandler = async ({ condition, target, timeoutMs, intervalM
       return ok({ ok: true, condition, elapsedMs: r.elapsedMs, observed: r.value });
     }
 
-    return fail({
-      ok: false,
-      code: "WaitTimeout",
-      error: `wait_until(${condition}) timed out after ${r.elapsedMs}ms`,
-      suggest: [
-        "Increase timeoutMs",
-        "Verify the target is correct",
-        "Inspect intermediate state with screenshot(detail='meta')",
-      ],
-      context: { condition, target, timeoutMs },
-    });
+    return failCode(
+      "WaitTimeout",
+      `wait_until(${condition}) timed out after ${r.elapsedMs}ms`,
+      {
+        suggest: [
+          "Increase timeoutMs",
+          "Verify the target is correct",
+          "Inspect intermediate state with screenshot(detail='meta')",
+        ],
+        context: { condition, target, timeoutMs },
+      },
+    );
   } catch (err) {
     return failWith(err, "wait_until", { condition, target });
   }

--- a/src/tools/wait-until.ts
+++ b/src/tools/wait-until.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { ok, fail, buildDesc } from "./_types.js";
+import { ok, buildDesc } from "./_types.js";
 import type { ToolResult } from "./_types.js";
 import { failWith, failCode } from "./_errors.js";
 import { coercedBoolean, coercedJsonObject } from "./_coerce.js";

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -7,9 +7,9 @@
  * 主 scope のため、handler 内部の throw → Result.err 全件 migrate は scope 外
  * (sub-plan §2 北極星 6 = gradual migration 採用)。
  *
- * `failWith` 経路 (171 migratable callsite、`_errors.ts`、`ToolFailure` shape) は
- * 本 SR-2 scope 外、ADR-021 Phase 2 で migrate (canonical count は
- * `errors/typed-errors.ts` ToolFailureError doc 参照)。
+ * `failWith` 経路 (`_errors.ts`、`ToolFailure` flat shape) は本 SR-2 scope 外。
+ * ADR-021 Phase 2 で B′ presenter family の thin wrapper 化 + canonical 化
+ * (OQ-1 RE-DECISION で keep、`errors/typed-errors.ts` ToolFailureError doc 参照)。
  */
 export type Result<Ok, Err> =
   | { readonly ok: true; readonly value: Ok }

--- a/tests/fixtures/failwith-callsite-shapes.json
+++ b/tests/fixtures/failwith-callsite-shapes.json
@@ -79,112 +79,112 @@
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 602,
+      "line": 601,
       "tool": "browser_fill",
       "errKind": "member",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 738,
+      "line": 737,
       "tool": "browser_fill",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 844,
+      "line": 843,
       "tool": "browser_form",
       "errKind": "string-literal",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 858,
+      "line": 857,
       "tool": "browser_form",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 910,
+      "line": 909,
       "tool": "browser_open",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 962,
+      "line": 961,
       "tool": "browser_locate",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 998,
+      "line": 997,
       "tool": "browser_click",
       "errKind": "new-error",
       "contextShape": "object-hoisted"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1030,
+      "line": 1029,
       "tool": "browser_click",
       "errKind": "new-error",
       "contextShape": "object-hoisted"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1305,
+      "line": 1304,
       "tool": "browser_eval",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1388,
+      "line": 1387,
       "tool": "browser_eval",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1415,
+      "line": 1414,
       "tool": "browser_navigate",
       "errKind": "new-error",
       "contextShape": "object-hoisted"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1432,
+      "line": 1431,
       "tool": "browser_navigate",
       "errKind": "new-error",
       "contextShape": "object-hoisted"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1724,
+      "line": 1723,
       "tool": "browser_overview",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1876,
+      "line": 1875,
       "tool": "browser_open",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 2189,
+      "line": 2188,
       "tool": "browser_search",
       "errKind": "identifier",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 2337,
+      "line": 2336,
       "tool": "browser_disconnect",
       "errKind": "identifier",
       "contextShape": "none"

--- a/tests/fixtures/failwith-callsite-shapes.json
+++ b/tests/fixtures/failwith-callsite-shapes.json
@@ -128,63 +128,63 @@
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1029,
+      "line": 1030,
       "tool": "browser_click",
       "errKind": "new-error",
       "contextShape": "object-hoisted"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1303,
+      "line": 1305,
       "tool": "browser_eval",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1386,
+      "line": 1388,
       "tool": "browser_eval",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1413,
+      "line": 1415,
       "tool": "browser_navigate",
       "errKind": "new-error",
       "contextShape": "object-hoisted"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1430,
+      "line": 1432,
       "tool": "browser_navigate",
       "errKind": "new-error",
       "contextShape": "object-hoisted"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1721,
+      "line": 1724,
       "tool": "browser_overview",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1873,
+      "line": 1876,
       "tool": "browser_open",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 2186,
+      "line": 2189,
       "tool": "browser_search",
       "errKind": "identifier",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 2334,
+      "line": 2337,
       "tool": "browser_disconnect",
       "errKind": "identifier",
       "contextShape": "none"
@@ -506,14 +506,14 @@
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 466,
+      "line": 467,
       "tool": "terminal:send",
       "errKind": "new-error",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 833,
+      "line": 834,
       "tool": "terminal:send",
       "errKind": "new-error",
       "contextShape": "object-plain"

--- a/tests/unit/issue-211-classify-branch-producer-pin.test.ts
+++ b/tests/unit/issue-211-classify-branch-producer-pin.test.ts
@@ -238,6 +238,12 @@ function findFirstProducer(branch: ClassifyBranch, srcFiles: string[]): string |
   const codeReDirects = [
     new RegExp(`new Error\\("${escCode}["\\s:]`, "i"),
     new RegExp(`code:\\s*"${escCode}"`),
+    // ADR-021 PR-P2-3: `failCode("<typedCode>", ...)` is the explicit-code
+    // sanctioned emit helper that replaced the hand-built `fail({code:"X",...})`
+    // literals (TerminalTextPatternUnavailable, WaitTimeout, etc.). Same
+    // producer role as a `code: "X"` literal — recognise it so the §1.3 row C
+    // sweep doesn't make these classify branches look dead.
+    new RegExp(`failCode\\(\\s*"${escCode}"`),
     // browser.ts:1960 internal `__error: "ScopeNotFound"` shape and the
     // mapping at browser.ts:2150 `__error === "ScopeNotFound" ? "..."`.
     new RegExp(`__error:\\s*"${escCode}"`),

--- a/tests/unit/path-class-contract/failcode-sweep.test.ts
+++ b/tests/unit/path-class-contract/failcode-sweep.test.ts
@@ -100,7 +100,7 @@ describe("PR-P2-3 layer B: failCode reproduces the (C) literals byte-for-byte", 
     );
   });
 
-  it("terminal:read TerminalTextPatternUnavailable (NO context) — terminal.ts:318", () => {
+  it("TerminalTextPatternUnavailable shape (no-context variant of the contract) — cf. terminal.ts:318", () => {
     expect(
       wireText(
         failCode("TerminalTextPatternUnavailable", "TextPattern not available and no OCR fallback usable", {

--- a/tests/unit/path-class-contract/failcode-sweep.test.ts
+++ b/tests/unit/path-class-contract/failcode-sweep.test.ts
@@ -1,0 +1,134 @@
+/**
+ * tests/unit/path-class-contract/failcode-sweep.test.ts
+ * — ADR-021 Phase 2 PR-P2-3 (Plan: desktop-touch-mcp-internal#7 §3.3.2 step 4).
+ *
+ * PR-P2-3 routes the hand-built `fail({ ok:false, code, ... })` literals (the
+ * §1.3 row C drift surface — failures that bypassed the sanctioned converter)
+ * through the B′ presenter family via the new `failCode` helper. `failCode` is
+ * the explicit-code sibling of `failWith` (classify-derived) and `failArgs`
+ * (fixed InvalidArgs): the handler already knows the typed code, so no message
+ * classification is needed, and the bespoke `error` string is emitted verbatim.
+ *
+ * Layer A pins `failCode`'s rendering contract with FROZEN literals (independent
+ * of production composition). Layer B pins that `failCode(<the same code / error
+ * / suggest / context the literal carried>)` reproduces the pre-migration wire
+ * bytes for representative (C) sites byte-for-byte, so the literal → failCode
+ * refactor is bit-equal (snapshot-first discipline).
+ *
+ * @see src/tools/_errors.ts  failCode / toToolFailure
+ */
+
+import { describe, it, expect } from "vitest";
+import { failCode } from "../../../src/tools/_errors.js";
+
+/** Extract the single JSON text block `failCode` (via `fail`) emits. */
+function wireText(result: { content: ReadonlyArray<{ type: string; text?: string }> }): string {
+  const block = result.content[0];
+  if (!block || block.type !== "text" || typeof block.text !== "string") {
+    throw new Error("expected a text content block");
+  }
+  return block.text;
+}
+
+// ── Layer A: failCode rendering contract (frozen) ─────────────────────────────
+
+describe("PR-P2-3 layer A: failCode shape contract (frozen, key-order + omission)", () => {
+  it("code + error only → no suggest, no context", () => {
+    expect(wireText(failCode("ToolError", "boom"))).toBe(
+      '{"ok":false,"code":"ToolError","error":"boom"}',
+    );
+  });
+
+  it("emits `error` VERBATIM (no '<tool> failed:' prefix — unlike failWith)", () => {
+    expect(wireText(failCode("NavigateFailed", "browser_navigate failed: net::ERR"))).toBe(
+      '{"ok":false,"code":"NavigateFailed","error":"browser_navigate failed: net::ERR"}',
+    );
+  });
+
+  it("+ suggest → present; + context → present; key order ok,code,error,suggest,context", () => {
+    expect(
+      wireText(failCode("X", "msg", { suggest: ["a", "b"], context: { sel: "#x", n: 2 } })),
+    ).toBe(
+      '{"ok":false,"code":"X","error":"msg","suggest":["a","b"],"context":{"sel":"#x","n":2}}',
+    );
+  });
+
+  it("empty suggest → OMITTED (same guard as failWith)", () => {
+    expect(wireText(failCode("X", "msg", { suggest: [], context: { a: 1 } }))).toBe(
+      '{"ok":false,"code":"X","error":"msg","context":{"a":1}}',
+    );
+  });
+
+  it("rootExtras spread at root, after context", () => {
+    expect(
+      wireText(
+        failCode("X", "msg", { suggest: ["s"], context: { a: 1 }, rootExtras: { _perceptionForPost: { p: 1 } } }),
+      ),
+    ).toBe(
+      '{"ok":false,"code":"X","error":"msg","suggest":["s"],"context":{"a":1},"_perceptionForPost":{"p":1}}',
+    );
+  });
+});
+
+// ── Layer B: bit-equal with the pre-migration (C) literals ────────────────────
+//
+// Each expected string is the EXACT wire bytes the hand-built `fail({...})`
+// literal produced before PR-P2-3 (read from the pre-migration source). Proves
+// the literal → failCode refactor preserves the shape byte-for-byte.
+
+describe("PR-P2-3 layer B: failCode reproduces the (C) literals byte-for-byte", () => {
+  it("browser_click ElementNotInViewport (with context) — browser.ts:1010/1048", () => {
+    const sel = "#submit";
+    expect(
+      wireText(
+        failCode(
+          "ElementNotInViewport",
+          `browser_click: element "${sel}" is outside the visible viewport.`,
+          {
+            suggest: [
+              "Element is outside the visible viewport. Scroll it into view first using browser_eval with element.scrollIntoView(), then retry browser_click.",
+            ],
+            context: { selector: sel },
+          },
+        ),
+      ),
+    ).toBe(
+      '{"ok":false,"code":"ElementNotInViewport",' +
+        '"error":"browser_click: element \\"#submit\\" is outside the visible viewport.",' +
+        '"suggest":["Element is outside the visible viewport. Scroll it into view first using browser_eval with element.scrollIntoView(), then retry browser_click."],' +
+        '"context":{"selector":"#submit"}}',
+    );
+  });
+
+  it("terminal:read TerminalTextPatternUnavailable (NO context) — terminal.ts:318", () => {
+    expect(
+      wireText(
+        failCode("TerminalTextPatternUnavailable", "TextPattern not available and no OCR fallback usable", {
+          suggest: [
+            "Retry with source:'ocr' to force OCR",
+            "Verify the window is actually a terminal (Windows Terminal, conhost, PowerShell)",
+          ],
+        }),
+      ),
+    ).toBe(
+      '{"ok":false,"code":"TerminalTextPatternUnavailable",' +
+        '"error":"TextPattern not available and no OCR fallback usable",' +
+        '"suggest":["Retry with source:\'ocr\' to force OCR",' +
+        '"Verify the window is actually a terminal (Windows Terminal, conhost, PowerShell)"]}',
+    );
+  });
+
+  it("browser_search runtime-computed code (variable code + suggest) — browser.ts:2159", () => {
+    // The handler computes `code` and `suggest` at runtime; failCode takes them as
+    // values, which failWith's classify(message) path could not do.
+    const code = "ScopeNotFound";
+    const suggest = ["Verify the scope CSS selector matches at least one element", "Omit scope to search the full document"];
+    expect(
+      wireText(failCode(code, "browser_search: ScopeNotFound", { suggest, context: { by: "text", pattern: "x", scope: "#s" } })),
+    ).toBe(
+      '{"ok":false,"code":"ScopeNotFound","error":"browser_search: ScopeNotFound",' +
+        '"suggest":["Verify the scope CSS selector matches at least one element","Omit scope to search the full document"],' +
+        '"context":{"by":"text","pattern":"x","scope":"#s"}}',
+    );
+  });
+});


### PR DESCRIPTION
## What

ADR-021 PR-P2-3 **part a** (Option B re-scope, OQ-1 RE-DECISION). Two things, both staying inside the B′ presenter family:

### 1. Un-deprecate `failWith`, reframe as the canonical failure window
OQ-1(a) "delete failWith" was decided **before B′ was finalized**. B′ + PR-P2-2 already made `failWith` a thin wrapper over the presenter (the typed error model is the SSOT), so the dual-failure system is gone and removal would only churn the ~171 already-sanctioned callsites. Per **OQ-1 RE-DECISION (Round 6)** `failWith` is **kept** as the canonical single window.
- Remove the `@deprecated` JSDoc added in PR-P2-2; reframe its doc + the 3 cross-ref docs (`typed-errors.ts` / `result.ts` / `_envelope.ts`) to the Option B framing. Behavior unchanged (frozen golden 10/10 green).

### 2. Sweep the (C) code-bearing hand-built failure literals
The real drift surface (`§1.3 row C`): handlers hand-building `fail({ ok:false, code, error, suggest, context })` and bypassing the sanctioned converter. New helper:

```
failCode(code, error, { suggest?, context?, rootExtras? })
```

— the **explicit-code** sibling of `failWith` (classify-derived) and `failArgs` (fixed InvalidArgs). Routes through `toToolFailure(new ToolFailureError(...))`, emits `error` verbatim (no `<tool> failed:` prefix), so the wire shape is **bit-equal** with the literal it replaces.

Swept 9 (C) sites → `failCode`, bit-equal:
- `browser.ts` ×5 (ElementNotInViewport ×2, NavigateFailed, browser_search runtime-computed code, BrowserSearchNoResults)
- `terminal.ts` ×3 (TerminalTextPatternUnavailable, InvalidArgs ×2)
- `wait-until.ts` ×1 (WaitTimeout)

## Tests / gates
- New `failcode-sweep.test.ts`: `failCode` shape contract (frozen) + byte-for-byte pins vs the pre-migration literals (snapshot-first bit-equal proof).
- `issue-211-classify-branch-producer-pin.test.ts`: taught the structural guard that `failCode("<code>")` is a sanctioned producer form (was only `code:"X"` / `failWith`) — otherwise the sweep makes TerminalTextPatternUnavailable / WaitTimeout look like dead classify codes.
- Regenerated `failwith-callsite-shapes.json` (line shifts only; totalCallsites still 171 — no failWith call added/removed). `check:failwith-fixtures` green.
- Unit suite green (pre-existing benchmark-gate + PERSIST-14 timing flakes only, pass in isolation); tsc + lint clean.

## Scope note
This is **part a** (canonical-ize + (C) bit-equal sweep). **Part b** = the (D) code-less literals (`scroll-read` / `pin` / `scroll-capture` / `desktop-register` / `macro`) with **OQ-9 (c) per-site codes** (intentional shape change: adds recovery-hint codes), kept separate because it changes wire shape. The (E) failure-as-success class (`ok()`-wrapped failures) is carried over to OQ-10 (not regex-enumerable).

Plan: `desktop-touch-mcp-internal#7` (Round 6 OQ-1 RE-DECISION) §3.3.2 step 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
