### PR TITLE
fix(terminal): #386 — bounded retry for exit-mode conhost clipboard set

### DIFF
--- a/src/engine/bg-input.ts
+++ b/src/engine/bg-input.ts
@@ -317,7 +317,10 @@ export const CLIPBOARD_SET_MAX_ATTEMPTS = 3;
 
 /**
  * Backoff (ms) before the retry that FOLLOWS failed attempt `attempt` (0-based):
- * 120 ms after attempt 0, 240 ms after attempt 1, … Pure — unit-testable.
+ * 120 ms after attempt 0, 240 ms after attempt 1, … Pure — unit-testable. Grows
+ * linearly with no cap; with CLIPBOARD_SET_MAX_ATTEMPTS=3 production only ever
+ * uses attempts 0 and 1 (120 / 240 ms) — there is no sleep after the final
+ * attempt — so raise the cap deliberately if you bump the attempt count.
  */
 export function clipboardSetBackoffMs(attempt: number): number {
   return 120 * (attempt + 1);
@@ -357,6 +360,38 @@ export async function setClipboardWithRetry(
 }
 
 /**
+ * Front half of the console-paste flow: set the clipboard with retry and, ONLY
+ * on total failure, restore the snapshot exactly once. Returns true when the
+ * clipboard now holds `text` (caller posts the paste) or false when the set
+ * failed after retries (caller returns clipboard_set_failed — this already
+ * restored, so the caller must NOT restore again).
+ *
+ * Split out so the restore-exactly-once invariant — never restored on the
+ * success path here, restored exactly once on total failure, never inside the
+ * retry loop — is unit-testable with injected setFn / restoreFn. The full
+ * `pasteIntoConsoleNoFocus` is otherwise wrapped around native PostMessage calls
+ * that a unit test cannot drive, which is where a future regression (e.g.
+ * restore moved inside the loop) would slip past review unnoticed.
+ */
+export async function prepareClipboardForPaste(
+  text: string,
+  saved: string | null,
+  deps: {
+    setFn: (text: string) => Promise<boolean>;
+    restoreFn: (saved: string | null) => Promise<void>;
+    sleepFn?: (ms: number) => Promise<void>;
+    maxAttempts?: number;
+  },
+): Promise<boolean> {
+  const setResult = await setClipboardWithRetry(text, deps);
+  if (!setResult.ok) {
+    await deps.restoreFn(saved);
+    return false;
+  }
+  return true;
+}
+
+/**
  * Paste `text` into a conhost (ConsoleWindowClass) window atomically WITHOUT
  * stealing foreground, via clipboard + the console Paste command. Multiline-safe.
  *
@@ -381,15 +416,17 @@ export async function pasteIntoConsoleNoFocus(
   const crlf = text.replace(/\r?\n/g, "\r\n");
 
   const saved = await getClipboardB64(); // null = read failed; "" = empty clipboard
-  // Retry the set-and-verify a few times: a momentary clipboard lock by another
-  // process makes the first try miss (dogfood #386 P3 follow-up — surfaced as a
-  // one-off clipboard_set_failed during a busy window-launch storm). `saved` is
-  // captured ONCE above and restoreClipboard runs at most once (here on total
-  // failure, or after the paste on success), so a failed set never leaves the
-  // user's clipboard clobbered (Opus #389 round 1 P2-1 invariant preserved).
-  const setResult = await setClipboardWithRetry(crlf, { setFn: setClipboardVerified });
-  if (!setResult.ok) {
-    await restoreClipboard(saved);
+  // Set-and-verify with retry: a momentary clipboard lock by another process
+  // makes the first try miss (dogfood #386 P3 follow-up — surfaced as a one-off
+  // clipboard_set_failed during a busy window-launch storm). `saved` is captured
+  // ONCE above; prepareClipboardForPaste restores it exactly once on total
+  // failure, and the success path restores once after the paste (below), so a
+  // failed set never leaves the user's clipboard clobbered (#389 r1 P2-1).
+  const ready = await prepareClipboardForPaste(crlf, saved, {
+    setFn: setClipboardVerified,
+    restoreFn: restoreClipboard,
+  });
+  if (!ready) {
     return { ok: false, reason: "clipboard_set_failed" };
   }
 

--- a/src/engine/bg-input.ts
+++ b/src/engine/bg-input.ts
@@ -312,6 +312,50 @@ export interface ConsolePasteOutcome {
   reason?: "clipboard_set_failed" | "console_paste_post_failed";
 }
 
+/** Max attempts to set+verify the clipboard before giving up (1 try + 2 retries). */
+export const CLIPBOARD_SET_MAX_ATTEMPTS = 3;
+
+/**
+ * Backoff (ms) before the retry that FOLLOWS failed attempt `attempt` (0-based):
+ * 120 ms after attempt 0, 240 ms after attempt 1, … Pure — unit-testable.
+ */
+export function clipboardSetBackoffMs(attempt: number): number {
+  return 120 * (attempt + 1);
+}
+
+/**
+ * Set the clipboard with bounded retry + backoff, returning whether any attempt
+ * succeeded and how many were made.
+ *
+ * The global clipboard is a single OS resource; when another process holds it
+ * open (a busy desktop, a clipboard manager, our own back-to-back PowerShell
+ * spawns) the set-and-verify misses on the first try — a transient that clears
+ * in well under a second. Retrying turns that recoverable race into a success
+ * instead of a hard send failure.
+ *
+ * This helper owns NEITHER the save NOR the restore: the caller captures the
+ * clipboard snapshot once and restores at most once, so the restore invariant
+ * (never leave the user's clipboard clobbered) is preserved by construction.
+ * `setFn` / `sleepFn` are injectable so the retry policy can be unit-tested with
+ * no real clipboard and no real timers.
+ */
+export async function setClipboardWithRetry(
+  text: string,
+  deps: {
+    setFn: (text: string) => Promise<boolean>;
+    sleepFn?: (ms: number) => Promise<void>;
+    maxAttempts?: number;
+  },
+): Promise<{ ok: boolean; attempts: number }> {
+  const maxAttempts = deps.maxAttempts ?? CLIPBOARD_SET_MAX_ATTEMPTS;
+  const sleepFn = deps.sleepFn ?? ((ms) => new Promise<void>((r) => setTimeout(r, ms)));
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    if (await deps.setFn(text)) return { ok: true, attempts: attempt + 1 };
+    if (attempt < maxAttempts - 1) await sleepFn(clipboardSetBackoffMs(attempt));
+  }
+  return { ok: false, attempts: maxAttempts };
+}
+
 /**
  * Paste `text` into a conhost (ConsoleWindowClass) window atomically WITHOUT
  * stealing foreground, via clipboard + the console Paste command. Multiline-safe.
@@ -337,10 +381,14 @@ export async function pasteIntoConsoleNoFocus(
   const crlf = text.replace(/\r?\n/g, "\r\n");
 
   const saved = await getClipboardB64(); // null = read failed; "" = empty clipboard
-  if (!(await setClipboardVerified(crlf))) {
-    // Set-Clipboard may have landed before the read-back mismatch (another app
-    // raced, or newline tolerance missed) — restore so we never leave the user's
-    // clipboard clobbered on a failed paste (Opus #389 round 1 P2-1).
+  // Retry the set-and-verify a few times: a momentary clipboard lock by another
+  // process makes the first try miss (dogfood #386 P3 follow-up — surfaced as a
+  // one-off clipboard_set_failed during a busy window-launch storm). `saved` is
+  // captured ONCE above and restoreClipboard runs at most once (here on total
+  // failure, or after the paste on success), so a failed set never leaves the
+  // user's clipboard clobbered (Opus #389 round 1 P2-1 invariant preserved).
+  const setResult = await setClipboardWithRetry(crlf, { setFn: setClipboardVerified });
+  if (!setResult.ok) {
     await restoreClipboard(saved);
     return { ok: false, reason: "clipboard_set_failed" };
   }

--- a/tests/unit/bg-input.test.ts
+++ b/tests/unit/bg-input.test.ts
@@ -284,6 +284,9 @@ describe("prepareClipboardForPaste — restore-exactly-once invariant", () => {
     const ok = await prepareClipboardForPaste("x", SAVED, { setFn, restoreFn, sleepFn });
     expect(ok).toBe(true);
     expect(restoreFn).not.toHaveBeenCalled();
+    // the injected sleepFn propagates through to the retry backoff (one 120ms
+    // wait between the failed first attempt and the successful second)
+    expect(sleepFn.mock.calls).toEqual([[120]]);
   });
 
   it("returns false and restores EXACTLY ONCE (with the snapshot) when every set fails", async () => {

--- a/tests/unit/bg-input.test.ts
+++ b/tests/unit/bg-input.test.ts
@@ -35,6 +35,9 @@ import {
   postEnterToHwnd,
   postKeyComboToHwnd,
   isBgAutoEnabled,
+  clipboardSetBackoffMs,
+  setClipboardWithRetry,
+  CLIPBOARD_SET_MAX_ATTEMPTS,
 } from "../../src/engine/bg-input.js";
 import { postMessageToHwnd, getWindowClassName, getProcessIdentityByPid } from "../../src/engine/win32.js";
 
@@ -199,6 +202,59 @@ describe("canInjectViaPostMessage — terminal classification", () => {
     vi.mocked(getWindowClassName).mockReturnValue("ConsoleWindowClass");
     const result = canInjectViaPostMessage(11n);
     expect(result.supported).toBe(true);
+  });
+});
+
+describe("clipboardSetBackoffMs", () => {
+  it("grows linearly: 120ms after attempt 0, 240ms after attempt 1, 360ms after attempt 2", () => {
+    expect(clipboardSetBackoffMs(0)).toBe(120);
+    expect(clipboardSetBackoffMs(1)).toBe(240);
+    expect(clipboardSetBackoffMs(2)).toBe(360);
+  });
+});
+
+describe("setClipboardWithRetry", () => {
+  // No real clipboard / timers: setFn and sleepFn are injected so the retry
+  // policy (and the latency / restore-safety invariants) is tested deterministically.
+  it("succeeds on the first attempt without sleeping", async () => {
+    const setFn = vi.fn().mockResolvedValue(true);
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+    const res = await setClipboardWithRetry("x", { setFn, sleepFn });
+    expect(res).toEqual({ ok: true, attempts: 1 });
+    expect(setFn).toHaveBeenCalledTimes(1);
+    expect(sleepFn).not.toHaveBeenCalled();
+  });
+
+  it("retries the transient and succeeds: fail, fail, then succeed", async () => {
+    const setFn = vi.fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+    const res = await setClipboardWithRetry("x", { setFn, sleepFn });
+    expect(res).toEqual({ ok: true, attempts: 3 });
+    expect(setFn).toHaveBeenCalledTimes(3);
+    // backoff between attempts only (2 sleeps for 3 attempts): 120ms then 240ms
+    expect(sleepFn.mock.calls).toEqual([[120], [240]]);
+  });
+
+  it("gives up after the max attempts when every try fails", async () => {
+    const setFn = vi.fn().mockResolvedValue(false);
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+    const res = await setClipboardWithRetry("x", { setFn, sleepFn });
+    expect(res).toEqual({ ok: false, attempts: CLIPBOARD_SET_MAX_ATTEMPTS });
+    expect(setFn).toHaveBeenCalledTimes(CLIPBOARD_SET_MAX_ATTEMPTS);
+    // never sleeps after the final attempt — latency bounded to (N-1) backoffs
+    expect(sleepFn).toHaveBeenCalledTimes(CLIPBOARD_SET_MAX_ATTEMPTS - 1);
+  });
+
+  it("honours a custom maxAttempts", async () => {
+    const setFn = vi.fn().mockResolvedValue(false);
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+    const res = await setClipboardWithRetry("x", { setFn, sleepFn, maxAttempts: 1 });
+    expect(res).toEqual({ ok: false, attempts: 1 });
+    expect(setFn).toHaveBeenCalledTimes(1);
+    expect(sleepFn).not.toHaveBeenCalled(); // single attempt → no backoff
   });
 });
 

--- a/tests/unit/bg-input.test.ts
+++ b/tests/unit/bg-input.test.ts
@@ -37,6 +37,7 @@ import {
   isBgAutoEnabled,
   clipboardSetBackoffMs,
   setClipboardWithRetry,
+  prepareClipboardForPaste,
   CLIPBOARD_SET_MAX_ATTEMPTS,
 } from "../../src/engine/bg-input.js";
 import { postMessageToHwnd, getWindowClassName, getProcessIdentityByPid } from "../../src/engine/win32.js";
@@ -255,6 +256,55 @@ describe("setClipboardWithRetry", () => {
     expect(res).toEqual({ ok: false, attempts: 1 });
     expect(setFn).toHaveBeenCalledTimes(1);
     expect(sleepFn).not.toHaveBeenCalled(); // single attempt → no backoff
+  });
+});
+
+describe("prepareClipboardForPaste — restore-exactly-once invariant", () => {
+  // Guards the most important invariant of pasteIntoConsoleNoFocus: a failed set
+  // restores the snapshot exactly once (never leaving the user's clipboard
+  // clobbered), and the success path does NOT restore here (the post-paste
+  // restore in pasteIntoConsoleNoFocus owns that). A future regression that
+  // moved restore inside the retry loop would fail these.
+  const SAVED = "AAA="; // opaque snapshot token
+
+  it("returns true and does NOT restore when the set succeeds first try", async () => {
+    const setFn = vi.fn().mockResolvedValue(true);
+    const restoreFn = vi.fn().mockResolvedValue(undefined);
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+    const ok = await prepareClipboardForPaste("x", SAVED, { setFn, restoreFn, sleepFn });
+    expect(ok).toBe(true);
+    expect(restoreFn).not.toHaveBeenCalled();
+    expect(setFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns true and does NOT restore when the set succeeds after a retry", async () => {
+    const setFn = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    const restoreFn = vi.fn().mockResolvedValue(undefined);
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+    const ok = await prepareClipboardForPaste("x", SAVED, { setFn, restoreFn, sleepFn });
+    expect(ok).toBe(true);
+    expect(restoreFn).not.toHaveBeenCalled();
+  });
+
+  it("returns false and restores EXACTLY ONCE (with the snapshot) when every set fails", async () => {
+    const setFn = vi.fn().mockResolvedValue(false);
+    const restoreFn = vi.fn().mockResolvedValue(undefined);
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+    const ok = await prepareClipboardForPaste("x", SAVED, { setFn, restoreFn, sleepFn });
+    expect(ok).toBe(false);
+    expect(setFn).toHaveBeenCalledTimes(CLIPBOARD_SET_MAX_ATTEMPTS);
+    expect(restoreFn).toHaveBeenCalledTimes(1);
+    expect(restoreFn).toHaveBeenCalledWith(SAVED);
+  });
+
+  it("restores once even when the snapshot was unreadable (null)", async () => {
+    const setFn = vi.fn().mockResolvedValue(false);
+    const restoreFn = vi.fn().mockResolvedValue(undefined);
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+    const ok = await prepareClipboardForPaste("x", null, { setFn, restoreFn, sleepFn });
+    expect(ok).toBe(false);
+    expect(restoreFn).toHaveBeenCalledTimes(1);
+    expect(restoreFn).toHaveBeenCalledWith(null);
   });
 });
 


### PR DESCRIPTION
## What & why

Real-machine dogfood (2026-05-23, conhost + Windows Terminal on WSL Ubuntu) of the terminal completion-detection series (#383 / #386 / #384) passed all 12 happy-path runs + 3 documented guardrails. One finding (F1): the **first** exit-mode `terminal(action='run', until:{mode:'exit'})` against a **conhost** window returned `completion.reason:'send_failed'`, empty output, and `warnings:["terminal(action='send') failed: clipboard_set_failed"]`. A manual retry and a back-to-back 5-run probe both succeeded immediately (1/12 across the session) — a textbook transient that coincided with a busy window-launch storm holding the global clipboard.

**Root cause.** Exit-mode delivery on conhost uses `pasteIntoConsoleNoFocus` (clipboard + console Paste). `setClipboardVerified` did a single `Set-Clipboard` + `Get-Clipboard` read-back via a spawned `powershell.exe`; the global clipboard is one OS resource, so a momentary lock by another process makes the set/verify miss — and there was no retry, so a recoverable race became a hard `send_failed`.

## How it's fixed

- `setClipboardWithRetry` wraps the set-and-verify with **3 attempts (1 + 2 retries), 120/240 ms backoff**.
- The clipboard snapshot is captured **once outside the loop**; `restoreClipboard` runs **at most once** (on total failure, or after the paste on success), so a failed set never leaves the user's clipboard clobbered (#389 round-1 P2-1 invariant preserved by construction).
- `setClipboardWithRetry` + `clipboardSetBackoffMs` are **pure / injectable** (`setFn`, `sleepFn`) and unit-tested with no real clipboard or timers.
- `console_paste_post_failed` is intentionally **not** retried (a PostMessage/HWND-liveness failure is not a transient).
- Worst-case added send latency ≈ 1.6 s and only on the failure path — negligible vs exit-mode's seconds-to-minutes completion wait.

Scope is closed by construction: `pasteIntoConsoleNoFocus` has a single caller (exit-mode delivery in `src/tools/terminal.ts`).

## Tests

- `tests/unit/bg-input.test.ts`: backoff growth; first-attempt success (no sleep); fail/fail/succeed → ok at attempt 3 with 120 then 240 ms backoff; all-fail → ok:false with N-1 sleeps; custom `maxAttempts`.
- `npm run test:unit`: 3660 passed (the single failure on a full run was a pre-existing timing-sensitive test in `input-pipeline-dispatch.test.ts` unrelated to this change — passes 70/70 in isolation). `eslint` clean.

## Design / follow-ups

Opus design (option A, bounded retry; B WM_CHAR-fallback and C native-clipboard rejected for this PR). The native-clipboard route (drop the `powershell.exe` spawn — impl already exists in `clipboard_snapshot.rs` but has no standalone napi export) is recorded as future work.

Plan: `desktop-touch-mcp-internal@4b887a8:docs/issue-386-followups.md` (F1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)