### PR TITLE
fix(terminal): #384 — opt-in quietMs settle fallback for until:{mode:'pattern'}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,21 @@
   unaffected. This covers single-command idioms (`cmd; echo "DONE"`); multi-line
   commands retain the prior scanning behaviour and are unchanged. (issue #383)
 
+- **`terminal(action='run')` with `until:{mode:'pattern'}` no longer has to hang
+  until the hard timeout when a command finishes without ever printing the
+  pattern.** A command whose final line has no trailing newline glues the marker
+  to the next shell prompt with no line boundary (e.g. `printf X` →
+  `Xuser@host:~$`), so an end-anchored pattern (`X\s*\n` or `X$`) can never match
+  and the run waited the full `timeoutMs`. You can now pass an optional `quietMs`
+  on the pattern spec — `until:{mode:'pattern', pattern, quietMs:1000}` — and the
+  run completes with `completion.reason:'quiet'` (and no
+  `completion.matchedPattern`; check its presence to tell a match from a settle)
+  once output has been stable for that long without a match, instead of hanging.
+  This is opt-in: omit `quietMs` to keep the default behaviour (wait for the
+  pattern until `timeoutMs`, so long-running commands with mid-run silent gaps are
+  unaffected). To detect genuine command completion — and get the exit code —
+  prefer `until:{mode:'exit'}`. (issue #384)
+
 ## [1.7.2] - 2026-05-19 — Emergency-stop now requires a deliberate dwell (no more drive-by failsafe kills)
 
 ### Fixed

--- a/README.ja.md
+++ b/README.ja.md
@@ -275,6 +275,8 @@ Reactive Perception Graph は desktop-touch の低コストな状況把握レイ
 | `pattern` | 出力に現れる文字列/正規表現 | 最終マーカーが分かる長時間コマンド |
 | `exit` | コマンドの**終了そのもの** | 完了や exit code が必要なとき |
 
+> **アンカーの注意 (#384):** 最終行が改行で終わらない出力は、マーカーが次プロンプトに密着して行境界が無くなります（`printf X` → `Xuser@host:~$`）。よって行末アンカー付き `pattern`（`X\s*\n` / `X$`）は**バインド不能**です。**完了検出は `mode:'exit'`**、content マッチは**裸マーカー**（`\n`/`$` を付けない）を使ってください。`mode:'pattern'` には opt-in の `quietMs` settle fallback もあります: `until:{mode:'pattern', pattern, quietMs:1000}` は、pattern 未一致でも出力が指定 ms 安定したら `reason:'quiet'`（`matchedPattern` なし）で完了し、`timeoutMs` までのハングを防ぎます。opt-in（未指定なら pattern を待ち続ける＝silent gap のある長時間コマンドは無影響）。
+
 ### `until:{mode:'exit'}` — 本当の完了 + exit code
 
 ヒューリスティックなモードは「センチネルを末尾に付ける」定番（`some-task; echo DONE` を `DONE` で待つ）で誤判定しがちです。センチネルは**エコーされたコマンド行**にも現れ、複数行コマンドではそのエコーと実出力をバッファだけから区別できません。`mode:'exit'` はこれを構造的に解決します — サーバが**表示形と入力形が異なる**完了マーカーをコマンド末尾に注入するため、エコーには決して一致せず（複数行入力でも）、実際のプロセス exit code を返します:

--- a/README.md
+++ b/README.md
@@ -214,6 +214,17 @@ output in one call. How it decides "complete" is controlled by `until`:
 | `pattern` | a string/regex you expect in the output | long commands with a known final marker |
 | `exit` | the command to actually **finish** | when you need completion or the exit code |
 
+> **Anchoring caveat (#384):** a command whose final line has no trailing newline
+> glues the marker to the next prompt with no line boundary (`printf X` →
+> `Xuser@host:~$`), so an end-anchored `pattern` (`X\s*\n` / `X$`) can never bind.
+> For *completion* use `mode:'exit'`; for *content* matching use a bare marker
+> (no `\n`/`$`). `mode:'pattern'` also accepts an optional `quietMs` settle
+> fallback: `until:{mode:'pattern', pattern, quietMs:1000}` completes with
+> `reason:'quiet'` (no `matchedPattern`) once output is stable for that long
+> without a match — instead of hanging until `timeoutMs`. It is opt-in (omit
+> `quietMs` to keep waiting for the pattern; long commands with mid-run silent
+> gaps are unaffected).
+
 ### `until:{mode:'exit'}` — real completion + exit code
 
 The heuristic modes can misfire on the common "append a sentinel" idiom

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -1680,7 +1680,7 @@ export const terminalRunHandler = async ({
   input: string;
   until:
     | { mode: "quiet"; quietMs: number }
-    | { mode: "pattern"; pattern: string; regex: boolean }
+    | { mode: "pattern"; pattern: string; regex: boolean; quietMs?: number }
     | { mode: "exit"; shell: "bash" | "powershell" | "cmd" | "auto" };
   timeoutMs: number;
   sendOptions?: Record<string, unknown>;
@@ -1967,6 +1967,15 @@ export const terminalRunHandler = async ({
   // side; this immediate value must stay in sync so the fallback path is not
   // a hidden short-default outlier.
   const quietMs = until.mode === "quiet" ? until.quietMs : 1500;
+  // issue #384: opt-in settle fallback for pattern mode. When the caller sets
+  // until.quietMs on a pattern-mode run, the run also completes (reason:'quiet',
+  // no matchedPattern) once output has been stable for that long WITHOUT the
+  // pattern matching — instead of hanging until the hard timeout. This handles
+  // commands that finish without ever printing the pattern (e.g. output with no
+  // trailing newline that an end-anchored pattern can't bind — issue #384). It is
+  // OPT-IN so the default pattern-mode contract (wait through silent gaps until
+  // the pattern appears — issue #196) is unchanged. undefined = no fallback.
+  const patternFallbackQuietMs = until.mode === "pattern" ? until.quietMs : undefined;
 
   // Compile pattern if pattern mode
   let patternRe: RegExp | null = null;
@@ -2044,6 +2053,13 @@ export const terminalRunHandler = async ({
       if (newContent !== undefined && patternRe.test(newContent)) {
         completionReason = "pattern_matched";
         matchedPattern = until.mode === "pattern" ? until.pattern : undefined;
+      } else if (patternFallbackQuietMs !== undefined && initialPostSend.text !== lastText) {
+        // issue #384: seed settle-tracking off the RAW buffer (like quiet mode)
+        // so the opt-in fallback's quiet window starts from the first observed
+        // change rather than missing this first tick.
+        lastText = initialPostSend.text;
+        lastTextTime = Date.now();
+        firstChangeTime ??= lastTextTime;
       }
     }
   }
@@ -2089,10 +2105,35 @@ export const terminalRunHandler = async ({
       const newContent = newContentSinceBaseline(currentText);
       // newContent === undefined → baseline lost, skip to avoid prior-history match.
       // newContent === "" is still valid input for patterns like /^$/.
+      // Match takes priority over the settle fallback on the same tick.
       if (newContent !== undefined && patternRe.test(newContent)) {
         completionReason = "pattern_matched";
         matchedPattern = until.mode === "pattern" ? until.pattern : undefined;
         break;
+      }
+      // issue #384: opt-in settle fallback. When until.quietMs is set, complete
+      // with reason:'quiet' (matchedPattern stays undefined) once output has been
+      // stable for quietMs WITHOUT a match — so a command that finishes without
+      // ever printing the pattern (e.g. a no-trailing-newline final line an
+      // end-anchored pattern can't bind) ends gracefully instead of hard-timing
+      // out. Track changes off the RAW buffer (like quiet mode) so baseline-lost
+      // runs still settle. No-op when until.quietMs is unset (default contract).
+      if (patternFallbackQuietMs !== undefined) {
+        if (currentText !== lastText) {
+          lastText = currentText;
+          lastTextTime = Date.now();
+          firstChangeTime ??= lastTextTime;
+        } else if (
+          evaluateQuietState({
+            now: Date.now(),
+            lastTextChangedAt: lastTextTime,
+            firstChangeAt: firstChangeTime,
+            quietMs: patternFallbackQuietMs,
+          }) === "quiet"
+        ) {
+          completionReason = "quiet";
+          break;
+        }
       }
     } else {
       // quiet mode: track changes and consult the pure helper. The helper
@@ -2298,6 +2339,15 @@ export const terminalSchema = z.discriminatedUnion("action", [
         mode: z.literal("pattern"),
         pattern: z.string().describe("Stop when output matches this string (or regex if regex:true)"),
         regex: coercedBoolean().default(false).describe("If true, treat pattern as a regex"),
+        // issue #384: opt-in settle fallback.
+        quietMs: z.coerce.number().int().min(50).max(30000).optional().describe(
+          "Optional settle fallback. When set, also completes with completion.reason:'quiet' " +
+          "(completion.matchedPattern stays absent — check it to tell a match from a settle) " +
+          "if output stays stable for this many ms WITHOUT the pattern matching, instead of " +
+          "waiting for the hard timeout. Use for commands that may finish without ever printing " +
+          "the pattern — e.g. a final line with no trailing newline that an end-anchored pattern " +
+          "(\\n / $) can't bind (issue #384). Omit to keep waiting for the pattern until timeoutMs."
+        ),
       }),
       // issue #386: echo-immune completion. Appends a driver-controlled sentinel
       // after the command whose ECHO form differs from its OUTPUT form, so it

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -1962,11 +1962,18 @@ export const terminalRunHandler = async ({
   let lastText = baselineRead?.text ?? "";
   let lastTextTime = Date.now();
   let firstChangeTime: number | null = null;
-  // Pattern-mode fallback (when patternRe compile fails — see warnings) uses
-  // the same updated default. Issue #196 (b) raised 800 → 1500 on the schema
-  // side; this immediate value must stay in sync so the fallback path is not
-  // a hidden short-default outlier.
-  const quietMs = until.mode === "quiet" ? until.quietMs : 1500;
+  // Quiet timer for (a) quiet mode and (b) the pattern-mode INVALID-REGEX
+  // fallback (patternRe compile failed → this run degrades to the quiet branch).
+  // For pattern mode, honour the caller's until.quietMs when provided — Codex
+  // #391 P2: an invalid-regex fallback must NOT ignore e.g. quietMs:10000 and
+  // complete after the 1500 default. When unset, 1500 (issue #196 (b) raised the
+  // schema default 800 → 1500; this immediate value stays in sync).
+  const quietMs =
+    until.mode === "quiet"
+      ? until.quietMs
+      : until.mode === "pattern"
+        ? until.quietMs ?? 1500
+        : 1500;
   // issue #384: opt-in settle fallback for pattern mode. When the caller sets
   // until.quietMs on a pattern-mode run, the run also completes (reason:'quiet',
   // no matchedPattern) once output has been stable for that long WITHOUT the

--- a/tests/e2e/terminal-exit-mode.test.ts
+++ b/tests/e2e/terminal-exit-mode.test.ts
@@ -237,6 +237,37 @@ describe("[bash@wsl-ssh] terminal exit mode (#386 core)", () => {
     expect(res.completion.exitCode).toBe(3);
   }, 45_000);
 
+  // issue #384 (the actual repro): bash `printf 'X'` emits NO trailing newline,
+  // so the marker is glued to the next prompt (`Xroot@host:~#`) with no line
+  // boundary — an end-anchored pattern (`X\s*\n`) can never bind and pattern mode
+  // would hard-time-out. The opt-in quietMs settle fallback completes with
+  // reason:'quiet' (NOT pattern_matched) once output settles. (PowerShell can't
+  // reproduce this — PSReadline inserts a newline before the prompt.)
+  it("#384: a no-trailing-newline pattern that can't bind settles to 'quiet', not timeout", async ({ skip }) => {
+    if (!available || !sh) skip("SSH-into-WSL bash harness unavailable (env)");
+    const tag = `nl384_${Date.now().toString(36)}`;
+    const res = parsePayload(
+      await terminalRunHandler({
+        windowTitle: sh!.title,
+        input: `sleep 1; printf '${tag}'`, // no trailing newline → glued to the prompt
+        until: { mode: "pattern", pattern: `${tag}\\s*\\n`, regex: true, quietMs: 1000 },
+        timeoutMs: 15_000,
+      }),
+    );
+    // Only a refused send is an env skip. baseline_lost is NOT skipped here: it
+    // affects output-content trust (asserted conditionally below), not the
+    // completion-detection behavior #384 is about. (SSH-bash reads often can't
+    // re-anchor the pre-send marker — orthogonal to the settle fallback.)
+    if (res.completion?.reason === "send_failed") skip(`env: ${JSON.stringify(res.completion)}`);
+    // The end-anchored pattern cannot bind (no newline); the fallback settles.
+    expect(res.completion.reason, JSON.stringify(res)).toBe("quiet");
+    expect(res.completion.matchedPattern).toBeUndefined();
+    expect(res.completion.elapsedMs).toBeLessThan(12_000); // well before the 15s timeout
+    if (res.outputIntegrity === "ok") {
+      expect(res.output).toContain(tag); // the no-newline marker is captured when anchored
+    }
+  }, 25_000);
+
   // NOTE on the SSH/WSL wall (P3 measured): the SSH-bash window is conhost-hosted
   // (window process 'powershell'), so shell:'auto' here resolves to powershell —
   // a SILENTLY WRONG shell for the remote bash, which degrades to a loud

--- a/tests/e2e/terminal.test.ts
+++ b/tests/e2e/terminal.test.ts
@@ -442,4 +442,39 @@ describe.each(SCENARIOS)("[$label] terminal", ({ host, label, expectedClassPatte
       expect(res.output).toContain(tag);
     }, 30_000);
   });
+
+  // Issue #384: when a command finishes WITHOUT ever producing the pattern (the
+  // #384 class: an end-anchored pattern that can't bind because the final line
+  // has no trailing newline / is glued to the next prompt), the opt-in `quietMs`
+  // settle fallback completes with reason:'quiet' (matchedPattern absent) once
+  // output settles — instead of hanging until the hard timeout. Tested here with
+  // a guaranteed-absent pattern so the fallback is exercised on any host (in
+  // PowerShell, PSReadline inserts a newline before the prompt, so the literal
+  // no-newline glue is bash-specific — see the SSH-WSL bash repro in
+  // terminal-exit-mode.test.ts).
+  describe(`terminal_run [${label}] — issue #384 quietMs settle fallback`, () => {
+    it("a never-matching pattern settles to reason:'quiet' instead of hard-timeout", async ({ skip }) => {
+      const tag = `run384-${host}-${Date.now().toString(36)}`;
+      const res = parsePayload(await terminalRunHandler({
+        windowTitle: ps.title,
+        input: `Start-Sleep -Seconds 1; Write-Output '${tag}'`,
+        until: { mode: "pattern", pattern: `__never_appears_${tag}__`, regex: false, quietMs: 1000 },
+        timeoutMs: 15_000,
+      }));
+
+      if (res.completion?.reason === "send_failed") {
+        skip(`terminal_run send_failed — foreground transfer refused (env). ${JSON.stringify(res.completion)}`);
+      }
+      if (res.outputIntegrity === "baseline_lost") {
+        skip(`terminal_run baseline_lost — focus did not transfer (env).`);
+      }
+
+      // Settled, not matched, not hard-timeout: the whole point of #384.
+      expect(res.completion.reason, JSON.stringify(res)).toBe("quiet");
+      expect(res.completion.matchedPattern).toBeUndefined();
+      // Completed well before the 15s hard timeout (≈ 1s sleep + 1s settle + slack).
+      expect(res.completion.elapsedMs).toBeLessThan(12_000);
+      expect(res.output).toContain(tag);
+    }, 25_000);
+  });
 });

--- a/tests/unit/issue-384-pattern-quiet-fallback.test.ts
+++ b/tests/unit/issue-384-pattern-quiet-fallback.test.ts
@@ -1,0 +1,97 @@
+/**
+ * issue-384-pattern-quiet-fallback.test.ts
+ *
+ * #384: terminal(action='run', until:{mode:'pattern'}) hard-times-out when the
+ * command's final output line has no trailing newline (an end-anchored pattern
+ * like `\s*\n` / `$` can't bind — the marker is glued to the next prompt with no
+ * boundary). The fix adds an OPT-IN `quietMs` to the pattern variant: when set,
+ * the run also completes with reason:'quiet' (matchedPattern absent) once output
+ * settles WITHOUT a match, instead of hanging until the hard timeout. Default
+ * (quietMs unset) keeps the pre-#384 pattern contract (wait through silent gaps —
+ * issue #196), so this pins the schema surface + the no-regression default.
+ *
+ * The settle BEHAVIOUR itself drives a real terminal and is covered by the e2e
+ * suite; here we pin the schema (the public surface).
+ */
+
+import { describe, it, expect } from "vitest";
+import { terminalSchema, terminalRegistrationSchema } from "../../src/tools/terminal.js";
+
+describe("issue #384: pattern variant opt-in quietMs settle fallback (schema)", () => {
+  it("accepts until={mode:'pattern', pattern, quietMs} and coerces quietMs", () => {
+    const r = terminalSchema.safeParse({
+      action: "run",
+      windowTitle: "pwsh",
+      input: "printf NLMARK",
+      until: { mode: "pattern", pattern: "NLMARK", quietMs: 1000 },
+    });
+    expect(r.success, r.success ? "" : JSON.stringify(r.error.issues)).toBe(true);
+    if (r.success && r.data.action === "run" && r.data.until.mode === "pattern") {
+      expect(r.data.until.quietMs).toBe(1000);
+      expect(r.data.until.regex).toBe(false);
+    }
+  });
+
+  it("leaves quietMs undefined when omitted (default contract — no fallback)", () => {
+    const r = terminalSchema.safeParse({
+      action: "run",
+      windowTitle: "pwsh",
+      input: "npm test",
+      until: { mode: "pattern", pattern: "Test Files" },
+    });
+    expect(r.success).toBe(true);
+    if (r.success && r.data.action === "run" && r.data.until.mode === "pattern") {
+      expect(r.data.until.quietMs).toBeUndefined();
+    }
+  });
+
+  it("rejects an out-of-range quietMs (bounds shared with quiet mode)", () => {
+    expect(
+      terminalSchema.safeParse({
+        action: "run",
+        windowTitle: "pwsh",
+        input: "x",
+        until: { mode: "pattern", pattern: "x", quietMs: 49 }, // min is 50
+      }).success,
+    ).toBe(false);
+    expect(
+      terminalSchema.safeParse({
+        action: "run",
+        windowTitle: "pwsh",
+        input: "x",
+        until: { mode: "pattern", pattern: "x", quietMs: 30001 }, // max is 30000
+      }).success,
+    ).toBe(false);
+  });
+
+  it("registration schema (post include-wrap) + JSON-string until both accept quietMs", () => {
+    const wrapped = terminalRegistrationSchema.safeParse({
+      action: "run",
+      windowTitle: "pwsh",
+      input: "printf X",
+      until: { mode: "pattern", pattern: "X", quietMs: 800 },
+    });
+    expect(wrapped.success, wrapped.success ? "" : JSON.stringify(wrapped.error.issues)).toBe(true);
+
+    const asString = terminalRegistrationSchema.safeParse({
+      action: "run",
+      windowTitle: "pwsh",
+      input: "printf X",
+      until: JSON.stringify({ mode: "pattern", pattern: "X", quietMs: 800 }),
+    });
+    expect(asString.success, asString.success ? "" : JSON.stringify(asString.error.issues)).toBe(true);
+  });
+
+  it("quiet mode is unaffected (quietMs still required-with-default there)", () => {
+    const r = terminalSchema.safeParse({
+      action: "run",
+      windowTitle: "pwsh",
+      input: "ls",
+      until: { mode: "quiet" },
+    });
+    expect(r.success).toBe(true);
+    if (r.success && r.data.action === "run" && r.data.until.mode === "quiet") {
+      expect(r.data.until.quietMs).toBe(1500);
+    }
+  });
+});


### PR DESCRIPTION
Fixes issue #384: `terminal(action='run', until:{mode:'pattern'})` hung until the hard timeout when a command finished without ever producing the pattern.

## Root cause (research-backed)
A command whose final line has no trailing newline glues the marker to the next shell prompt with no line boundary (`printf X` → `Xuser@host:~$`), so an end-anchored pattern (`X\s*\n` / `X$`) can never bind. Web/deep research (pexpect, expect) confirmed this is the fundamental "no end-marker" problem: `$` premature-matches on streaming output, a literal `\n` requires a newline that may never arrive, and the canonical completion solution is a guaranteed end-marker — which is exactly the already-shipped `until:{mode:'exit'}`.

## Fix — opt-in `quietMs` settle fallback
`until:{mode:'pattern', pattern, quietMs:1000}`: when `quietMs` is set, the run also completes with `completion.reason:'quiet'` (`completion.matchedPattern` absent — check it to tell a match from a settle) once output is stable for that long **without** a match, instead of hanging until `timeoutMs`.
- **Opt-in** — omit `quietMs` to keep the default contract (wait through silent gaps until the pattern appears, issue #196). No regression for long-running commands.
- Match takes priority over settle on the same tick.
- Settle-tracking keys off the raw buffer (like quiet mode), so baseline-lost runs still settle.

## Changes
- schema: pattern variant gains optional `quietMs` (bounds shared with quiet mode).
- handler: pattern branch tracks raw-buffer change + completes on settle when `until.quietMs` set; the immediate post-send check seeds the change-tracking; fallback `quietMs` derived from `until.quietMs` (not the hardcoded 1500) — the three points Opus's design review flagged as load-bearing.
- docs: README (en/ja) completion section + CHANGELOG Fixed entry — anchors can't bind on no-newline output; use exit mode for completion, bare markers for content, or the opt-in settle fallback.

## Verification
- `npm run build` clean; full unit suite green (the 2 transient failures during a parallel e2e run are pre-existing timing flakes — `input-pipeline-dispatch` ADR-019 timeout test + `ui-pattern-store-persistence` debounce — both pass in isolation; neither touches terminal pattern mode).
- e2e: **conhost** never-match pattern → `quiet` (terminal.test.ts); **SSH-into-WSL bash** the actual no-newline repro (`printf X` + `X\s*\n` + quietMs) → `quiet` not timeout (terminal-exit-mode.test.ts). `#383` match-priority e2e unaffected.
- All push-pre guards pass (failwith-fixtures / stub-catalog / napi-safe / native-types).

## Review asks
- **Opus**: the opt-in design (no #196 regression), match-vs-settle priority, raw-buffer change-tracking for baseline-lost, reason:'quiet'+absent matchedPattern honesty, en/ja+CHANGELOG 強制命令 10.
- **Codex** (API-contract): the optional `quietMs` schema field on the pattern discriminated-union variant + the handler completion contract.

Plan: `desktop-touch-mcp-internal@4aa52eb:docs/issue-384-pattern-mode-quiet-settle-fallback-plan.md` (Opus design GO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
