### PR TITLE
feat(lint): ADR-021 P4-1 — no-tool-failure-shape-direct-construct ESLint rule (Option B enforcement)

### DIFF
--- a/eslint-rules/no-tool-failure-shape-direct-construct.mjs
+++ b/eslint-rules/no-tool-failure-shape-direct-construct.mjs
@@ -1,0 +1,98 @@
+/**
+ * ESLint rule: no-tool-failure-shape-direct-construct
+ * — ADR-021 Phase 4 PR-P4-1 (Option B North Star enforcement).
+ *
+ * Bans hand-building the flat tool-failure WIRE shape (`{ ok:false, ..., error,
+ * ... }`) at an emission point — i.e. as the argument to `fail(...)` or
+ * `JSON.stringify(...)`. Every handler failure must instead go through the
+ * single sanctioned presenter family in `src/tools/_errors.ts`:
+ *
+ *   failWith(err, toolName, context?)   — code via classify(message)
+ *   failCode(code, error, { suggest?, context?, rootExtras? })  — explicit code
+ *   failArgs(message, toolName, context?)  — fixed InvalidArgs
+ *   fail(toToolFailure(errorFromMessage(...)))  — the underlying composition
+ *
+ * or the envelope-family `toFailureEnvelope(...)`. This is what makes the
+ * ADR-021 drift North Star ("単体 OK / 繋ぐと破綻 を型/lint/SSOT で書けなくする")
+ * structural rather than test-only: PR-P2-2/P2-3 swept every existing hand-built
+ * literal, and this rule prevents new ones from re-appearing (plan §3.5.1; closes
+ * the R12 "un-deprecate window").
+ *
+ * Discriminator = `ok:false` AND an `error` property. Internal discriminated-union
+ * returns (`{ ok:false, reason }`, `{ ok:false, errorResult }`, CDP eval helper
+ * shapes) have no `error` key, so they are NOT flagged. Only the wire-emission
+ * contexts (`fail(...)` / `JSON.stringify(...)` arguments) are checked, so the
+ * `(E)` failure-as-success returns carried over to OQ-10 (e.g. `dock.ts`'s
+ * `return { ok:false, title, error }` consumed by `ok()`) are intentionally out of
+ * scope here — they are a different mechanism needing semantic detection.
+ *
+ * Scope (wired in eslint.config.mjs): `src/tools/**` minus the sanctioned
+ * converters `_errors.ts` (defines fail* helpers) and `_envelope.ts`
+ * (defines toFailureEnvelope / buildFailureEnvelope).
+ */
+
+/** @type {import("eslint").Rule.RuleModule} */
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow hand-building the flat tool-failure wire shape ({ok:false, error, ...}); route failures through failWith / failCode / failArgs / toFailureEnvelope (ADR-021 Option B).",
+    },
+    messages: {
+      directConstruct:
+        "Do not hand-build the tool-failure wire shape ({{where}}). Use failWith / failCode / failArgs (src/tools/_errors.ts) or toFailureEnvelope so the failure path stays single-sourced (ADR-021 Phase 4 / OQ-1 RE).",
+    },
+    schema: [],
+  },
+
+  create(context) {
+    /** Does an ObjectExpression look like the flat failure wire shape? */
+    function isFailureShape(node) {
+      if (!node || node.type !== "ObjectExpression") return false;
+      let hasOkFalse = false;
+      let hasError = false;
+      for (const p of node.properties) {
+        if (p.type !== "Property" || p.computed) continue;
+        const key =
+          p.key.type === "Identifier"
+            ? p.key.name
+            : p.key.type === "Literal"
+              ? p.key.value
+              : null;
+        if (key === "ok" && p.value.type === "Literal" && p.value.value === false) {
+          hasOkFalse = true;
+        }
+        if (key === "error") hasError = true;
+      }
+      return hasOkFalse && hasError;
+    }
+
+    function report(arg, where) {
+      if (isFailureShape(arg)) {
+        context.report({ node: arg, messageId: "directConstruct", data: { where } });
+      }
+    }
+
+    return {
+      CallExpression(node) {
+        const callee = node.callee;
+        // fail({ ok:false, error, ... })
+        if (callee.type === "Identifier" && callee.name === "fail") {
+          report(node.arguments[0], "fail(...) argument");
+        }
+        // JSON.stringify({ ok:false, error, ... })  (hand-built content-block body)
+        if (
+          callee.type === "MemberExpression" &&
+          !callee.computed &&
+          callee.object.type === "Identifier" &&
+          callee.object.name === "JSON" &&
+          callee.property.type === "Identifier" &&
+          callee.property.name === "stringify"
+        ) {
+          report(node.arguments[0], "JSON.stringify(...) argument");
+        }
+      },
+    };
+  },
+};

--- a/eslint-rules/no-tool-failure-shape-direct-construct.mjs
+++ b/eslint-rules/no-tool-failure-shape-direct-construct.mjs
@@ -47,12 +47,45 @@ export default {
   },
 
   create(context) {
-    /** Does an ObjectExpression look like the flat failure wire shape? */
-    function isFailureShape(node) {
-      if (!node || node.type !== "ObjectExpression") return false;
+    /**
+     * Peel TS-only wrappers so `fail({ ... } as ToolFailure)` /
+     * `... satisfies T` / `...!` reach the underlying ObjectExpression (the rule
+     * runs under the TS parser, so these are the common bypass — Codex PR #381 P1).
+     */
+    function unwrap(node) {
+      let n = node;
+      while (
+        n &&
+        (n.type === "TSAsExpression" ||
+          n.type === "TSSatisfiesExpression" ||
+          n.type === "TSNonNullExpression" ||
+          n.type === "TSTypeAssertion")
+      ) {
+        n = n.expression;
+      }
+      return n;
+    }
+
+    /**
+     * Scan an ObjectExpression (recursing into object-literal spreads) for the
+     * failure-shape markers. `{ hasOkFalse, hasError }`. Spread of a variable /
+     * call contributes nothing statically (that laundering stays out of scope,
+     * like `fail(variable)`); spread of a literal object is inspected so
+     * `fail({ ...{ ok:false, error } })` is still caught (Codex PR #381 P2).
+     */
+    function scan(objNode) {
       let hasOkFalse = false;
       let hasError = false;
-      for (const p of node.properties) {
+      for (const p of objNode.properties) {
+        if (p.type === "SpreadElement") {
+          const inner = unwrap(p.argument);
+          if (inner && inner.type === "ObjectExpression") {
+            const r = scan(inner);
+            hasOkFalse ||= r.hasOkFalse;
+            hasError ||= r.hasError;
+          }
+          continue;
+        }
         if (p.type !== "Property" || p.computed) continue;
         const key =
           p.key.type === "Identifier"
@@ -65,11 +98,23 @@ export default {
         }
         if (key === "error") hasError = true;
       }
-      return hasOkFalse && hasError;
+      return { hasOkFalse, hasError };
     }
 
-    function report(arg, where) {
-      if (isFailureShape(arg)) {
+    /**
+     * `requireError` is the false-positive guard. For `JSON.stringify(...)`
+     * (general-purpose) we require BOTH `ok:false` and `error` so unrelated
+     * `{ ok:false }` shapes are not flagged. For `fail(...)` we require only
+     * `ok:false`: `fail()` must only ever receive a presenter's output
+     * (`toToolFailure(...)`), never a literal — any `{ ok:false, ... }` literal
+     * there is hand-building by definition, so this also catches
+     * `fail({ ok:false, ...spread })`.
+     */
+    function report(arg, where, requireError) {
+      const obj = unwrap(arg);
+      if (!obj || obj.type !== "ObjectExpression") return;
+      const { hasOkFalse, hasError } = scan(obj);
+      if (hasOkFalse && (hasError || !requireError)) {
         context.report({ node: arg, messageId: "directConstruct", data: { where } });
       }
     }
@@ -77,11 +122,11 @@ export default {
     return {
       CallExpression(node) {
         const callee = node.callee;
-        // fail({ ok:false, error, ... })
+        // fail({ ok:false, ... }) — ok:false literal alone is the signature.
         if (callee.type === "Identifier" && callee.name === "fail") {
-          report(node.arguments[0], "fail(...) argument");
+          report(node.arguments[0], "fail(...) argument", false);
         }
-        // JSON.stringify({ ok:false, error, ... })  (hand-built content-block body)
+        // JSON.stringify({ ok:false, error, ... }) — hand-built content-block body.
         if (
           callee.type === "MemberExpression" &&
           !callee.computed &&
@@ -90,7 +135,7 @@ export default {
           callee.property.type === "Identifier" &&
           callee.property.name === "stringify"
         ) {
-          report(node.arguments[0], "JSON.stringify(...) argument");
+          report(node.arguments[0], "JSON.stringify(...) argument", true);
         }
       },
     };

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,6 +8,7 @@
 import js from "@eslint/js";
 import globals from "globals";
 import tseslint from "typescript-eslint";
+import noToolFailureShapeDirectConstruct from "./eslint-rules/no-tool-failure-shape-direct-construct.mjs";
 
 export default [
   {
@@ -45,6 +46,23 @@ export default [
     files: ["src/**/*.ts"],
     rules: {
       "no-console": ["error", { allow: ["error", "warn"] }],
+    },
+  },
+
+  // src/tools/ — ADR-021 Option B North Star enforcement. Hand-built failure
+  // wire literals ({ ok:false, ..., error } as a fail() / JSON.stringify()
+  // argument) are banned; failures must go through failWith / failCode / failArgs
+  // / toFailureEnvelope. PR-P2-2/P2-3 swept every existing one, so this lands as
+  // `error` (0 violations). The converters themselves are exempt: _errors.ts
+  // defines the fail* helpers, _envelope.ts defines toFailureEnvelope.
+  {
+    files: ["src/tools/**/*.ts"],
+    ignores: ["src/tools/_errors.ts", "src/tools/_envelope.ts"],
+    plugins: {
+      adr021: { rules: { "no-tool-failure-shape-direct-construct": noToolFailureShapeDirectConstruct } },
+    },
+    rules: {
+      "adr021/no-tool-failure-shape-direct-construct": "error",
     },
   },
 

--- a/tests/unit/path-class-contract/eslint-no-tool-failure-shape.test.ts
+++ b/tests/unit/path-class-contract/eslint-no-tool-failure-shape.test.ts
@@ -1,0 +1,64 @@
+/**
+ * tests/unit/path-class-contract/eslint-no-tool-failure-shape.test.ts
+ * — ADR-021 Phase 4 PR-P4-1.
+ *
+ * Pins the custom ESLint rule `no-tool-failure-shape-direct-construct` (the
+ * Option B structural enforcement): hand-built failure wire literals
+ * (`{ ok:false, ..., error }` as a `fail()` / `JSON.stringify()` argument) are
+ * rejected, while the sanctioned presenter family (failWith / failCode /
+ * failArgs / fail(toToolFailure(...))) and non-failure shapes are allowed.
+ *
+ * Uses ESLint's RuleTester wired into vitest so the rule's accept/reject
+ * contract is verified directly (espree default parser — the rule only touches
+ * plain-ESTree nodes shared by JS and TS).
+ */
+
+import { afterAll, describe, it } from "vitest";
+import { RuleTester } from "eslint";
+import rule from "../../../eslint-rules/no-tool-failure-shape-direct-construct.mjs";
+
+// Wire RuleTester's lifecycle hooks into vitest.
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-tool-failure-shape-direct-construct", rule, {
+  valid: [
+    // Sanctioned presenter family.
+    'failWith(new Error("boom"), "keyboard");',
+    'failCode("ElementNotInViewport", "msg", { suggest: ["a"], context: { selector: "#x" } });',
+    'failArgs("bad arg", "desktop_act");',
+    'fail(toToolFailure(errorFromMessage(e, "tool", ctx)));',
+    // `fail(variable)` — not a literal at the emission point.
+    "fail(failureObject);",
+    // Internal discriminated-union returns have no `error` key → not the wire shape.
+    'const r = { ok: false, reason: "entity_not_found" };',
+    'fail({ ok: false, reason: "x" });',
+    "JSON.stringify({ ok: false, errorResult: r });",
+    // Success payloads.
+    "JSON.stringify({ ok: true, data: 1 });",
+    'fail({ ok: true, value: "x" });',
+  ],
+  invalid: [
+    {
+      code: 'fail({ ok: false, code: "X", error: "y" });',
+      errors: [{ messageId: "directConstruct" }],
+    },
+    {
+      code: 'fail({ ok: false, error: "y", suggest: ["a"] });',
+      errors: [{ messageId: "directConstruct" }],
+    },
+    {
+      code: 'JSON.stringify({ ok: false, error: "Window not found" });',
+      errors: [{ messageId: "directConstruct" }],
+    },
+    {
+      // The macro / (D) content-block pattern (pretty-printed).
+      code: 'JSON.stringify({ ok: false, error: "v2 disabled" }, null, 2);',
+      errors: [{ messageId: "directConstruct" }],
+    },
+  ],
+});

--- a/tests/unit/path-class-contract/eslint-no-tool-failure-shape.test.ts
+++ b/tests/unit/path-class-contract/eslint-no-tool-failure-shape.test.ts
@@ -4,26 +4,28 @@
  *
  * Pins the custom ESLint rule `no-tool-failure-shape-direct-construct` (the
  * Option B structural enforcement): hand-built failure wire literals
- * (`{ ok:false, ..., error }` as a `fail()` / `JSON.stringify()` argument) are
- * rejected, while the sanctioned presenter family (failWith / failCode /
- * failArgs / fail(toToolFailure(...))) and non-failure shapes are allowed.
+ * (`{ ok:false, ... }` at a `fail()` / `JSON.stringify()` argument) are rejected,
+ * while the sanctioned presenter family (failWith / failCode / failArgs /
+ * fail(toToolFailure(...))) and non-failure shapes are allowed.
  *
- * Uses ESLint's RuleTester wired into vitest so the rule's accept/reject
- * contract is verified directly (espree default parser — the rule only touches
- * plain-ESTree nodes shared by JS and TS).
+ * Uses ESLint's RuleTester (wired into vitest) under the @typescript-eslint
+ * parser so TS-only wrappers like `{ ... } as ToolFailure` are exercised — that
+ * wrapper was the Codex PR #381 P1 bypass.
  */
 
 import { afterAll, describe, it } from "vitest";
 import { RuleTester } from "eslint";
+import tsParser from "@typescript-eslint/parser";
 import rule from "../../../eslint-rules/no-tool-failure-shape-direct-construct.mjs";
 
-// Wire RuleTester's lifecycle hooks into vitest.
 RuleTester.afterAll = afterAll;
 RuleTester.describe = describe;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({
+  languageOptions: { parser: tsParser, ecmaVersion: 2022, sourceType: "module" },
+});
 
 ruleTester.run("no-tool-failure-shape-direct-construct", rule, {
   valid: [
@@ -34,22 +36,23 @@ ruleTester.run("no-tool-failure-shape-direct-construct", rule, {
     'fail(toToolFailure(errorFromMessage(e, "tool", ctx)));',
     // `fail(variable)` — not a literal at the emission point.
     "fail(failureObject);",
-    // Scope boundary (Opus Round 1 P2-2): the rule targets the LITERAL `ok:false`
-    // + `error` form at the emission point. These laundering shapes intentionally
-    // escape PR-P4-1 (contrived, not used in practice; tightening them is future
-    // work / OQ-10 territory). Pinned as valid so the boundary is explicit and a
-    // future strictening is a deliberate test change.
-    "fail({ ...failureBase });", // ok:false comes from the spread, no literal property
-    'fail({ ["ok"]: false, error: "y" });', // computed key — not statically `ok: false`
-    // Internal discriminated-union returns have no `error` key → not the wire shape.
-    'const r = { ok: false, reason: "entity_not_found" };',
-    'fail({ ok: false, reason: "x" });',
-    "JSON.stringify({ ok: false, errorResult: r });",
     // Success payloads.
     "JSON.stringify({ ok: true, data: 1 });",
     'fail({ ok: true, value: "x" });',
+    // Internal discriminated-union return spread into JSON.stringify with no
+    // `error` key → not the wire shape (JSON.stringify requires ok:false + error).
+    "JSON.stringify({ ok: false, errorResult: r });",
+    "JSON.stringify({ ok: false, reason: 'x' });",
+    // Scope boundary (Opus Round 1 P2-2 / Codex P2): laundering shapes the simple
+    // AST rule intentionally does NOT catch — pinned valid so a future strictening
+    // is a deliberate test change. (a) pure variable spread (no literal markers),
+    // (b) computed key (not statically `ok: false`).
+    "fail({ ...failureBase });",
+    'fail({ ["ok"]: false, error: "y" });',
   ],
   invalid: [
+    // Direct fail() literal — ok:false alone is the signature (fail() only ever
+    // receives presenter output, never a literal).
     {
       code: 'fail({ ok: false, code: "X", error: "y" });',
       errors: [{ messageId: "directConstruct" }],
@@ -59,12 +62,37 @@ ruleTester.run("no-tool-failure-shape-direct-construct", rule, {
       errors: [{ messageId: "directConstruct" }],
     },
     {
+      // No error key, but still a hand-built failure literal at fail() — flagged.
+      code: 'fail({ ok: false, reason: "x" });',
+      errors: [{ messageId: "directConstruct" }],
+    },
+    {
+      // Codex P1: TS assertion wrapper must be unwrapped.
+      code: 'fail({ ok: false, error: "y" } as ToolFailure);',
+      errors: [{ messageId: "directConstruct" }],
+    },
+    {
+      // Codex P2: literal ok:false + spread for the rest still hand-builds at fail().
+      code: "fail({ ok: false, ...errExtra });",
+      errors: [{ messageId: "directConstruct" }],
+    },
+    {
+      // Spread of a literal object is inspected (recursion).
+      code: 'fail({ ...{ ok: false, error: "y" } });',
+      errors: [{ messageId: "directConstruct" }],
+    },
+    // JSON.stringify hand-built content-block body (requires ok:false + error).
+    {
       code: 'JSON.stringify({ ok: false, error: "Window not found" });',
       errors: [{ messageId: "directConstruct" }],
     },
     {
-      // The macro / (D) content-block pattern (pretty-printed).
       code: 'JSON.stringify({ ok: false, error: "v2 disabled" }, null, 2);',
+      errors: [{ messageId: "directConstruct" }],
+    },
+    {
+      // TS assertion under JSON.stringify too.
+      code: 'JSON.stringify({ ok: false, error: "x" } as ToolFailure);',
       errors: [{ messageId: "directConstruct" }],
     },
   ],

--- a/tests/unit/path-class-contract/eslint-no-tool-failure-shape.test.ts
+++ b/tests/unit/path-class-contract/eslint-no-tool-failure-shape.test.ts
@@ -34,6 +34,13 @@ ruleTester.run("no-tool-failure-shape-direct-construct", rule, {
     'fail(toToolFailure(errorFromMessage(e, "tool", ctx)));',
     // `fail(variable)` — not a literal at the emission point.
     "fail(failureObject);",
+    // Scope boundary (Opus Round 1 P2-2): the rule targets the LITERAL `ok:false`
+    // + `error` form at the emission point. These laundering shapes intentionally
+    // escape PR-P4-1 (contrived, not used in practice; tightening them is future
+    // work / OQ-10 territory). Pinned as valid so the boundary is explicit and a
+    // future strictening is a deliberate test change.
+    "fail({ ...failureBase });", // ok:false comes from the spread, no literal property
+    'fail({ ["ok"]: false, error: "y" });', // computed key — not statically `ok: false`
     // Internal discriminated-union returns have no `error` key → not the wire shape.
     'const r = { ok: false, reason: "entity_not_found" };',
     'fail({ ok: false, reason: "x" });',


### PR DESCRIPTION
## What

ADR-021 **Phase 4 PR-P4-1** — the custom ESLint rule `no-tool-failure-shape-direct-construct`. This is the **structural half** of the Option B North Star: it bans hand-building the flat tool-failure wire shape so failures can *only* be emitted through the sanctioned presenter family.

After PR-P2-2/P2-3 swept every existing hand-built literal, this rule makes that sweep **permanent** and closes the R12 "un-deprecate window" (without it, new PRs could re-introduce raw `fail({ok:false,...})` literals).

## The rule

`eslint-rules/no-tool-failure-shape-direct-construct.mjs`:
- **Flags** an `ObjectExpression` with `ok:false` **and** an `error` key when it is the argument to `fail(...)` or `JSON.stringify(...)` (the two wire-emission contexts the swept literals used).
- **Allows**: `failWith` / `failCode` / `failArgs` / `fail(toToolFailure(...))` / `toFailureEnvelope`; `fail(variable)`; success payloads.
- **Does NOT flag** (by design): internal discriminated-union returns (`{ok:false, reason}`, `{ok:false, errorResult}` — no `error` key) and the `(E)` failure-as-success returns (`dock.ts` `return {ok:false, title, error}` consumed by `ok()`) — those are the OQ-10 carry-over (different mechanism, needs semantic detection).
- Wired in `eslint.config.mjs` for `src/tools/**` as **error**, exempting the converters `_errors.ts` / `_envelope.ts`.

## warn vs error (deviation from plan §3.5.1)

The plan said *warn-first → observe → error*. I landed it as **error directly** because:
1. PR-P2-2/P2-3 already swept every violation — `npm run lint` reports **0**, so there is nothing to migrate gradually.
2. A `warn` rule does **not** fail CI (eslint exits 0 on warnings without `--max-warnings`), so it would not actually block new literals — only `error` is real enforcement.
3. Rule correctness is verified up front (RuleTester 14 cases + a live injection check), so the false-positive risk warn-first was meant to surface is already characterized.

(Same shape as the OQ-1 RE-DECISION: the sweep changed the premise the staged rollout assumed.) Flagged for Opus/user; plan §3.5.1 + Phase 4 acceptance sync in a follow-up internal PR.

## Verification
- `tests/unit/path-class-contract/eslint-no-tool-failure-shape.test.ts`: RuleTester, **14 cases** (10 valid sanctioned/non-failure forms + 4 invalid hand-built literals).
- `npm run lint`: **0 errors** (rule clean on current code — sweep complete). Injecting `fail({ok:false,code,error})` reproduces the error; reverting clears it.
- `tsc` clean.

Plan: `desktop-touch-mcp-internal@0c4b960` §3.5.1 (Phase 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
