### PR TITLE
docs: #386 P4 — document terminal until:{mode:'exit'} (README + CHANGELOG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,13 @@
     the shell from the terminal window, but it cannot see a shell running *inside*
     SSH or WSL (the window still looks like its local host), so for remote/nested
     sessions pass the shell of the remote side — `auto` will otherwise warn and
-    may pick the outer shell.
+    may pick the outer shell. A window whose process can't be identified at all
+    (e.g. Windows Terminal) returns `ExitModeShellAmbiguous` so you pass `shell`
+    explicitly.
   - `bash` and `powershell` are first-class; `cmd.exe` is not supported yet and
     returns `ExitModeShellUnsupported`. A command that ends mid-construct
-    (unterminated quote, here-doc, `$(…)`, trailing `\`) is rejected up front
-    with `ExitModeUnsafeInput` instead of hanging.
+    (unterminated quote, here-doc, `$(…)`, a trailing `\` or PowerShell backtick)
+    is rejected up front with `ExitModeUnsafeInput` instead of hanging.
 
   Prefer `mode:'exit'` whenever you care about completion or exit status; keep
   `mode:'pattern'` for matching output that appears mid-run, and `mode:'quiet'`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`terminal(action='run')` can now wait for a command to *finish* and report
+  its exit code, via `until:{mode:'exit', shell:'bash'|'powershell'}`.** The
+  other completion modes infer "done" heuristically — `quiet` waits for output
+  to fall silent, `pattern` waits for a marker you embed in the command. Both
+  struggle with the usual completion idiom (`some-task; echo DONE` + matching
+  `DONE`): the marker also appears in the *echoed command line*, and for
+  multi-line commands there is no reliable way to tell that echo apart from real
+  output. `mode:'exit'` removes the guesswork — the server appends its own
+  completion marker whose printed form differs from its typed form, so it can
+  never match the echoed command (even for multi-line input) — and it returns
+  the real process exit code in `completion.exitCode` with
+  `completion.reason:'exited'`.
+
+  How to use it:
+  - `terminal({action:'run', windowTitle:'pwsh', input:'npm run build', until:{mode:'exit', shell:'powershell'}})`
+    waits until the build finishes and returns `completion.exitCode` (0 on
+    success, the process code otherwise).
+  - Pass `shell` explicitly (`'bash'` or `'powershell'`). `shell:'auto'` detects
+    the shell from the terminal window, but it cannot see a shell running *inside*
+    SSH or WSL (the window still looks like its local host), so for remote/nested
+    sessions pass the shell of the remote side — `auto` will otherwise warn and
+    may pick the outer shell.
+  - `bash` and `powershell` are first-class; `cmd.exe` is not supported yet and
+    returns `ExitModeShellUnsupported`. A command that ends mid-construct
+    (unterminated quote, here-doc, `$(…)`, trailing `\`) is rejected up front
+    with `ExitModeUnsafeInput` instead of hanging.
+
+  Prefer `mode:'exit'` whenever you care about completion or exit status; keep
+  `mode:'pattern'` for matching output that appears mid-run, and `mode:'quiet'`
+  for short interactive commands.
+
 ### Fixed
 
 - **`terminal(action='run')` with `until:{mode:'pattern'}` now matches the

--- a/README.ja.md
+++ b/README.ja.md
@@ -197,6 +197,7 @@ DOM を触る `browser_*` ツールは `includeContext:false` で末尾の `acti
 ### ターミナル (2)
 | ツール | 概要 |
 |---|---|
+| `terminal(action='run')` | コマンド送信 → 完了待ち → 出力取得を 1 コールで実行。完了判定は `until`: `quiet` / `pattern` / `exit`（コマンドの**終了**を待ち exit code を返す → [ターミナルの完了判定](#ターミナルの完了判定-until)） |
 | `terminal(action='read')` | Windows Terminal / PowerShell / cmd / WSL のテキストをUIA/OCRで取得。`sinceMarker`差分対応 |
 | `terminal(action='send')` | ターミナルへコマンド送信。clipboard paste既定でIME安全 |
 
@@ -262,6 +263,37 @@ Lease ライフサイクル:
 | `perception_list` | 登録中 lens を一覧し、再利用やクリーンアップに使う |
 
 Reactive Perception Graph は desktop-touch の低コストな状況把握レイヤーです。対象の同一性・フォーカス・矩形・準備状態・guard 結果を操作間で維持し、Claude が小さな操作のたびにスクリーンショットで確認し直さなくて済むようにします。
+
+---
+## ターミナルの完了判定 (`until`)
+
+`terminal(action='run')` はコマンド送信 → 完了待ち → 出力取得を 1 コールで行います。「完了」の判定方法は `until` で選びます:
+
+| モード | 待つ対象 | 用途 |
+|---|---|---|
+| `quiet`（既定） | 出力が `quietMs` 静かになるまで | 短い対話コマンド |
+| `pattern` | 出力に現れる文字列/正規表現 | 最終マーカーが分かる長時間コマンド |
+| `exit` | コマンドの**終了そのもの** | 完了や exit code が必要なとき |
+
+### `until:{mode:'exit'}` — 本当の完了 + exit code
+
+ヒューリスティックなモードは「センチネルを末尾に付ける」定番（`some-task; echo DONE` を `DONE` で待つ）で誤判定しがちです。センチネルは**エコーされたコマンド行**にも現れ、複数行コマンドではそのエコーと実出力をバッファだけから区別できません。`mode:'exit'` はこれを構造的に解決します — サーバが**表示形と入力形が異なる**完了マーカーをコマンド末尾に注入するため、エコーには決して一致せず（複数行入力でも）、実際のプロセス exit code を返します:
+
+```js
+terminal({
+  action: 'run',
+  windowTitle: 'pwsh',
+  input: 'npm run build',
+  until: { mode: 'exit', shell: 'powershell' },
+})
+// → completion: { reason: 'exited', exitCode: 0, elapsedMs: … }
+//   output: 注入マーカーは除去され、コマンドの実出力のみ
+```
+
+- **`shell` は明示指定推奨**（`'bash'` / `'powershell'`）。`shell:'auto'` はターミナル窓のプロセスから判定しますが、SSH / WSL の**中で**動く shell は見えません（窓はローカルホストのまま）。リモート/ネストしたセッションではリモート側の shell を渡してください（`auto` は警告を出し外側の shell を選ぶ場合があります）。プロセスを真に特定できない窓（Windows Terminal 等）は `ExitModeShellAmbiguous` を返します。
+- **first-class shell:** `bash` と `powershell`。`cmd.exe` は未対応（`ExitModeShellUnsupported`）。
+- **未完の構文で終わる入力は即座に reject**（`ExitModeUnsafeInput`）。閉じていない引用符 / here-doc / `$(…)` / 末尾の `\` などはハングせず弾きます。
+- exit mode は配送を自前制御するため、配送系の `sendOptions`（`method` / `preferClipboard` / `pressEnter` / `chunkSize` / `pasteKey`）は `InvalidArgs` で reject します（focus 系オプションは利用可）。
 
 ---
 ## ブラウザ CDP 自動化

--- a/README.ja.md
+++ b/README.ja.md
@@ -292,7 +292,7 @@ terminal({
 
 - **`shell` は明示指定推奨**（`'bash'` / `'powershell'`）。`shell:'auto'` はターミナル窓のプロセスから判定しますが、SSH / WSL の**中で**動く shell は見えません（窓はローカルホストのまま）。リモート/ネストしたセッションではリモート側の shell を渡してください（`auto` は警告を出し外側の shell を選ぶ場合があります）。プロセスを真に特定できない窓（Windows Terminal 等）は `ExitModeShellAmbiguous` を返します。
 - **first-class shell:** `bash` と `powershell`。`cmd.exe` は未対応（`ExitModeShellUnsupported`）。
-- **未完の構文で終わる入力は即座に reject**（`ExitModeUnsafeInput`）。閉じていない引用符 / here-doc / `$(…)` / 末尾の `\` などはハングせず弾きます。
+- **未完の構文で終わる入力は即座に reject**（`ExitModeUnsafeInput`）。閉じていない引用符 / here-doc / `$(…)` / 末尾の `\` または PowerShell バッククォートなどはハングせず弾きます。
 - exit mode は配送を自前制御するため、配送系の `sendOptions`（`method` / `preferClipboard` / `pressEnter` / `chunkSize` / `pasteKey`）は `InvalidArgs` で reject します（focus 系オプションは利用可）。
 
 ---

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ For a local checkout, register the built server directly:
 ### 🛠️ Utilities & Workflow
 | Tool | Description |
 |---|---|
-| `terminal` | Unified command execution: `run` (send + wait + read), `read` (OCR/UIA), and `send`. |
+| `terminal` | Unified command execution: `run` (send + wait + read), `read` (OCR/UIA), and `send`. `run` completion modes: `quiet`, `pattern`, and `exit` (waits for the command to finish + returns its exit code — see [Terminal command completion](#terminal-command-completion-until)). |
 | `wait_until` | Efficient server-side polling for window, focus, text, or URL state changes. |
 | `window_dock` / `focus_window` | Window management: `pin` (always-on-top), `unpin`, `dock` (corner snap), and `focus`. |
 | `workspace_launch` | Launch apps and auto-detect new HWNDs (supports localized titles). |
@@ -200,6 +200,55 @@ Lease lifecycle:
 - Each `desktop_discover` response carries `softExpiresAtMs` (≈ 60 % of the TTL window). Past that timestamp the LLM should consider re-calling `desktop_discover` even though the lease is still technically valid — `lease.expiresAtMs` is the only correctness wall.
 - TTL adapts to `view` mode (`action`/`explore`/`debug`), entity count, and response payload size. Cap is 60 s.
 - Set `DESKTOP_TOUCH_DISABLE_FUKUWARAI_V2=1` to fall back to the v1 tool surface (`get_windows` / `get_ui_elements` / `set_element_value`) for troubleshooting only — V2 is the recommended default.
+
+---
+
+## Terminal command completion (`until`)
+
+`terminal(action='run')` sends a command, waits for it to complete, and reads the
+output in one call. How it decides "complete" is controlled by `until`:
+
+| Mode | Waits for | Best for |
+|---|---|---|
+| `quiet` (default) | output to fall silent for `quietMs` | short interactive commands |
+| `pattern` | a string/regex you expect in the output | long commands with a known final marker |
+| `exit` | the command to actually **finish** | when you need completion or the exit code |
+
+### `until:{mode:'exit'}` — real completion + exit code
+
+The heuristic modes can misfire on the common "append a sentinel" idiom
+(`some-task; echo DONE` matched by `DONE`): the sentinel also shows up in the
+**echoed command line**, and for multi-line commands there is no reliable way to
+tell that echo apart from real output. `mode:'exit'` removes the guesswork — the
+server appends its own completion marker whose *printed* form differs from its
+*typed* form, so it never matches the echoed command (even for multi-line input),
+and it returns the real process exit code:
+
+```js
+terminal({
+  action: 'run',
+  windowTitle: 'pwsh',
+  input: 'npm run build',
+  until: { mode: 'exit', shell: 'powershell' },
+})
+// → completion: { reason: 'exited', exitCode: 0, elapsedMs: … }
+//   output: just the command's real output (the injected marker is stripped)
+```
+
+- **Pass `shell` explicitly** (`'bash'` or `'powershell'`). `shell:'auto'` detects
+  the shell from the terminal window, but it cannot see a shell running *inside*
+  SSH or WSL — the window still looks like its local host — so for remote/nested
+  sessions pass the remote side's shell (`auto` otherwise warns and may pick the
+  outer shell). A window whose process is genuinely unidentifiable (e.g. Windows
+  Terminal) returns `ExitModeShellAmbiguous`.
+- **First-class shells:** `bash` and `powershell`. `cmd.exe` is not supported yet
+  (`ExitModeShellUnsupported`).
+- **Unsafe input is rejected up front** (`ExitModeUnsafeInput`) rather than
+  hanging: a command ending mid-construct (unterminated quote, here-doc, `$(…)`,
+  trailing `\`).
+- Exit mode controls its own delivery, so delivery-shaping `sendOptions`
+  (`method` / `preferClipboard` / `pressEnter` / `chunkSize` / `pasteKey`) are
+  rejected with `InvalidArgs`; focus options remain accepted.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ terminal({
   (`ExitModeShellUnsupported`).
 - **Unsafe input is rejected up front** (`ExitModeUnsafeInput`) rather than
   hanging: a command ending mid-construct (unterminated quote, here-doc, `$(…)`,
-  trailing `\`).
+  a trailing `\` or PowerShell backtick).
 - Exit mode controls its own delivery, so delivery-shaping `sendOptions`
   (`method` / `preferClipboard` / `pressEnter` / `chunkSize` / `pasteKey`) are
   rejected with `InvalidArgs`; focus options remain accepted.


### PR DESCRIPTION
P4 (final phase) of issue #386: user-facing documentation for `terminal(action='run')` `until:{mode:'exit'}`. Docs-only — the tool description already documents exit mode (from P2); this adds the README + CHANGELOG surfaces.

## Changes
- **CHANGELOG.md** `[Unreleased]` → **Added**: `until:{mode:'exit', shell}` — waits for the command to actually finish + returns `completion.exitCode`, echo-immune (works for multi-line input that `pattern` can't anchor), with shell-explicit guidance for SSH/WSL nesting, `cmd` unsupported (`ExitModeShellUnsupported`), and unsafe-input rejection (`ExitModeUnsafeInput`). Written What/Why/How, user-facing English (強制命令 10).
- **README.md**: new "Terminal command completion (`until`)" section (quiet/pattern/exit comparison table + exit-mode details + error codes + the `sendOptions` note); the `terminal` tool row now links to it.
- **README.ja.md**: Japanese mirror; also added the previously-missing `terminal(action='run')` row to the tool table.

## Verification
- No code/schema change → build clean, `check:stub-catalog` + `check:failwith-fixtures` unchanged.
- Anchor links verified (`#terminal-command-completion-until` / `#ターミナルの完了判定-until`).
- Jargon scan: no PR#/ADR/Phase/OQ/Codex/Opus/internal-paths in the new content (public tool names / typed error codes / shell names / env-style option names retained per 強制命令 10).

## Review ask
- **Opus**: 強制命令 10 compliance (no internal jargon, "first-time reader understands what changed"), technical accuracy of the exit-mode description vs the merged behavior (esp. the SSH/WSL `auto` caveat and the `sendOptions` reject), and en/ja parity.

Plan: `desktop-touch-mcp-internal@…:docs/issue-386-multiline-echo-completion-sentinel-plan.md` (§13 P4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
