### PR TITLE
fix(terminal): #383 anchor run until:pattern past the echoed command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`terminal(action='run')` with `until:{mode:'pattern'}` now matches the
+  command's actual output, not the echoed command line.** Previously, when the
+  wait pattern also appeared in the command you sent — which is exactly the
+  completion idiom the tool documents, e.g. `some-long-task; echo "DONE"` with
+  `pattern:"DONE"` — the matcher matched the *echoed command line itself* and
+  returned `completion.reason:"pattern_matched"` before the command had produced
+  any output. Callers then had to follow every `run` with a separate
+  `action:"read"`, defeating the purpose of `run` (send → wait → read in one
+  call). The matcher now anchors past the echoed command, so a sentinel is
+  matched only when the command genuinely prints it. Patterns that appear only
+  in the output, and fast commands whose echo and output arrive together, are
+  unaffected. (issue #383)
+
 ## [1.7.2] - 2026-05-19 — Emergency-stop now requires a deliberate dwell (no more drive-by failsafe kills)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
   call). The matcher now anchors past the echoed command, so a sentinel is
   matched only when the command genuinely prints it. Patterns that appear only
   in the output, and fast commands whose echo and output arrive together, are
-  unaffected. (issue #383)
+  unaffected. This covers single-command idioms (`cmd; echo "DONE"`); multi-line
+  commands retain the prior scanning behaviour and are unchanged. (issue #383)
 
 ## [1.7.2] - 2026-05-19 — Emergency-stop now requires a deliberate dwell (no more drive-by failsafe kills)
 

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -301,11 +301,23 @@ function applySinceMarker(text: string, marker: string): { text: string; matched
  * hash window. Both `postBaseline` (via applySinceMarker) and `input` are run
  * through `normalizeForMarker` so CRLF/LF and trailing-whitespace rendering
  * differences do not break the match.
+ *
+ * `inputEchoes=false` — for hidden-input prompts (password / passphrase /
+ * secret / sudo, detected via isHiddenInputPrompt on the pre-send baseline) the
+ * input is never echoed into the buffer, so there is no echo to skip and no
+ * echoed command for a sentinel to self-match. The anchor is bypassed and the
+ * full slice is returned, otherwise the indexOf below would never find the
+ * needle and we would defer forever → until:{mode:'pattern'} would time out on
+ * a perfectly valid hidden-input flow (Codex P1 on #383).
  */
 export function scanRegionAfterEcho(
   postBaseline: string,
   input: string,
+  inputEchoes = true,
 ): string | undefined {
+  // Hidden-input prompt: nothing was echoed → scan the whole slice so the real
+  // post-prompt output can still match.
+  if (!inputEchoes) return postBaseline;
   const needle = normalizeForMarker(input);
   // Empty/blank input has no echo to skip — scan the whole slice.
   if (needle.length === 0) return postBaseline;
@@ -1372,6 +1384,13 @@ export const terminalRunHandler = async ({
   // the final sinceMarker diff.
   const baselineRead = await readTerminalRaw(windowTitle);
   const sinceMarker = baselineRead?.marker;
+  // Codex P1 (#383): if the pre-send prompt suppresses echo (password /
+  // passphrase / secret / sudo), the sent `input` is not echoed into the
+  // buffer, so the echo-anchor (scanRegionAfterEcho) could never locate it and
+  // would defer forever → until:{mode:'pattern'} would time out on a valid
+  // hidden-input flow. Detect that from the pre-send baseline (same heuristic
+  // terminal_send uses) and bypass the anchor in that case.
+  const inputEchoes = !isHiddenInputPrompt(baselineRead?.text ?? null);
 
   const sendArgs = {
     windowTitle,
@@ -1478,12 +1497,14 @@ export const terminalRunHandler = async ({
   //           re-introduce prior-history false positives.
   //       (b) echo not yet located (#383 defer) — the real output cannot exist
   //           before the full echo renders, so any match would be inside the
-  //           still-rendering echo; defer and retry on the next tick.
+  //           still-rendering echo; defer and retry on the next tick. Hidden-input
+  //           prompts (password/secret) suppress the echo entirely, so the anchor
+  //           is bypassed there (inputEchoes=false) rather than deferring forever.
   const newContentSinceBaseline = (text: string): string | undefined => {
     if (!sinceMarker) return undefined;
     const sliced = applySinceMarker(text, sinceMarker);
     if (!sliced.matched) return undefined;
-    return scanRegionAfterEcho(sliced.text, input);
+    return scanRegionAfterEcho(sliced.text, input, inputEchoes);
   };
 
   // Immediate post-send pattern check — runs once before the first POLL_INTERVAL_MS

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -271,6 +271,49 @@ function applySinceMarker(text: string, marker: string): { text: string; matched
   return { text, matched: false };
 }
 
+/**
+ * Issue #383: anchor pattern scanning PAST the echoed command line.
+ *
+ * `terminal(action='run')` captures the baseline marker BEFORE sending, so the
+ * post-baseline slice from `applySinceMarker` begins at (or just after) the
+ * echoed command — the terminal echoes the sent `input` before running it.
+ * Matching a pattern against that echo self-matches any sentinel embedded in
+ * the command (e.g. `…; echo "DONE"` + pattern "DONE"), firing before the
+ * command produces any output. This locates the (normalised) `input` inside the
+ * already-normalised `postBaseline` slice and returns only what FOLLOWS it, so
+ * matching considers the command's real output rather than its echo.
+ *
+ * Returns:
+ *   - string: the scan region after the echoed input (may be "" when the echo
+ *     has rendered but no output has followed yet — "" is a valid target for
+ *     patterns like /^$/).
+ *   - undefined: the echo is not yet located → DEFER. Because the shell renders
+ *     the full command echo before the command emits output, the real output
+ *     cannot exist before the full echo is present; any match at this point
+ *     would be inside the still-rendering echo. Callers MUST skip matching and
+ *     retry. Returning the full slice instead would re-introduce #383 (e.g. an
+ *     SSH-chunked echo where the sentinel arrived but the closing quote had
+ *     not). On terminals where the echo never renders verbatim this defers
+ *     until timeout — a loud failure preferable to a silent echo self-match.
+ *
+ * `indexOf` (not `startsWith`) tolerates a prompt-prefix remnant that can
+ * precede the echo when the prompt line is shorter than makeMarker's 256-char
+ * hash window. Both `postBaseline` (via applySinceMarker) and `input` are run
+ * through `normalizeForMarker` so CRLF/LF and trailing-whitespace rendering
+ * differences do not break the match.
+ */
+export function scanRegionAfterEcho(
+  postBaseline: string,
+  input: string,
+): string | undefined {
+  const needle = normalizeForMarker(input);
+  // Empty/blank input has no echo to skip — scan the whole slice.
+  if (needle.length === 0) return postBaseline;
+  const idx = postBaseline.indexOf(needle);
+  if (idx < 0) return undefined; // defer: echo not yet located
+  return postBaseline.slice(idx + needle.length);
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // terminal_read
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1419,21 +1462,28 @@ export const terminalRunHandler = async ({
     }
   }
 
-  // Pattern matching must only consider content that appeared AFTER the
-  // baseline marker. Otherwise prompt-shaped patterns (e.g. "PS>", "$ ") that
-  // already exist in scrollback would fire pattern_matched immediately.
+  // Pattern matching must only consider content that appeared AFTER the echoed
+  // command line. The baseline marker is captured before sending, so the slice
+  // from applySinceMarker begins at the echoed `input`; matching there would
+  // self-match a sentinel embedded in the command (issue #383). We therefore
+  // (1) slice to content after the baseline marker (applySinceMarker), then
+  // (2) anchor PAST the echoed input (scanRegionAfterEcho).
   // Returns:
-  //   - string: the new content since the baseline marker (may be "" when no
-  //     diff has accumulated yet — empty is a valid pattern target).
-  //   - undefined: the baseline boundary has been lost (no marker, or
-  //     applySinceMarker scanned past its 32k window without finding it).
-  //     Callers MUST skip pattern matching in this case — falling back to the
-  //     full buffer would re-introduce prior-history false positives because
-  //     scrollback past the scan window can still hold pre-baseline text.
+  //   - string: content after the echoed input (may be "" — a valid target for
+  //     patterns like /^$/).
+  //   - undefined: skip matching this tick. Two distinct causes, both honoured
+  //     by the same caller guard (newContent !== undefined):
+  //       (a) baseline boundary lost (no marker, or applySinceMarker scanned
+  //           past its 32k window) — falling back to the full buffer would
+  //           re-introduce prior-history false positives.
+  //       (b) echo not yet located (#383 defer) — the real output cannot exist
+  //           before the full echo renders, so any match would be inside the
+  //           still-rendering echo; defer and retry on the next tick.
   const newContentSinceBaseline = (text: string): string | undefined => {
     if (!sinceMarker) return undefined;
     const sliced = applySinceMarker(text, sinceMarker);
-    return sliced.matched ? sliced.text : undefined;
+    if (!sliced.matched) return undefined;
+    return scanRegionAfterEcho(sliced.text, input);
   };
 
   // Immediate post-send pattern check — runs once before the first POLL_INTERVAL_MS

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -323,12 +323,14 @@ function applySinceMarker(text: string, marker: string): { text: string; matched
  *
  * Single-line input is located with `indexOf` (not `startsWith`), tolerating a
  * prompt-prefix remnant before the echo (when the prompt line is shorter than
- * makeMarker's 256-char hash window). Multiline input is matched CONTIGUOUSLY,
- * tolerating only a continuation-prompt prefix between lines (Bash PS2 `> `,
- * PowerShell `>>`) — never arbitrary text, which could anchor inside an earlier
- * line's output and match before the echo boundary. Both `postBaseline` (via
- * applySinceMarker) and `input` are run through `normalizeForMarker` so CRLF/LF
- * and trailing-whitespace rendering differences do not break the match.
+ * makeMarker's 256-char hash window). Anchoring is applied to SINGLE-LINE input
+ * only: multiline input is echoed shell/terminal-dependently (continuation
+ * prompts AND interleaved line-by-line output) with no reliable echo-boundary
+ * discriminator in the buffer, so it is NOT anchored and falls back to the
+ * pre-#383 full scan (residual multiline echo self-match tracked in #386). Both
+ * `postBaseline` (via applySinceMarker) and `input` are run through
+ * `normalizeForMarker` so CRLF/LF and trailing-whitespace rendering differences
+ * do not break the single-line match.
  *
  * `inputEchoes=false` — for hidden-input prompts (password / passphrase /
  * secret / sudo, detected via isHiddenInputPrompt on the pre-send baseline) the
@@ -349,28 +351,23 @@ export function scanRegionAfterEcho(
   const needle = normalizeForMarker(input);
   // Empty/blank input has no echo to skip — scan the whole slice.
   if (needle.length === 0) return postBaseline;
-  const lines = needle.split("\n");
-  if (lines.length === 1) {
-    // Single-line: locate the echoed command and scan past it. indexOf (not
-    // startsWith) tolerates a prompt-prefix remnant before the echo.
-    const idx = postBaseline.indexOf(needle);
-    if (idx < 0) return undefined; // defer: echo not yet located
-    return postBaseline.slice(idx + needle.length);
-  }
-  // Multiline: match the echoed lines CONTIGUOUSLY, tolerating ONLY a
-  // continuation-prompt prefix between lines (Bash PS2 `> `, PowerShell `>>`),
-  // never arbitrary intervening text. Allowing arbitrary gaps (a per-line
-  // indexOf) could match a later line inside an earlier line's OUTPUT before
-  // that line was echoed, anchoring before the real echo boundary and
-  // re-opening premature pattern_matched (Codex #385 P2). The separator is a
-  // newline + an optional short run of `>`/`.` continuation chars + optional
-  // space. The first contiguous occurrence is the echo (echo precedes output);
-  // anchoring past it keeps a sentinel in the final command out of scope.
-  const escapeRe = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const re = new RegExp(lines.map(escapeRe).join("\\n[>.]{0,4} ?"));
-  const m = re.exec(postBaseline);
-  if (m === null) return undefined; // defer: contiguous echo not located yet
-  return postBaseline.slice(m.index + m[0].length);
+  // Multiline input: do NOT anchor — fall back to the pre-#383 full scan. A
+  // multiline command is echoed shell/terminal-dependently: continuation
+  // prompts (Bash PS2 `> `, PowerShell `>>`) AND interleaved line-by-line output
+  // (conhost/pwsh run embedded newlines line-by-line, inserting each line's
+  // output before the next line's echo) mean the buffer carries no reliable
+  // discriminator for the echo boundary — locating it either matches prematurely
+  // or defers forever (the #385 review history proved this is structural, not a
+  // tunable parameter). Anchoring is therefore scoped to single-line input — the
+  // case the #383 idiom (`cmd; echo "SENTINEL"`) and the issue cover. Multiline
+  // keeps the prior behaviour (no regression); residual multiline echo
+  // self-match is a pre-existing niche tracked in #386.
+  if (needle.includes("\n")) return postBaseline;
+  // Single-line: locate the echoed command and scan past it. indexOf (not
+  // startsWith) tolerates a prompt-prefix remnant before the echo.
+  const idx = postBaseline.indexOf(needle);
+  if (idx < 0) return undefined; // defer: echo not yet located
+  return postBaseline.slice(idx + needle.length);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -179,7 +179,8 @@ function makeMarker(text: string): string {
 // match for sudo) so partial mentions in earlier output do not trigger.
 // Future expansion (e.g. ssh-keygen "Enter passphrase (empty for no
 // passphrase):") should follow the same anchored-strict rule.
-const HIDDEN_INPUT_PROMPT_PATTERNS: readonly RegExp[] = [
+// UNAMBIGUOUS secret prompts: the input is genuinely NOT echoed back.
+const SECRET_INPUT_PROMPT_PATTERNS: readonly RegExp[] = [
   /(password|passphrase|secret|sudo)[\s:]*$/i,
   // Codex P1+P2: original `/Password for /` was case-sensitive AND unanchored.
   // - Case-sensitive: missed `[sudo] password for alice:` (lowercase "password")
@@ -193,35 +194,59 @@ const HIDDEN_INPUT_PROMPT_PATTERNS: readonly RegExp[] = [
   //   normal verification path. Future expansion should keep the trailing-anchor
   //   discipline.
   /password for \S+:\s*$/i,
+];
+
+// HIDDEN = SECRET + the bare-`>` PowerShell `Read-Host` continuation prompt.
+// CAUTION (Codex #385 P2): a bare `>` is ALSO Bash's default PS2 continuation
+// prompt, where input IS echoed. This broader set is only safe for the
+// terminal_send verification skip (a false-positive there merely skips
+// read-back — conservative). The terminal_run echo-anchor MUST instead use
+// isSecretInputPrompt (excludes `>`): treating a Bash PS2 baseline as
+// hidden-input would bypass the anchor, full-scan, and re-introduce #383.
+const HIDDEN_INPUT_PROMPT_PATTERNS: readonly RegExp[] = [
+  ...SECRET_INPUT_PROMPT_PATTERNS,
   /^>\s*$/,
 ];
 
 /**
- * Return true when the baseline text's cursor row matches a known
- * hidden-input prompt pattern. `baselineRaw` is the raw UIA TextPattern
- * snapshot taken just before send (ANSI strip is performed here so callers
- * can pass either ANSI-laden or pre-cleaned text).
- *
- * Returns false on null / empty input — verification continues normally
- * for unreadable buffers.
+ * Return the last non-empty (trailing-whitespace-stripped) line of a UIA
+ * TextPattern snapshot — the cursor row. ANSI is stripped here so callers can
+ * pass either ANSI-laden or pre-cleaned text. Returns null for null/blank input.
  */
-export function isHiddenInputPrompt(baselineRaw: string | null): boolean {
-  if (!baselineRaw) return false;
+function lastNonEmptyPromptLine(baselineRaw: string | null): string | null {
+  if (!baselineRaw) return null;
   const cleaned = stripAnsi(baselineRaw).replace(/\r\n/g, "\n");
-  // Take the last non-empty line — the cursor row. Trailing blank lines are
-  // padding from Windows Terminal's row-padding behaviour (see
-  // normalizeForMarker docstring).
   const lines = cleaned.split("\n");
-  let lastNonEmpty = "";
   for (let i = lines.length - 1; i >= 0; i--) {
     const trimmed = lines[i]!.replace(/[ \t]+$/, "");
-    if (trimmed.length > 0) {
-      lastNonEmpty = trimmed;
-      break;
-    }
+    if (trimmed.length > 0) return trimmed;
   }
-  if (lastNonEmpty.length === 0) return false;
-  return HIDDEN_INPUT_PROMPT_PATTERNS.some((re) => re.test(lastNonEmpty));
+  return null;
+}
+
+/**
+ * Return true when the baseline cursor row matches a known hidden-input prompt
+ * (credential prompts OR the bare-`>` Read-Host continuation). Used by
+ * terminal_send to skip post-send read-back verification (a false-positive is
+ * conservative there). Returns false on null / empty input.
+ */
+export function isHiddenInputPrompt(baselineRaw: string | null): boolean {
+  const line = lastNonEmptyPromptLine(baselineRaw);
+  if (line === null) return false;
+  return HIDDEN_INPUT_PROMPT_PATTERNS.some((re) => re.test(line));
+}
+
+/**
+ * Stricter sibling of isHiddenInputPrompt for the terminal_run echo-anchor:
+ * matches ONLY unambiguous secret prompts (password / passphrase / secret /
+ * sudo), excluding the bare-`>` pattern that doubles as Bash's PS2 continuation
+ * prompt (where input IS echoed). Deciding `inputEchoes` from this avoids
+ * full-scanning a Bash PS2 baseline and re-introducing #383 (Codex #385 P2).
+ */
+export function isSecretInputPrompt(baselineRaw: string | null): boolean {
+  const line = lastNonEmptyPromptLine(baselineRaw);
+  if (line === null) return false;
+  return SECRET_INPUT_PROMPT_PATTERNS.some((re) => re.test(line));
 }
 
 function applySinceMarker(text: string, marker: string): { text: string; matched: boolean } {
@@ -1403,14 +1428,16 @@ export const terminalRunHandler = async ({
   // passphrase / secret / sudo), the sent `input` is not echoed into the
   // buffer, so the echo-anchor (scanRegionAfterEcho) could never locate it and
   // would defer forever → until:{mode:'pattern'} would time out on a valid
-  // hidden-input flow. Detect that from the pre-send baseline (same heuristic
-  // terminal_send uses) and bypass the anchor in that case.
-  // Note (Opus R2 P3-1): a false-positive here bypasses the anchor (full scan),
-  // which in the run context could re-introduce #383 — the opposite direction
-  // of harm from terminal_send, where a false-positive only skips delivery
-  // verification. HIDDEN_INPUT_PROMPT_PATTERNS are end-anchored and strict, so
-  // normal bash ($ /# ) and PowerShell (>) prompts do not match (low risk).
-  const inputEchoes = !isHiddenInputPrompt(baselineRead?.text ?? null);
+  // hidden-input flow. Detect that from the pre-send baseline and bypass the
+  // anchor in that case.
+  // Use isSecretInputPrompt (NOT isHiddenInputPrompt): the latter also matches a
+  // bare `>`, which is Bash's PS2 continuation prompt where input IS echoed —
+  // bypassing the anchor there would full-scan and re-introduce #383 (Codex
+  // #385 P2). A false-positive here harms in the #383 direction (vs send, where
+  // it merely skips read-back), so the stricter end-anchored secret-only set is
+  // required. The narrow PowerShell Read-Host (`>`) hidden-input case is not
+  // bypassed and degrades to a loud timeout — safer than a silent echo match.
+  const inputEchoes = !isSecretInputPrompt(baselineRead?.text ?? null);
 
   const sendArgs = {
     windowTitle,

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -296,10 +296,12 @@ function applySinceMarker(text: string, marker: string): { text: string; matched
  *     not). On terminals where the echo never renders verbatim this defers
  *     until timeout — a loud failure preferable to a silent echo self-match.
  *
- * `indexOf` (not `startsWith`) tolerates a prompt-prefix remnant that can
- * precede the echo when the prompt line is shorter than makeMarker's 256-char
- * hash window. Both `postBaseline` (via applySinceMarker) and `input` are run
- * through `normalizeForMarker` so CRLF/LF and trailing-whitespace rendering
+ * Matching is line-by-line via `indexOf` (not `startsWith`): this tolerates a
+ * prompt-prefix remnant that can precede the echo (when the prompt line is
+ * shorter than makeMarker's 256-char hash window) AND the continuation-prompt
+ * text a shell injects between the lines of a multiline command (Bash PS2,
+ * PowerShell `>>`). Both `postBaseline` (via applySinceMarker) and `input` are
+ * run through `normalizeForMarker` so CRLF/LF and trailing-whitespace rendering
  * differences do not break the match.
  *
  * `inputEchoes=false` — for hidden-input prompts (password / passphrase /
@@ -321,9 +323,22 @@ export function scanRegionAfterEcho(
   const needle = normalizeForMarker(input);
   // Empty/blank input has no echo to skip — scan the whole slice.
   if (needle.length === 0) return postBaseline;
-  const idx = postBaseline.indexOf(needle);
-  if (idx < 0) return undefined; // defer: echo not yet located
-  return postBaseline.slice(idx + needle.length);
+  // Locate each echoed input LINE in order, allowing arbitrary text between
+  // lines. Interactive shells inject continuation-prompt text (Bash PS2 `> `,
+  // PowerShell `>>`) before the continuation lines of a multiline command, so
+  // the echo is not the raw input verbatim and a single full-input indexOf
+  // would miss it and defer forever (Codex P2 on #383). Searching line-by-line
+  // from the previous match skips those prefixes. Anchoring past the LAST line
+  // keeps a sentinel in the final command out of the scan region. For
+  // single-line input this is exactly one indexOf — identical to matching the
+  // whole input.
+  let pos = 0;
+  for (const line of needle.split("\n")) {
+    const at = postBaseline.indexOf(line, pos);
+    if (at < 0) return undefined; // defer: this echoed line not located yet
+    pos = at + line.length;
+  }
+  return postBaseline.slice(pos);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1390,6 +1405,11 @@ export const terminalRunHandler = async ({
   // would defer forever → until:{mode:'pattern'} would time out on a valid
   // hidden-input flow. Detect that from the pre-send baseline (same heuristic
   // terminal_send uses) and bypass the anchor in that case.
+  // Note (Opus R2 P3-1): a false-positive here bypasses the anchor (full scan),
+  // which in the run context could re-introduce #383 — the opposite direction
+  // of harm from terminal_send, where a false-positive only skips delivery
+  // verification. HIDDEN_INPUT_PROMPT_PATTERNS are end-anchored and strict, so
+  // normal bash ($ /# ) and PowerShell (>) prompts do not match (low risk).
   const inputEchoes = !isHiddenInputPrompt(baselineRead?.text ?? null);
 
   const sendArgs = {

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -321,13 +321,14 @@ function applySinceMarker(text: string, marker: string): { text: string; matched
  *     not). On terminals where the echo never renders verbatim this defers
  *     until timeout — a loud failure preferable to a silent echo self-match.
  *
- * Matching is line-by-line via `indexOf` (not `startsWith`): this tolerates a
- * prompt-prefix remnant that can precede the echo (when the prompt line is
- * shorter than makeMarker's 256-char hash window) AND the continuation-prompt
- * text a shell injects between the lines of a multiline command (Bash PS2,
- * PowerShell `>>`). Both `postBaseline` (via applySinceMarker) and `input` are
- * run through `normalizeForMarker` so CRLF/LF and trailing-whitespace rendering
- * differences do not break the match.
+ * Single-line input is located with `indexOf` (not `startsWith`), tolerating a
+ * prompt-prefix remnant before the echo (when the prompt line is shorter than
+ * makeMarker's 256-char hash window). Multiline input is matched CONTIGUOUSLY,
+ * tolerating only a continuation-prompt prefix between lines (Bash PS2 `> `,
+ * PowerShell `>>`) — never arbitrary text, which could anchor inside an earlier
+ * line's output and match before the echo boundary. Both `postBaseline` (via
+ * applySinceMarker) and `input` are run through `normalizeForMarker` so CRLF/LF
+ * and trailing-whitespace rendering differences do not break the match.
  *
  * `inputEchoes=false` — for hidden-input prompts (password / passphrase /
  * secret / sudo, detected via isHiddenInputPrompt on the pre-send baseline) the
@@ -348,22 +349,28 @@ export function scanRegionAfterEcho(
   const needle = normalizeForMarker(input);
   // Empty/blank input has no echo to skip — scan the whole slice.
   if (needle.length === 0) return postBaseline;
-  // Locate each echoed input LINE in order, allowing arbitrary text between
-  // lines. Interactive shells inject continuation-prompt text (Bash PS2 `> `,
-  // PowerShell `>>`) before the continuation lines of a multiline command, so
-  // the echo is not the raw input verbatim and a single full-input indexOf
-  // would miss it and defer forever (Codex P2 on #383). Searching line-by-line
-  // from the previous match skips those prefixes. Anchoring past the LAST line
-  // keeps a sentinel in the final command out of the scan region. For
-  // single-line input this is exactly one indexOf — identical to matching the
-  // whole input.
-  let pos = 0;
-  for (const line of needle.split("\n")) {
-    const at = postBaseline.indexOf(line, pos);
-    if (at < 0) return undefined; // defer: this echoed line not located yet
-    pos = at + line.length;
+  const lines = needle.split("\n");
+  if (lines.length === 1) {
+    // Single-line: locate the echoed command and scan past it. indexOf (not
+    // startsWith) tolerates a prompt-prefix remnant before the echo.
+    const idx = postBaseline.indexOf(needle);
+    if (idx < 0) return undefined; // defer: echo not yet located
+    return postBaseline.slice(idx + needle.length);
   }
-  return postBaseline.slice(pos);
+  // Multiline: match the echoed lines CONTIGUOUSLY, tolerating ONLY a
+  // continuation-prompt prefix between lines (Bash PS2 `> `, PowerShell `>>`),
+  // never arbitrary intervening text. Allowing arbitrary gaps (a per-line
+  // indexOf) could match a later line inside an earlier line's OUTPUT before
+  // that line was echoed, anchoring before the real echo boundary and
+  // re-opening premature pattern_matched (Codex #385 P2). The separator is a
+  // newline + an optional short run of `>`/`.` continuation chars + optional
+  // space. The first contiguous occurrence is the echo (echo precedes output);
+  // anchoring past it keeps a sentinel in the final command out of scope.
+  const escapeRe = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(lines.map(escapeRe).join("\\n[>.]{0,4} ?"));
+  const m = re.exec(postBaseline);
+  if (m === null) return undefined; // defer: contiguous echo not located yet
+  return postBaseline.slice(m.index + m[0].length);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/e2e/terminal.test.ts
+++ b/tests/e2e/terminal.test.ts
@@ -17,7 +17,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { execSync } from "node:child_process";
-import { terminalReadHandler, terminalSendHandler } from "../../src/tools/terminal.js";
+import { terminalReadHandler, terminalSendHandler, terminalRunHandler } from "../../src/tools/terminal.js";
 import { launchPowerShell, type PsInstance, type TerminalHost } from "./helpers/powershell-launcher.js";
 import { sleep, parsePayload } from "./helpers/wait.js";
 
@@ -405,5 +405,41 @@ describe.each(SCENARIOS)("[$label] terminal", ({ host, label, expectedClassPatte
         expect(readRes.text).toContain(tag);
       }, 15_000);
     }
+  });
+
+  // Issue #383: terminal_run with until:{mode:'pattern'} must match the
+  // command's REAL output, not the echoed command line. The sentinel `tag`
+  // appears inside the command (Write-Output "tag"), so its echo line contains
+  // `tag`. Pre-fix the matcher fired on that echo (~1.5s) and returned before
+  // the sleep elapsed; the fix anchors scanning past the echoed input.
+  describe(`terminal_run [${label}] — issue #383 echo anchoring`, () => {
+    it("until:pattern waits for the real output, not the echoed sentinel", async ({ skip }) => {
+      const tag = `run383-${host}-${Date.now().toString(36)}`;
+      const res = parsePayload(await terminalRunHandler({
+        windowTitle: ps.title,
+        input: `Start-Sleep -Seconds 4; Write-Output "${tag}"`,
+        until: { mode: "pattern", pattern: tag, regex: false },
+        timeoutMs: 20_000,
+      }));
+
+      // Env conditions (same skip policy as terminal_send): a refused
+      // foreground transfer prevents the send, or focus loss loses the
+      // baseline — neither lets us assert echo anchoring.
+      if (res.completion?.reason === "send_failed") {
+        skip(`terminal_run send_failed — foreground transfer refused (env). ${JSON.stringify(res.completion)}`);
+      }
+      if (res.outputIntegrity === "baseline_lost") {
+        skip(`terminal_run baseline_lost — focus did not transfer (env).`);
+      }
+
+      expect(res.completion.reason, JSON.stringify(res)).toBe("pattern_matched");
+      expect(res.completion.matchedPattern).toBe(tag);
+      // #383 core assertion: the echo (containing `tag`) renders within ~1.5s,
+      // but the real output appears only after the 4s sleep. A lower bound well
+      // above the echo render proves the matcher waited for the real output
+      // rather than self-matching the echoed command line.
+      expect(res.completion.elapsedMs).toBeGreaterThanOrEqual(3000);
+      expect(res.output).toContain(tag);
+    }, 30_000);
   });
 });

--- a/tests/fixtures/failwith-callsite-shapes.json
+++ b/tests/fixtures/failwith-callsite-shapes.json
@@ -492,28 +492,28 @@
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 312,
+      "line": 411,
       "tool": "terminal:read",
       "errKind": "identifier",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 382,
+      "line": 481,
       "tool": "terminal:read",
       "errKind": "identifier",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 569,
+      "line": 668,
       "tool": "terminal:send",
       "errKind": "new-error",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 628,
+      "line": 727,
       "tool": "terminal:send",
       "errKind": "new-error",
       "contextShape": "object-plain"

--- a/tests/unit/issue-383-terminal-run-echo-anchor.test.ts
+++ b/tests/unit/issue-383-terminal-run-echo-anchor.test.ts
@@ -144,4 +144,21 @@ describe("scanRegionAfterEcho — issue #383 echo anchoring", () => {
       expect(scanRegionAfterEcho(`whatever output`, `   `)).toBe(`whatever output`);
     });
   });
+
+  describe("hidden-input prompts (inputEchoes=false): bypass the anchor (Codex P1)", () => {
+    it("scans the full slice when the input is not echoed (e.g. a password)", () => {
+      // Password/secret sent to a prompt that suppresses echo: the input never
+      // appears in the buffer, but the post-auth output does. The matcher must
+      // see that output, not defer forever.
+      const post = `Login succeeded\nDONE`;
+      expect(scanRegionAfterEcho(post, `hunter2`, false)).toBe(post);
+    });
+
+    it("does NOT defer when the hidden input is absent (the regression Codex caught)", () => {
+      // Same args: inputEchoes=false scans the full slice; the default (true)
+      // would defer (undefined) and time out — the #383 fix's regression.
+      expect(scanRegionAfterEcho(`some output`, `secretpw`, false)).toBe(`some output`);
+      expect(scanRegionAfterEcho(`some output`, `secretpw`, true)).toBeUndefined();
+    });
+  });
 });

--- a/tests/unit/issue-383-terminal-run-echo-anchor.test.ts
+++ b/tests/unit/issue-383-terminal-run-echo-anchor.test.ts
@@ -108,6 +108,28 @@ describe("scanRegionAfterEcho — issue #383 echo anchoring", () => {
     });
   });
 
+  describe("continuation prompts on multiline input (Codex P2)", () => {
+    it("locates input across a Bash PS2 ('> ') continuation prompt", () => {
+      // The shell injected "> " before the continuation line, so the echo is
+      // not the raw input verbatim; line-by-line indexOf skips the prefix.
+      const post = `echo A\n> sleep 1; echo DONE\nA\nDONE`;
+      const input = `echo A\nsleep 1; echo DONE`;
+      expect(scanRegionAfterEcho(post, input)).toBe(`\nA\nDONE`);
+    });
+
+    it("locates input across a PowerShell ('>>') continuation prompt", () => {
+      const post = `Get-Process |\n>> Select-Object Name\nRESULT`;
+      const input = `Get-Process |\nSelect-Object Name`;
+      expect(scanRegionAfterEcho(post, input)).toBe(`\nRESULT`);
+    });
+
+    it("still defers when a later continuation line has not rendered yet", () => {
+      const post = `echo A\n> `; // first line echoed, continuation not yet
+      const input = `echo A\nsleep 1; echo DONE`;
+      expect(scanRegionAfterEcho(post, input)).toBeUndefined();
+    });
+  });
+
   describe("non-ASCII (CJK) input", () => {
     it("locates a CJK echo verbatim (clipboard send keeps it intact)", () => {
       const region = scanRegionAfterEcho(`echo "完了"\n完了`, `echo "完了"`);

--- a/tests/unit/issue-383-terminal-run-echo-anchor.test.ts
+++ b/tests/unit/issue-383-terminal-run-echo-anchor.test.ts
@@ -98,52 +98,32 @@ describe("scanRegionAfterEcho — issue #383 echo anchoring", () => {
     });
   });
 
-  describe("multiline input", () => {
-    it("anchors after the LAST echoed line (output follows the full echo)", () => {
+  describe("multiline input is NOT anchored — full-scan fallback (Option X / #386)", () => {
+    // The buffer carries no reliable echo-boundary discriminator for multiline
+    // input (continuation prompts + interleaved line-by-line output), so #383
+    // anchoring is scoped to single-line input. Multiline keeps the pre-#383
+    // behaviour: scanRegionAfterEcho returns the whole slice unchanged. This
+    // means a sentinel in a multiline command can still self-match (#386), but
+    // there is no defer→timeout regression and no premature anchoring.
+    it("returns the full slice for multiline input (no anchoring)", () => {
       const post = `echo A\nsleep 1; echo DONE\nA\nDONE`;
       const input = `echo A\nsleep 1; echo DONE`;
-      const region = scanRegionAfterEcho(post, input);
-      expect(region).toBe(`\nA\nDONE`);
-      expect(/DONE/.test(region!)).toBe(true);
+      expect(scanRegionAfterEcho(post, input)).toBe(post);
     });
-  });
 
-  describe("continuation prompts on multiline input (Codex P2)", () => {
-    it("locates input across a Bash PS2 ('> ') continuation prompt", () => {
-      // The shell injected "> " before the continuation line, so the echo is
-      // not the raw input verbatim; line-by-line indexOf skips the prefix.
+    it("returns the full slice even with continuation prompts in the echo", () => {
       const post = `echo A\n> sleep 1; echo DONE\nA\nDONE`;
       const input = `echo A\nsleep 1; echo DONE`;
-      expect(scanRegionAfterEcho(post, input)).toBe(`\nA\nDONE`);
+      expect(scanRegionAfterEcho(post, input)).toBe(post);
     });
 
-    it("locates input across a PowerShell ('>>') continuation prompt", () => {
-      const post = `Get-Process |\n>> Select-Object Name\nRESULT`;
-      const input = `Get-Process |\nSelect-Object Name`;
-      expect(scanRegionAfterEcho(post, input)).toBe(`\nRESULT`);
-    });
-
-    it("still defers when a later continuation line has not rendered yet", () => {
-      const post = `echo A\n> `; // first line echoed, continuation not yet
-      const input = `echo A\nsleep 1; echo DONE`;
-      expect(scanRegionAfterEcho(post, input)).toBeUndefined();
-    });
-
-    it("does NOT match prematurely when an earlier line's output contains a later line (Codex Round 4 P2)", () => {
-      // line1 `cat f` has not finished echoing line2 yet, but its OUTPUT already
-      // contains line2's text. A per-line indexOf with arbitrary gaps would
-      // anchor inside that output; contiguous matching must defer instead.
-      const input = `cat f\necho DONE`;
+    it("never defers on multiline — no defer→timeout regression (Codex Round 5 P1)", () => {
+      // Line-by-line execution inserts output between echoes; the earlier
+      // contiguous approach returned undefined (→ timeout) here. Full-scan must
+      // not defer.
       const post = `cat f\nsome echo DONE inside file output`;
-      expect(scanRegionAfterEcho(post, input)).toBeUndefined();
-    });
-
-    it("requires contiguity: rejects arbitrary text between echoed lines", () => {
-      // Only continuation-prompt prefixes (>/. + space) are allowed between
-      // lines — not arbitrary words.
-      const input = `line one\nline two`;
-      expect(scanRegionAfterEcho(`line one\nXX line two\nOUT`, input)).toBeUndefined();
-      expect(scanRegionAfterEcho(`line one\n>> line two\nOUT`, input)).toBe(`\nOUT`);
+      const input = `cat f\necho DONE`;
+      expect(scanRegionAfterEcho(post, input)).toBe(post);
     });
   });
 
@@ -154,23 +134,17 @@ describe("scanRegionAfterEcho — issue #383 echo anchoring", () => {
     });
   });
 
-  describe("needle normalisation (P2-2)", () => {
+  describe("needle normalisation (P2-2, single-line)", () => {
     it("strips trailing whitespace from the input before matching", () => {
       const post = `sleep 1; echo DONE\nDONE`;
       const input = `sleep 1; echo DONE   `; // trailing spaces
       expect(scanRegionAfterEcho(post, input)).toBe(`\nDONE`);
     });
 
-    it("normalises CRLF in the input to match the LF post-baseline slice", () => {
-      const post = `echo A\nsleep 1; echo DONE\nA\nDONE`;
-      const input = `echo A\r\nsleep 1; echo DONE`; // CRLF
-      expect(scanRegionAfterEcho(post, input)).toBe(`\nA\nDONE`);
-    });
-
-    it("preserves inner blank lines in the needle", () => {
-      const post = `echo A\n\necho DONE\nA\n\nDONE`;
-      const input = `echo A\n\necho DONE`; // inner blank line is significant
-      expect(scanRegionAfterEcho(post, input)).toBe(`\nA\n\nDONE`);
+    it("strips a trailing CRLF from the input before matching", () => {
+      const post = `sleep 1; echo DONE\nDONE`;
+      const input = `sleep 1; echo DONE\r\n`; // trailing CRLF
+      expect(scanRegionAfterEcho(post, input)).toBe(`\nDONE`);
     });
   });
 

--- a/tests/unit/issue-383-terminal-run-echo-anchor.test.ts
+++ b/tests/unit/issue-383-terminal-run-echo-anchor.test.ts
@@ -128,6 +128,23 @@ describe("scanRegionAfterEcho — issue #383 echo anchoring", () => {
       const input = `echo A\nsleep 1; echo DONE`;
       expect(scanRegionAfterEcho(post, input)).toBeUndefined();
     });
+
+    it("does NOT match prematurely when an earlier line's output contains a later line (Codex Round 4 P2)", () => {
+      // line1 `cat f` has not finished echoing line2 yet, but its OUTPUT already
+      // contains line2's text. A per-line indexOf with arbitrary gaps would
+      // anchor inside that output; contiguous matching must defer instead.
+      const input = `cat f\necho DONE`;
+      const post = `cat f\nsome echo DONE inside file output`;
+      expect(scanRegionAfterEcho(post, input)).toBeUndefined();
+    });
+
+    it("requires contiguity: rejects arbitrary text between echoed lines", () => {
+      // Only continuation-prompt prefixes (>/. + space) are allowed between
+      // lines — not arbitrary words.
+      const input = `line one\nline two`;
+      expect(scanRegionAfterEcho(`line one\nXX line two\nOUT`, input)).toBeUndefined();
+      expect(scanRegionAfterEcho(`line one\n>> line two\nOUT`, input)).toBe(`\nOUT`);
+    });
   });
 
   describe("non-ASCII (CJK) input", () => {

--- a/tests/unit/issue-383-terminal-run-echo-anchor.test.ts
+++ b/tests/unit/issue-383-terminal-run-echo-anchor.test.ts
@@ -22,7 +22,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { scanRegionAfterEcho } from "../../src/tools/terminal.js";
+import { scanRegionAfterEcho, isSecretInputPrompt, isHiddenInputPrompt } from "../../src/tools/terminal.js";
 
 describe("scanRegionAfterEcho — issue #383 echo anchoring", () => {
   describe("core fix: scan region excludes the echoed command", () => {
@@ -164,6 +164,32 @@ describe("scanRegionAfterEcho — issue #383 echo anchoring", () => {
 
     it("returns the full slice for whitespace-only input", () => {
       expect(scanRegionAfterEcho(`whatever output`, `   `)).toBe(`whatever output`);
+    });
+  });
+
+  describe("isSecretInputPrompt vs isHiddenInputPrompt — bare '>' is Bash PS2 (Codex P2)", () => {
+    it("treats credential prompts as secret (input not echoed)", () => {
+      expect(isSecretInputPrompt("$ sudo apt update\n[sudo] password for alice:")).toBe(true);
+      expect(isSecretInputPrompt("Enter passphrase:")).toBe(true);
+      expect(isSecretInputPrompt("Password:")).toBe(true);
+    });
+
+    it("does NOT treat a bare '>' (Bash PS2 continuation) as secret", () => {
+      // Codex P2: bypassing the echo anchor for a Bash PS2 baseline would
+      // full-scan and re-introduce #383 — so the run echo-anchor must not treat
+      // '>' as hidden input.
+      expect(isSecretInputPrompt(">")).toBe(false);
+      expect(isSecretInputPrompt("> ")).toBe(false);
+    });
+
+    it("does NOT treat normal prompts as secret (low false-positive)", () => {
+      expect(isSecretInputPrompt("user@host:~/secret$ ")).toBe(false); // dir named 'secret'
+      expect(isSecretInputPrompt("PS C:\\Users\\me>")).toBe(false);
+    });
+
+    it("isHiddenInputPrompt still matches '>' (unchanged — used by terminal_send)", () => {
+      expect(isHiddenInputPrompt(">")).toBe(true);
+      expect(isHiddenInputPrompt("Password:")).toBe(true);
     });
   });
 

--- a/tests/unit/issue-383-terminal-run-echo-anchor.test.ts
+++ b/tests/unit/issue-383-terminal-run-echo-anchor.test.ts
@@ -1,0 +1,147 @@
+/**
+ * issue-383-terminal-run-echo-anchor.test.ts
+ *
+ * Unit tests for scanRegionAfterEcho — the fix for issue #383.
+ *
+ * Bug: `terminal(action='run')` + `until:{mode:'pattern'}` captured the
+ * baseline marker BEFORE sending, so pattern matching scanned the echoed
+ * command line and self-matched a sentinel embedded in the command
+ * (e.g. `…; echo "DONE"` + pattern "DONE"), returning before the command
+ * produced output.
+ *
+ * Fix: scanRegionAfterEcho locates the (normalised) input inside the
+ * (already-normalised) post-baseline slice and returns only what FOLLOWS it,
+ * so matching considers the command's real output, not its echo. When the echo
+ * is not yet located it returns undefined (defer) rather than scanning the
+ * whole slice, which would re-introduce the bug.
+ *
+ * scanRegionAfterEcho's contract: `postBaseline` is ALREADY normalised (it
+ * comes from applySinceMarker in production); only `input` is normalised inside
+ * the function. Tests therefore pass LF / no-trailing-whitespace postBaseline
+ * strings.
+ */
+
+import { describe, it, expect } from "vitest";
+import { scanRegionAfterEcho } from "../../src/tools/terminal.js";
+
+describe("scanRegionAfterEcho — issue #383 echo anchoring", () => {
+  describe("core fix: scan region excludes the echoed command", () => {
+    it("returns content AFTER the echoed input (real output)", () => {
+      const post = `sleep 3; echo "DONE"\nDONE`;
+      const input = `sleep 3; echo "DONE"`;
+      expect(scanRegionAfterEcho(post, input)).toBe(`\nDONE`);
+    });
+
+    it("excludes a sentinel that appears in the command echo (the #383 bug)", () => {
+      // Echo rendered, no output yet → region is "" so /DONE/ does NOT match
+      // the echo's DONE (which would be a premature pattern_matched).
+      const region = scanRegionAfterEcho(`sleep 3; echo "TASKDONE"`, `sleep 3; echo "TASKDONE"`);
+      expect(region).toBe("");
+      expect(/TASKDONE/.test(region!)).toBe(false);
+    });
+
+    it("matches the real output once it follows the echo", () => {
+      const region = scanRegionAfterEcho(
+        `sleep 3; echo "TASKDONE"\nTASKDONE`,
+        `sleep 3; echo "TASKDONE"`,
+      );
+      expect(region).toBe(`\nTASKDONE`);
+      expect(/TASKDONE/.test(region!)).toBe(true);
+    });
+
+    it("when the sentinel appears in BOTH echo and output, only the output remains", () => {
+      const post = `echo "FOUND"; sleep 1; echo "FOUND"\nFOUND`;
+      const input = `echo "FOUND"; sleep 1; echo "FOUND"`;
+      const region = scanRegionAfterEcho(post, input);
+      expect(region).toBe(`\nFOUND`);
+      // The two FOUNDs in the echo are gone; only the real output FOUND is left.
+      expect((region!.match(/FOUND/g) ?? []).length).toBe(1);
+    });
+  });
+
+  describe("locate uses indexOf, not startsWith (prompt-prefix remnant, P2-1)", () => {
+    it("locates the echo even when a prompt prefix precedes it", () => {
+      // applySinceMarker can leave a prompt remnant at the head of the slice
+      // when the prompt line is shorter than makeMarker's 256-char window.
+      const post = `PS C:\\Users\\harus> echo "DONE"\nDONE`;
+      expect(scanRegionAfterEcho(post, `echo "DONE"`)).toBe(`\nDONE`);
+    });
+  });
+
+  describe("fast echo-only: no silent regression to timeout", () => {
+    it("returns the output region when echo and output co-render", () => {
+      const region = scanRegionAfterEcho(`echo "QUICK"\nQUICK`, `echo "QUICK"`);
+      expect(region).toBe(`\nQUICK`);
+      // Matches immediately — does NOT defer/timeout.
+      expect(/QUICK/.test(region!)).toBe(true);
+    });
+  });
+
+  describe("defer (return undefined) when the echo is not yet located", () => {
+    it("defers on a partially-rendered echo (sentinel substring present)", () => {
+      // The echo is mid-render: "TASK" is on screen but the full input isn't.
+      // Returning the partial would re-introduce #383; defer instead.
+      const region = scanRegionAfterEcho(`sleep 3; echo "TASK`, `sleep 3; echo "TASKDONE"`);
+      expect(region).toBeUndefined();
+    });
+
+    it("defers when nothing matching the input has rendered yet", () => {
+      expect(scanRegionAfterEcho(``, `sleep 3; echo "DONE"`)).toBeUndefined();
+    });
+  });
+
+  describe("echo located, no output yet → empty region (valid for /^$/)", () => {
+    it("returns '' so a sentinel pattern does not match the echo", () => {
+      const region = scanRegionAfterEcho(`sleep 3; echo "DONE"`, `sleep 3; echo "DONE"`);
+      expect(region).toBe("");
+      expect(/DONE/.test(region!)).toBe(false);
+    });
+  });
+
+  describe("multiline input", () => {
+    it("anchors after the LAST echoed line (output follows the full echo)", () => {
+      const post = `echo A\nsleep 1; echo DONE\nA\nDONE`;
+      const input = `echo A\nsleep 1; echo DONE`;
+      const region = scanRegionAfterEcho(post, input);
+      expect(region).toBe(`\nA\nDONE`);
+      expect(/DONE/.test(region!)).toBe(true);
+    });
+  });
+
+  describe("non-ASCII (CJK) input", () => {
+    it("locates a CJK echo verbatim (clipboard send keeps it intact)", () => {
+      const region = scanRegionAfterEcho(`echo "完了"\n完了`, `echo "完了"`);
+      expect(region).toBe(`\n完了`);
+    });
+  });
+
+  describe("needle normalisation (P2-2)", () => {
+    it("strips trailing whitespace from the input before matching", () => {
+      const post = `sleep 1; echo DONE\nDONE`;
+      const input = `sleep 1; echo DONE   `; // trailing spaces
+      expect(scanRegionAfterEcho(post, input)).toBe(`\nDONE`);
+    });
+
+    it("normalises CRLF in the input to match the LF post-baseline slice", () => {
+      const post = `echo A\nsleep 1; echo DONE\nA\nDONE`;
+      const input = `echo A\r\nsleep 1; echo DONE`; // CRLF
+      expect(scanRegionAfterEcho(post, input)).toBe(`\nA\nDONE`);
+    });
+
+    it("preserves inner blank lines in the needle", () => {
+      const post = `echo A\n\necho DONE\nA\n\nDONE`;
+      const input = `echo A\n\necho DONE`; // inner blank line is significant
+      expect(scanRegionAfterEcho(post, input)).toBe(`\nA\n\nDONE`);
+    });
+  });
+
+  describe("empty / blank input has no echo to skip", () => {
+    it("returns the full slice for empty input", () => {
+      expect(scanRegionAfterEcho(`whatever output`, ``)).toBe(`whatever output`);
+    });
+
+    it("returns the full slice for whitespace-only input", () => {
+      expect(scanRegionAfterEcho(`whatever output`, `   `)).toBe(`whatever output`);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #383.

## Problem
`terminal(action='run')` + `until:{mode:'pattern'}` captured the baseline marker **before** sending, so pattern matching scanned the **echoed command line** and self-matched a sentinel embedded in the command (e.g. `…; echo "DONE"` + `pattern:"DONE"`) — returning `pattern_matched` *before the command produced any output*. This is exactly the completion idiom the tool documents, so the recommended pattern backfired; callers had to follow every `run` with a separate `read`, defeating `run`'s send → wait → read in one call.

## Fix
New pure, exported `scanRegionAfterEcho(postBaseline, input)`: locates the (normalised) `input` inside the (already-normalised) post-baseline slice via `indexOf` and returns only what **follows** it. `newContentSinceBaseline` calls it.

- **`indexOf` (not `startsWith`)** tolerates a prompt-prefix remnant left when the prompt line is shorter than `makeMarker`'s 256-char hash window.
- **Locate failure → `undefined` (defer):** the shell renders the full command echo before the command emits output, so if the full input isn't located yet the real output cannot exist — any match would be inside the still-rendering echo. Deferring avoids re-introducing the bug (e.g. SSH-chunked echo where the sentinel arrived but the closing quote had not). On terminals where the echo never renders verbatim this defers to timeout — a **loud** failure, preferable to a **silent** echo self-match.

## Verification (live)
Reproduced and validated on a live harness (Local PowerShell 7.6.1 + SSH to WSL Ubuntu 26.04 over loopback + `netem` latency) per the plan's measurement appendix. Findings: the bug reproduces across Local / SSH / latency; UIA returns **logical** (not visual) lines, so wrapped / multiline / CJK echoes locate verbatim; fast echo-only co-renders echo+output (no silent regression to timeout).

## Tests
- `tests/unit/issue-383-terminal-run-echo-anchor.test.ts` — `scanRegionAfterEcho` matrix: echo-skip, prompt residue, fast echo-only, multiline, CJK, needle normalisation, defer.
- `tests/e2e/terminal.test.ts` — new `run` + `until:pattern` regression asserting an **elapsed lower bound** (waited for the real output, not the echo). Verified live.
- Full unit suite green (233 files / 3593 pass), `tsc` clean.

## Notes
- An **independent** trailing-newline defect (`\s*\n`-style patterns time out when the output lacks a trailing newline) is filed separately as #384 — not addressed here. The #383 fix removes the need for that `\s*\n` workaround in the common case.
- Design rationale + measurement appendix + OQ-1 (locate-failure = defer, decided): plan in the internal repo — https://github.com/Harusame64/desktop-touch-mcp-internal/blob/8578c45ba3865a29bb07c3c2b87df3a247f9b231/docs/issue-383-terminal-run-echo-anchor-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
