### PR TITLE
feat(envelope): #352 — fire success-path advisory for unnamed text inputs

### DIFF
--- a/src/engine/uia-bridge.ts
+++ b/src/engine/uia-bridge.ts
@@ -410,6 +410,25 @@ export interface UiaFocusInfo {
 }
 
 /**
+ * Should a focused / at-point row be dropped? (#352 follow-up, ADR-022 §5.5)
+ *
+ * A `name`-empty row is dropped by DEFAULT — this is the historical behavior and
+ * keeps `_mouse-verify` / `desktop_state` / perception byte-equal (none of them
+ * pass `includeUnnamed`). The advisory/post path (`_post.ts snapshotFocusedElement`)
+ * opts in with `includeUnnamed:true` so an UNNAMED text input (many real
+ * Edit/Document fields expose ValuePattern with an empty Name) can reach the #352
+ * advisory gate. Even when opted in, a degenerate row (no name AND no controlType)
+ * is still dropped. Single predicate so the native + PS guards cannot drift.
+ */
+function dropFocusRow(
+  name: string | undefined,
+  controlType: string | undefined,
+  includeUnnamed: boolean
+): boolean {
+  return includeUnnamed ? (!name && !controlType) : !name;
+}
+
+/**
  * Run a single PowerShell script that returns both:
  *   focused — the element that currently has keyboard focus (FocusedElement)
  *   atPoint — the element under screen coordinates (x, y)  [skipped when includePoint=false]
@@ -419,12 +438,16 @@ export interface UiaFocusInfo {
  *
  * Timeout is intentionally short (default 2 s) — these are non-essential fields;
  * null is acceptable when UIA is unavailable or slow.
+ *
+ * `includeUnnamed` (default false): see {@link dropFocusRow}. Only the advisory/post
+ * path opts in; all other callers keep the name-empty drop (byte-equal).
  */
 export async function getFocusedAndPointInfo(
   x = 0,
   y = 0,
   includePoint = true,
-  timeoutMs = 2000
+  timeoutMs = 2000,
+  includeUnnamed = false
 ): Promise<{ focused: UiaFocusInfo | null; atPoint: UiaFocusInfo | null }> {
   // ★ Rust native path
   if (nativeUia?.uiaGetFocusedAndPoint) {
@@ -436,7 +459,7 @@ export async function getFocusedAndPointInfo(
         cursorY: safeY,
       });
       const toInfo = (obj: { name: string; controlType: string; automationId?: string; value?: string } | null | undefined): UiaFocusInfo | null => {
-        if (!obj || !obj.name) return null;
+        if (!obj || dropFocusRow(obj.name, obj.controlType, includeUnnamed)) return null;
         const info: UiaFocusInfo = { name: obj.name, controlType: obj.controlType ?? "" };
         if (obj.automationId) info.automationId = obj.automationId;
         if (obj.value != null) info.value = obj.value;
@@ -505,8 +528,8 @@ $result | ConvertTo-Json -Compress
       atPoint?: Record<string, string | undefined> | null;
     };
     const toInfo = (obj: Record<string, string | undefined> | null | undefined): UiaFocusInfo | null => {
-      if (!obj || !obj.name) return null;
-      const info: UiaFocusInfo = { name: obj.name, controlType: obj.controlType ?? "" };
+      if (!obj || dropFocusRow(obj.name, obj.controlType, includeUnnamed)) return null;
+      const info: UiaFocusInfo = { name: obj.name ?? "", controlType: obj.controlType ?? "" };
       if (obj.automationId) info.automationId = obj.automationId;
       if (obj.value != null) info.value = obj.value;
       return info;

--- a/src/tools/_post.ts
+++ b/src/tools/_post.ts
@@ -92,14 +92,16 @@ function snapshotFocus(): { title: string | null; hwnd: string | null; processNa
  */
 async function snapshotFocusedElement(): Promise<PostElementInfo | null> {
   try {
-    const { focused } = await getFocusedAndPointInfo(0, 0, false, 800);
-    // NOTE (#352): `getFocusedAndPointInfo`'s `toInfo` already returns null for
-    // name-empty elements (`uia-bridge.ts` `if (!obj || !obj.name) return null`),
-    // so an unnamed UIA text input never reaches here. The #352 advisory therefore
-    // fires only for NAMED text inputs in Round 1; widening to unlabeled inputs is
-    // an upstream change to that guard (shared with desktop_state / mouse-verify),
-    // tracked in remaining-work.md (Opus PR #395 R2 P2).
-    if (!focused?.name) return null;
+    // #352 follow-up (ADR-022 §5.5): pass includeUnnamed=true so an UNNAMED UIA
+    // text input (Edit/Document with ValuePattern but an empty Name) survives the
+    // bridge's name-empty guard and can reach the success-path advisory gate. This
+    // opt-in is scoped to the post/advisory path only — `desktop_state` /
+    // `_mouse-verify` / perception do NOT pass the flag, so they stay byte-equal.
+    const { focused } = await getFocusedAndPointInfo(0, 0, false, 800, true);
+    // Drop only when there is no focused element at all (the bridge already dropped
+    // degenerate no-name-no-controlType rows under includeUnnamed). A name-empty
+    // editable element flows through with name:"" so the #352 advisory can fire.
+    if (!focused) return null;
     const info: PostElementInfo = { name: focused.name, type: focused.controlType };
     if (focused.automationId) info.automationId = focused.automationId;
     if (focused.value != null) info.value = focused.value;

--- a/tests/unit/advisory-hints.test.ts
+++ b/tests/unit/advisory-hints.test.ts
@@ -68,6 +68,36 @@ describe("maybeAdvisory — keyboard(type) → desktop_act", () => {
   });
 });
 
+describe("maybeAdvisory — unnamed text input (#352 follow-up, ADR-022 §5.5)", () => {
+  // The gate is NAME-AGNOSTIC (it checks type / value / automationId / process,
+  // never name). The Round-1 under-fire was upstream — the bridge dropped
+  // name-empty rows before they reached this gate. This pins that an unnamed Edit
+  // that DOES reach the gate fires, so the upstream relax (includeUnnamed) is the
+  // only thing needed to widen coverage to unlabeled inputs.
+  it("fires for an unnamed Edit with value:'' (empty string = ValuePattern PRESENT)", () => {
+    const hint = maybeAdvisory(
+      "keyboard",
+      { action: "type", windowTitle: "App", text: "x" },
+      { name: "", type: "Edit", value: "" }, // name-empty editable, ValuePattern exposed
+      NATIVE,
+    );
+    expect(hint).not.toBeNull();
+    expect(hint!.preferredPath).toBe("desktop_act");
+  });
+
+  it("does NOT fire for an unnamed Edit with value ABSENT (undefined = no ValuePattern)", () => {
+    // Guard against conflating value:'' (fires) with value missing (drops). The
+    // gate is `value === undefined` (_advisory.ts) — empty string passes, absent drops.
+    const hint = maybeAdvisory(
+      "keyboard",
+      { action: "type", text: "x" },
+      { name: "", type: "Edit" }, // no `value` field at all
+      NATIVE,
+    );
+    expect(hint).toBeNull();
+  });
+});
+
 describe("maybeAdvisory — suppression (no hint)", () => {
   it("returns null when the focused element is not a text input (UIA-blind / wrong control)", () => {
     expect(

--- a/tests/unit/path-class-contract/post-writer-ownership.test.ts
+++ b/tests/unit/path-class-contract/post-writer-ownership.test.ts
@@ -196,6 +196,30 @@ describe("ADR-022: obj.advisory owned by withPostState (success only)", () => {
     expect((parsed.post as Record<string, unknown>).advisory).toBeUndefined();
   });
 
+  it("G4-survival (#352 follow-up): an UNNAMED Edit reaches post.focusedElement and fires advisory", async () => {
+    // The bridge is mocked, so this pins the _post.ts G4 belt relax specifically:
+    // a name-empty editable element (name:"") must survive snapshotFocusedElement
+    // (was dropped by `if (!focused?.name) return null`) into post.focusedElement
+    // with name:"", AND the name-agnostic advisory gate then fires.
+    vi.mocked(getFocusedAndPointInfo).mockResolvedValueOnce(
+      { focused: { name: "", controlType: "Edit", value: "" } } as never,
+    );
+    const parsed = parse(
+      await withPostState("keyboard", async () => ok({ ok: true, method: "background" }))(
+        { action: "type", windowTitle: "App", text: "hi" },
+      ),
+    );
+    const post = parsed.post as Record<string, unknown>;
+    const fe = post.focusedElement as Record<string, unknown> | null;
+    expect(fe).not.toBeNull();
+    expect(fe!.name).toBe(""); // survived G4 relax with empty name (was → null before)
+    expect(fe!.type).toBe("Edit");
+    expect(fe!.value).toBe("");
+    const advisory = parsed.advisory as Record<string, unknown> | undefined;
+    expect(advisory).toBeDefined();
+    expect(advisory!.preferredPath).toBe("desktop_act");
+  });
+
   it("does NOT set advisory when the focused element is not a text input", async () => {
     vi.mocked(getFocusedAndPointInfo).mockResolvedValueOnce({ focused: { name: "Canvas", controlType: "Pane" } } as never);
     const parsed = parse(

--- a/tests/unit/uia-focused-unnamed.test.ts
+++ b/tests/unit/uia-focused-unnamed.test.ts
@@ -1,0 +1,71 @@
+/**
+ * tests/unit/uia-focused-unnamed.test.ts
+ * #352 follow-up (ADR-022 §5.5) — `getFocusedAndPointInfo` `includeUnnamed` opt-in.
+ *
+ * Pins the bridge-level guard relax (G1 native `toInfo`, via the shared
+ * `dropFocusRow` predicate) and — critically — the REGRESSION invariant: without
+ * the flag, a name-empty row is still dropped, so `_mouse-verify` / `desktop_state`
+ * / perception (none of which pass the flag) stay byte-equal. The native path is
+ * mocked; G2 (PowerShell) shares the same `dropFocusRow` predicate, so this also
+ * covers the predicate logic G2 uses.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/engine/native-engine.js", () => ({
+  nativeUia: { uiaGetFocusedAndPoint: vi.fn() },
+}));
+
+import { getFocusedAndPointInfo } from "../../src/engine/uia-bridge.js";
+import { nativeUia } from "../../src/engine/native-engine.js";
+
+const mockGetFocusedAndPoint = vi.mocked(nativeUia!.uiaGetFocusedAndPoint);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getFocusedAndPointInfo — includeUnnamed opt-in (#352)", () => {
+  it("DEFAULT (no flag): drops a name-empty editable row (byte-equal regression pin)", async () => {
+    // mouse-verify / desktop_state / perception all call WITHOUT the flag. A
+    // name-empty Edit must still resolve to null exactly as before this change.
+    mockGetFocusedAndPoint.mockResolvedValue({
+      focused: { name: "", controlType: "Edit", value: "" },
+      atPoint: null,
+    } as never);
+    const { focused } = await getFocusedAndPointInfo(0, 0, false, 800);
+    expect(focused).toBeNull();
+  });
+
+  it("includeUnnamed=true: keeps a name-empty editable row (name:'')", async () => {
+    mockGetFocusedAndPoint.mockResolvedValue({
+      focused: { name: "", controlType: "Edit", value: "" },
+      atPoint: null,
+    } as never);
+    const { focused } = await getFocusedAndPointInfo(0, 0, false, 800, true);
+    expect(focused).not.toBeNull();
+    expect(focused!.name).toBe("");
+    expect(focused!.controlType).toBe("Edit");
+    expect(focused!.value).toBe("");
+  });
+
+  it("includeUnnamed=true: still drops a DEGENERATE row (no name AND no controlType)", async () => {
+    mockGetFocusedAndPoint.mockResolvedValue({
+      focused: { name: "", controlType: "" },
+      atPoint: null,
+    } as never);
+    const { focused } = await getFocusedAndPointInfo(0, 0, false, 800, true);
+    expect(focused).toBeNull();
+  });
+
+  it("named rows are unaffected by the flag (kept either way)", async () => {
+    mockGetFocusedAndPoint.mockResolvedValue({
+      focused: { name: "Editor", controlType: "Edit", value: "v" },
+      atPoint: null,
+    } as never);
+    const off = await getFocusedAndPointInfo(0, 0, false, 800);
+    const on = await getFocusedAndPointInfo(0, 0, false, 800, true);
+    expect(off.focused).toEqual({ name: "Editor", controlType: "Edit", value: "v" });
+    expect(on.focused).toEqual({ name: "Editor", controlType: "Edit", value: "v" });
+  });
+});


### PR DESCRIPTION
## What changed
The `keyboard:type → desktop_act` success-path advisory (issue #352, PR #395) only fired for **named** UIA text inputs. The focused-element bridge dropped name-empty elements before they reached the advisory gate — yet many real `Edit`/`Document` fields expose `ValuePattern` with an empty `Name`. Typing into such an unlabeled input now also surfaces the `desktop_act` nudge.

## Why it matters
Live dogfood (2026-05-23) measured the emit rate: 1 fire for the named Notepad case, **0 for any unnamed field**. The headline case worked, but unlabeled inputs systematically under-fired.

## How it's scoped (no behavior change for other consumers)
- `getFocusedAndPointInfo` gains an `includeUnnamed` param (default `false`) via a shared `dropFocusRow` predicate so the native + PowerShell guards cannot drift.
- **Only** `_post`'s `snapshotFocusedElement` opts in (`includeUnnamed:true`) and relaxes its own name-empty belt, so the unnamed editable element reaches `post.focusedElement` and the (already name-agnostic) advisory gate fires. A degenerate row (no name **and** no controlType) is still dropped.
- `desktop_state` / `mouse_click` verification / perception pass **no flag → byte-equal** (they keep dropping name-empty rows exactly as before). `desktop_state` is additionally self-protected by its own belt guards.

## Tests
- `advisory-hints`: unnamed Edit with `value:""` (ValuePattern present) fires; `value` absent (no ValuePattern) drops — pins the `value:"" ≠ undefined` distinction.
- `uia-focused-unnamed` (new): `includeUnnamed` off → name-empty dropped (byte-equal regression pin); on → kept; degenerate row still dropped; named rows unaffected.
- `post-writer-ownership` G4-survival pin: an unnamed Edit reaches `post.focusedElement` (name:"") and fires the advisory.

Full unit suite green; the only full-suite failures were pre-existing flaky/perf/e2e (confirmed: identical failures on `main`, and the unit ones pass in isolation).

## Plan / design
Opus-reviewed 2 rounds (GO). Plan + blast-radius analysis (corrects ADR-022 §5.5): [`adr-022-unnamed-input-followup-plan.md`](https://github.com/Harusame64/desktop-touch-mcp-internal/blob/6553afbf9e7f4533323a6feca1e8ed1fec4c76e4/docs/adr-022-unnamed-input-followup-plan.md) (private repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
