### PR TITLE
feat(envelope): #352 — success-path advisory hints (keyboard:type → desktop_act)

### DIFF
--- a/src/tools/_advisory.ts
+++ b/src/tools/_advisory.ts
@@ -102,7 +102,9 @@ function truncate(text: string): string {
   return text.length > EXAMPLE_TEXT_MAX ? `${text.slice(0, EXAMPLE_TEXT_MAX)}…` : text;
 }
 
-/** Make a string safe to embed inside the single-quoted example literal. */
+/** Make a string safe to embed inside the single-quoted example literal.
+ *  Escape backslash FIRST (else a later `'`→`\'` would be mis-paired), then the
+ *  quote, then collapse newlines (CodeQL: incomplete string escaping). */
 function sanitize(s: string): string {
-  return s.replace(/[\r\n]+/g, " ").replace(/'/g, "\\'");
+  return s.replace(/\\/g, "\\\\").replace(/'/g, "\\'").replace(/[\r\n]+/g, " ");
 }

--- a/src/tools/_advisory.ts
+++ b/src/tools/_advisory.ts
@@ -28,8 +28,30 @@ export interface AdvisoryHint {
   example: string;
 }
 
-/** UIA control types that represent an editable text input. */
+/** UIA control types that represent an editable text input. NOTE: ComboBox is
+ *  deliberately EXCLUDED — dogfood (ADR-022) showed Chromium exposes web text
+ *  inputs (e.g. Google search) as ComboBox, so admitting it would mis-fire on
+ *  browser content where browser_* / keyboard is the right path, not desktop_act. */
 const TEXT_INPUT_CONTROL_TYPES = new Set(["Edit", "Document"]);
+
+/** UIA automationId of a Chromium web-area root. dogfood (ADR-022) showed a
+ *  browser's focused element resolves to this Document with value=URL — a wrong
+ *  desktop_act nudge (web content uses browser_* / keyboard, not desktop_act). */
+const WEB_AREA_AUTOMATION_ID = "RootWebArea";
+
+/** Browser executables — when the focused window is one of these, the target is
+ *  web content (UIA-blind / RootWebArea / web ComboBox/Edit) where browser_* is
+ *  the right path, so the keyboard→desktop_act advisory is suppressed entirely
+ *  (belt-and-suspenders beyond the RootWebArea check; ADR-022 dogfood). */
+const BROWSER_PROCESS_NAMES = new Set([
+  "chrome", "msedge", "brave", "opera", "vivaldi", "chromium",
+]);
+
+function isBrowserProcess(processName: string): boolean {
+  // processName may carry a ".exe" suffix or different case depending on source.
+  const base = processName.toLowerCase().replace(/\.exe$/, "");
+  return BROWSER_PROCESS_NAMES.has(base);
+}
 
 /** Max length of the `text` echoed into the example before truncation. */
 const EXAMPLE_TEXT_MAX = 40;
@@ -50,13 +72,15 @@ export function getAdvisoryEmitCount(): number {
  * @param toolName  the wrapping tool name (e.g. "keyboard")
  * @param args      the tool call args (read-only; e.g. {action,windowTitle,text})
  * @param focusedElement  the snapshot `withPostState` already captured (may be null)
+ * @param processName  the focused window's process (for browser suppression)
  */
 export function maybeAdvisory(
   toolName: string,
   args: Record<string, unknown>,
   focusedElement: PostElementInfo | null,
+  processName: string,
 ): AdvisoryHint | null {
-  const hint = buildHint(toolName, args, focusedElement);
+  const hint = buildHint(toolName, args, focusedElement, processName);
   if (hint) advisoryEmitCount++;
   return hint;
 }
@@ -65,18 +89,26 @@ function buildHint(
   toolName: string,
   args: Record<string, unknown>,
   focusedElement: PostElementInfo | null,
+  processName: string,
 ): AdvisoryHint | null {
   // Round 1: keyboard(action='type') → desktop_act.
   if (toolName !== "keyboard" || args["action"] !== "type") return null;
+  // Browser suppression (ADR-022 dogfood): web content uses browser_* / keyboard,
+  // not desktop_act — never advise desktop_act when the focused window is a browser.
+  if (isBrowserProcess(processName)) return null;
   // Gate on the already-paid focused-element observation (built by
   // `_post.ts::snapshotFocusedElement`). UIA-blind targets and non-text controls
   // fail here (suppression is definitional, ADR-022 §5.3):
   //  - `type` is the UIA controlType (PostElementInfo.type)
   //  - `value !== undefined` ⇒ UIA exposed ValuePattern on it (set only when the
   //    focused element's UIA `value` is non-null)
+  //  - automationId !== RootWebArea ⇒ not an embedded web-area root (a Chromium
+  //    page root reports Document + value=URL; that is a wrong desktop_act nudge —
+  //    belt with the browser-process check above for Electron/embedded Chromium).
   if (!focusedElement) return null;
   if (!TEXT_INPUT_CONTROL_TYPES.has(focusedElement.type)) return null;
   if (focusedElement.value === undefined) return null;
+  if (focusedElement.automationId === WEB_AREA_AUTOMATION_ID) return null;
 
   const windowTitle = typeof args["windowTitle"] === "string" ? (args["windowTitle"] as string) : undefined;
   const text = typeof args["text"] === "string" ? (args["text"] as string) : undefined;

--- a/src/tools/_advisory.ts
+++ b/src/tools/_advisory.ts
@@ -68,10 +68,12 @@ function buildHint(
 ): AdvisoryHint | null {
   // Round 1: keyboard(action='type') → desktop_act.
   if (toolName !== "keyboard" || args["action"] !== "type") return null;
-  // Gate on the already-paid focused-element observation. UIA-blind targets and
-  // non-text controls fail here (suppression is definitional, ADR-022 §5.3):
-  //  - `type` is the UIA controlType (PostElementInfo.type, _post.ts:96)
-  //  - `value !== undefined` ⇒ UIA exposed ValuePattern on it (_post.ts:98)
+  // Gate on the already-paid focused-element observation (built by
+  // `_post.ts::snapshotFocusedElement`). UIA-blind targets and non-text controls
+  // fail here (suppression is definitional, ADR-022 §5.3):
+  //  - `type` is the UIA controlType (PostElementInfo.type)
+  //  - `value !== undefined` ⇒ UIA exposed ValuePattern on it (set only when the
+  //    focused element's UIA `value` is non-null)
   if (!focusedElement) return null;
   if (!TEXT_INPUT_CONTROL_TYPES.has(focusedElement.type)) return null;
   if (focusedElement.value === undefined) return null;

--- a/src/tools/_advisory.ts
+++ b/src/tools/_advisory.ts
@@ -1,0 +1,106 @@
+/**
+ * _advisory.ts — success-path advisory hints (ADR-022 / issue #352).
+ *
+ * When a tool SUCCEEDS but a better path was available, attach an additive
+ * `advisory` to the response with a concrete, filled-in example. LLMs follow a
+ * corrected example in their own tool history far more strongly than an abstract
+ * instruction (compiler "did you mean…?" / ESLint-autofix principle).
+ *
+ * Round 1 wires one pair: `keyboard(action='type')` → `desktop_act`, emitted only
+ * when the focused element is a UIA text input (so UIA-blind targets — PWA /
+ * Electron / Canvas — get no advisory and keyboard stays the right call).
+ *
+ * Probe cost: ZERO. The gate reads the focused-element snapshot `withPostState`
+ * already takes every call (`_post.ts` `snapshotFocusedElement`) — no fresh UIA
+ * round-trip. This module is a pure builder over `PostElementInfo`; it calls no
+ * UIA and has no dependency on the discover handler (no `keyboard → desktop_discover`
+ * edge). Design: `desktop-touch-mcp-internal/docs/adr-022-success-path-advisory-hints.md`.
+ */
+
+import type { PostElementInfo } from "./_post.js";
+
+export interface AdvisoryHint {
+  /** The tool/path the LLM should prefer next time (e.g. "desktop_act"). */
+  preferredPath: string;
+  /** Why the preferred path is better — concrete, not a generic rule. */
+  reason: string;
+  /** A filled-in call sequence with the real args bound (windowTitle / text). */
+  example: string;
+}
+
+/** UIA control types that represent an editable text input. */
+const TEXT_INPUT_CONTROL_TYPES = new Set(["Edit", "Document"]);
+
+/** Max length of the `text` echoed into the example before truncation. */
+const EXAMPLE_TEXT_MAX = 40;
+
+// ── Emit counter (OQ-5) ───────────────────────────────────────────────────────
+// The only objective fire-rate signal (the LLM-driven E2E harness was scrapped).
+// Surfaced via server_status; lets dogfood see whether advisories are emitted at
+// all (under-fire risk, ADR-022 R2). Process-lifetime cumulative.
+let advisoryEmitCount = 0;
+export function getAdvisoryEmitCount(): number {
+  return advisoryEmitCount;
+}
+
+/**
+ * Build a success-path advisory for `toolName(args)` given the focused-element
+ * snapshot, or `null` when none applies. Increments the emit counter on a hit.
+ *
+ * @param toolName  the wrapping tool name (e.g. "keyboard")
+ * @param args      the tool call args (read-only; e.g. {action,windowTitle,text})
+ * @param focusedElement  the snapshot `withPostState` already captured (may be null)
+ */
+export function maybeAdvisory(
+  toolName: string,
+  args: Record<string, unknown>,
+  focusedElement: PostElementInfo | null,
+): AdvisoryHint | null {
+  const hint = buildHint(toolName, args, focusedElement);
+  if (hint) advisoryEmitCount++;
+  return hint;
+}
+
+function buildHint(
+  toolName: string,
+  args: Record<string, unknown>,
+  focusedElement: PostElementInfo | null,
+): AdvisoryHint | null {
+  // Round 1: keyboard(action='type') → desktop_act.
+  if (toolName !== "keyboard" || args["action"] !== "type") return null;
+  // Gate on the already-paid focused-element observation. UIA-blind targets and
+  // non-text controls fail here (suppression is definitional, ADR-022 §5.3):
+  //  - `type` is the UIA controlType (PostElementInfo.type, _post.ts:96)
+  //  - `value !== undefined` ⇒ UIA exposed ValuePattern on it (_post.ts:98)
+  if (!focusedElement) return null;
+  if (!TEXT_INPUT_CONTROL_TYPES.has(focusedElement.type)) return null;
+  if (focusedElement.value === undefined) return null;
+
+  const windowTitle = typeof args["windowTitle"] === "string" ? (args["windowTitle"] as string) : undefined;
+  const text = typeof args["text"] === "string" ? (args["text"] as string) : undefined;
+
+  const discoverArg = windowTitle
+    ? `{target:{windowTitle:'${sanitize(windowTitle)}'}}`
+    : `{target:{focused:true}}`;
+  const actArg =
+    text !== undefined
+      ? `{lease, action:'type', text:'${sanitize(truncate(text))}'}`
+      : `{lease, action:'type', text:'…'}`;
+
+  return {
+    preferredPath: "desktop_act",
+    reason:
+      "the focused element is a UIA text input (ValuePattern) — desktop_act runs the lease flow (lease verification, modal-blocking detection, attention diff) that keyboard:type does not. keyboard is correct only for UIA-blind targets (PWA / Electron / Canvas).",
+    example: `desktop_discover(${discoverArg}) → desktop_act(${actArg})`,
+  };
+}
+
+/** Truncate `text` for the illustrative example (keeps the hint compact). */
+function truncate(text: string): string {
+  return text.length > EXAMPLE_TEXT_MAX ? `${text.slice(0, EXAMPLE_TEXT_MAX)}…` : text;
+}
+
+/** Make a string safe to embed inside the single-quoted example literal. */
+function sanitize(s: string): string {
+  return s.replace(/[\r\n]+/g, " ").replace(/'/g, "\\'");
+}

--- a/src/tools/_post.ts
+++ b/src/tools/_post.ts
@@ -93,13 +93,14 @@ function snapshotFocus(): { title: string | null; hwnd: string | null; processNa
 async function snapshotFocusedElement(): Promise<PostElementInfo | null> {
   try {
     const { focused } = await getFocusedAndPointInfo(0, 0, false, 800);
-    // Gate on controlType, not name (Codex PR #395 P2): many real Edit/Document
-    // fields expose ValuePattern with an EMPTY Name. The old `!focused?.name`
-    // guard dropped them, so post.focusedElement (and the #352 advisory that reads
-    // it) systematically missed unlabeled text inputs. controlType is the true
-    // "is there a real focused element" signal; junk / no-element has none.
-    if (!focused?.controlType) return null;
-    const info: PostElementInfo = { name: focused.name ?? "", type: focused.controlType };
+    // NOTE (#352): `getFocusedAndPointInfo`'s `toInfo` already returns null for
+    // name-empty elements (`uia-bridge.ts` `if (!obj || !obj.name) return null`),
+    // so an unnamed UIA text input never reaches here. The #352 advisory therefore
+    // fires only for NAMED text inputs in Round 1; widening to unlabeled inputs is
+    // an upstream change to that guard (shared with desktop_state / mouse-verify),
+    // tracked in remaining-work.md (Opus PR #395 R2 P2).
+    if (!focused?.name) return null;
+    const info: PostElementInfo = { name: focused.name, type: focused.controlType };
     if (focused.automationId) info.automationId = focused.automationId;
     if (focused.value != null) info.value = focused.value;
     return info;

--- a/src/tools/_post.ts
+++ b/src/tools/_post.ts
@@ -18,6 +18,7 @@ import type { ToolResult } from "./_types.js";
 import type { RichBlock } from "../engine/uia-diff.js";
 import type { PerceptionEnvelope, PostPerception } from "../engine/perception/types.js";
 import { appendEvent } from "../engine/perception/target-timeline.js";
+import { maybeAdvisory } from "./_advisory.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -125,6 +126,11 @@ async function snapshotFocusedElement(): Promise<PostElementInfo | null> {
  *   - `obj.post.perception`              → withPostState ONLY (moved from the
  *        root `_perceptionForPost` marker, then the marker is `delete`d — on
  *        BOTH the success and failure branches).
+ *   - `obj.advisory` (root, success ONLY) → withPostState ONLY (ADR-022 / #352).
+ *        Built by `maybeAdvisory(toolName, args, post.focusedElement)` from the
+ *        already-captured focused-element snapshot (no handler input, no marker,
+ *        no UIA call). Absent when no better path applies; never written on the
+ *        failure branch.
  *   - `obj.post.rich`                    → COORDINATED two writers, NOT
  *        single-writer: withPostState moves it from the root `_richForPost`
  *        marker (browser CDP, success path, takes precedence); `spliceRich`
@@ -196,6 +202,13 @@ export function withPostState<T extends Record<string, unknown>>(
             }
           } else {
             obj.post = post;
+            // ADR-022 / issue #352: success-path advisory. Reuses the
+            // focused-element snapshot already taken above (post.focusedElement) —
+            // zero extra UIA cost. `_advisory.ts` owns the per-tool logic; this
+            // wrapper stays generic. Additive root field `advisory` (sibling of
+            // `hints`); absent when no better path applies.
+            const advisory = maybeAdvisory(toolName, args as Record<string, unknown>, post.focusedElement);
+            if (advisory) obj.advisory = advisory;
             // If the handler injected a CDP-sourced rich block via _richForPost,
             // move it into post.rich and remove the temporary key.
             // Convention: browser handlers set result._richForPost = RichBlock before returning.

--- a/src/tools/_post.ts
+++ b/src/tools/_post.ts
@@ -93,8 +93,13 @@ function snapshotFocus(): { title: string | null; hwnd: string | null; processNa
 async function snapshotFocusedElement(): Promise<PostElementInfo | null> {
   try {
     const { focused } = await getFocusedAndPointInfo(0, 0, false, 800);
-    if (!focused?.name) return null;
-    const info: PostElementInfo = { name: focused.name, type: focused.controlType };
+    // Gate on controlType, not name (Codex PR #395 P2): many real Edit/Document
+    // fields expose ValuePattern with an EMPTY Name. The old `!focused?.name`
+    // guard dropped them, so post.focusedElement (and the #352 advisory that reads
+    // it) systematically missed unlabeled text inputs. controlType is the true
+    // "is there a real focused element" signal; junk / no-element has none.
+    if (!focused?.controlType) return null;
+    const info: PostElementInfo = { name: focused.name ?? "", type: focused.controlType };
     if (focused.automationId) info.automationId = focused.automationId;
     if (focused.value != null) info.value = focused.value;
     return info;

--- a/src/tools/_post.ts
+++ b/src/tools/_post.ts
@@ -213,7 +213,7 @@ export function withPostState<T extends Record<string, unknown>>(
             // zero extra UIA cost. `_advisory.ts` owns the per-tool logic; this
             // wrapper stays generic. Additive root field `advisory` (sibling of
             // `hints`); absent when no better path applies.
-            const advisory = maybeAdvisory(toolName, args as Record<string, unknown>, post.focusedElement);
+            const advisory = maybeAdvisory(toolName, args as Record<string, unknown>, post.focusedElement, after.processName);
             if (advisory) obj.advisory = advisory;
             // If the handler injected a CDP-sourced rich block via _richForPost,
             // move it into post.rich and remove the temporary key.

--- a/src/tools/server-status.ts
+++ b/src/tools/server-status.ts
@@ -4,6 +4,7 @@ import type { ToolResult } from "./_types.js";
 import { failWith } from "./_errors.js";
 import { getEngineStatus } from "../engine/status.js";
 import { getProcessHealth } from "../engine/process-health.js";
+import { getAdvisoryEmitCount } from "./_advisory.js";
 import { makeQueryWrapper, withEnvelopeIncludeSchema, genericQueryCausedByProjector, defaultQuerySessionId } from "./_envelope.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -20,7 +21,11 @@ export const serverStatusHandler = async (): Promise<ToolResult> => {
   try {
     const status = getEngineStatus();
     const health = getProcessHealth();
-    return ok({ engine: status, health });
+    // ADR-022 / issue #352: cumulative count of success-path advisories emitted
+    // (process lifetime). The only objective fire-rate signal — surfaced so
+    // dogfood can see whether advisories fire at all (under-fire risk).
+    const counters = { advisoryEmitted: getAdvisoryEmitCount() };
+    return ok({ engine: status, health, counters });
   } catch (err) {
     return failWith(err, "server_status");
   }

--- a/tests/fixtures/failwith-callsite-shapes.json
+++ b/tests/fixtures/failwith-callsite-shapes.json
@@ -471,7 +471,7 @@
     },
     {
       "file": "src/tools/server-status.ts",
-      "line": 25,
+      "line": 30,
       "tool": "server_status",
       "errKind": "identifier",
       "contextShape": "none"

--- a/tests/unit/advisory-hints.test.ts
+++ b/tests/unit/advisory-hints.test.ts
@@ -1,0 +1,99 @@
+/**
+ * tests/unit/advisory-hints.test.ts
+ * ADR-022 / issue #352 — success-path advisory builder (`_advisory.ts`).
+ *
+ * Pure builder over the focused-element snapshot withPostState already captures.
+ * No UIA, no timers — fully deterministic.
+ */
+
+import { describe, it, expect } from "vitest";
+import { maybeAdvisory, getAdvisoryEmitCount } from "../../src/tools/_advisory.js";
+import type { PostElementInfo } from "../../src/tools/_post.js";
+
+const edit = (value: string | undefined = "existing"): PostElementInfo => ({
+  name: "Text Editor",
+  type: "Edit",
+  ...(value !== undefined ? { value } : {}),
+});
+
+describe("maybeAdvisory — keyboard(type) → desktop_act", () => {
+  it("emits for a focused UIA Edit (ValuePattern) with the windowTitle + text bound", () => {
+    const hint = maybeAdvisory(
+      "keyboard",
+      { action: "type", windowTitle: "メモ帳", text: "hello" },
+      edit(),
+    );
+    expect(hint).not.toBeNull();
+    expect(hint!.preferredPath).toBe("desktop_act");
+    expect(hint!.example).toContain("windowTitle:'メモ帳'");
+    expect(hint!.example).toContain("text:'hello'");
+    expect(hint!.example).toContain("desktop_discover");
+    expect(hint!.example).toContain("desktop_act");
+  });
+
+  it("emits for a Document control type too", () => {
+    const hint = maybeAdvisory(
+      "keyboard",
+      { action: "type", windowTitle: "Word", text: "x" },
+      { name: "Doc", type: "Document", value: "" },
+    );
+    expect(hint).not.toBeNull();
+  });
+
+  it("falls back to focused:true when no windowTitle, and text:'…' when no text", () => {
+    const hint = maybeAdvisory("keyboard", { action: "type" }, edit());
+    expect(hint).not.toBeNull();
+    expect(hint!.example).toContain("focused:true");
+    expect(hint!.example).toContain("text:'…'");
+  });
+
+  it("truncates long text and sanitises quotes/newlines in the example", () => {
+    const longText = "a".repeat(50) + "'b\nc";
+    const hint = maybeAdvisory(
+      "keyboard",
+      { action: "type", windowTitle: "x", text: longText },
+      edit(),
+    );
+    expect(hint).not.toBeNull();
+    // truncated to 40 chars + ellipsis, no raw newline, no unescaped quote breaking the literal
+    expect(hint!.example).toContain("…");
+    expect(hint!.example).not.toMatch(/\n/);
+  });
+});
+
+describe("maybeAdvisory — suppression (no hint)", () => {
+  it("returns null when the focused element is not a text input (UIA-blind / wrong control)", () => {
+    expect(
+      maybeAdvisory("keyboard", { action: "type", text: "x" }, { name: "Canvas", type: "Pane", value: "" }),
+    ).toBeNull();
+  });
+
+  it("returns null when the focused element exposes no value (no ValuePattern)", () => {
+    // An Edit with NO `value` field = UIA did not expose ValuePattern → suppress.
+    expect(
+      maybeAdvisory("keyboard", { action: "type", text: "x" }, { name: "Text Editor", type: "Edit" }),
+    ).toBeNull();
+  });
+
+  it("returns null when there is no focused element", () => {
+    expect(maybeAdvisory("keyboard", { action: "type", text: "x" }, null)).toBeNull();
+  });
+
+  it("returns null for a non-type keyboard action", () => {
+    expect(maybeAdvisory("keyboard", { action: "press", keys: "enter" }, edit())).toBeNull();
+  });
+
+  it("returns null for a different tool", () => {
+    expect(maybeAdvisory("mouse_click", { action: "type", text: "x" }, edit())).toBeNull();
+  });
+});
+
+describe("getAdvisoryEmitCount", () => {
+  it("increments on a hit and not on a miss", () => {
+    const before = getAdvisoryEmitCount();
+    maybeAdvisory("keyboard", { action: "type", text: "x" }, edit()); // hit
+    maybeAdvisory("keyboard", { action: "type", text: "x" }, null); // miss
+    maybeAdvisory("mouse_click", {}, edit()); // miss
+    expect(getAdvisoryEmitCount()).toBe(before + 1);
+  });
+});

--- a/tests/unit/advisory-hints.test.ts
+++ b/tests/unit/advisory-hints.test.ts
@@ -2,8 +2,10 @@
  * tests/unit/advisory-hints.test.ts
  * ADR-022 / issue #352 — success-path advisory builder (`_advisory.ts`).
  *
- * Pure builder over the focused-element snapshot withPostState already captures.
- * No UIA, no timers — fully deterministic.
+ * Pure builder over the focused-element snapshot withPostState already captures
+ * + the focused window's processName. No UIA, no timers — fully deterministic.
+ * Gate (ADR-022 dogfood): keyboard(type) + Edit/Document + value + NOT a browser
+ * process + automationId !== RootWebArea.
  */
 
 import { describe, it, expect } from "vitest";
@@ -16,12 +18,16 @@ const edit = (value: string | undefined = "existing"): PostElementInfo => ({
   ...(value !== undefined ? { value } : {}),
 });
 
+// A non-browser process so the browser-suppression gate is not the thing under test.
+const NATIVE = "notepad";
+
 describe("maybeAdvisory — keyboard(type) → desktop_act", () => {
   it("emits for a focused UIA Edit (ValuePattern) with the windowTitle + text bound", () => {
     const hint = maybeAdvisory(
       "keyboard",
       { action: "type", windowTitle: "メモ帳", text: "hello" },
       edit(),
+      NATIVE,
     );
     expect(hint).not.toBeNull();
     expect(hint!.preferredPath).toBe("desktop_act");
@@ -36,26 +42,27 @@ describe("maybeAdvisory — keyboard(type) → desktop_act", () => {
       "keyboard",
       { action: "type", windowTitle: "Word", text: "x" },
       { name: "Doc", type: "Document", value: "" },
+      "winword",
     );
     expect(hint).not.toBeNull();
   });
 
   it("falls back to focused:true when no windowTitle, and text:'…' when no text", () => {
-    const hint = maybeAdvisory("keyboard", { action: "type" }, edit());
+    const hint = maybeAdvisory("keyboard", { action: "type" }, edit(), NATIVE);
     expect(hint).not.toBeNull();
     expect(hint!.example).toContain("focused:true");
     expect(hint!.example).toContain("text:'…'");
   });
 
-  it("truncates long text and sanitises quotes/newlines in the example", () => {
-    const longText = "a".repeat(50) + "'b\nc";
+  it("truncates long text and sanitises quotes/newlines/backslashes in the example", () => {
+    const longText = "a".repeat(50) + "'b\nc\\d";
     const hint = maybeAdvisory(
       "keyboard",
       { action: "type", windowTitle: "x", text: longText },
       edit(),
+      NATIVE,
     );
     expect(hint).not.toBeNull();
-    // truncated to 40 chars + ellipsis, no raw newline, no unescaped quote breaking the literal
     expect(hint!.example).toContain("…");
     expect(hint!.example).not.toMatch(/\n/);
   });
@@ -64,36 +71,59 @@ describe("maybeAdvisory — keyboard(type) → desktop_act", () => {
 describe("maybeAdvisory — suppression (no hint)", () => {
   it("returns null when the focused element is not a text input (UIA-blind / wrong control)", () => {
     expect(
-      maybeAdvisory("keyboard", { action: "type", text: "x" }, { name: "Canvas", type: "Pane", value: "" }),
+      maybeAdvisory("keyboard", { action: "type", text: "x" }, { name: "Canvas", type: "Pane", value: "" }, NATIVE),
     ).toBeNull();
   });
 
   it("returns null when the focused element exposes no value (no ValuePattern)", () => {
     // An Edit with NO `value` field = UIA did not expose ValuePattern → suppress.
     expect(
-      maybeAdvisory("keyboard", { action: "type", text: "x" }, { name: "Text Editor", type: "Edit" }),
+      maybeAdvisory("keyboard", { action: "type", text: "x" }, { name: "Text Editor", type: "Edit" }, NATIVE),
     ).toBeNull();
   });
 
+  it("returns null for a Chromium web-area root (Document + value=URL + RootWebArea automationId)", () => {
+    // dogfood: a browser's focused element is Document+value(URL)+RootWebArea — a
+    // wrong desktop_act nudge. Suppressed even with a non-browser processName.
+    expect(
+      maybeAdvisory(
+        "keyboard",
+        { action: "type", text: "x" },
+        { name: "ホーム / X", type: "Document", value: "https://x.com/home", automationId: "RootWebArea" },
+        NATIVE,
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null when the focused window is a browser (web content uses browser_*, not desktop_act)", () => {
+    // Even an Edit-typed web input inside a browser must not be nudged to desktop_act.
+    for (const proc of ["chrome", "msedge", "chrome.exe", "MSEDGE", "brave"]) {
+      expect(
+        maybeAdvisory("keyboard", { action: "type", text: "x" }, edit(), proc),
+      ).toBeNull();
+    }
+  });
+
   it("returns null when there is no focused element", () => {
-    expect(maybeAdvisory("keyboard", { action: "type", text: "x" }, null)).toBeNull();
+    expect(maybeAdvisory("keyboard", { action: "type", text: "x" }, null, NATIVE)).toBeNull();
   });
 
   it("returns null for a non-type keyboard action", () => {
-    expect(maybeAdvisory("keyboard", { action: "press", keys: "enter" }, edit())).toBeNull();
+    expect(maybeAdvisory("keyboard", { action: "press", keys: "enter" }, edit(), NATIVE)).toBeNull();
   });
 
   it("returns null for a different tool", () => {
-    expect(maybeAdvisory("mouse_click", { action: "type", text: "x" }, edit())).toBeNull();
+    expect(maybeAdvisory("mouse_click", { action: "type", text: "x" }, edit(), NATIVE)).toBeNull();
   });
 });
 
 describe("getAdvisoryEmitCount", () => {
   it("increments on a hit and not on a miss", () => {
     const before = getAdvisoryEmitCount();
-    maybeAdvisory("keyboard", { action: "type", text: "x" }, edit()); // hit
-    maybeAdvisory("keyboard", { action: "type", text: "x" }, null); // miss
-    maybeAdvisory("mouse_click", {}, edit()); // miss
+    maybeAdvisory("keyboard", { action: "type", text: "x" }, edit(), NATIVE); // hit
+    maybeAdvisory("keyboard", { action: "type", text: "x" }, null, NATIVE); // miss
+    maybeAdvisory("keyboard", { action: "type", text: "x" }, edit(), "chrome"); // miss (browser)
+    maybeAdvisory("mouse_click", {}, edit(), NATIVE); // miss
     expect(getAdvisoryEmitCount()).toBe(before + 1);
   });
 });

--- a/tests/unit/path-class-contract/dxgi-broker-cacheState-coexistence.test.ts
+++ b/tests/unit/path-class-contract/dxgi-broker-cacheState-coexistence.test.ts
@@ -1,0 +1,145 @@
+/**
+ * tests/unit/path-class-contract/dxgi-broker-cacheState-coexistence.test.ts
+ * ADR-021 Phase 4 PR-P4-3 — deterministic regression: DXGI broker SSOT coexistence.
+ *
+ * `b-dxgi-cache-state.test.ts` already pins the single-consumer, single-output
+ * 5-value state machine. This pins the ORTHOGONAL axis the SR-4 broker exists
+ * for — multi-consumer / multi-output coexistence through ONE SSOT. Pre-SR-4,
+ * vision-gpu / DirtyRectRouter / Stage5 each held their own cache (parallel
+ * writers → cacheState drift, issue #327 item B). SR-4 (PR-SR4-1/2,
+ * `DirtyRectBroker`) made the broker the single owner. This regression pins:
+ *   1. **SSOT** — one native subscription per `outputIndex` regardless of how
+ *      many consumers acquire it (the factory is called once, not once per
+ *      consumer);
+ *   2. **per-output isolation** — `outputIndex` entries do not contaminate each
+ *      other (the secondary-monitor / output_index lesson, CLAUDE.md §3.2 / PR
+ *      #102 monitor_index regression class);
+ *   3. **invalidate is output-scoped** — invalidating one output does not leak
+ *      into another output's cached subscription.
+ *
+ * Detection power vs b-dxgi: reverting SR-4 to per-consumer caches makes #1 fail
+ * (factory called per consumer) while b-dxgi (single consumer) stays green. #2/#3
+ * pin the per-`outputIndex` Map isolation that a single-output test never
+ * exercises.
+ *
+ * NOTE on the mock: ADR-021 §3.5.2 named ReplayBackend, but post-SR-4 the broker
+ * consumes `factory: (outputIndex) => SubscriptionLike`, whereas ReplayBackend
+ * implements `VisualBackend` (recognize/dispose) — a different abstraction, not a
+ * subscription source. The correct mock is an instrumented `SubscriptionLike`
+ * factory (the b-dxgi idiom), which also lets us count factory calls per output
+ * = the direct SSOT assertion. Time is deterministic via an injected `nowFn`.
+ *
+ * @see docs/adr-021-result-migration-drift-prevention-plan.md §3.5.2 (PR-P4-3)
+ * @see tests/unit/path-class-contract/b-dxgi-cache-state.test.ts (state machine axis)
+ * @see src/engine/dxgi-broker.ts (DirtyRectBroker SSOT)
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  DirtyRectBroker,
+  type SubscriptionLike,
+} from "../../../src/engine/dxgi-broker.js";
+
+function makeFakeSub(): SubscriptionLike {
+  let disposed = false;
+  return {
+    get isDisposed() {
+      return disposed;
+    },
+    next: async () => [],
+    dispose: () => {
+      disposed = true;
+    },
+  };
+}
+
+/** Factory that records how many native subscriptions it built per outputIndex.
+ *  The call count is the direct SSOT proxy: one entry per output, shared across
+ *  all consumers, means exactly one factory call per output. */
+function countingFactory() {
+  const callsPerOutput = new Map<number, number>();
+  const factory = (outputIndex: number): SubscriptionLike => {
+    callsPerOutput.set(outputIndex, (callsPerOutput.get(outputIndex) ?? 0) + 1);
+    return makeFakeSub();
+  };
+  return { factory, callsPerOutput };
+}
+
+function makeBroker(
+  factory: (outputIndex: number) => SubscriptionLike,
+  nowFn: () => number,
+): DirtyRectBroker {
+  return new DirtyRectBroker(
+    factory,
+    nowFn,
+    20_000, // idleTimeoutMs (Stage 5 SSOT)
+    60_000, // unavailableTtlMs
+    5, // fanOutPollMs
+    2_000, // negativeBackoffMs
+  );
+}
+
+describe("DXGI broker SSOT coexistence (ADR-021 Phase 4 PR-P4-3)", () => {
+  it("N consumers acquiring the same outputIndex share ONE native subscription (factory called once)", () => {
+    const { factory, callsPerOutput } = countingFactory();
+    const broker = makeBroker(factory, () => 0);
+
+    const a = broker.acquire(0); // consumer A
+    const b = broker.acquire(0); // consumer B
+    const c = broker.acquire(0); // consumer C
+
+    expect(a.state).toBe("miss-init");
+    expect(b.state).toBe("hit-subscription");
+    expect(c.state).toBe("hit-subscription");
+    // SSOT: one native subscription for three consumers. A per-consumer cache
+    // (the pre-SR-4 drift) would call the factory 3×.
+    expect(callsPerOutput.get(0)).toBe(1);
+    // Each acquire still returns its own polling handle (per-consumer cursor).
+    expect(a.sub).not.toBeNull();
+    expect(b.sub).not.toBeNull();
+    expect(c.sub).not.toBeNull();
+
+    broker.disposeAll();
+  });
+
+  it("outputIndex entries are isolated — acquiring output 1 does not disturb output 0 (output_index, PR #102)", () => {
+    const { factory, callsPerOutput } = countingFactory();
+    const broker = makeBroker(factory, () => 0);
+
+    const a0 = broker.acquire(0); // miss-init (output 0)
+    const a1 = broker.acquire(1); // miss-init (output 1) — independent, NOT a hit
+    const a0again = broker.acquire(0); // hit-subscription (output 0 untouched by output 1)
+
+    expect(a0.state).toBe("miss-init");
+    expect(a1.state).toBe("miss-init");
+    expect(a0again.state).toBe("hit-subscription");
+    // Handles are labelled with their own output — no cross-output mislabel.
+    expect(a0.sub?.outputIndex).toBe(0);
+    expect(a1.sub?.outputIndex).toBe(1);
+    expect(callsPerOutput.get(0)).toBe(1);
+    expect(callsPerOutput.get(1)).toBe(1);
+
+    broker.disposeAll();
+  });
+
+  it("invalidate() is scoped to its outputIndex — it does not leak into other outputs", () => {
+    let now = 0;
+    const { factory } = countingFactory();
+    const broker = makeBroker(factory, () => now);
+
+    broker.acquire(0); // miss-init (output 0)
+    broker.acquire(1); // miss-init (output 1)
+    broker.invalidate(0); // invalidate output 0 ONLY
+    now = 500; // < 2s negativeBackoffMs
+
+    const r0 = broker.acquire(0); // output 0 is in negative-backoff
+    const r1 = broker.acquire(1); // output 1 is untouched
+
+    expect(r0.state).toBe("hit-negative-backoff");
+    expect(r0.sub).toBeNull();
+    expect(r1.state).toBe("hit-subscription");
+    expect(r1.sub).not.toBeNull();
+
+    broker.disposeAll();
+  });
+});

--- a/tests/unit/path-class-contract/dxgi-broker-cacheState-coexistence.test.ts
+++ b/tests/unit/path-class-contract/dxgi-broker-cacheState-coexistence.test.ts
@@ -18,9 +18,15 @@
  *      into another output's cached subscription.
  *
  * Detection power vs b-dxgi: reverting SR-4 to per-consumer caches makes #1 fail
- * (factory called per consumer) while b-dxgi (single consumer) stays green. #2/#3
- * pin the per-`outputIndex` Map isolation that a single-output test never
- * exercises.
+ * (factory called per consumer); b-dxgi stays green precisely because it never
+ * asserts the factory call count (it only checks one consumer's state
+ * transitions, which a per-consumer cache reproduces). #2/#3 pin the
+ * per-`outputIndex` Map isolation that a single-output test never exercises.
+ *
+ * Out of scope (the other half of SR-4's "SSOT but independent cursor"): that
+ * each consumer's polling handle drains its OWN queue cursor over the shared
+ * native subscription. That is a separate axis (cursor non-interleaving, not a
+ * past *drift* regression) — tracked in remaining-work.md, not pinned here.
  *
  * NOTE on the mock: ADR-021 §3.5.2 named ReplayBackend, but post-SR-4 the broker
  * consumes `factory: (outputIndex) => SubscriptionLike`, whereas ReplayBackend
@@ -132,8 +138,8 @@ describe("DXGI broker SSOT coexistence (ADR-021 Phase 4 PR-P4-3)", () => {
     broker.invalidate(0); // invalidate output 0 ONLY
     now = 500; // < 2s negativeBackoffMs
 
-    const r0 = broker.acquire(0); // output 0 is in negative-backoff
-    const r1 = broker.acquire(1); // output 1 is untouched
+    const r0 = broker.acquire(0); // output 0: negative-backoff fast-path → sub:null
+    const r1 = broker.acquire(1); // output 1 is untouched → still hit-subscription
 
     expect(r0.state).toBe("hit-negative-backoff");
     expect(r0.sub).toBeNull();

--- a/tests/unit/path-class-contract/post-writer-ownership.test.ts
+++ b/tests/unit/path-class-contract/post-writer-ownership.test.ts
@@ -46,6 +46,7 @@ vi.mock("../../../src/engine/uia-bridge.js", () => ({
 import { withPostState } from "../../../src/tools/_post.js";
 import { ok, fail } from "../../../src/tools/_types.js";
 import { errorFromMessage, toToolFailure, failWith } from "../../../src/tools/_errors.js";
+import { getFocusedAndPointInfo } from "../../../src/engine/uia-bridge.js";
 
 function parse(result: { content: ReadonlyArray<{ type: string; text?: string }> }): Record<string, unknown> {
   const block = result.content[0];
@@ -173,6 +174,46 @@ describe("PR-P2-1: ROOT_HOISTED_KEYS asymmetries", () => {
 // That route MUST keep placing `_perceptionForPost` at the ROOT (via
 // ROOT_HOISTED_KEYS), because withPostState only looks at the root. If a future
 // change pushed it under `context`, post.perception would silently vanish.
+
+// ── ADR-022 / #352: obj.advisory is a withPostState success-only writer ───────
+
+describe("ADR-022: obj.advisory owned by withPostState (success only)", () => {
+  const editFocus = { focused: { name: "Editor", controlType: "Edit", value: "old" } };
+
+  it("sets root obj.advisory for keyboard(type) when the focused element is a UIA text input", async () => {
+    vi.mocked(getFocusedAndPointInfo).mockResolvedValueOnce(editFocus as never);
+    const parsed = parse(
+      await withPostState("keyboard", async () => ok({ ok: true, method: "background" }))(
+        { action: "type", windowTitle: "メモ帳", text: "hi" },
+      ),
+    );
+    const advisory = parsed.advisory as Record<string, unknown> | undefined;
+    expect(advisory).toBeDefined();
+    expect(advisory!.preferredPath).toBe("desktop_act");
+    expect(String(advisory!.example)).toContain("windowTitle:'メモ帳'");
+    // advisory is a ROOT sibling of post — not nested inside post
+    expect((parsed.post as Record<string, unknown>).advisory).toBeUndefined();
+  });
+
+  it("does NOT set advisory when the focused element is not a text input", async () => {
+    vi.mocked(getFocusedAndPointInfo).mockResolvedValueOnce({ focused: { name: "Canvas", controlType: "Pane" } } as never);
+    const parsed = parse(
+      await withPostState("keyboard", async () => ok({ ok: true }))({ action: "type", text: "hi" }),
+    );
+    expect("advisory" in parsed).toBe(false);
+  });
+
+  it("never sets advisory on the failure branch (even with a qualifying focused element)", async () => {
+    vi.mocked(getFocusedAndPointInfo).mockResolvedValueOnce(editFocus as never);
+    const parsed = parse(
+      await withPostState("keyboard", async () => fail({ ok: false, code: "ToolError", error: "e" }))(
+        { action: "type", text: "hi" },
+      ),
+    );
+    expect(parsed.ok).toBe(false);
+    expect("advisory" in parsed).toBe(false);
+  });
+});
 
 describe("PR-P2-1: B′ presenter routes _perceptionForPost to ROOT (R1 codemod safety)", () => {
   const env = { kind: "auto", status: "needs_escalation", next: "re-focus and retry" };

--- a/tests/unit/path-class-contract/post-writer-ownership.test.ts
+++ b/tests/unit/path-class-contract/post-writer-ownership.test.ts
@@ -47,6 +47,7 @@ import { withPostState } from "../../../src/tools/_post.js";
 import { ok, fail } from "../../../src/tools/_types.js";
 import { errorFromMessage, toToolFailure, failWith } from "../../../src/tools/_errors.js";
 import { getFocusedAndPointInfo } from "../../../src/engine/uia-bridge.js";
+import { enumWindowsInZOrder, getWindowProcessId, getProcessIdentityByPid } from "../../../src/engine/win32.js";
 
 function parse(result: { content: ReadonlyArray<{ type: string; text?: string }> }): Record<string, unknown> {
   const block = result.content[0];
@@ -212,6 +213,26 @@ describe("ADR-022: obj.advisory owned by withPostState (success only)", () => {
     );
     expect(parsed.ok).toBe(false);
     expect("advisory" in parsed).toBe(false);
+  });
+
+  it("does NOT set advisory when the focused window is a browser (after.processName wiring)", async () => {
+    // Pin the processName wiring (_post.ts → maybeAdvisory): an active browser
+    // window suppresses the advisory even with a qualifying focused Edit. Without
+    // the `after.processName` arg this would (wrongly) fire — guards the wiring.
+    vi.mocked(enumWindowsInZOrder).mockReturnValue([{ hwnd: 1, title: "X", isActive: true } as never]);
+    vi.mocked(getWindowProcessId).mockReturnValue(123 as never);
+    vi.mocked(getProcessIdentityByPid).mockReturnValue({ processName: "chrome" } as never);
+    vi.mocked(getFocusedAndPointInfo).mockResolvedValueOnce(editFocus as never);
+    try {
+      const parsed = parse(
+        await withPostState("keyboard", async () => ok({ ok: true }))({ action: "type", text: "hi" }),
+      );
+      expect("advisory" in parsed).toBe(false);
+    } finally {
+      vi.mocked(enumWindowsInZOrder).mockReturnValue([]);
+      vi.mocked(getWindowProcessId).mockReturnValue(null as never);
+      vi.mocked(getProcessIdentityByPid).mockReturnValue(null as never);
+    }
   });
 });
 


### PR DESCRIPTION
## What & why

Implements **issue #352** (ADR-022). Dogfood shows the LLM skips `desktop_discover`, can't hand a lease to `desktop_act`, falls back to `keyboard(type)`, it succeeds, and the LLM then biases toward `keyboard` even where a UIA entity was visible. No tool bug — a **discoverability** problem.

When `keyboard(action='type')` succeeds **but the focused element is a UIA text input** (ValuePattern), attach an additive `advisory` to the response:
```json
"advisory": {
  "preferredPath": "desktop_act",
  "reason": "the focused element is a UIA text input (ValuePattern) — desktop_act runs the lease flow … that keyboard:type does not. keyboard is correct only for UIA-blind targets (PWA / Electron / Canvas).",
  "example": "desktop_discover({target:{windowTitle:'メモ帳'}}) → desktop_act({lease, action:'type', text:'hello'})"
}
```
LLMs follow a concrete corrected example in their own tool history far more strongly than an abstract instruction (compiler "did you mean…?" principle).

## How (probe = zero cost)

The central design decision (Opus design review): the gate reuses the **focused-element snapshot `withPostState` already takes every call** (`post.focusedElement`) — `keyboard(type)` focuses its target, so that *is* the Edit to probe. **No fresh UIA round-trip**, so the non-blocking / latency-budget invariants are structurally true (+0 ms). (The candidate cache is cold on discover-skip; the reactive view is empty for non-critical lenses; verify-readback is text-only — all unworkable, per Opus R1.)

- `src/tools/_advisory.ts` (new): `AdvisoryHint` + `maybeAdvisory(toolName, args, focusedElement)` pure builder + emit counter. Gate = `type ∈ {Edit, Document}` + `value !== undefined` (ValuePattern exposed). Per-tool logic lives here; no `keyboard → desktop_discover` dep (pure over `PostElementInfo`, calls no UIA).
- `_post.ts` `withPostState`: success branch calls `maybeAdvisory(...)` and sets root `obj.advisory`. Writer-ownership doc extended (ADR-021 PR-P2-1 pattern). **No marker / no ROOT_HOISTED_KEYS change** — `withPostState` already holds both `args` and `post.focusedElement`.
- `server-status.ts`: `counters.advisoryEmitted` (OQ-5 — the only objective fire-rate / under-fire signal; the LLM-driven E2E harness was scrapped).

**Suppression (false positives):** UIA-blind targets (PWA / Electron / Canvas) expose no text-input `value`, so the gate fails → no advisory. Definitional, no app-class probe.

## Scope

Round 1 = the keyboard pair only. Other pairs (`click_element` / `mouse_click` / `screenshot`→`terminal`) and a bounded fresh probe (if dogfood shows under-fire) are future rounds. The deep fix (auto-lease on `desktop_act`) is a separate future ADR. **Measurement is dogfood-only** + the emit counter (harness scrapped — acknowledged limitation).

## Tests

- `tests/unit/advisory-hints.test.ts` (10): builder hits / suppression (non-text / no-value / null / non-keyboard / non-type) / example filling + truncation/sanitize / emit counter.
- `post-writer-ownership.test.ts` (+3): `obj.advisory` is a withPostState success-only writer; never on failure; ROOT sibling of `post`.
- Full unit suite 3681 passed; eslint + tsc clean. Additive — advisory-off path byte-equal to today.

Plan: `desktop-touch-mcp-internal@1626d6a:docs/adr-022-success-path-advisory-hints.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)