### PR TITLE
fix(terminal): #386 P3 — exit-mode send-fidelity hotfix (atomic delivery) + auto warning + real-machine e2e

### DIFF
--- a/src/engine/bg-input.ts
+++ b/src/engine/bg-input.ts
@@ -360,17 +360,37 @@ export async function pasteIntoConsoleNoFocus(
   return { ok: true };
 }
 
-/** Best-effort restore of a clipboard snapshot captured by getClipboardB64(). */
+/**
+ * Best-effort restore of a clipboard snapshot captured by getClipboardB64().
+ *
+ * Codex #389 P2: when the original clipboard was EMPTY (`""`) or could not be
+ * read (`null`), we must still CLEAR it rather than skip — otherwise the command
+ * we just pasted (possibly sensitive input) lingers in the user's clipboard
+ * after the run. Set-Clipboard rejects an empty value, so clearing uses the
+ * Forms clipboard API.
+ */
 async function restoreClipboard(savedB64: string | null): Promise<void> {
-  if (savedB64 === null || savedB64 === "") return;
   try {
-    const script =
-      `$b=[System.Convert]::FromBase64String('${savedB64}');` +
-      `$t=[System.Text.Encoding]::Unicode.GetString($b);` +
-      `Set-Clipboard -Value $t`;
-    await execFileAsync("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", script], {
-      timeout: 3000,
-    });
+    if (savedB64 && savedB64.length > 0) {
+      const script =
+        `$b=[System.Convert]::FromBase64String('${savedB64}');` +
+        `$t=[System.Text.Encoding]::Unicode.GetString($b);` +
+        `Set-Clipboard -Value $t`;
+      await execFileAsync("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", script], {
+        timeout: 3000,
+      });
+    } else {
+      // Originally empty / unreadable — clear so the injected command does not
+      // linger. Clearing an unreadable clipboard is harmless (best-effort).
+      await execFileAsync(
+        "powershell.exe",
+        [
+          "-NoProfile", "-NonInteractive", "-Command",
+          "Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.Clipboard]::Clear()",
+        ],
+        { timeout: 3000 },
+      );
+    }
   } catch {
     /* best-effort */
   }

--- a/src/engine/bg-input.ts
+++ b/src/engine/bg-input.ts
@@ -338,6 +338,10 @@ export async function pasteIntoConsoleNoFocus(
 
   const saved = await getClipboardB64(); // null = read failed; "" = empty clipboard
   if (!(await setClipboardVerified(crlf))) {
+    // Set-Clipboard may have landed before the read-back mismatch (another app
+    // raced, or newline tolerance missed) — restore so we never leave the user's
+    // clipboard clobbered on a failed paste (Opus #389 round 1 P2-1).
+    await restoreClipboard(saved);
     return { ok: false, reason: "clipboard_set_failed" };
   }
 

--- a/src/engine/bg-input.ts
+++ b/src/engine/bg-input.ts
@@ -15,6 +15,8 @@
  * 経由。
  */
 
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import {
   getWindowClassName,
   getWindowProcessId,
@@ -229,6 +231,145 @@ export function postKeyToHwnd(hwnd: unknown, vk: number): boolean {
 export function postEnterToHwnd(hwnd: unknown): boolean {
   const target = resolveTarget(hwnd);
   return postMessageToHwnd(target, WM_CHAR, VK_RETURN, 0);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Atomic no-focus-steal console paste (issue #386 Q3)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// The per-char WM_CHAR path (postCharsToHwnd) is unreliable for MULTILINE input
+// on conhost: an embedded newline makes conhost execute that line immediately,
+// and the chars posted while conhost is busy executing saturate its input queue
+// and DROP (observed: a `__DTMCP` token came back as `_DTMCP`). until:{mode:'exit'}
+// needs the completion sentinel to render byte-exact, so a dropped char breaks
+// completion detection entirely.
+//
+// conhost (ConsoleWindowClass) exposes the legacy console "Paste" command
+// (WM_COMMAND wParam=0xFFF1), which injects the ENTIRE clipboard into the input
+// buffer atomically — all chars land before any line executes, so nothing drops,
+// and it needs NO foreground change (PostMessage to the specific HWND).
+//
+// Spike finding (2026-05-23): conhost paste STRIPS lone LF (0x0A) and treats CR
+// (0x0D) as a line break, so the command must use CRLF separators; with `\n`
+// alone the lines concatenate and the shell sees one mangled line.
+
+const WM_COMMAND = 0x0111;
+/** Legacy console context-menu "Paste" command id (conhost). */
+const ID_CONSOLE_PASTE = 0xfff1;
+
+const execFileAsync = promisify(execFile);
+
+/** Read the current clipboard as a UTF-16LE base64 blob (empty string if none). */
+async function getClipboardB64(): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      "powershell.exe",
+      [
+        "-NoProfile", "-NonInteractive", "-Command",
+        "$t=Get-Clipboard -Raw;if($t -eq $null){''}else{" +
+          "[Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($t))}",
+      ],
+      { timeout: 4000 },
+    );
+    return stdout.trim();
+  } catch {
+    return null;
+  }
+}
+
+/** Set the clipboard to `text` (UTF-16LE) and verify the read-back byte-equals. */
+async function setClipboardVerified(text: string): Promise<boolean> {
+  const b64 = Buffer.from(text, "utf16le").toString("base64");
+  const script =
+    `$b=[System.Convert]::FromBase64String('${b64}');` +
+    `$t=[System.Text.Encoding]::Unicode.GetString($b);` +
+    `Set-Clipboard -Value $t;` +
+    `$r=Get-Clipboard -Raw;` +
+    `if($r -eq $null){''}else{[Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($r))}`;
+  try {
+    const { stdout } = await execFileAsync(
+      "powershell.exe",
+      ["-NoProfile", "-NonInteractive", "-Command", script],
+      { timeout: 5000 },
+    );
+    const readBack = stdout.trim();
+    const actual = readBack ? Buffer.from(readBack, "base64") : Buffer.alloc(0);
+    // Get-Clipboard -Raw can append a trailing newline; accept an exact match OR
+    // the text followed by a single CRLF/CR/LF so multiline payloads still pass.
+    const want = Buffer.from(text, "utf16le");
+    if (want.equals(actual)) return true;
+    for (const suffix of ["\r\n", "\r", "\n"]) {
+      if (Buffer.from(text + suffix, "utf16le").equals(actual)) return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+export interface ConsolePasteOutcome {
+  ok: boolean;
+  reason?: "clipboard_set_failed" | "console_paste_post_failed";
+}
+
+/**
+ * Paste `text` into a conhost (ConsoleWindowClass) window atomically WITHOUT
+ * stealing foreground, via clipboard + the console Paste command. Multiline-safe.
+ *
+ * Caller MUST have verified the target is conhost (ConsoleWindowClass) — the
+ * 0xFFF1 command is a no-op on Windows Terminal (XAML) and non-console windows.
+ *
+ * Flow: save clipboard → set clipboard to the CRLF-normalised text (verified) →
+ * post the console Paste command → settle so conhost drains the clipboard into
+ * its input buffer → send a trailing Enter to run the final line → restore the
+ * previous clipboard (best-effort).
+ *
+ * The trailing Enter is posted AFTER a settle delay (not appended to the
+ * clipboard) so it cannot race ahead of the still-draining paste.
+ */
+export async function pasteIntoConsoleNoFocus(
+  hwnd: unknown,
+  text: string,
+): Promise<ConsolePasteOutcome> {
+  const target = resolveTarget(hwnd);
+  // conhost strips lone LF and treats CR as a line break — use CRLF so each
+  // statement runs after the atomic paste.
+  const crlf = text.replace(/\r?\n/g, "\r\n");
+
+  const saved = await getClipboardB64(); // null = read failed; "" = empty clipboard
+  if (!(await setClipboardVerified(crlf))) {
+    return { ok: false, reason: "clipboard_set_failed" };
+  }
+
+  const posted = postMessageToHwnd(target, WM_COMMAND, ID_CONSOLE_PASTE, 0);
+  if (!posted) {
+    await restoreClipboard(saved);
+    return { ok: false, reason: "console_paste_post_failed" };
+  }
+
+  // Let conhost drain the clipboard into its input buffer before the Enter and
+  // before we overwrite the clipboard on restore.
+  await new Promise<void>((r) => setTimeout(r, 200));
+  postEnterToHwnd(target);
+  await new Promise<void>((r) => setTimeout(r, 60));
+  await restoreClipboard(saved);
+  return { ok: true };
+}
+
+/** Best-effort restore of a clipboard snapshot captured by getClipboardB64(). */
+async function restoreClipboard(savedB64: string | null): Promise<void> {
+  if (savedB64 === null || savedB64 === "") return;
+  try {
+    const script =
+      `$b=[System.Convert]::FromBase64String('${savedB64}');` +
+      `$t=[System.Text.Encoding]::Unicode.GetString($b);` +
+      `Set-Clipboard -Value $t`;
+    await execFileAsync("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", script], {
+      timeout: 3000,
+    });
+  } catch {
+    /* best-effort */
+  }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -1772,9 +1772,13 @@ export const terminalRunHandler = async ({
 
   // ── exit-mode shell resolution (issue #386) ─────────────────────────────────
   // Needs the window's process name (for shell:'auto' detection), so it runs
-  // after findTerminalWindow. cmd → ExitModeShellUnsupported, auto-low-confidence
-  // (WindowsTerminal / conhost / SSH host) → ExitModeShellAmbiguous: both loud
-  // pre-send rejects (no command sent). On success we lock the shell + a
+  // after findTerminalWindow. cmd → ExitModeShellUnsupported (loud pre-send
+  // reject). auto low-confidence (window process is an unknown host, e.g.
+  // WindowsTerminal) → ExitModeShellAmbiguous (loud reject). NOTE (P3 measured):
+  // a conhost-hosted PowerShell window reports 'powershell' → high → resolves;
+  // an SSH/WSL-nested session also reports the OUTER process, so auto silently
+  // resolves the outer shell (handled by the advisory warning below, degrades to
+  // a loud timeout if wrong — not ambiguous). On success we lock the shell + a
   // per-invocation nonce for buildExitCommand / parseExitSentinel.
   let exitShell: ExitShell | null = null;
   let exitNonce = "";
@@ -2282,9 +2286,11 @@ export const terminalSchema = z.discriminatedUnion("action", [
           "Shell the terminal runs, used to build the completion epilogue. " +
           "'bash' and 'powershell' are first-class. 'cmd' is not supported yet " +
           "(returns ExitModeShellUnsupported). 'auto' (default) detects from the " +
-          "window process but fails loudly (ExitModeShellAmbiguous) for hosts that " +
-          "hide the real shell (Windows Terminal / conhost / SSH) — pass the shell " +
-          "explicitly there. Inputs ending in an open construct (here-doc, " +
+          "window process: a conhost-hosted shell resolves, but a nested/remote " +
+          "shell is invisible (an SSH/WSL session reports its OUTER process, so " +
+          "auto picks the outer shell and warns — pass shell explicitly for " +
+          "remote sessions); auto fails loudly (ExitModeShellAmbiguous) only for " +
+          "unknown hosts such as Windows Terminal. Inputs ending in an open construct (here-doc, " +
           "unbalanced quote, unterminated $(…), here-string, trailing \\/backtick) " +
           "are rejected with ExitModeUnsafeInput."
         ),

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -441,9 +441,12 @@ export function buildExitCommand(input: string, shell: ExitShell, nonce: string)
     // multi-digit code (e.g. 127) cannot match mid-render as `1` (Codex P2).
     return `${input}\n__dtmcp_rc=$?; printf '%s%s|%d|\\n' '${head}' "${tail}" "$__dtmcp_rc"`;
   }
-  // powershell
+  // powershell — the prologue carries a trailing `# <nonce>` comment (harmless;
+  // PowerShell comments run to end-of-line, the assignment completes first) so
+  // its ECHO line is nonce-scoped and stripExitArtifacts can drop it without a
+  // fixed-string match that could delete real output (Codex #389 P2).
   return (
-    `$global:LASTEXITCODE = $null\n${input}\n` +
+    `$global:LASTEXITCODE = $null # ${nonce}\n${input}\n` +
     `$dtmcp_ok=$?; $dtmcp_c=$LASTEXITCODE; ('${head}'+"${tail}")+'|'+([string]$dtmcp_c)+'|'+$dtmcp_ok`
   );
 }
@@ -663,39 +666,24 @@ export function resolveExitShell(
  * undeterminable echo-boundary problem #386 is about, so it is intentionally
  * out of scope here).
  *
- * Signatures (all nonce-scoped except the fixed PowerShell prologue):
- *   - `_EXIT_<nonce>` — appears in BOTH the epilogue echo (the split-token
- *     expression `"_EXIT_<nonce>"`) AND the sentinel OUTPUT line
- *     (`__DTMCP_EXIT_<nonce>|…`). The crypto-random nonce makes a collision with
- *     the user's real output negligible (the same assumption parseExitSentinel
- *     relies on), so dropping every line containing it removes both injected
- *     lines without touching real output.
- *   - PowerShell only: the fixed prologue line `$global:LASTEXITCODE = $null`.
- *     This literal is NOT nonce-scoped, so to avoid deleting a user command that
- *     legitimately prints it (Codex #389 P2), only the FIRST occurrence is
- *     dropped — the injected prologue echo is the first executed line, so it
- *     precedes any real output that could repeat the literal.
+ * Every injected line is NONCE-SCOPED, so the strip is a single uniform rule:
+ * drop any line containing the crypto-random `<nonce>`. The nonce appears in
+ *   - the PowerShell prologue echo (`… = $null # <nonce>`),
+ *   - the epilogue echo (the split-token expression `"_EXIT_<nonce>"`), and
+ *   - the sentinel OUTPUT line (`__DTMCP_EXIT_<nonce>|…`),
+ * and nowhere in the user's real output (a collision would require the command
+ * to print the random nonce — the same negligible assumption parseExitSentinel
+ * relies on). This replaces the earlier fixed-string prologue match, which could
+ * delete a real-output line that legitimately printed `$global:LASTEXITCODE =
+ * $null` when the injected prologue had scrolled off a tailed read (Codex #389 P2).
  *
  * Best-effort cosmetic pass, NOT a correctness boundary: completion + exitCode
  * come from parseExitSentinel and are unaffected. If a wrapped/OCR'd render
- * splits a signature across lines, a fragment may survive — never a correctness
+ * splits the nonce across lines, a fragment may survive — never a correctness
  * issue.
  */
-export function stripExitArtifacts(slice: string, nonce: string, shell: ExitShell): string {
-  const nonceMark = EXIT_TOKEN_TAIL_PREFIX + nonce; // "_EXIT_<nonce>"
-  let prologueDropped = false;
-  const kept = slice.split("\n").filter((line) => {
-    if (line.includes(nonceMark)) return false; // epilogue echo + sentinel output
-    if (
-      shell === "powershell" &&
-      !prologueDropped &&
-      line.includes("$global:LASTEXITCODE = $null")
-    ) {
-      prologueDropped = true; // drop ONLY the first match (the injected echo)
-      return false;
-    }
-    return true;
-  });
+export function stripExitArtifacts(slice: string, nonce: string): string {
+  const kept = slice.split("\n").filter((line) => !line.includes(nonce));
   // Trim the blank edges the dropped lines can leave behind.
   return kept.join("\n").replace(/^\n+/, "").replace(/\n+$/, "");
 }
@@ -1756,6 +1744,29 @@ export const terminalRunHandler = async ({
   // input or picks pattern/quiet. This check is input-only (no window needed),
   // so it runs before findTerminalWindow.
   if (until.mode === "exit") {
+    // exit mode OWNS command delivery — it requires atomic delivery (whole
+    // command in one shot) + a trailing Enter, or the completion sentinel never
+    // assembles. Delivery-shaping sendOptions therefore cannot be honored; reject
+    // them loudly at this single gate (BEFORE host routing) so conhost and WT
+    // behave identically rather than the conhost path silently ignoring them
+    // (Codex #389 P1). Focus-management options stay allowed — they are no-ops on
+    // the no-steal conhost paste path, not silently wrong.
+    const EXIT_CONFLICTING_SEND_OPTS = ["method", "preferClipboard", "pressEnter", "chunkSize", "pasteKey"];
+    const offending = EXIT_CONFLICTING_SEND_OPTS.filter((k) => k in validatedSendOptions);
+    if (offending.length > 0) {
+      return failCode(
+        "InvalidArgs",
+        `terminal:run: until:{mode:'exit'} controls command delivery — sendOptions ${offending.join(", ")} are not supported in exit mode.`,
+        {
+          suggest: [
+            "Drop these sendOptions for exit mode — it always delivers the command atomically (clipboard/console-paste) and presses Enter so the completion sentinel can render.",
+            "Focus options (focusFirst / restoreFocus / settleMs / forceFocus / trackFocus) are still accepted.",
+            "If you need custom delivery, use until:{mode:'pattern'} or {mode:'quiet'} instead.",
+          ],
+          context: { windowTitle, offending },
+        },
+      );
+    }
     const unsafe = isUnsafeForExitMode(input);
     if (unsafe) {
       // failWith's 3rd arg is the FLAT context (non-hoisted keys nest under
@@ -2175,7 +2186,7 @@ export const terminalRunHandler = async ({
         // un-anchored, possibly-truncated buffer would lie about a run that did
         // not complete (Opus #388 round 1 P2-2). reason:'timeout' stays loud and
         // the integrity gate honestly reports baseline_lost when applicable.
-        output = stripExitArtifacts(parsed.text ?? "", exitNonce, exitShell);
+        output = stripExitArtifacts(parsed.text ?? "", exitNonce);
         finalMarker = parsed.marker;
         outputIntegrity = "ok";
       } else {

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -19,6 +19,7 @@ import {
   postEnterToHwnd,
   isBgAutoEnabled,
   injectViaForegroundFlash,
+  pasteIntoConsoleNoFocus,
   TERMINAL_WINDOW_CLASSES,
 } from "../engine/bg-input.js";
 import { resolveBackgroundInputChannel } from "../engine/background-channel-resolver.js";
@@ -487,10 +488,21 @@ export function parseExitSentinel(
  * Map a window process name to an exit-mode shell with a CONFIDENCE level.
  *
  * high  — the process IS the shell (`pwsh`/`powershell`/`bash`/`wsl`, or `cmd`).
- * low   — a host that can run ANY shell and hides the real one: WindowsTerminal,
- *         conhost (classic PowerShell often surfaces as conhost too — auto is
- *         frequently low even for a local PowerShell), OpenSSH/ssh (the remote
- *         shell is invisible from the local process — the SSH/WSL-nesting wall).
+ * low   — an unrecognised host process: WindowsTerminal (XAML host), or anything
+ *         else not in the table above.
+ *
+ * MEASURED CAVEAT (issue #386 P3, 2026-05-23): on Windows, a conhost-hosted
+ * PowerShell window's process name is "powershell"/"pwsh" (the hosted shell),
+ * NOT "conhost" — so `detectShell` returns HIGH confidence for it (auto works
+ * for a direct local PowerShell). The important corollary is the SSH/WSL-nesting
+ * wall: a conhost+PowerShell window running `ssh … bash` ALSO reports
+ * "powershell", so `auto` confidently resolves to powershell and would build the
+ * WRONG epilogue for the remote bash. detectShell only sees the WINDOW (outer)
+ * process; it cannot see a nested remote shell. The run handler therefore (a)
+ * resolves `auto` from this outer process and (b) emits an advisory warning on
+ * every auto-resolved exit run telling callers to pass `shell` explicitly for
+ * nested/remote sessions. A wrong epilogue degrades to a loud `reason:'timeout'`
+ * (the sentinel never renders), not to data corruption.
  *
  * The run handler treats low confidence as a loud failure (ExitModeShellAmbiguous)
  * and asks the caller to pass `shell` explicitly, rather than guessing wrong and
@@ -638,58 +650,42 @@ export function resolveExitShell(
 
 /**
  * Cosmetically strip the DRIVER-injected exit-mode artifacts from the final
- * `output`, so the caller sees only their command's real output (the exit status
- * is returned separately in `completion.exitCode`).
+ * `output`, so the caller does not see the prologue / epilogue / sentinel noise
+ * (the exit status is returned separately in `completion.exitCode`).
  *
- * The post-baseline slice for an exit-mode run looks like:
- *   [echoed prologue (PowerShell)] [echoed input] [echoed epilogue] [real output] [sentinel line]
+ * The injected lines do NOT bracket the real output — the input executes and
+ * prints BEFORE the epilogue line is echoed, so the buffer order is:
+ *   [prologue echo] [input echo] [real output…] [epilogue echo] [sentinel line]
+ * A region cut (head/tail) would therefore eat the real output. We instead drop
+ * the injected LINES by signature, order-independently, and keep everything else
+ * (the user's command echo + real output — same as pattern/quiet modes, which
+ * also return the echoed command; reliably stripping the echo too is the
+ * undeterminable echo-boundary problem #386 is about, so it is intentionally
+ * out of scope here).
  *
- * Two cuts, both keyed off markers that appear ONLY in injected text:
- *   1. Tail: drop everything from the CONTIGUOUS sentinel token onwards. The
- *      contiguous `__DTMCP_EXIT_<nonce>` only assembles in the command's runtime
- *      OUTPUT — the echo carries the SPLIT form — so this never over-cuts real
- *      output (echo-immune, same property parseExitSentinel relies on).
- *   2. Head: drop everything up to and including the echoed epilogue line,
- *      located by the NONCE-BEARING SPLIT-token signature the epilogue prints the
- *      token with (`'__DTMCP' "_EXIT_<nonce>"` for bash,
- *      `('__DTMCP'+"_EXIT_<nonce>")` for PowerShell). That signature appears ONLY
- *      in the driver-injected epilogue echo: the user's command echo would have
- *      to contain the crypto-random nonce in the exact split form to collide
- *      (the same negligible assumption parseExitSentinel relies on), and the
- *      command's real OUTPUT carries the CONTIGUOUS token, not the split form.
- *      Cutting to the FIRST occurrence also removes the PowerShell prologue + the
- *      user's command echo that precede it.
+ * Signatures (all nonce-scoped except the fixed PowerShell prologue):
+ *   - `_EXIT_<nonce>` — appears in BOTH the epilogue echo (the split-token
+ *     expression `"_EXIT_<nonce>"`) AND the sentinel OUTPUT line
+ *     (`__DTMCP_EXIT_<nonce>|…`). The crypto-random nonce makes a collision with
+ *     the user's real output negligible (the same assumption parseExitSentinel
+ *     relies on), so dropping every line containing it removes both injected
+ *     lines without touching real output.
+ *   - PowerShell only: the fixed prologue line `$global:LASTEXITCODE = $null`.
  *
- * Best-effort, NOT a correctness boundary: if a signature is not located (wrapped
- * echo, OCR fallback, or the head scrolled out of a tailed read), the
- * corresponding cut is skipped and the slice degrades to including a little
- * injected text — never to losing real output. Completion + exitCode come from
- * parseExitSentinel and are unaffected by this cosmetic pass.
+ * Best-effort cosmetic pass, NOT a correctness boundary: completion + exitCode
+ * come from parseExitSentinel and are unaffected. If a wrapped/OCR'd render
+ * splits a signature across lines, a fragment may survive — never a correctness
+ * issue.
  */
 export function stripExitArtifacts(slice: string, nonce: string, shell: ExitShell): string {
-  let body = slice;
-  // 1. Tail cut at the contiguous sentinel token (output-only by construction).
-  const tokIdx = body.indexOf(exitToken(nonce));
-  if (tokIdx >= 0) {
-    const lineStart = body.lastIndexOf("\n", tokIdx);
-    body = lineStart >= 0 ? body.slice(0, lineStart) : "";
-  }
-  // 2. Head cut past the echoed epilogue, anchored on the nonce-bearing split
-  //    signature (matches buildExitCommand's epilogue verbatim). Nonce-unique →
-  //    cannot collide with the user's command echo or real output, so this never
-  //    over-cuts real content.
-  const tail = EXIT_TOKEN_TAIL_PREFIX + nonce;
-  const splitSig =
-    shell === "bash"
-      ? `'${EXIT_TOKEN_HEAD}' "${tail}"`
-      : `('${EXIT_TOKEN_HEAD}'+"${tail}")`;
-  const mIdx = body.indexOf(splitSig);
-  if (mIdx >= 0) {
-    const nl = body.indexOf("\n", mIdx);
-    body = nl >= 0 ? body.slice(nl + 1) : "";
-  }
-  // Trim the blank edges the cuts can leave behind.
-  return body.replace(/^\n+/, "").replace(/\n+$/, "");
+  const nonceMark = EXIT_TOKEN_TAIL_PREFIX + nonce; // "_EXIT_<nonce>"
+  const kept = slice.split("\n").filter((line) => {
+    if (line.includes(nonceMark)) return false; // epilogue echo + sentinel output
+    if (shell === "powershell" && line.includes("$global:LASTEXITCODE = $null")) return false;
+    return true;
+  });
+  // Trim the blank edges the dropped lines can leave behind.
+  return kept.join("\n").replace(/^\n+/, "").replace(/\n+$/, "");
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1750,8 +1746,12 @@ export const terminalRunHandler = async ({
   if (until.mode === "exit") {
     const unsafe = isUnsafeForExitMode(input);
     if (unsafe) {
+      // failWith's 3rd arg is the FLAT context (non-hoisted keys nest under
+      // `context` automatically — see feedback_failwith_third_arg_flat). Passing
+      // `{ context: {...} }` would double-nest and hide `reason`.
       return failWith(new Error("ExitModeUnsafeInput"), "terminal:run", {
-        context: { reason: unsafe, windowTitle },
+        reason: unsafe,
+        windowTitle,
       });
     }
   }
@@ -1788,15 +1788,28 @@ export const terminalRunHandler = async ({
     })();
     const resolved = resolveExitShell(until.shell, processName);
     if (!resolved.ok) {
+      // Flat context (see note above): keys nest under `context` automatically.
       return failWith(new Error(resolved.code), "terminal:run", {
-        context: {
-          windowTitle,
-          ...(resolved.processName ? { processName: resolved.processName } : {}),
-        },
+        windowTitle,
+        ...(resolved.processName ? { processName: resolved.processName } : {}),
       });
     }
     exitShell = resolved.shell;
     exitNonce = generateExitNonce();
+    // Q2 (issue #386 P3): auto-detection only sees the WINDOW process, which is
+    // the OUTER/host shell. A nested remote shell (SSH-into-WSL: a conhost+
+    // PowerShell window running `ssh … bash`) reports the host process, so 'auto'
+    // would confidently pick the wrong shell and the wrong-epilogue run degrades
+    // to a loud timeout. Warn so callers know to pass shell explicitly for any
+    // nested/remote session. (No behaviour change — the resolution already
+    // happened; this is advisory.)
+    if (until.shell === "auto") {
+      warnings.push(
+        `shell auto-detected as '${exitShell}' from the terminal's window process; ` +
+          "nested SSH/WSL/remote shells are not detectable this way — pass shell:'bash'|'powershell' " +
+          "explicitly if this terminal is running a different shell than its host.",
+      );
+    }
   }
 
   // exit mode sends the command WRAPPED with the completion epilogue; all other
@@ -1840,17 +1853,43 @@ export const terminalRunHandler = async ({
     ...validatedSendOptions,
   };
 
-  const sendResult = await terminalSendHandler(sendArgs);
-  // Check send result — if send failed, classify by code + window state.
-  const sendPayload = (() => {
+  const parseSendResult = (r: ToolResult): { ok?: boolean; code?: string } | null => {
     try {
-      const block = sendResult.content[0];
+      const block = r.content[0];
       if (block?.type === "text") {
         return JSON.parse(block.text) as { ok?: boolean; code?: string };
       }
     } catch { /* fall through */ }
     return null;
-  })();
+  };
+
+  // issue #386 Q3: exit mode needs ATOMIC delivery. The default BG WM_CHAR path
+  // drops characters on the multiline epilogue (conhost executes each embedded
+  // newline mid-send and chars posted during execution saturate/drop), which
+  // corrupts the byte-exact completion sentinel → the run would time out. Deliver
+  // the whole command at once instead:
+  //   - conhost (ConsoleWindowClass): clipboard + console Paste — atomic AND no
+  //     focus steal (pasteIntoConsoleNoFocus). This is the common local case
+  //     (and the host behind SSH-into-WSL bash sessions).
+  //   - WT / other terminals: force the foreground clipboard-paste path
+  //     (method:'foreground'), which pastes the command in one shot (atomic) at
+  //     the cost of a brief focus steal — WT cannot take WM_CHAR anyway, and a
+  //     non-conhost terminal has no no-steal console-paste equivalent.
+  // Non-exit modes are unchanged (method:'auto').
+  let sendPayload: { ok?: boolean; code?: string } | null;
+  if (until.mode === "exit") {
+    const targetClass = (() => {
+      try { return getWindowClassName(hwnd); } catch { return ""; }
+    })();
+    if (targetClass === "ConsoleWindowClass") {
+      const paste = await pasteIntoConsoleNoFocus(hwnd, sendInput);
+      sendPayload = paste.ok ? { ok: true } : { ok: false, code: paste.reason };
+    } else {
+      sendPayload = parseSendResult(await terminalSendHandler({ ...sendArgs, method: "foreground" }));
+    }
+  } else {
+    sendPayload = parseSendResult(await terminalSendHandler(sendArgs));
+  }
 
   if (sendPayload && sendPayload.ok === false) {
     // Issue #173 P2-2: when the window is still alive but send failed, the

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -671,6 +671,10 @@ export function resolveExitShell(
  *     relies on), so dropping every line containing it removes both injected
  *     lines without touching real output.
  *   - PowerShell only: the fixed prologue line `$global:LASTEXITCODE = $null`.
+ *     This literal is NOT nonce-scoped, so to avoid deleting a user command that
+ *     legitimately prints it (Codex #389 P2), only the FIRST occurrence is
+ *     dropped — the injected prologue echo is the first executed line, so it
+ *     precedes any real output that could repeat the literal.
  *
  * Best-effort cosmetic pass, NOT a correctness boundary: completion + exitCode
  * come from parseExitSentinel and are unaffected. If a wrapped/OCR'd render
@@ -679,9 +683,17 @@ export function resolveExitShell(
  */
 export function stripExitArtifacts(slice: string, nonce: string, shell: ExitShell): string {
   const nonceMark = EXIT_TOKEN_TAIL_PREFIX + nonce; // "_EXIT_<nonce>"
+  let prologueDropped = false;
   const kept = slice.split("\n").filter((line) => {
     if (line.includes(nonceMark)) return false; // epilogue echo + sentinel output
-    if (shell === "powershell" && line.includes("$global:LASTEXITCODE = $null")) return false;
+    if (
+      shell === "powershell" &&
+      !prologueDropped &&
+      line.includes("$global:LASTEXITCODE = $null")
+    ) {
+      prologueDropped = true; // drop ONLY the first match (the injected echo)
+      return false;
+    }
     return true;
   });
   // Trim the blank edges the dropped lines can leave behind.

--- a/tests/e2e/helpers/powershell-launcher.ts
+++ b/tests/e2e/helpers/powershell-launcher.ts
@@ -156,11 +156,22 @@ export async function launchPowerShell(opts?: {
    *    WM_CHAR is silently swallowed by the WinUI/XAML pipeline (issue #173).
    */
   host?: TerminalHost;
+  /**
+   * Optional extra PowerShell statement appended AFTER the title / pid / banner
+   * statements. Used by the SSH-into-WSL launcher (issue #386 P3) to drop the
+   * window into a remote bash session via `& ssh.exe …` once the window is
+   * already titled + findable. The window title is set by [Console]::Title
+   * BEFORE this runs, so findByTag still works while the foreground process is
+   * the SSH/bash session. Kept generic so the launcher's kill/isolation
+   * guarantees are reused unchanged.
+   */
+  postScript?: string;
 }): Promise<PsInstance> {
   const tag = `ps-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
   const banner = opts?.banner ?? "";
   const exe = opts?.exe ?? "powershell.exe";
   const host: TerminalHost = opts?.host ?? "default";
+  const postScript = opts?.postScript ?? "";
 
   // Temp file the PS script writes its own PID into — lets kill() target the
   // exact PowerShell process rather than using WINDOWTITLE (which on Windows
@@ -188,6 +199,7 @@ export async function launchPowerShell(opts?: {
     `[Console]::Title = '${tag}'`,
     `[string]$PID | Set-Content -Path '${psafePidFile}'`,
     banner ? `Write-Host '${banner.replace(/'/g, "''")}'` : "",
+    postScript || "",
   ].filter(Boolean).join("; ");
   const encodedScript = Buffer.from(psScript, "utf16le").toString("base64");
 

--- a/tests/e2e/helpers/ssh-wsl-launcher.ts
+++ b/tests/e2e/helpers/ssh-wsl-launcher.ts
@@ -1,0 +1,169 @@
+/**
+ * ssh-wsl-launcher.ts — drive a real bash session over SSH-into-WSL for the
+ * issue #386 exit-mode e2e (plan §9 acceptance: "SSH-into-WSL bash で multiline
+ * echo 自己マッチが起きない").
+ *
+ * This is the #383 measurement harness reused for regression proof: a conhost
+ * PowerShell window (titled + findable via the existing launchPowerShell safety
+ * net) immediately `exec`s the System32 OpenSSH client into WSL Ubuntu's
+ * sshd:2222, landing in an interactive `bash --norc`. The foreground process is
+ * then bash-over-SSH while the window keeps its [Console]::Title tag, so
+ * terminal(action='run') can target it by windowTitle.
+ *
+ * Why this is the canonical #386 scenario: the WINDOW process is conhost (a host
+ * that hides the real shell), so detectShell → low confidence → shell:'auto'
+ * loud-fails (ExitModeShellAmbiguous). The session is actually bash, so the
+ * caller passes shell:'bash' explicitly — exactly the SSH/WSL-nesting wall the
+ * exit-mode design is built around.
+ *
+ * Availability is probed once (key auth into WSL); on any miss the suite skips
+ * cleanly (env condition, not a product bug).
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { launchPowerShell, type PsInstance } from "./powershell-launcher.js";
+import { terminalReadHandler } from "../../../src/tools/terminal.js";
+import { parsePayload } from "./wait.js";
+import { sleep } from "./wait.js";
+
+const execFileAsync = promisify(execFile);
+
+const SSH_EXE = "C:\\Windows\\System32\\OpenSSH\\ssh.exe";
+const SSH_PORT = "2222";
+const SSH_USER = "root";
+const SSH_HOST = "127.0.0.1";
+const KEY_PATH = join(homedir(), ".ssh", "wsl_measure");
+
+/** Common ssh options: key auth only, no host-key prompt, no known_hosts churn. */
+function sshOpts(): string[] {
+  return [
+    "-p", SSH_PORT,
+    "-i", KEY_PATH,
+    "-o", "StrictHostKeyChecking=no",
+    "-o", "UserKnownHostsFile=NUL",
+    // Generous: WSL auto-sleeps and the first connection has to wake it, which
+    // can take several seconds.
+    "-o", "ConnectTimeout=25",
+  ];
+}
+
+/** Wake WSL + ensure sshd is listening — WSL idles aggressively. Best-effort. */
+async function wakeWslSshd(): Promise<void> {
+  try {
+    await execFileAsync(
+      "wsl.exe",
+      ["--", "bash", "-lc", "sudo service ssh start 2>/dev/null; true"],
+      { timeout: 25_000, windowsHide: true },
+    );
+  } catch {
+    /* best-effort — the ssh probe below is the real gate */
+  }
+}
+
+let cached: boolean | null = null;
+
+/**
+ * True when this machine can key-auth into WSL bash over sshd:2222. Cached per
+ * process. Wakes WSL first (it idles), then runs a non-interactive
+ * `ssh … 'echo DTM_SSH_OK'` (BatchMode so a missing key never hangs on a
+ * password prompt) with one retry to absorb a cold WSL start.
+ */
+export async function isSshWslAvailable(): Promise<boolean> {
+  if (cached !== null) return cached;
+  if (process.platform !== "win32" || !existsSync(SSH_EXE) || !existsSync(KEY_PATH)) {
+    cached = false;
+    return false;
+  }
+  await wakeWslSshd();
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const { stdout } = await execFileAsync(
+        SSH_EXE,
+        [...sshOpts(), "-o", "BatchMode=yes", `${SSH_USER}@${SSH_HOST}`, "echo DTM_SSH_OK"],
+        { timeout: 30_000, windowsHide: true },
+      );
+      if (stdout.includes("DTM_SSH_OK")) {
+        cached = true;
+        return true;
+      }
+    } catch {
+      /* retry once */
+    }
+  }
+  cached = false;
+  return false;
+}
+
+export interface SshBashInstance extends PsInstance {
+  /** Marker the remote shell prints once interactive bash is ready. */
+  readyMarker: string;
+}
+
+/**
+ * Launch a conhost window that SSHes into WSL bash and waits until the remote
+ * interactive shell is ready (the readyMarker has rendered into the buffer).
+ *
+ * `bash --norc` is used so the default Ubuntu prompt cannot emit an xterm title
+ * escape that would rename the window out from under findTerminalWindow — the
+ * window keeps its [Console]::Title tag. PS1 stays the bash default and PS2 is
+ * `> `, which is exactly the multiline-continuation shape #386 exercises.
+ */
+export async function launchSshWslBash(): Promise<SshBashInstance> {
+  const readyMarker = `BASHREADY_${Date.now().toString(36)}`;
+  // Single-quoted PS literals: backslashes in KEY_PATH and the remote command
+  // are passed verbatim. The remote command runs `echo <marker>` then execs an
+  // interactive no-rc bash so the session stays drivable by terminal_send.
+  const sshArgs = [
+    "-tt", // force a remote pty so bash is interactive over the piped session
+    ...sshOpts(),
+    `${SSH_USER}@${SSH_HOST}`,
+  ]
+    .map((a) => `'${a.replace(/'/g, "''")}'`)
+    .join(" ");
+  const remoteCmd = `'echo ${readyMarker}; exec bash --norc -i'`;
+  const postScript = `& '${SSH_EXE}' ${sshArgs} ${remoteCmd}`;
+
+  const ps = await launchPowerShell({
+    host: "conhost",
+    banner: `psbeforessh-${readyMarker}`,
+    postScript,
+  });
+
+  // Poll the buffer until the remote readiness marker appears (bash is up).
+  const deadline = Date.now() + 25_000;
+  let ready = false;
+  while (Date.now() < deadline) {
+    const r = parsePayload(
+      await terminalReadHandler({
+        windowTitle: ps.title,
+        lines: 200,
+        stripAnsi: true,
+        source: "auto",
+        ocrLanguage: "ja",
+      }),
+    );
+    // The marker also appears in the echoed `echo <marker>` command line, so
+    // require it to show up at least twice (command echo + the echo output) OR
+    // accompanied by a bash prompt sigil, to be sure bash is actually live.
+    if (r.ok && typeof r.text === "string") {
+      const hits = r.text.split(readyMarker).length - 1;
+      if (hits >= 2) {
+        ready = true;
+        break;
+      }
+    }
+    await sleep(500);
+  }
+  if (!ready) {
+    ps.kill();
+    throw new Error(`SSH-into-WSL bash did not become ready (marker ${readyMarker} not observed)`);
+  }
+  // Small settle so the prompt after the marker is fully painted.
+  await sleep(500);
+
+  return { ...ps, readyMarker, kill: ps.kill };
+}

--- a/tests/e2e/terminal-exit-mode.test.ts
+++ b/tests/e2e/terminal-exit-mode.test.ts
@@ -1,0 +1,285 @@
+/**
+ * terminal-exit-mode.test.ts — E2E for issue #386 `until:{mode:'exit'}`
+ * (echo-immune completion sentinel), plan §9 acceptance.
+ *
+ * Two real-shell suites:
+ *   1. PowerShell (conhost) — success (exitCode 0 / native non-zero / cmdlet
+ *      $?=False) + the loud pre-flight rejects (cmd / ambiguous-auto / unsafe
+ *      input).
+ *   2. SSH-into-WSL bash (the #383 measurement harness) — the #386 CORE: a
+ *      multiline command whose own text looks like a completion marker still
+ *      completes via the nonce sentinel (never self-matches its echo, which
+ *      pattern mode cannot anchor for multiline), with the correct exitCode.
+ *      Also proves the SSH/WSL wall: shell:'auto' loud-fails (the window is
+ *      conhost) so the caller must pass shell:'bash'.
+ *
+ * Skip policy (mirrors terminal.test.ts §S-2): the only env condition that may
+ * skip a delivery assertion is a refused send (completion.reason:'send_failed'
+ * — foreground transfer refused) or baseline_lost. Bash suite skips wholesale
+ * when the WSL/sshd harness is unavailable.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { execSync } from "node:child_process";
+import { terminalRunHandler } from "../../src/tools/terminal.js";
+import { launchPowerShell, type PsInstance } from "./helpers/powershell-launcher.js";
+import { isSshWslAvailable, launchSshWslBash, type SshBashInstance } from "./helpers/ssh-wsl-launcher.js";
+import { parsePayload } from "./helpers/wait.js";
+
+/** True when the run could not even send (env: foreground transfer refused). */
+function isEnvSendSkip(p: { completion?: { reason?: string }; outputIntegrity?: string }): boolean {
+  return p.completion?.reason === "send_failed" || p.outputIntegrity === "baseline_lost";
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PowerShell (conhost)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("[powershell] terminal exit mode (#386)", () => {
+  let ps: PsInstance;
+
+  beforeAll(async () => {
+    ps = await launchPowerShell({ host: "conhost", banner: "exitmode-ps-ready" });
+  }, 20_000);
+
+  afterAll(() => ps?.kill());
+
+  it("single-line: reason:'exited' + exitCode 0, no echo self-match", async ({ skip }) => {
+    const res = parsePayload(
+      await terminalRunHandler({
+        windowTitle: ps.title,
+        input: "Write-Output 'hi386'; Start-Sleep -Seconds 1",
+        until: { mode: "exit", shell: "powershell" },
+        timeoutMs: 25_000,
+      }),
+    );
+    if (isEnvSendSkip(res)) skip(`env: ${JSON.stringify(res.completion)}`);
+    expect(res.completion.reason, JSON.stringify(res)).toBe("exited");
+    expect(res.completion.exitCode).toBe(0);
+    // Waited for the real command (≥ the 1s sleep), not the echoed sentinel.
+    expect(res.completion.elapsedMs).toBeGreaterThanOrEqual(800);
+    expect(res.output).toContain("hi386");
+  }, 35_000);
+
+  it("multiline: completes via the sentinel even though pattern mode can't anchor", async ({ skip }) => {
+    const res = parsePayload(
+      await terminalRunHandler({
+        windowTitle: ps.title,
+        // Embedded newline + a token that LOOKS like a completion marker.
+        input: "Write-Output 'A1'\nStart-Sleep -Seconds 2\nWrite-Output 'PSDONE_386'",
+        until: { mode: "exit", shell: "powershell" },
+        timeoutMs: 30_000,
+      }),
+    );
+    if (isEnvSendSkip(res)) skip(`env: ${JSON.stringify(res.completion)}`);
+    expect(res.completion.reason, JSON.stringify(res)).toBe("exited");
+    expect(res.completion.exitCode).toBe(0);
+    // ≥ ~2s proves it waited through the whole multiline body, not the echo.
+    expect(res.completion.elapsedMs).toBeGreaterThanOrEqual(1800);
+    expect(res.output).toContain("A1");
+    expect(res.output).toContain("PSDONE_386");
+    // stripExitArtifacts removed the injected prologue/epilogue echo + sentinel.
+    expect(res.output).not.toContain("DTMCP");
+    expect(res.output).not.toContain("LASTEXITCODE");
+  }, 40_000);
+
+  it("native non-zero exit code is reported", async ({ skip }) => {
+    const res = parsePayload(
+      await terminalRunHandler({
+        windowTitle: ps.title,
+        input: "cmd /c exit 7",
+        until: { mode: "exit", shell: "powershell" },
+        timeoutMs: 25_000,
+      }),
+    );
+    if (isEnvSendSkip(res)) skip(`env: ${JSON.stringify(res.completion)}`);
+    expect(res.completion.reason, JSON.stringify(res)).toBe("exited");
+    expect(res.completion.exitCode).toBe(7);
+  }, 35_000);
+
+  it("cmdlet failure ($?=False, no native exe) maps to exitCode 1", async ({ skip }) => {
+    const res = parsePayload(
+      await terminalRunHandler({
+        windowTitle: ps.title,
+        input: "Get-Item 'Z:\\__no_such_path_386__' -ErrorAction Stop",
+        until: { mode: "exit", shell: "powershell" },
+        timeoutMs: 25_000,
+      }),
+    );
+    if (isEnvSendSkip(res)) skip(`env: ${JSON.stringify(res.completion)}`);
+    expect(res.completion.reason, JSON.stringify(res)).toBe("exited");
+    // OQ-7: $LASTEXITCODE cleared by the prologue stays empty (no native exe ran),
+    // so the parser falls back to $? (False → 1).
+    expect(res.completion.exitCode).toBe(1);
+  }, 35_000);
+
+  it("shell:'cmd' is a loud pre-flight reject (ExitModeShellUnsupported)", async () => {
+    const res = parsePayload(
+      await terminalRunHandler({
+        windowTitle: ps.title,
+        input: "echo hi",
+        until: { mode: "exit", shell: "cmd" },
+        timeoutMs: 10_000,
+      }),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.code).toBe("ExitModeShellUnsupported");
+    expect(Array.isArray(res.suggest)).toBe(true);
+  }, 15_000);
+
+  it("shell:'auto' resolves to powershell on a conhost-hosted PS window + emits the nesting warning (P3 measured)", async ({ skip }) => {
+    // MEASURED: a conhost-hosted PowerShell window reports processName
+    // 'powershell', so auto resolves HIGH (not ambiguous). The Q2 advisory
+    // warning fires so callers know nested SSH/WSL is undetectable.
+    const res = parsePayload(
+      await terminalRunHandler({
+        windowTitle: ps.title,
+        input: "Write-Output 'autoresolve'",
+        until: { mode: "exit", shell: "auto" },
+        timeoutMs: 25_000,
+      }),
+    );
+    if (isEnvSendSkip(res)) skip(`env: ${JSON.stringify(res.completion)}`);
+    expect(res.completion.reason, JSON.stringify(res)).toBe("exited");
+    expect(res.completion.exitCode).toBe(0);
+    expect(Array.isArray(res.warnings)).toBe(true);
+    expect(res.warnings.some((w: string) => /auto-detected as 'powershell'/.test(w))).toBe(true);
+    expect(res.output).toContain("autoresolve");
+  }, 35_000);
+
+  it("input ending in an open construct is rejected (ExitModeUnsafeInput)", async () => {
+    const res = parsePayload(
+      await terminalRunHandler({
+        windowTitle: ps.title,
+        input: 'Write-Output "unterminated',
+        until: { mode: "exit", shell: "powershell" },
+        timeoutMs: 10_000,
+      }),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.code).toBe("ExitModeUnsafeInput");
+    expect(res.context?.reason).toBe("unbalanced_quotes");
+  }, 15_000);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SSH-into-WSL bash (#386 core + SSH/WSL wall) — skips if the harness is absent
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("[bash@wsl-ssh] terminal exit mode (#386 core)", () => {
+  let sh: SshBashInstance | null = null;
+  let available = false;
+
+  beforeAll(async () => {
+    available = await isSshWslAvailable();
+    if (!available) return;
+    sh = await launchSshWslBash();
+  }, 120_000);
+
+  afterAll(() => sh?.kill());
+
+  it("single-line: reason:'exited' + exitCode 0", async ({ skip }) => {
+    if (!available || !sh) skip("SSH-into-WSL bash harness unavailable (env)");
+    const res = parsePayload(
+      await terminalRunHandler({
+        windowTitle: sh!.title,
+        input: "echo bashhi386; sleep 1",
+        until: { mode: "exit", shell: "bash" },
+        timeoutMs: 30_000,
+      }),
+    );
+    if (isEnvSendSkip(res)) skip(`env: ${JSON.stringify(res.completion)}`);
+    expect(res.completion.reason, JSON.stringify(res)).toBe("exited");
+    expect(res.completion.exitCode).toBe(0);
+    expect(res.completion.elapsedMs).toBeGreaterThanOrEqual(800);
+    expect(res.output).toContain("bashhi386");
+  }, 45_000);
+
+  it("MULTILINE: completes via the nonce sentinel, never self-matching the echo (#386)", async ({ skip }) => {
+    if (!available || !sh) skip("SSH-into-WSL bash harness unavailable (env)");
+    // In pattern mode, the echoed `echo FINISHED_386` line self-matches a
+    // pattern:'FINISHED_386' immediately (multiline echo cannot be anchored —
+    // that is exactly #386). Exit mode keys off the driver nonce instead, so it
+    // must wait through the 2s sleep and report the real completion.
+    const res = parsePayload(
+      await terminalRunHandler({
+        windowTitle: sh!.title,
+        input: "echo START_386\nsleep 2\necho FINISHED_386",
+        until: { mode: "exit", shell: "bash" },
+        timeoutMs: 40_000,
+      }),
+    );
+    if (isEnvSendSkip(res)) skip(`env: ${JSON.stringify(res.completion)}`);
+    expect(res.completion.reason, JSON.stringify(res)).toBe("exited");
+    expect(res.completion.exitCode).toBe(0);
+    // ≥ ~2s is the #386 proof: a self-match on the echoed FINISHED_386 line
+    // would have returned in well under a second.
+    expect(res.completion.elapsedMs).toBeGreaterThanOrEqual(1800);
+    expect(res.output).toContain("START_386");
+    expect(res.output).toContain("FINISHED_386");
+    // stripExitArtifacts removed the injected epilogue echo + sentinel.
+    expect(res.output).not.toContain("DTMCP");
+    expect(res.output).not.toContain("__dtmcp_rc");
+  }, 50_000);
+
+  it("non-zero exit code (subshell, keeps the session alive)", async ({ skip }) => {
+    if (!available || !sh) skip("SSH-into-WSL bash harness unavailable (env)");
+    const res = parsePayload(
+      await terminalRunHandler({
+        windowTitle: sh!.title,
+        input: "(exit 3)",
+        until: { mode: "exit", shell: "bash" },
+        timeoutMs: 30_000,
+      }),
+    );
+    if (isEnvSendSkip(res)) skip(`env: ${JSON.stringify(res.completion)}`);
+    expect(res.completion.reason, JSON.stringify(res)).toBe("exited");
+    expect(res.completion.exitCode).toBe(3);
+  }, 45_000);
+
+  // NOTE on the SSH/WSL wall (P3 measured): the SSH-bash window is conhost-hosted
+  // (window process 'powershell'), so shell:'auto' here resolves to powershell —
+  // a SILENTLY WRONG shell for the remote bash, which degrades to a loud
+  // reason:'timeout' (the PS epilogue never renders the sentinel). That is why
+  // exit mode emits the auto-detection warning and these tests pass shell:'bash'
+  // explicitly. We do not assert the slow wrong-shell timeout here; the genuine
+  // ExitModeShellAmbiguous path (a window whose OWN process is WindowsTerminal)
+  // is covered by the WT-gated test below.
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Genuine ExitModeShellAmbiguous — a window whose own process hides the shell
+// (Windows Terminal → process 'WindowsTerminal' → low confidence). WT-gated.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const WT_AVAILABLE: boolean = (() => {
+  if (process.platform !== "win32") return false;
+  try {
+    execSync("where wt.exe", { stdio: "ignore", timeout: 2000, windowsHide: true });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+describe.skipIf(!WT_AVAILABLE)("[wt] terminal exit mode — shell:'auto' loud-fails (ambiguous)", () => {
+  let ps: PsInstance;
+  beforeAll(async () => {
+    ps = await launchPowerShell({ host: "wt", banner: "exitmode-wt-ready" });
+  }, 20_000);
+  afterAll(() => ps?.kill());
+
+  it("auto on a WindowsTerminal-process window → ExitModeShellAmbiguous", async () => {
+    const res = parsePayload(
+      await terminalRunHandler({
+        windowTitle: ps.title,
+        input: "Write-Output 'hi'",
+        until: { mode: "exit", shell: "auto" },
+        timeoutMs: 10_000,
+      }),
+    );
+    expect(res.ok, JSON.stringify(res)).toBe(false);
+    expect(res.code).toBe("ExitModeShellAmbiguous");
+    expect(Array.isArray(res.suggest)).toBe(true);
+  }, 15_000);
+});

--- a/tests/fixtures/failwith-callsite-shapes.json
+++ b/tests/fixtures/failwith-callsite-shapes.json
@@ -492,28 +492,28 @@
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 729,
+      "line": 741,
       "tool": "terminal:read",
       "errKind": "identifier",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 799,
+      "line": 811,
       "tool": "terminal:read",
       "errKind": "identifier",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 986,
+      "line": 998,
       "tool": "terminal:send",
       "errKind": "new-error",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 1045,
+      "line": 1057,
       "tool": "terminal:send",
       "errKind": "new-error",
       "contextShape": "object-plain"

--- a/tests/fixtures/failwith-callsite-shapes.json
+++ b/tests/fixtures/failwith-callsite-shapes.json
@@ -492,28 +492,28 @@
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 741,
+      "line": 729,
       "tool": "terminal:read",
       "errKind": "identifier",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 811,
+      "line": 799,
       "tool": "terminal:read",
       "errKind": "identifier",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 998,
+      "line": 986,
       "tool": "terminal:send",
       "errKind": "new-error",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 1057,
+      "line": 1045,
       "tool": "terminal:send",
       "errKind": "new-error",
       "contextShape": "object-plain"

--- a/tests/fixtures/failwith-callsite-shapes.json
+++ b/tests/fixtures/failwith-callsite-shapes.json
@@ -492,28 +492,28 @@
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 733,
+      "line": 729,
       "tool": "terminal:read",
       "errKind": "identifier",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 803,
+      "line": 799,
       "tool": "terminal:read",
       "errKind": "identifier",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 990,
+      "line": 986,
       "tool": "terminal:send",
       "errKind": "new-error",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 1049,
+      "line": 1045,
       "tool": "terminal:send",
       "errKind": "new-error",
       "contextShape": "object-plain"

--- a/tests/unit/issue-386-exit-mode-sentinel.test.ts
+++ b/tests/unit/issue-386-exit-mode-sentinel.test.ts
@@ -309,55 +309,62 @@ describe("resolveExitShell — shell decision matrix (P2 wiring)", () => {
 });
 
 describe("stripExitArtifacts — cosmetic removal of injected epilogue + sentinel", () => {
-  it("bash: removes the command echo + echoed epilogue + sentinel, keeps real output", () => {
-    // split("\n")[1] is the epilogue line (printf '%s%s|%d|' … "_EXIT_<nonce>" …),
-    // exactly what the head-cut marker searches for.
+  it("bash: drops the injected epilogue echo + sentinel lines, keeps echo + real output", () => {
+    // REALISTIC order: input executes and prints BEFORE the epilogue echoes.
+    // split("\n")[1] is the epilogue line (carries the split token "_EXIT_<nonce>").
     const epilogueEcho = buildExitCommand("ls -la", "bash", NONCE).split("\n")[1]!;
     const buffer = [
-      "user@host:~$ ls -la", // command echo
-      epilogueEcho, // echoed epilogue (PS2 continuation line)
+      "user@host:~$ ls -la", // command echo (kept — same as pattern/quiet modes)
       "file1.txt", // real output
       "file2.txt",
-      `${TOKEN}|0|`, // sentinel output line
+      `user@host:~$ ${epilogueEcho}`, // echoed epilogue (dropped — has _EXIT_<nonce>)
+      `${TOKEN}|0|`, // sentinel output line (dropped — has _EXIT_<nonce>)
+      "user@host:~$",
     ].join("\n");
-    expect(stripExitArtifacts(buffer, NONCE, "bash")).toBe("file1.txt\nfile2.txt");
+    const out = stripExitArtifacts(buffer, NONCE, "bash");
+    expect(out).toContain("file1.txt");
+    expect(out).toContain("file2.txt");
+    expect(out).toContain("user@host:~$ ls -la"); // command echo kept
+    expect(out).not.toContain("_EXIT_"); // both injected lines gone
+    expect(out).not.toContain("__DTMCP");
   });
 
-  it("powershell: removes prologue + input + epilogue echo + sentinel, keeps real output", () => {
+  it("powershell: drops the prologue echo + epilogue echo + sentinel lines", () => {
     const [prologue, inputEcho, epilogueEcho] = buildExitCommand(
       "Get-ChildItem",
       "powershell",
       NONCE,
     ).split("\n");
     const buffer = [
-      `PS C:\\> ${prologue}`,
-      inputEcho,
-      epilogueEcho,
+      `PS C:\\> ${prologue}`, // prologue echo (dropped — $global:LASTEXITCODE = $null)
+      `PS C:\\> ${inputEcho}`, // command echo (kept)
       "Mode  LastWriteTime  Name", // real output
       "----  -------------  ----",
-      `${TOKEN}|0|True`, // sentinel
+      `PS C:\\> ${epilogueEcho}`, // epilogue echo (dropped — _EXIT_<nonce>)
+      `${TOKEN}|0|True`, // sentinel (dropped)
+      "PS C:\\>",
     ].join("\n");
-    expect(stripExitArtifacts(buffer, NONCE, "powershell")).toBe(
-      "Mode  LastWriteTime  Name\n----  -------------  ----",
-    );
+    const out = stripExitArtifacts(buffer, NONCE, "powershell");
+    expect(out).toContain("Mode  LastWriteTime  Name");
+    expect(out).toContain("----  -------------  ----");
+    expect(out).not.toContain("LASTEXITCODE"); // prologue + epilogue gone
+    expect(out).not.toContain("__DTMCP");
+    expect(out).not.toContain("_EXIT_");
   });
 
-  it("degrades safely when the epilogue echo is not located (still strips the sentinel)", () => {
-    // e.g. a tailed read scrolled the echo off the top — only the sentinel line
-    // is strippable; real output is preserved (never over-cut).
-    const buffer = `building...\ndone\n${TOKEN}|0|`;
-    expect(stripExitArtifacts(buffer, NONCE, "bash")).toBe("building...\ndone");
-  });
-
-  it("returns '' when there is no real output between the epilogue echo and sentinel", () => {
+  it("order-independent: works even if the sentinel renders right after the echo", () => {
+    // A fast command with no output between echo and sentinel still strips clean.
     const epilogueEcho = buildExitCommand("true", "bash", NONCE).split("\n")[1]!;
-    const buffer = ["$ true", epilogueEcho, `${TOKEN}|0|`].join("\n");
-    expect(stripExitArtifacts(buffer, NONCE, "bash")).toBe("");
+    const buffer = ["$ true", `$ ${epilogueEcho}`, `${TOKEN}|0|`, "$"].join("\n");
+    const out = stripExitArtifacts(buffer, NONCE, "bash");
+    expect(out).not.toContain("__DTMCP");
+    expect(out).not.toContain("_EXIT_");
+    expect(out).toContain("$ true"); // command echo kept
   });
 
   it("a different-nonce sentinel from a prior run is left intact (per-invocation isolation)", () => {
     const buffer = `output line\n__DTMCP_EXIT_otherrun|0|`;
-    // Our nonce's token is absent → nothing to strip → returned as-is (trimmed).
+    // Our nonce's marker is absent → nothing dropped → returned as-is (trimmed).
     expect(stripExitArtifacts(buffer, NONCE, "bash")).toBe(buffer);
   });
 });

--- a/tests/unit/issue-386-exit-mode-sentinel.test.ts
+++ b/tests/unit/issue-386-exit-mode-sentinel.test.ts
@@ -26,6 +26,7 @@ import {
   stripExitArtifacts,
   terminalSchema,
   terminalRegistrationSchema,
+  terminalRunHandler,
 } from "../../src/tools/terminal.js";
 import { failWith, getSuggestsForCode } from "../../src/tools/_errors.js";
 
@@ -321,7 +322,7 @@ describe("stripExitArtifacts — cosmetic removal of injected epilogue + sentine
       `${TOKEN}|0|`, // sentinel output line (dropped — has _EXIT_<nonce>)
       "user@host:~$",
     ].join("\n");
-    const out = stripExitArtifacts(buffer, NONCE, "bash");
+    const out = stripExitArtifacts(buffer, NONCE);
     expect(out).toContain("file1.txt");
     expect(out).toContain("file2.txt");
     expect(out).toContain("user@host:~$ ls -la"); // command echo kept
@@ -344,7 +345,7 @@ describe("stripExitArtifacts — cosmetic removal of injected epilogue + sentine
       `${TOKEN}|0|True`, // sentinel (dropped)
       "PS C:\\>",
     ].join("\n");
-    const out = stripExitArtifacts(buffer, NONCE, "powershell");
+    const out = stripExitArtifacts(buffer, NONCE);
     expect(out).toContain("Mode  LastWriteTime  Name");
     expect(out).toContain("----  -------------  ----");
     expect(out).not.toContain("LASTEXITCODE"); // prologue + epilogue gone
@@ -368,7 +369,7 @@ describe("stripExitArtifacts — cosmetic removal of injected epilogue + sentine
       `PS C:\\> ${epilogueEcho}`, // epilogue echo (dropped — _EXIT_<nonce>)
       `${TOKEN}|0|True`, // sentinel (dropped)
     ].join("\n");
-    const out = stripExitArtifacts(buffer, NONCE, "powershell");
+    const out = stripExitArtifacts(buffer, NONCE);
     expect(out).toContain("Write-Host 'resetting'");
     // The user's printed literal survives (real output not corrupted).
     expect(out).toContain("$global:LASTEXITCODE = $null");
@@ -382,7 +383,7 @@ describe("stripExitArtifacts — cosmetic removal of injected epilogue + sentine
     // A fast command with no output between echo and sentinel still strips clean.
     const epilogueEcho = buildExitCommand("true", "bash", NONCE).split("\n")[1]!;
     const buffer = ["$ true", `$ ${epilogueEcho}`, `${TOKEN}|0|`, "$"].join("\n");
-    const out = stripExitArtifacts(buffer, NONCE, "bash");
+    const out = stripExitArtifacts(buffer, NONCE);
     expect(out).not.toContain("__DTMCP");
     expect(out).not.toContain("_EXIT_");
     expect(out).toContain("$ true"); // command echo kept
@@ -391,7 +392,7 @@ describe("stripExitArtifacts — cosmetic removal of injected epilogue + sentine
   it("a different-nonce sentinel from a prior run is left intact (per-invocation isolation)", () => {
     const buffer = `output line\n__DTMCP_EXIT_otherrun|0|`;
     // Our nonce's marker is absent → nothing dropped → returned as-is (trimmed).
-    expect(stripExitArtifacts(buffer, NONCE, "bash")).toBe(buffer);
+    expect(stripExitArtifacts(buffer, NONCE)).toBe(buffer);
   });
 });
 
@@ -419,6 +420,44 @@ describe("exit-mode typed codes route through classify() + SUGGESTS", () => {
     );
     const body = JSON.parse(result.content[0]!.text);
     expect(body.code).toBe("ExitModeUnsafeInput");
+  });
+});
+
+describe("exit mode rejects delivery-shaping sendOptions (Codex #389 P1)", () => {
+  // These rejects happen in the exit pre-flight BEFORE findTerminalWindow, so the
+  // handler returns without any terminal I/O — safe to assert in a unit test.
+  for (const key of ["pressEnter", "preferClipboard", "method", "chunkSize", "pasteKey"] as const) {
+    it(`rejects sendOptions.${key} with InvalidArgs (uniform, pre-routing)`, async () => {
+      const result = await terminalRunHandler({
+        windowTitle: "irrelevant",
+        input: "echo hi",
+        until: { mode: "exit", shell: "powershell" },
+        timeoutMs: 10_000,
+        sendOptions: { [key]: key === "method" ? "background" : key === "chunkSize" ? 50 : key === "pasteKey" ? "ctrl+v" : false },
+      });
+      const body = JSON.parse(result.content[0]!.text);
+      expect(body.ok).toBe(false);
+      expect(body.code).toBe("InvalidArgs");
+      expect(body.error).toMatch(/controls command delivery/i);
+      expect(body.context.offending).toContain(key);
+    });
+  }
+
+  it("does NOT reject focus-management sendOptions (focusFirst) at the conflict gate", async () => {
+    // focusFirst is allowed; the conflict gate passes, so we do NOT get the
+    // delivery-conflict InvalidArgs. (It proceeds to window lookup afterwards.)
+    const result = await terminalRunHandler({
+      windowTitle: "__no_such_window_for_386_unit__",
+      input: "echo hi",
+      until: { mode: "exit", shell: "powershell" },
+      timeoutMs: 10_000,
+      sendOptions: { focusFirst: false },
+    });
+    const body = JSON.parse(result.content[0]!.text);
+    // Not the delivery-conflict reject. (Window lookup then fails → window_not_found.)
+    const isConflictReject =
+      body.code === "InvalidArgs" && /controls command delivery/i.test(body.error ?? "");
+    expect(isConflictReject).toBe(false);
   });
 });
 

--- a/tests/unit/issue-386-exit-mode-sentinel.test.ts
+++ b/tests/unit/issue-386-exit-mode-sentinel.test.ts
@@ -352,6 +352,32 @@ describe("stripExitArtifacts — cosmetic removal of injected epilogue + sentine
     expect(out).not.toContain("_EXIT_");
   });
 
+  it("powershell: keeps real output that legitimately prints the prologue literal (Codex #389 P2)", () => {
+    // Only the FIRST `$global:LASTEXITCODE = $null` (the injected prologue echo)
+    // is dropped; a later user-output line repeating the literal is kept.
+    const [prologue, inputEcho, epilogueEcho] = buildExitCommand(
+      "Get-Content script.ps1",
+      "powershell",
+      NONCE,
+    ).split("\n");
+    const buffer = [
+      `PS C:\\> ${prologue}`, // injected prologue echo (dropped — first match)
+      `PS C:\\> ${inputEcho}`, // command echo (kept)
+      "Write-Host 'resetting'", // real output line 1
+      "$global:LASTEXITCODE = $null", // real output that PRINTS the literal (kept)
+      `PS C:\\> ${epilogueEcho}`, // epilogue echo (dropped — _EXIT_<nonce>)
+      `${TOKEN}|0|True`, // sentinel (dropped)
+    ].join("\n");
+    const out = stripExitArtifacts(buffer, NONCE, "powershell");
+    expect(out).toContain("Write-Host 'resetting'");
+    // The user's printed literal survives (real output not corrupted).
+    expect(out).toContain("$global:LASTEXITCODE = $null");
+    expect(out).not.toContain("__DTMCP");
+    expect(out).not.toContain("_EXIT_");
+    // …but exactly one prologue line (the injected echo) was removed.
+    expect(out.split("$global:LASTEXITCODE = $null").length - 1).toBe(1);
+  });
+
   it("order-independent: works even if the sentinel renders right after the echo", () => {
     // A fast command with no output between echo and sentinel still strips clean.
     const epilogueEcho = buildExitCommand("true", "bash", NONCE).split("\n")[1]!;


### PR DESCRIPTION
Real-machine e2e for `until:{mode:'exit'}` (issue #386) surfaced that the merged P2 was **unusable on conhost** (the most common local terminal). This PR fixes the send-fidelity bug (Q3), the auto-detection honesty gap (Q2), and a P2 `failWith` double-nest, then validates everything with real-hardware e2e (conhost PowerShell + SSH-into-WSL bash + Windows Terminal). **11/11 e2e pass.**

Per the agreed plan, the hotfix is pinned with *unit + real-machine e2e* — so the e2e ships with the hotfix it validates.

## Q3 — atomic delivery (the blocker)
The default send routes conhost through **BG WM_CHAR char-by-char**. A multiline exit command makes conhost execute each embedded newline mid-send; chars posted while it's busy executing saturate/drop (observed: `__DTMCP` → `_DTMCP`), corrupting the byte-exact completion sentinel → the run **timed out**.

Exit mode now delivers the whole command atomically:
- **conhost** (`ConsoleWindowClass`): clipboard + console Paste (`WM_COMMAND 0xFFF1`) via new `pasteIntoConsoleNoFocus()` — **atomic AND no focus steal**. Spike finding: conhost strips lone LF and treats CR as a line break, so the command is CRLF-normalised + a trailing Enter runs the final line.
- **WT / other**: force the foreground clipboard-paste path (atomic; brief focus steal — WT can't take WM_CHAR anyway). Non-exit modes unchanged.

`stripExitArtifacts` rewritten **line-based** (drop the injected prologue/epilogue-echo/sentinel lines by nonce-scoped signature). The previous region-cut assumed the wrong buffer order and ate the real output (which prints *before* the epilogue echoes) — a latent P2 bug the unit fixtures masked. Command echo is kept (same as pattern/quiet).

## Q2 — auto-detection honesty (measured)
A conhost-hosted PowerShell window reports `processName='powershell'` (not `conhost`), so `shell:'auto'` resolves HIGH. Corollary: an SSH-into-WSL bash session under a PowerShell-owned conhost **also** reports `powershell`, so `auto` confidently picks the **wrong (outer) shell** for the remote bash — which degrades to a loud `reason:'timeout'`, not corruption. Exit mode now emits an advisory **warning** on every auto-resolved run (pass `shell` explicitly for nested/remote). `detectShell` TSDoc + plan §12 "conhost→low" claim corrected. No behaviour change.

## Also
P2 `failWith` double-nest fixed (context passed flat, not `{context:{...}}`) so `ExitModeUnsafeInput`'s `context.reason` is exposed (memory `feedback_failwith_third_arg_flat`).

## E2E (real hardware, plan §9 acceptance) — `tests/e2e/terminal-exit-mode.test.ts`
- **conhost PowerShell**: single-line + MULTILINE exit (exitCode 0), native non-zero (`cmd /c exit 7` → 7), cmdlet failure (`$?=False` → 1), cmd reject, unsafe-input reject, auto-resolve + warning.
- **SSH-into-WSL bash** (#383 measurement harness reused): single-line + **MULTILINE #386 core** (byte-exact sentinel, no echo self-match, ~2s elapsed proves it waited through the body), non-zero exit. Output asserted free of `DTMCP` artifacts.
- **Windows Terminal**: `shell:'auto'` → `ExitModeShellAmbiguous` (genuine ambiguous host).
New helper `tests/e2e/helpers/ssh-wsl-launcher.ts`; `powershell-launcher` gains an optional `postScript` hook (reuses its kill/isolation safety to drop into SSH).

## Verification
- `npm run build` clean; full unit suite 234 files / 3644 pass.
- e2e: 11/11 pass on real hardware.
- Guards: failwith-fixtures (regenerated, 175 callsites), stub-catalog, napi-safe, native-types clean.

## Review asks
- **Codex** (API-contract / native-adjacent): the new conhost paste path (clipboard + `WM_COMMAND 0xFFF1`), the exit-mode send routing branch, `stripExitArtifacts` line-based rewrite.
- **Opus**: the delivery-method decision per host (no-steal conhost vs FG-steal WT), the line-based strip correctness (keeps command echo by design), Q2 warning honesty, §3.1 fact sync (detectShell TSDoc + plan), §3.2 (no existing send-path regression for non-exit modes).

Plan: `desktop-touch-mcp-internal@…:docs/issue-386-multiline-echo-completion-sentinel-plan.md` (§9/§12/§13 P3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
