### PR TITLE
feat(terminal): #386 — native console-paste for conhost exit-mode (drop powershell clipboard)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -156,6 +156,19 @@ export interface NativeForegroundFlashResult {
   pasteWarningDetected: boolean
 }
 
+// issue #386 — native no-steal console-paste (conhost exit-mode path).
+export interface NativeConsolePasteSkippedFormat {
+  formatId: number
+  reason: string
+}
+
+export interface NativeConsolePasteResult {
+  ok: boolean
+  reason?: string
+  skippedFormats: Array<NativeConsolePasteSkippedFormat>
+  restoreSkippedRace: boolean
+}
+
 export interface NativeProcessParentEntry {
   pid: number
   parentPid: number
@@ -330,6 +343,7 @@ export declare function win32BuildProcessParentMap(): NativeProcessParentEntry[]
 export declare function win32GetProcessIdentity(pid: number): NativeProcessIdentity
 export declare function win32GetScrollInfo(hwnd: bigint, axis: string): NativeScrollInfo | null
 export declare function win32PostMessage(hwnd: bigint, msg: number, wParam: bigint, lParam: bigint): boolean
+export declare function win32ConsolePasteNoFocus(hwnd: bigint, text: string): NativeConsolePasteResult
 export declare function win32GetFocus(): bigint | null
 export declare function win32VkToScanCode(vk: number): number
 

--- a/src/engine/bg-input.ts
+++ b/src/engine/bg-input.ts
@@ -15,8 +15,6 @@
  * 経由。
  */
 
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
 import {
   getWindowClassName,
   getWindowProcessId,
@@ -253,232 +251,84 @@ export function postEnterToHwnd(hwnd: unknown): boolean {
 // (0x0D) as a line break, so the command must use CRLF separators; with `\n`
 // alone the lines concatenate and the shell sees one mangled line.
 
-const WM_COMMAND = 0x0111;
-/** Legacy console context-menu "Paste" command id (conhost). */
-const ID_CONSOLE_PASTE = 0xfff1;
-
-const execFileAsync = promisify(execFile);
-
-/** Read the current clipboard as a UTF-16LE base64 blob (empty string if none). */
-async function getClipboardB64(): Promise<string | null> {
-  try {
-    const { stdout } = await execFileAsync(
-      "powershell.exe",
-      [
-        "-NoProfile", "-NonInteractive", "-Command",
-        "$t=Get-Clipboard -Raw;if($t -eq $null){''}else{" +
-          "[Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($t))}",
-      ],
-      { timeout: 4000 },
-    );
-    return stdout.trim();
-  } catch {
-    return null;
-  }
-}
-
-/** Set the clipboard to `text` (UTF-16LE) and verify the read-back byte-equals. */
-async function setClipboardVerified(text: string): Promise<boolean> {
-  const b64 = Buffer.from(text, "utf16le").toString("base64");
-  const script =
-    `$b=[System.Convert]::FromBase64String('${b64}');` +
-    `$t=[System.Text.Encoding]::Unicode.GetString($b);` +
-    `Set-Clipboard -Value $t;` +
-    `$r=Get-Clipboard -Raw;` +
-    `if($r -eq $null){''}else{[Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($r))}`;
-  try {
-    const { stdout } = await execFileAsync(
-      "powershell.exe",
-      ["-NoProfile", "-NonInteractive", "-Command", script],
-      { timeout: 5000 },
-    );
-    const readBack = stdout.trim();
-    const actual = readBack ? Buffer.from(readBack, "base64") : Buffer.alloc(0);
-    // Get-Clipboard -Raw can append a trailing newline; accept an exact match OR
-    // the text followed by a single CRLF/CR/LF so multiline payloads still pass.
-    const want = Buffer.from(text, "utf16le");
-    if (want.equals(actual)) return true;
-    for (const suffix of ["\r\n", "\r", "\n"]) {
-      if (Buffer.from(text + suffix, "utf16le").equals(actual)) return true;
-    }
-    return false;
-  } catch {
-    return false;
-  }
-}
+/**
+ * Failure reasons for {@link pasteIntoConsoleNoFocus}. All but the last come
+ * straight from the native engine's `ClipboardError::as_reason()` /
+ * console-paste path; `native_engine_unavailable` is added TS-side when the
+ * addon is missing.
+ */
+export type ConsolePasteReason =
+  | "clipboard_lock_contention"
+  | "clipboard_empty_failed"
+  | "clipboard_alloc_failed"
+  | "clipboard_set_data_failed"
+  | "hidden_owner_create_failed"
+  | "post_paste_failed"
+  | "native_engine_unavailable";
 
 export interface ConsolePasteOutcome {
   ok: boolean;
-  reason?: "clipboard_set_failed" | "console_paste_post_failed";
-}
-
-/** Max attempts to set+verify the clipboard before giving up (1 try + 2 retries). */
-export const CLIPBOARD_SET_MAX_ATTEMPTS = 3;
-
-/**
- * Backoff (ms) before the retry that FOLLOWS failed attempt `attempt` (0-based):
- * 120 ms after attempt 0, 240 ms after attempt 1, … Pure — unit-testable. Grows
- * linearly with no cap; with CLIPBOARD_SET_MAX_ATTEMPTS=3 production only ever
- * uses attempts 0 and 1 (120 / 240 ms) — there is no sleep after the final
- * attempt — so raise the cap deliberately if you bump the attempt count.
- */
-export function clipboardSetBackoffMs(attempt: number): number {
-  return 120 * (attempt + 1);
-}
-
-/**
- * Set the clipboard with bounded retry + backoff, returning whether any attempt
- * succeeded and how many were made.
- *
- * The global clipboard is a single OS resource; when another process holds it
- * open (a busy desktop, a clipboard manager, our own back-to-back PowerShell
- * spawns) the set-and-verify misses on the first try — a transient that clears
- * in well under a second. Retrying turns that recoverable race into a success
- * instead of a hard send failure.
- *
- * This helper owns NEITHER the save NOR the restore: the caller captures the
- * clipboard snapshot once and restores at most once, so the restore invariant
- * (never leave the user's clipboard clobbered) is preserved by construction.
- * `setFn` / `sleepFn` are injectable so the retry policy can be unit-tested with
- * no real clipboard and no real timers.
- */
-export async function setClipboardWithRetry(
-  text: string,
-  deps: {
-    setFn: (text: string) => Promise<boolean>;
-    sleepFn?: (ms: number) => Promise<void>;
-    maxAttempts?: number;
-  },
-): Promise<{ ok: boolean; attempts: number }> {
-  const maxAttempts = deps.maxAttempts ?? CLIPBOARD_SET_MAX_ATTEMPTS;
-  const sleepFn = deps.sleepFn ?? ((ms) => new Promise<void>((r) => setTimeout(r, ms)));
-  for (let attempt = 0; attempt < maxAttempts; attempt++) {
-    if (await deps.setFn(text)) return { ok: true, attempts: attempt + 1 };
-    if (attempt < maxAttempts - 1) await sleepFn(clipboardSetBackoffMs(attempt));
-  }
-  return { ok: false, attempts: maxAttempts };
-}
-
-/**
- * Front half of the console-paste flow: set the clipboard with retry and, ONLY
- * on total failure, restore the snapshot exactly once. Returns true when the
- * clipboard now holds `text` (caller posts the paste) or false when the set
- * failed after retries (caller returns clipboard_set_failed — this already
- * restored, so the caller must NOT restore again).
- *
- * Split out so the restore-exactly-once invariant — never restored on the
- * success path here, restored exactly once on total failure, never inside the
- * retry loop — is unit-testable with injected setFn / restoreFn. The full
- * `pasteIntoConsoleNoFocus` is otherwise wrapped around native PostMessage calls
- * that a unit test cannot drive, which is where a future regression (e.g.
- * restore moved inside the loop) would slip past review unnoticed.
- */
-export async function prepareClipboardForPaste(
-  text: string,
-  saved: string | null,
-  deps: {
-    setFn: (text: string) => Promise<boolean>;
-    restoreFn: (saved: string | null) => Promise<void>;
-    sleepFn?: (ms: number) => Promise<void>;
-    maxAttempts?: number;
-  },
-): Promise<boolean> {
-  const setResult = await setClipboardWithRetry(text, deps);
-  if (!setResult.ok) {
-    await deps.restoreFn(saved);
-    return false;
-  }
-  return true;
+  reason?: ConsolePasteReason;
+  /**
+   * Clipboard formats that could NOT be preserved across the paste (e.g. an
+   * image: `non_hglobal`), with the reason. Surfaced so callers can warn the
+   * user that part of their clipboard was lost. Present only when non-empty.
+   */
+  skippedFormats?: Array<{ formatId: number; reason: string }>;
+  /**
+   * The user's clipboard was intentionally NOT restored because another writer
+   * changed it after our inject (race detection). Still a success — the paste
+   * worked; we just did not clobber the other writer.
+   */
+  restoreSkippedRace?: boolean;
 }
 
 /**
  * Paste `text` into a conhost (ConsoleWindowClass) window atomically WITHOUT
- * stealing foreground, via clipboard + the console Paste command. Multiline-safe.
+ * stealing foreground. Delegates the whole save → set → console-Paste → Enter →
+ * restore clipboard transaction to the native engine
+ * (`win32_console_paste_no_focus`, issue #386), which talks to the Win32
+ * clipboard directly (no `powershell.exe` spawn): contention is absorbed by the
+ * native `OpenClipboard` retry, the user's clipboard is saved/restored with
+ * 3-point sequence race detection, and formats that cannot be preserved (e.g. an
+ * image) are reported back in `skippedFormats`.
  *
  * Caller MUST have verified the target is conhost (ConsoleWindowClass) — the
- * 0xFFF1 command is a no-op on Windows Terminal (XAML) and non-console windows.
+ * console Paste command is a no-op on Windows Terminal (XAML) / non-console
+ * windows.
  *
- * Flow: save clipboard → set clipboard to the CRLF-normalised text (verified) →
- * post the console Paste command → settle so conhost drains the clipboard into
- * its input buffer → send a trailing Enter to run the final line → restore the
- * previous clipboard (best-effort).
+ * Never throws on a Win32 failure: returns `{ ok: false, reason }`. When the
+ * native addon is unavailable (an older `.node`), returns
+ * `reason: "native_engine_unavailable"` — the conhost class check already
+ * requires the native engine, so this is effectively unreachable in practice.
  *
- * The trailing Enter is posted AFTER a settle delay (not appended to the
- * clipboard) so it cannot race ahead of the still-draining paste.
+ * `async` is kept for signature stability (callers `await` it); the native call
+ * itself is synchronous (it blocks ~260 ms on the settle delays — acceptable for
+ * the exit-mode path, which already waits seconds-to-minutes for completion).
  */
 export async function pasteIntoConsoleNoFocus(
   hwnd: unknown,
   text: string,
 ): Promise<ConsolePasteOutcome> {
+  if (!nativeWin32 || typeof nativeWin32.win32ConsolePasteNoFocus !== "function") {
+    return { ok: false, reason: "native_engine_unavailable" };
+  }
+  // Resolve the focused child (the same target the legacy WM_COMMAND path used)
+  // and hand the whole transaction to the native engine.
   const target = resolveTarget(hwnd);
-  // conhost strips lone LF and treats CR as a line break — use CRLF so each
-  // statement runs after the atomic paste.
-  const crlf = text.replace(/\r?\n/g, "\r\n");
-
-  const saved = await getClipboardB64(); // null = read failed; "" = empty clipboard
-  // Set-and-verify with retry: a momentary clipboard lock by another process
-  // makes the first try miss (dogfood #386 P3 follow-up — surfaced as a one-off
-  // clipboard_set_failed during a busy window-launch storm). `saved` is captured
-  // ONCE above; prepareClipboardForPaste restores it exactly once on total
-  // failure, and the success path restores once after the paste (below), so a
-  // failed set never leaves the user's clipboard clobbered (#389 r1 P2-1).
-  const ready = await prepareClipboardForPaste(crlf, saved, {
-    setFn: setClipboardVerified,
-    restoreFn: restoreClipboard,
-  });
-  if (!ready) {
-    return { ok: false, reason: "clipboard_set_failed" };
+  const targetBig =
+    typeof target === "bigint" ? target : BigInt(target as number | string);
+  const r = nativeWin32.win32ConsolePasteNoFocus(targetBig, text);
+  const outcome: ConsolePasteOutcome = { ok: r.ok };
+  if (r.reason) outcome.reason = r.reason as ConsolePasteReason;
+  if (r.skippedFormats && r.skippedFormats.length > 0) {
+    outcome.skippedFormats = r.skippedFormats.map((f) => ({
+      formatId: f.formatId,
+      reason: f.reason,
+    }));
   }
-
-  const posted = postMessageToHwnd(target, WM_COMMAND, ID_CONSOLE_PASTE, 0);
-  if (!posted) {
-    await restoreClipboard(saved);
-    return { ok: false, reason: "console_paste_post_failed" };
-  }
-
-  // Let conhost drain the clipboard into its input buffer before the Enter and
-  // before we overwrite the clipboard on restore.
-  await new Promise<void>((r) => setTimeout(r, 200));
-  postEnterToHwnd(target);
-  await new Promise<void>((r) => setTimeout(r, 60));
-  await restoreClipboard(saved);
-  return { ok: true };
-}
-
-/**
- * Best-effort restore of a clipboard snapshot captured by getClipboardB64().
- *
- * Codex #389 P2: when the original clipboard was EMPTY (`""`) or could not be
- * read (`null`), we must still CLEAR it rather than skip — otherwise the command
- * we just pasted (possibly sensitive input) lingers in the user's clipboard
- * after the run. Set-Clipboard rejects an empty value, so clearing uses the
- * Forms clipboard API.
- */
-async function restoreClipboard(savedB64: string | null): Promise<void> {
-  try {
-    if (savedB64 && savedB64.length > 0) {
-      const script =
-        `$b=[System.Convert]::FromBase64String('${savedB64}');` +
-        `$t=[System.Text.Encoding]::Unicode.GetString($b);` +
-        `Set-Clipboard -Value $t`;
-      await execFileAsync("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", script], {
-        timeout: 3000,
-      });
-    } else {
-      // Originally empty / unreadable — clear so the injected command does not
-      // linger. Clearing an unreadable clipboard is harmless (best-effort).
-      await execFileAsync(
-        "powershell.exe",
-        [
-          "-NoProfile", "-NonInteractive", "-Command",
-          "Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.Clipboard]::Clear()",
-        ],
-        { timeout: 3000 },
-      );
-    }
-  } catch {
-    /* best-effort */
-  }
+  if (r.restoreSkippedRace) outcome.restoreSkippedRace = true;
+  return outcome;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/engine/native-engine.ts
+++ b/src/engine/native-engine.ts
@@ -39,6 +39,7 @@ import type {
   NativeForceFocusResult,
   NativeForegroundFlashOptions,
   NativeForegroundFlashResult,
+  NativeConsolePasteResult,
   NativeProcessParentEntry,
   NativeProcessIdentity,
   NativeScrollInfo,
@@ -179,6 +180,13 @@ export interface NativeWin32 {
     text: string,
     options: NativeForegroundFlashOptions,
   ): NativeForegroundFlashResult;
+
+  // issue #386 — native no-steal console-paste for the conhost exit-mode path.
+  // Sync; runs the whole save → set → console-Paste → Enter → restore clipboard
+  // transaction natively (reuses clipboard_snapshot). Never throws on a Win32
+  // failure — reports it via `ok=false` + `reason`. Optional so an older `.node`
+  // build (pre-#386) cleanly falls back (TS wrapper surfaces native_engine_unavailable).
+  win32ConsolePasteNoFocus?(hwnd: bigint, text: string): NativeConsolePasteResult;
 
   // Issue #245 系統②: IME open-status query / control via Imm32.dll +
   // WM_IME_CONTROL. Returns `false` when the target HWND has no associated

--- a/src/engine/native-types.ts
+++ b/src/engine/native-types.ts
@@ -357,6 +357,31 @@ export interface NativeForegroundFlashResult {
   pasteWarningDetected: boolean
 }
 
+// ── issue #386 — native no-steal console-paste (conhost exit-mode path) ───────
+
+/** One clipboard format NOT preserved across the paste, with the reason
+ *  (`"non_hglobal"` / `"deferred_render"` / `"get_data_failed"`). */
+export interface NativeConsolePasteSkippedFormat {
+  formatId: number
+  reason: string
+}
+
+/** Result of `win32ConsolePasteNoFocus`. Never throws on a Win32 failure —
+ *  the failure is reported via `ok=false` + `reason`. `reason` is one of
+ *  `ClipboardError::as_reason()` (`clipboard_lock_contention` /
+ *  `clipboard_empty_failed` / `clipboard_alloc_failed` /
+ *  `clipboard_set_data_failed` / `hidden_owner_create_failed`) or the
+ *  console-paste-specific `post_paste_failed`. */
+export interface NativeConsolePasteResult {
+  ok: boolean
+  reason?: string
+  /** Formats not restored (e.g. an image: `non_hglobal`) — caller hints. */
+  skippedFormats: Array<NativeConsolePasteSkippedFormat>
+  /** Restore intentionally skipped: another writer changed the clipboard after
+   *  our inject (race). Still a success — the paste worked. */
+  restoreSkippedRace: boolean
+}
+
 /** One Toolhelp32 row. The TS wrapper builds a Map<number, number>. */
 export interface NativeProcessParentEntry {
   pid: number

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -1911,6 +1911,21 @@ export const terminalRunHandler = async ({
     if (targetClass === "ConsoleWindowClass") {
       const paste = await pasteIntoConsoleNoFocus(hwnd, sendInput);
       sendPayload = paste.ok ? { ok: true } : { ok: false, code: paste.reason };
+      // issue #386: surface native-clipboard hints (success-compatible). A
+      // non-text format that could not be preserved (e.g. an image) or a restore
+      // skipped because another app raced is worth telling the caller.
+      if (paste.skippedFormats && paste.skippedFormats.length > 0) {
+        warnings.push(
+          `clipboard formats not preserved across paste: ${paste.skippedFormats
+            .map((f) => `${f.formatId}(${f.reason})`)
+            .join(", ")}`,
+        );
+      }
+      if (paste.restoreSkippedRace) {
+        warnings.push(
+          "clipboard restore skipped — another app changed the clipboard during the paste",
+        );
+      }
     } else {
       sendPayload = parseSendResult(await terminalSendHandler({ ...sendArgs, method: "foreground" }));
     }
@@ -1938,6 +1953,7 @@ export const terminalRunHandler = async ({
       },
       hwnd: String(hwnd),
       warnings: [
+        ...warnings,
         sendCode
           ? `terminal(action='send') failed: ${sendCode}`
           : `terminal(action='send') failed`,

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -1911,20 +1911,24 @@ export const terminalRunHandler = async ({
     if (targetClass === "ConsoleWindowClass") {
       const paste = await pasteIntoConsoleNoFocus(hwnd, sendInput);
       sendPayload = paste.ok ? { ok: true } : { ok: false, code: paste.reason };
-      // issue #386: surface native-clipboard hints (success-compatible). A
-      // non-text format that could not be preserved (e.g. an image) or a restore
-      // skipped because another app raced is worth telling the caller.
-      if (paste.skippedFormats && paste.skippedFormats.length > 0) {
-        warnings.push(
-          `clipboard formats not preserved across paste: ${paste.skippedFormats
-            .map((f) => `${f.formatId}(${f.reason})`)
-            .join(", ")}`,
-        );
-      }
-      if (paste.restoreSkippedRace) {
-        warnings.push(
-          "clipboard restore skipped — another app changed the clipboard during the paste",
-        );
+      // issue #386: surface native-clipboard hints — ONLY on success. They are
+      // success-context ("the paste worked, but a format was not preserved" /
+      // "restore was skipped"); emitting them alongside a send failure would
+      // read as a contradiction ("couldn't paste, but your image wasn't saved").
+      // On failure the reason code is the message (Opus PR #393 R1 P2-1).
+      if (paste.ok) {
+        if (paste.skippedFormats && paste.skippedFormats.length > 0) {
+          warnings.push(
+            `clipboard formats not preserved across paste: ${paste.skippedFormats
+              .map((f) => `${f.formatId}(${f.reason})`)
+              .join(", ")}`,
+          );
+        }
+        if (paste.restoreSkippedRace) {
+          warnings.push(
+            "clipboard restore skipped — another app changed the clipboard during the paste",
+          );
+        }
       }
     } else {
       sendPayload = parseSendResult(await terminalSendHandler({ ...sendArgs, method: "foreground" }));

--- a/src/win32/console_paste.rs
+++ b/src/win32/console_paste.rs
@@ -22,14 +22,14 @@ use std::time::Duration;
 
 use napi::bindgen_prelude::BigInt;
 use napi_derive::napi;
-use windows::Win32::Foundation::{HWND, LPARAM, WPARAM};
+use windows::Win32::Foundation::{LPARAM, WPARAM};
 
 use super::clipboard_snapshot::{
     get_clipboard_sequence_number, restore_clipboard_supported_formats,
     save_clipboard_supported_formats, set_clipboard_unicode_text, with_hidden_owner,
     ClipboardSnapshot, RestoreOutcome,
 };
-use super::input::post_message;
+use super::input::{hwnd_from_bigint, post_message};
 use super::safety::napi_safe_call;
 
 // ── Constants ───────────────────────────────────────────────────────────────
@@ -74,11 +74,6 @@ pub struct ConsolePasteResult {
     pub restore_skipped_race: bool,
 }
 
-fn hwnd_from_bigint(b: BigInt) -> HWND {
-    let (_sign, val, _lossless) = b.get_u64();
-    HWND(val as isize as *mut std::ffi::c_void)
-}
-
 fn build_skipped(snapshot: &ClipboardSnapshot) -> Vec<ConsolePasteSkippedFormat> {
     snapshot
         .skipped_summary()
@@ -94,6 +89,37 @@ fn fail(reason: &str, skipped: Vec<ConsolePasteSkippedFormat>, restore_skipped_r
     ConsolePasteResult {
         ok: false,
         reason: Some(reason.to_string()),
+        skipped_formats: skipped,
+        restore_skipped_race,
+    }
+}
+
+/// Pure mapping from the executed step outcomes (after restore has already run)
+/// to the final result. Extracted so every reason branch — set failure, post
+/// failure, success — plus the `skipped_formats` / `restore_skipped_race`
+/// carry-through is unit-tested without touching Win32 (PR #393 R1 P3-2). The
+/// surrounding imperative flow (save → set → paste → restore-exactly-once) is
+/// verified by review + the `clipboard_snapshot` round-trip/race tests + dogfood.
+fn map_paste_outcome(
+    set_ok: bool,
+    set_reason: Option<&str>,
+    post_paste_failed: bool,
+    skipped: Vec<ConsolePasteSkippedFormat>,
+    restore_skipped_race: bool,
+) -> ConsolePasteResult {
+    if !set_ok {
+        return fail(
+            set_reason.unwrap_or("clipboard_set_data_failed"),
+            skipped,
+            restore_skipped_race,
+        );
+    }
+    if post_paste_failed {
+        return fail("post_paste_failed", skipped, restore_skipped_race);
+    }
+    ConsolePasteResult {
+        ok: true,
+        reason: None,
         skipped_formats: skipped,
         restore_skipped_race,
     }
@@ -159,19 +185,8 @@ pub fn win32_console_paste_no_focus(
             let restore = restore_clipboard_supported_formats(&snapshot, owner, seq_after);
             let restore_skipped_race = matches!(restore, RestoreOutcome::SkippedDueToRace { .. });
 
-            // 5. Map outcome.
-            if !set_ok {
-                return fail(set_reason.unwrap_or("clipboard_set_data_failed"), skipped, restore_skipped_race);
-            }
-            if post_paste_failed {
-                return fail("post_paste_failed", skipped, restore_skipped_race);
-            }
-            ConsolePasteResult {
-                ok: true,
-                reason: None,
-                skipped_formats: skipped,
-                restore_skipped_race,
-            }
+            // 5. Map outcome (pure — see map_paste_outcome).
+            map_paste_outcome(set_ok, set_reason, post_paste_failed, skipped, restore_skipped_race)
         });
 
         // `with_hidden_owner` only errors when the hidden owner window could not
@@ -211,5 +226,48 @@ mod tests {
         assert_eq!(normalise("a\r\nb"), "a\r\nb"); // already CRLF stays CRLF (no doubling)
         assert_eq!(normalise("a\nb\nc"), "a\r\nb\r\nc");
         assert_eq!(normalise("plain"), "plain");
+    }
+
+    fn one_skip() -> Vec<ConsolePasteSkippedFormat> {
+        vec![ConsolePasteSkippedFormat { format_id: 2, reason: "non_hglobal".to_string() }]
+    }
+
+    #[test]
+    fn map_outcome_success_carries_hints() {
+        let r = map_paste_outcome(true, None, false, one_skip(), true);
+        assert!(r.ok);
+        assert!(r.reason.is_none());
+        assert_eq!(r.skipped_formats.len(), 1); // skipped formats ride along on success
+        assert!(r.restore_skipped_race);
+    }
+
+    #[test]
+    fn map_outcome_set_failure_uses_set_reason() {
+        // each ClipboardError::as_reason value flows through unchanged
+        for reason in [
+            "clipboard_lock_contention",
+            "clipboard_empty_failed",
+            "clipboard_alloc_failed",
+            "clipboard_set_data_failed",
+        ] {
+            let r = map_paste_outcome(false, Some(reason), false, Vec::new(), false);
+            assert!(!r.ok);
+            assert_eq!(r.reason.as_deref(), Some(reason));
+        }
+    }
+
+    #[test]
+    fn map_outcome_set_failure_falls_back_when_reason_absent() {
+        let r = map_paste_outcome(false, None, false, Vec::new(), false);
+        assert_eq!(r.reason.as_deref(), Some("clipboard_set_data_failed"));
+    }
+
+    #[test]
+    fn map_outcome_post_paste_failure() {
+        // post failure only reachable when set succeeded; reason is console-paste-specific
+        let r = map_paste_outcome(true, None, true, one_skip(), false);
+        assert!(!r.ok);
+        assert_eq!(r.reason.as_deref(), Some("post_paste_failed"));
+        assert_eq!(r.skipped_formats.len(), 1);
     }
 }

--- a/src/win32/console_paste.rs
+++ b/src/win32/console_paste.rs
@@ -74,6 +74,15 @@ pub struct ConsolePasteResult {
     pub restore_skipped_race: bool,
 }
 
+/// Normalise every newline to CRLF (collapse CRLF→LF then LF→CRLF, so isolated
+/// `\r` is handled and existing CRLF is not doubled). conhost strips lone LF and
+/// treats CR as a line break, so each statement must be CRLF-terminated to run
+/// after the atomic paste. Equivalent to the previous TS `/\r?\n/g → \r\n`.
+/// Pure — shared by the paste body and its unit test (PR #393 R2 P3-new).
+fn normalise_crlf(text: &str) -> String {
+    text.replace("\r\n", "\n").replace('\n', "\r\n")
+}
+
 fn build_skipped(snapshot: &ClipboardSnapshot) -> Vec<ConsolePasteSkippedFormat> {
     snapshot
         .skipped_summary()
@@ -139,10 +148,7 @@ pub fn win32_console_paste_no_focus(
 ) -> napi::Result<ConsolePasteResult> {
     napi_safe_call("win32_console_paste_no_focus", || {
         let target = hwnd_from_bigint(hwnd);
-        // conhost strips lone LF and treats CR as a line break — normalise every
-        // newline to CRLF so each statement runs after the atomic paste (matches
-        // the previous TS path).
-        let crlf = text.replace("\r\n", "\n").replace('\n', "\r\n");
+        let crlf = normalise_crlf(&text);
 
         // The whole clipboard transaction runs under one hidden owner window
         // (per-call lifecycle) on this (V8) thread.
@@ -221,11 +227,11 @@ mod tests {
 
     #[test]
     fn crlf_normalisation_collapses_then_expands() {
-        let normalise = |s: &str| s.replace("\r\n", "\n").replace('\n', "\r\n");
-        assert_eq!(normalise("a\nb"), "a\r\nb");
-        assert_eq!(normalise("a\r\nb"), "a\r\nb"); // already CRLF stays CRLF (no doubling)
-        assert_eq!(normalise("a\nb\nc"), "a\r\nb\r\nc");
-        assert_eq!(normalise("plain"), "plain");
+        // invoke the production helper (not a copy) so the test tracks the body
+        assert_eq!(normalise_crlf("a\nb"), "a\r\nb");
+        assert_eq!(normalise_crlf("a\r\nb"), "a\r\nb"); // already CRLF stays CRLF (no doubling)
+        assert_eq!(normalise_crlf("a\nb\nc"), "a\r\nb\r\nc");
+        assert_eq!(normalise_crlf("plain"), "plain");
     }
 
     fn one_skip() -> Vec<ConsolePasteSkippedFormat> {

--- a/src/win32/console_paste.rs
+++ b/src/win32/console_paste.rs
@@ -1,0 +1,215 @@
+//! issue #386 — native no-steal console-paste for the conhost exit-mode path.
+//!
+//! Replaces the powershell-spawning TS clipboard handling in
+//! `src/engine/bg-input.ts::pasteIntoConsoleNoFocus` with a single sync `#[napi]`
+//! call that runs the whole save → set → console-Paste → Enter → restore
+//! transaction natively, reusing `clipboard_snapshot.rs` (HGLOBAL save/restore +
+//! 3-point sequence race detection + `OpenClipboard` 10×10 ms retry).
+//!
+//! Why sync (not AsyncTask): `win32_foreground_flash_inject` already runs the
+//! same clipboard transaction synchronously on the V8 thread and works — that is
+//! the thread clipboard ownership is known-good on. A libuv worker thread is a
+//! risky home for a top-level clipboard-owner window (the UIA backend stands up a
+//! *dedicated* thread for COM affinity precisely because worker threads are not).
+//! The body sleeps ~260 ms and may block ≤100 ms on OpenClipboard retry; the MCP
+//! server is a single stdio client and exit-mode already waits seconds-to-minutes
+//! for completion, so the event-loop block is immaterial. Sync also gets the
+//! ADR-007 §3.4 panic boundary for free via `napi_safe_call`.
+//!
+//! Design: `desktop-touch-mcp-internal/docs/issue-386-native-clipboard-plan.md`.
+
+use std::time::Duration;
+
+use napi::bindgen_prelude::BigInt;
+use napi_derive::napi;
+use windows::Win32::Foundation::{HWND, LPARAM, WPARAM};
+
+use super::clipboard_snapshot::{
+    get_clipboard_sequence_number, restore_clipboard_supported_formats,
+    save_clipboard_supported_formats, set_clipboard_unicode_text, with_hidden_owner,
+    ClipboardSnapshot, RestoreOutcome,
+};
+use super::input::post_message;
+use super::safety::napi_safe_call;
+
+// ── Constants ───────────────────────────────────────────────────────────────
+
+const WM_COMMAND: u32 = 0x0111;
+/// Legacy console context-menu "Paste" command id (conhost). Mirrors
+/// `ID_CONSOLE_PASTE` in `bg-input.ts`.
+const ID_CONSOLE_PASTE: usize = 0xFFF1;
+const WM_CHAR: u32 = 0x0102;
+/// VK_RETURN. Enter is sent as WM_CHAR only (bit-equal with the TS
+/// `postEnterToHwnd`, not WM_KEYDOWN/KEYUP).
+const VK_RETURN: usize = 0x0D;
+/// Let conhost drain the pasted clipboard into its input buffer before Enter.
+const PASTE_DRAIN_DELAY_MS: u64 = 200;
+/// Gap after Enter before restoring the clipboard.
+const ENTER_GAP_DELAY_MS: u64 = 60;
+
+// ── Result types (napi objects) ─────────────────────────────────────────────
+
+/// One clipboard format that was NOT preserved across the paste, with the
+/// reason (`non_hglobal` / `deferred_render` / `get_data_failed`). Surfaced as
+/// caller hints so a user who had e.g. an image on the clipboard learns it was
+/// not restored.
+#[napi(object)]
+pub struct ConsolePasteSkippedFormat {
+    pub format_id: u32,
+    pub reason: String,
+}
+
+/// Outcome of `win32_console_paste_no_focus`. `reason` is `None` on success;
+/// otherwise one of `ClipboardError::as_reason()` (`clipboard_lock_contention` /
+/// `clipboard_empty_failed` / `clipboard_alloc_failed` / `clipboard_set_data_failed`
+/// / `hidden_owner_create_failed`) or the console-paste-specific `post_paste_failed`.
+#[napi(object)]
+pub struct ConsolePasteResult {
+    pub ok: bool,
+    pub reason: Option<String>,
+    pub skipped_formats: Vec<ConsolePasteSkippedFormat>,
+    /// Restore was intentionally skipped because another writer changed the
+    /// clipboard after our inject (race detection). Still a success — the paste
+    /// worked; we just did not clobber the other writer.
+    pub restore_skipped_race: bool,
+}
+
+fn hwnd_from_bigint(b: BigInt) -> HWND {
+    let (_sign, val, _lossless) = b.get_u64();
+    HWND(val as isize as *mut std::ffi::c_void)
+}
+
+fn build_skipped(snapshot: &ClipboardSnapshot) -> Vec<ConsolePasteSkippedFormat> {
+    snapshot
+        .skipped_summary()
+        .into_iter()
+        .map(|(format_id, reason)| ConsolePasteSkippedFormat {
+            format_id,
+            reason: reason.to_string(),
+        })
+        .collect()
+}
+
+fn fail(reason: &str, skipped: Vec<ConsolePasteSkippedFormat>, restore_skipped_race: bool) -> ConsolePasteResult {
+    ConsolePasteResult {
+        ok: false,
+        reason: Some(reason.to_string()),
+        skipped_formats: skipped,
+        restore_skipped_race,
+    }
+}
+
+// ── napi entry point ─────────────────────────────────────────────────────────
+
+/// Paste `text` into a conhost (ConsoleWindowClass) window atomically WITHOUT
+/// stealing foreground, via the native clipboard + the console Paste command +
+/// Enter, restoring the user's clipboard afterwards. Caller MUST have verified
+/// the target is conhost. Sync (runs on the V8 thread); never throws on a Win32
+/// failure — the failure is reported via `ok=false` + `reason`.
+#[napi]
+pub fn win32_console_paste_no_focus(
+    hwnd: BigInt,
+    text: String,
+) -> napi::Result<ConsolePasteResult> {
+    napi_safe_call("win32_console_paste_no_focus", || {
+        let target = hwnd_from_bigint(hwnd);
+        // conhost strips lone LF and treats CR as a line break — normalise every
+        // newline to CRLF so each statement runs after the atomic paste (matches
+        // the previous TS path).
+        let crlf = text.replace("\r\n", "\n").replace('\n', "\r\n");
+
+        // The whole clipboard transaction runs under one hidden owner window
+        // (per-call lifecycle) on this (V8) thread.
+        let inner = with_hidden_owner(|owner| -> ConsolePasteResult {
+            // 1. Save the user's clipboard (3-point sequence: 1st point).
+            let snapshot = match save_clipboard_supported_formats(owner) {
+                Ok(s) => s,
+                // Nothing was changed yet → nothing to restore.
+                Err(e) => return fail(e.as_reason(), Vec::new(), false),
+            };
+            let skipped = build_skipped(&snapshot);
+
+            // 2. Set our text. `set_clipboard_unicode_text` empties the clipboard
+            //    BEFORE it can fail at GlobalAlloc/SetClipboardData, so on that
+            //    failure the clipboard is empty and MUST be restored. Capture the
+            //    post-set sequence on BOTH paths (it is callable with the clipboard
+            //    closed) so `restore` is always race-aware. If `set` instead failed
+            //    at OpenClipboard retry, EmptyClipboard was never reached → the
+            //    user's clipboard is untouched and restore is a harmless no-op /
+            //    will likewise fail on contention.
+            let (set_ok, seq_after, set_reason) = match set_clipboard_unicode_text(owner, &crlf) {
+                Ok(seq) => (true, seq, None),
+                Err(e) => (false, get_clipboard_sequence_number(), Some(e.as_reason())),
+            };
+
+            // 3. Post console Paste + Enter ONLY if the set succeeded.
+            let mut post_paste_failed = false;
+            if set_ok {
+                if !post_message(target, WM_COMMAND, WPARAM(ID_CONSOLE_PASTE), LPARAM(0)) {
+                    post_paste_failed = true;
+                } else {
+                    std::thread::sleep(Duration::from_millis(PASTE_DRAIN_DELAY_MS));
+                    // Enter — WM_CHAR VK_RETURN only (bit-equal with TS postEnterToHwnd).
+                    let _ = post_message(target, WM_CHAR, WPARAM(VK_RETURN), LPARAM(0));
+                    std::thread::sleep(Duration::from_millis(ENTER_GAP_DELAY_MS));
+                }
+            }
+
+            // 4. ALWAYS attempt restore (race-aware) — the restore-once contract.
+            let restore = restore_clipboard_supported_formats(&snapshot, owner, seq_after);
+            let restore_skipped_race = matches!(restore, RestoreOutcome::SkippedDueToRace { .. });
+
+            // 5. Map outcome.
+            if !set_ok {
+                return fail(set_reason.unwrap_or("clipboard_set_data_failed"), skipped, restore_skipped_race);
+            }
+            if post_paste_failed {
+                return fail("post_paste_failed", skipped, restore_skipped_race);
+            }
+            ConsolePasteResult {
+                ok: true,
+                reason: None,
+                skipped_formats: skipped,
+                restore_skipped_race,
+            }
+        });
+
+        // `with_hidden_owner` only errors when the hidden owner window could not
+        // be created — surface it the same typed way (not a panic / throw).
+        Ok(match inner {
+            Ok(result) => result,
+            Err(e) => fail(e.as_reason(), Vec::new(), false),
+        })
+    })
+}
+
+// ── Unit tests (pure mapping; Win32 path is exercised by dogfood) ────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fail_maps_reason_and_carries_hints() {
+        let skipped = vec![ConsolePasteSkippedFormat {
+            format_id: 2,
+            reason: "non_hglobal".to_string(),
+        }];
+        let r = fail("post_paste_failed", skipped, true);
+        assert!(!r.ok);
+        assert_eq!(r.reason.as_deref(), Some("post_paste_failed"));
+        assert_eq!(r.skipped_formats.len(), 1);
+        assert_eq!(r.skipped_formats[0].format_id, 2);
+        assert_eq!(r.skipped_formats[0].reason, "non_hglobal");
+        assert!(r.restore_skipped_race);
+    }
+
+    #[test]
+    fn crlf_normalisation_collapses_then_expands() {
+        let normalise = |s: &str| s.replace("\r\n", "\n").replace('\n', "\r\n");
+        assert_eq!(normalise("a\nb"), "a\r\nb");
+        assert_eq!(normalise("a\r\nb"), "a\r\nb"); // already CRLF stays CRLF (no doubling)
+        assert_eq!(normalise("a\nb\nc"), "a\r\nb\r\nc");
+        assert_eq!(normalise("plain"), "plain");
+    }
+}

--- a/src/win32/input.rs
+++ b/src/win32/input.rs
@@ -21,7 +21,11 @@ use windows::Win32::UI::WindowsAndMessaging::{
 use super::safety::napi_safe_call;
 use super::types::NativeForceFocusResult;
 
-fn hwnd_from_bigint(b: BigInt) -> HWND {
+/// Reinterpret a JS BigInt as an HWND. `get_u64` (magnitude) is correct for an
+/// HWND handle value; the signed `get_i64` is only needed for WPARAM/LPARAM
+/// payloads (see `win32_post_message`). Shared with `console_paste` so the HWND
+/// conversion lives in one place (PR #393 R1 P3-1).
+pub(crate) fn hwnd_from_bigint(b: BigInt) -> HWND {
     let (_sign, val, _lossless) = b.get_u64();
     HWND(val as isize as *mut std::ffi::c_void)
 }

--- a/src/win32/input.rs
+++ b/src/win32/input.rs
@@ -152,6 +152,16 @@ pub fn win32_get_focused_child_hwnd(
 
 // ── primitives ──────────────────────────────────────────────────────────────
 
+/// Internal `PostMessageW` wrapper shared by the napi export below and other
+/// native callers (issue #386 `console_paste` posts `WM_COMMAND 0xFFF1` + Enter
+/// through this). The napi *export* `win32_post_message` must not be called from
+/// Rust — it is an N-API boundary wrapper — so the shared logic lives here.
+/// Returns whether `PostMessageW` succeeded.
+pub(crate) fn post_message(hwnd: HWND, msg: u32, w_param: WPARAM, l_param: LPARAM) -> bool {
+    let result = unsafe { PostMessageW(Some(hwnd), msg, w_param, l_param) };
+    result.is_ok()
+}
+
 #[napi]
 pub fn win32_post_message(
     hwnd: BigInt,
@@ -170,15 +180,12 @@ pub fn win32_post_message(
         // (Codex review on PR #77.)
         let (w_val, _w_lossless) = w_param.get_i64();
         let (l_val, _l_lossless) = l_param.get_i64();
-        let result = unsafe {
-            PostMessageW(
-                Some(h),
-                msg,
-                WPARAM(w_val as usize),
-                LPARAM(l_val as isize),
-            )
-        };
-        Ok(result.is_ok())
+        Ok(post_message(
+            h,
+            msg,
+            WPARAM(w_val as usize),
+            LPARAM(l_val as isize),
+        ))
     })
 }
 

--- a/src/win32/mod.rs
+++ b/src/win32/mod.rs
@@ -40,6 +40,12 @@ pub(crate) mod foreground_flash;
 // `src/win32/clipboard_snapshot.rs`。
 #[cfg(windows)]
 pub(crate) mod clipboard_snapshot;
+// issue #386 — native no-steal console-paste for the conhost exit-mode path
+// (reuses clipboard_snapshot). Replaces the powershell-spawning TS clipboard
+// handling in `bg-input.ts::pasteIntoConsoleNoFocus`. 詳細は
+// `desktop-touch-mcp-internal/docs/issue-386-native-clipboard-plan.md`。
+#[cfg(windows)]
+pub(crate) mod console_paste;
 // LowLevel keyboard hook (option, default OFF) for `foreground_flash` channel
 // typing-leak mitigation (§3.4)。
 #[cfg(windows)]

--- a/tests/unit/bg-input.test.ts
+++ b/tests/unit/bg-input.test.ts
@@ -28,6 +28,14 @@ vi.mock("../../src/engine/win32.js", async () => {
   };
 });
 
+// Mock the native engine so pasteIntoConsoleNoFocus can be driven without a real
+// `.node` build (issue #386: the conhost console-paste is delegated to native).
+vi.mock("../../src/engine/native-engine.js", () => ({
+  nativeWin32: {
+    win32ConsolePasteNoFocus: vi.fn(),
+  },
+}));
+
 import {
   canInjectViaPostMessage,
   postCharsToHwnd,
@@ -35,12 +43,10 @@ import {
   postEnterToHwnd,
   postKeyComboToHwnd,
   isBgAutoEnabled,
-  clipboardSetBackoffMs,
-  setClipboardWithRetry,
-  prepareClipboardForPaste,
-  CLIPBOARD_SET_MAX_ATTEMPTS,
+  pasteIntoConsoleNoFocus,
 } from "../../src/engine/bg-input.js";
 import { postMessageToHwnd, getWindowClassName, getProcessIdentityByPid } from "../../src/engine/win32.js";
+import { nativeWin32 } from "../../src/engine/native-engine.js";
 
 const HWND = 0x1234n;
 
@@ -206,108 +212,51 @@ describe("canInjectViaPostMessage — terminal classification", () => {
   });
 });
 
-describe("clipboardSetBackoffMs", () => {
-  it("grows linearly: 120ms after attempt 0, 240ms after attempt 1, 360ms after attempt 2", () => {
-    expect(clipboardSetBackoffMs(0)).toBe(120);
-    expect(clipboardSetBackoffMs(1)).toBe(240);
-    expect(clipboardSetBackoffMs(2)).toBe(360);
-  });
-});
+describe("pasteIntoConsoleNoFocus — native delegation + outcome mapping", () => {
+  // issue #386: the conhost console-paste is delegated to the native engine
+  // (win32ConsolePasteNoFocus). These tests drive the TS mapping layer with the
+  // native call mocked — the real Win32 transaction is exercised by dogfood.
+  const nativeFn = vi.mocked(nativeWin32!.win32ConsolePasteNoFocus!);
+  beforeEach(() => nativeFn.mockReset());
 
-describe("setClipboardWithRetry", () => {
-  // No real clipboard / timers: setFn and sleepFn are injected so the retry
-  // policy (and the latency / restore-safety invariants) is tested deterministically.
-  it("succeeds on the first attempt without sleeping", async () => {
-    const setFn = vi.fn().mockResolvedValue(true);
-    const sleepFn = vi.fn().mockResolvedValue(undefined);
-    const res = await setClipboardWithRetry("x", { setFn, sleepFn });
-    expect(res).toEqual({ ok: true, attempts: 1 });
-    expect(setFn).toHaveBeenCalledTimes(1);
-    expect(sleepFn).not.toHaveBeenCalled();
+  it("maps a native success to ok:true with no reason/hints, passing the resolved bigint hwnd", async () => {
+    nativeFn.mockReturnValue({ ok: true, skippedFormats: [], restoreSkippedRace: false });
+    const r = await pasteIntoConsoleNoFocus(HWND, "echo hi");
+    expect(r).toEqual({ ok: true });
+    // getFocusedChildHwnd mock returns null → resolveTarget(HWND) === HWND (bigint)
+    expect(nativeFn).toHaveBeenCalledWith(HWND, "echo hi");
   });
 
-  it("retries the transient and succeeds: fail, fail, then succeed", async () => {
-    const setFn = vi.fn()
-      .mockResolvedValueOnce(false)
-      .mockResolvedValueOnce(false)
-      .mockResolvedValueOnce(true);
-    const sleepFn = vi.fn().mockResolvedValue(undefined);
-    const res = await setClipboardWithRetry("x", { setFn, sleepFn });
-    expect(res).toEqual({ ok: true, attempts: 3 });
-    expect(setFn).toHaveBeenCalledTimes(3);
-    // backoff between attempts only (2 sleeps for 3 attempts): 120ms then 240ms
-    expect(sleepFn.mock.calls).toEqual([[120], [240]]);
+  it("passes a native failure reason through unchanged", async () => {
+    nativeFn.mockReturnValue({ ok: false, reason: "clipboard_lock_contention", skippedFormats: [], restoreSkippedRace: false });
+    const r = await pasteIntoConsoleNoFocus(HWND, "x");
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("clipboard_lock_contention");
   });
 
-  it("gives up after the max attempts when every try fails", async () => {
-    const setFn = vi.fn().mockResolvedValue(false);
-    const sleepFn = vi.fn().mockResolvedValue(undefined);
-    const res = await setClipboardWithRetry("x", { setFn, sleepFn });
-    expect(res).toEqual({ ok: false, attempts: CLIPBOARD_SET_MAX_ATTEMPTS });
-    expect(setFn).toHaveBeenCalledTimes(CLIPBOARD_SET_MAX_ATTEMPTS);
-    // never sleeps after the final attempt — latency bounded to (N-1) backoffs
-    expect(sleepFn).toHaveBeenCalledTimes(CLIPBOARD_SET_MAX_ATTEMPTS - 1);
+  it("surfaces skippedFormats (non-text formats not preserved)", async () => {
+    nativeFn.mockReturnValue({ ok: true, skippedFormats: [{ formatId: 2, reason: "non_hglobal" }], restoreSkippedRace: false });
+    const r = await pasteIntoConsoleNoFocus(HWND, "x");
+    expect(r.ok).toBe(true);
+    expect(r.skippedFormats).toEqual([{ formatId: 2, reason: "non_hglobal" }]);
   });
 
-  it("honours a custom maxAttempts", async () => {
-    const setFn = vi.fn().mockResolvedValue(false);
-    const sleepFn = vi.fn().mockResolvedValue(undefined);
-    const res = await setClipboardWithRetry("x", { setFn, sleepFn, maxAttempts: 1 });
-    expect(res).toEqual({ ok: false, attempts: 1 });
-    expect(setFn).toHaveBeenCalledTimes(1);
-    expect(sleepFn).not.toHaveBeenCalled(); // single attempt → no backoff
-  });
-});
-
-describe("prepareClipboardForPaste — restore-exactly-once invariant", () => {
-  // Guards the most important invariant of pasteIntoConsoleNoFocus: a failed set
-  // restores the snapshot exactly once (never leaving the user's clipboard
-  // clobbered), and the success path does NOT restore here (the post-paste
-  // restore in pasteIntoConsoleNoFocus owns that). A future regression that
-  // moved restore inside the retry loop would fail these.
-  const SAVED = "AAA="; // opaque snapshot token
-
-  it("returns true and does NOT restore when the set succeeds first try", async () => {
-    const setFn = vi.fn().mockResolvedValue(true);
-    const restoreFn = vi.fn().mockResolvedValue(undefined);
-    const sleepFn = vi.fn().mockResolvedValue(undefined);
-    const ok = await prepareClipboardForPaste("x", SAVED, { setFn, restoreFn, sleepFn });
-    expect(ok).toBe(true);
-    expect(restoreFn).not.toHaveBeenCalled();
-    expect(setFn).toHaveBeenCalledTimes(1);
+  it("surfaces restoreSkippedRace as a success-compatible flag", async () => {
+    nativeFn.mockReturnValue({ ok: true, skippedFormats: [], restoreSkippedRace: true });
+    const r = await pasteIntoConsoleNoFocus(HWND, "x");
+    expect(r.ok).toBe(true);
+    expect(r.restoreSkippedRace).toBe(true);
   });
 
-  it("returns true and does NOT restore when the set succeeds after a retry", async () => {
-    const setFn = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
-    const restoreFn = vi.fn().mockResolvedValue(undefined);
-    const sleepFn = vi.fn().mockResolvedValue(undefined);
-    const ok = await prepareClipboardForPaste("x", SAVED, { setFn, restoreFn, sleepFn });
-    expect(ok).toBe(true);
-    expect(restoreFn).not.toHaveBeenCalled();
-    // the injected sleepFn propagates through to the retry backoff (one 120ms
-    // wait between the failed first attempt and the successful second)
-    expect(sleepFn.mock.calls).toEqual([[120]]);
-  });
-
-  it("returns false and restores EXACTLY ONCE (with the snapshot) when every set fails", async () => {
-    const setFn = vi.fn().mockResolvedValue(false);
-    const restoreFn = vi.fn().mockResolvedValue(undefined);
-    const sleepFn = vi.fn().mockResolvedValue(undefined);
-    const ok = await prepareClipboardForPaste("x", SAVED, { setFn, restoreFn, sleepFn });
-    expect(ok).toBe(false);
-    expect(setFn).toHaveBeenCalledTimes(CLIPBOARD_SET_MAX_ATTEMPTS);
-    expect(restoreFn).toHaveBeenCalledTimes(1);
-    expect(restoreFn).toHaveBeenCalledWith(SAVED);
-  });
-
-  it("restores once even when the snapshot was unreadable (null)", async () => {
-    const setFn = vi.fn().mockResolvedValue(false);
-    const restoreFn = vi.fn().mockResolvedValue(undefined);
-    const sleepFn = vi.fn().mockResolvedValue(undefined);
-    const ok = await prepareClipboardForPaste("x", null, { setFn, restoreFn, sleepFn });
-    expect(ok).toBe(false);
-    expect(restoreFn).toHaveBeenCalledTimes(1);
-    expect(restoreFn).toHaveBeenCalledWith(null);
+  it("returns native_engine_unavailable when the addon lacks the function", async () => {
+    const orig = nativeWin32!.win32ConsolePasteNoFocus;
+    try {
+      (nativeWin32 as { win32ConsolePasteNoFocus?: unknown }).win32ConsolePasteNoFocus = undefined;
+      const r = await pasteIntoConsoleNoFocus(HWND, "x");
+      expect(r).toEqual({ ok: false, reason: "native_engine_unavailable" });
+    } finally {
+      (nativeWin32 as { win32ConsolePasteNoFocus?: unknown }).win32ConsolePasteNoFocus = orig;
+    }
   });
 });
 

--- a/tests/unit/bg-input.test.ts
+++ b/tests/unit/bg-input.test.ts
@@ -234,6 +234,13 @@ describe("pasteIntoConsoleNoFocus — native delegation + outcome mapping", () =
     expect(r.reason).toBe("clipboard_lock_contention");
   });
 
+  it("passes the console-paste-specific post_paste_failed reason through", async () => {
+    nativeFn.mockReturnValue({ ok: false, reason: "post_paste_failed", skippedFormats: [], restoreSkippedRace: false });
+    const r = await pasteIntoConsoleNoFocus(HWND, "x");
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("post_paste_failed");
+  });
+
   it("surfaces skippedFormats (non-text formats not preserved)", async () => {
     nativeFn.mockReturnValue({ ok: true, skippedFormats: [{ formatId: 2, reason: "non_hglobal" }], restoreSkippedRace: false });
     const r = await pasteIntoConsoleNoFocus(HWND, "x");


### PR DESCRIPTION
## What & why

Follow-up to the #386 dogfood (PR #392): the conhost exit-mode no-steal console-paste used `powershell.exe` for every clipboard get/set/restore. That spawn was the root of both the one-off `clipboard_set_failed` transient and the failure-path latency blow-up (~6.5 s under load, measured in the post-merge dogfood). This replaces the whole thing with the native Win32 clipboard module that already existed (`clipboard_snapshot.rs`) but had no standalone napi export.

Design (Opus design review + User review applied): `desktop-touch-mcp-internal@571c9d1:docs/issue-386-native-clipboard-plan.md`.

## How

**P1 — Rust**
- `src/win32/console_paste.rs`: `win32_console_paste_no_focus(hwnd, text)` — a **sync** `#[napi]` (wrapped in `napi_safe_call`) that runs the whole save → set → console-Paste (`WM_COMMAND 0xFFF1`) → Enter → restore transaction under one `with_hidden_owner` on the V8 thread, reusing `save_clipboard_supported_formats` / `set_clipboard_unicode_text` / `restore_clipboard_supported_formats` (HGLOBAL save/restore + 3-point sequence race detection + `OpenClipboard` 10×10 ms retry).
  - **sync over AsyncTask**: `win32_foreground_flash_inject` already runs the same clipboard transaction synchronously on the V8 thread and works; a pump-less libuv worker thread is a risky home for a clipboard-owner window. Sync also gets the panic boundary for free via `napi_safe_call`.
  - **restore-once on set failure**: `set_clipboard_unicode_text` empties the clipboard before it can fail at alloc/SetClipboardData, so on that failure the clipboard is empty and MUST be restored. The post-set sequence is captured on **both** success and failure (`get_clipboard_sequence_number`), so the race-aware restore always runs.
  - Reuses `ClipboardError::as_reason` (single source of truth); adds `post_paste_failed`. Enter is **WM_CHAR only** (bit-equal with the old `postEnterToHwnd`).
- `src/win32/input.rs`: factor `pub(crate) fn post_message` shared by the napi export and `console_paste` (Rust never calls the napi wrapper).
- `index.d.ts` / `native-types.ts` / `native-engine.ts`: `NativeConsolePasteResult` + `win32ConsolePasteNoFocus` surface.

**P2 — TS**
- `bg-input.ts`: `pasteIntoConsoleNoFocus` now delegates to the native call; widened `ConsolePasteOutcome.reason`; surfaces `skippedFormats` (non-text formats that could not be preserved — e.g. an image) and `restoreSkippedRace`. Drops `getClipboardB64` / `setClipboardVerified` / `restoreClipboard` / `setClipboardWithRetry` / `prepareClipboardForPaste` / `clipboardSetBackoffMs` and the `execFile`/`promisify` imports. Returns `native_engine_unavailable` (hard-fail) when the addon is missing.
- `terminal.ts`: surface clipboard hints as run `warnings` (skipped non-text formats / restore-skipped-race) on both success and failure paths.

## Tests / guards

- `bg-input.test.ts`: native-mocked outcome + hints mapping (success / reason passthrough / skippedFormats / restoreSkippedRace / `native_engine_unavailable`). The restore-exactly-once invariant moves Rust-side (reason-mapping test in `console_paste.rs`).
- `cargo check` ✓; `check-napi-safe` ✓; `check-native-types` ✓ (68 exports); `eslint` ✓; `tsc` ✓; unit suite ✓ (2 unrelated flaky tests pass in isolation).
- Rust unit tests run on CI/MSVC — the local gnu toolchain lacks `libnode.a` to link the test binary (compile/typecheck passes).
- **The `.node` rebuild + real-machine dogfood is P3** (deferred): the rebuild can't run while an MCP server holds the loaded `.node`. Acceptance is two-tier (transient load = 10/10 hard gate; sustained-hammer = best-effort + typed `clipboard_lock_contention`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)