### PR TITLE
docs: refresh README / system-overview / site to the v1.8 surface (29 tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@
 npx -y @harusame64/desktop-touch-mcp
 ```
 
-28 tools, native Rust engine (UIA in 2 ms), zero-config PowerShell fallback, full CJK support, MIT licensed. Add the snippet above to your Claude / Cursor / VS Code Copilot config and Claude can drive Notepad, Excel, Chrome, Windows Terminal, and any other app on your machine.
+29 tools, native Rust engine (UIA in 2 ms), zero-config PowerShell fallback, full CJK support, MIT licensed. Add the snippet above to your Claude / Cursor / VS Code Copilot config and Claude can drive Notepad, Excel, Chrome, Windows Terminal, and any other app on your machine.
 
-> *v0.15: **82× average speedup** via Rust native engine — UIA focus queries in 2 ms, SSE2-accelerated image diffing at 13–15× native speed. Zero-config: the engine auto-loads when present, with transparent PowerShell fallback.*
-> *v0.15.5: **Pinned release verification** — the npm launcher now fetches only the matching GitHub Release tag and verifies the Windows runtime zip before extraction.*
+> **Why this over pixel-clicking?** Two ideas run through every tool: **discover-then-act** — `desktop_discover` returns interactive entities with short-lived leases instead of raw coordinates, so `desktop_act` operates on *what* you mean, not *where* it was — and **per-action perception guards** that verify the target window's identity and bounds before input lands, catching wrong-window typing and stale-coordinate clicks before they happen.
+>
+> Under the hood: an **82× average speedup** from the Rust native engine (UIA focus queries in 2 ms, SSE2-accelerated image diffing at 13–15×), with a transparent PowerShell fallback when the engine is absent. The npm launcher fetches only the GitHub Release tag matching the installed version and verifies the Windows runtime zip before extraction.
 
 ---
 
@@ -122,7 +123,7 @@ For a local checkout, register the built server directly:
 
 ---
 
-## Tools (28 Optimized Tools)
+## Tools (29 Optimized Tools)
 
 > 📖 **Full Reference**: [`docs/system-overview.md`](docs/system-overview.md) — Exhaustive guide on parameters, return schemas, and coordinate math.
 
@@ -165,6 +166,11 @@ For a local checkout, register the built server directly:
 | `workspace_launch` | Launch apps and auto-detect new HWNDs (supports localized titles). |
 | `run_macro` | Batch up to 50 operations into a single round-trip for maximum efficiency. |
 | `clipboard` / `notification_show` | System-level text exchange and user alerts. |
+
+### 📊 Office (Excel)
+| Tool | Description |
+|---|---|
+| `excel` | Author and run Excel VBA macros via COM. `action='run_vba'` writes a macro into a managed Trusted Location and runs it; `action='check_access_vbom'` is a read-only preflight. Runs VBA where formula-only tools cannot. One-time setup: `node scripts/enable-access-vbom.mjs`. |
 
 ---
 
@@ -558,7 +564,7 @@ Setting `DESKTOP_TOUCH_FORCE_FOCUS=1` makes `forceFocus: true` the default for a
 
 ---
 
-## Auto Guard (v0.12+)
+## Auto Guard
 
 Action tools (`mouse_click`, `mouse_drag`, `keyboard(action='type'/'press')`, `click_element`, `desktop_act`, `browser_click`, `browser_navigate`) automatically guard each action when you pass `windowTitle` / `tabId`:
 
@@ -608,32 +614,7 @@ The fix is one-shot and expires in 15 seconds. The server revalidates the target
 
 ---
 
-## v0.13 Additions
-
-### Target-Identity Timeline
-
-The server tracks a semantic timeline of what happened to each target window/tab. Recent events are included in:
-
-- `get_history` → `recentTargetKeys`: array of 3 most recently active target keys (compact, no event bodies)
-- `perception_read(lensId)` → `recentEvents`: up to 10 events for that lens's target, each with `tsMs`, `semantic`, `summary`
-
-Enable the MCP resources below to browse timelines:
-
-```json
-{ "env": { "DESKTOP_TOUCH_PERCEPTION_RESOURCES": "1" } }
-```
-
-MCP resources available when enabled:
-
-| URI | Content |
-|---|---|
-| `perception://target/{targetKey}/timeline` | Semantic event timeline for a target |
-| `perception://targets/recent` | Most recently active target keys |
-| `perception://lens/{lensId}/summary` | Lens attention/guard state |
-
-### Manual Lens Eviction: FIFO → LRU
-
-Manual lenses (created via `perception_register`) are now evicted by **least-recently-used** instead of insertion order. Using `perception_read`, `evaluatePreToolGuards`, or `buildEnvelopeFor` on a lens promotes it. The hard limit of 16 active lenses is unchanged.
+## Advanced response options
 
 ### browser_eval Structured Mode
 
@@ -748,7 +729,7 @@ Flag semantics (exact-match: only the literal string `"1"` counts):
 
 ### Deprecated: `DESKTOP_TOUCH_ENABLE_FUKUWARAI_V2`
 
-This was the opt-in switch in v0.16.x. From v0.17 it is accepted for compatibility but no longer required — the server prints a deprecation warning on startup when it is set. It will be removed in v0.18. Remove it from your config when you upgrade.
+This was the opt-in switch in v0.16.x. It is still accepted for backward compatibility but no longer required — the server prints a deprecation warning on startup when it is set. Remove it from your config; V2 is on by default.
 
 ### Recovery when V2 fails
 
@@ -759,7 +740,7 @@ If `desktop_act` returns `ok: false`, read `reason` and follow the built-in reco
 - `entity_outside_viewport` → `scroll` / `scroll(action='to_element')`, then re-call `desktop_discover`
 - `executor_failed` → fall back to `click_element` / `mouse_click` / `browser_click`
 
-For `desktop_discover` warnings (`visual_provider_unavailable`, `visual_provider_warming`, `cdp_provider_failed`, …), V1 tools (`screenshot`, `click_element`, `get_ui_elements`, `terminal(action='send')`, …) remain available as an escape hatch.
+For `desktop_discover` warnings (`visual_provider_unavailable`, `visual_provider_warming`, `cdp_provider_failed`, …), the coordinate-based tools (`screenshot(detail='text')`, `click_element`, `mouse_click`, `terminal`, …) remain available as an escape hatch.
 
 ---
 

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -11,8 +11,8 @@ MCP (Model Context Protocol) server that lets Claude CLI drive any Windows deskt
 ## Architecture
 
 ```
-Claude CLI
-    │  stdio (MCP protocol)
+MCP client (Claude CLI / Cursor / VS Code / …)
+    │  stdio or Streamable HTTP (MCP protocol)
     ▼
 desktop-touch-mcp (Node.js / TypeScript)
     ├── Layer 0: Rust Native Engine (.node addon — @harusame64/desktop-touch-engine)
@@ -54,7 +54,7 @@ desktop-touch-mcp (Node.js / TypeScript)
     │   ├── event-bus.ts    — Win32 window-state event bus used by perception sensors
     │   ├── identity-tracker.ts — processStartTimeMs-based window identity; detects restarts
     │   ├── poll.ts         — shared pollUntil utility
-    │   └── perception/     — Reactive Perception Graph (v0.11)
+    │   └── perception/     — Reactive Perception Graph (drives the Auto-Perception layer)
     │       ├── types.ts            — pure types: Observation / Fluent / PerceptionLens / GuardResult / PerceptionEnvelope
     │       ├── evidence.ts         — makeEvidence / isStale / confidenceFor (win32=0.98, image=0.60, inferred=0.50)
     │       ├── fluent-store.ts     — FluentStore: TMS-lite reconcile (newer seq wins; higher confidence wins)
@@ -65,7 +65,7 @@ desktop-touch-mcp (Node.js / TypeScript)
     │       ├── sensors-win32.ts    — only impure module; piggybacks event-bus 500 ms tick
     │       └── registry.ts         — central coordinator; max 16 lenses (LRU evict)
     └── Layer 2: 29 public MCP tools (27 stub catalog + 2 dynamic v2)
-        See [CHANGELOG.md](D:/git/desktop-touch-mcp/CHANGELOG.md) Phase 1+2+3+4 sections for the per-phase mapping. ADR-015 v1.5.0 adds the `excel` tool (invariant 6 explicit carve-out, see `docs/layer-constraints.md` §6.3 Note).
+        See the catalogue below and [CHANGELOG.md](../CHANGELOG.md) for per-version history.
 ```
 
 ### Surface status
@@ -73,10 +73,10 @@ desktop-touch-mcp (Node.js / TypeScript)
 - **Current public surface (v1.8.0)**: 29 tools — 27 stub catalog + 2 dynamic v2 (`desktop_discover` / `desktop_act`)
 - **Tool surface reduction (Phase 1–4) — shipped**: naming redesign, family merge dispatchers, browser rearrangement, privatize/absorb. Pre-Phase-1 surface was 65 tools.
 - Phase design references (all Implemented):
-  - [tool-surface-phase1-naming-design.md](D:/git/desktop-touch-mcp/docs/tool-surface-phase1-naming-design.md)
-  - [tool-surface-phase2-family-merge-design.md](D:/git/desktop-touch-mcp/docs/tool-surface-phase2-family-merge-design.md)
-  - [tool-surface-phase3-browser-rearrangement-design.md](D:/git/desktop-touch-mcp/docs/tool-surface-phase3-browser-rearrangement-design.md)
-  - [tool-surface-phase4-privatize-absorb-design.md](D:/git/desktop-touch-mcp/docs/tool-surface-phase4-privatize-absorb-design.md)
+  - [tool-surface-phase1-naming-design.md](./tool-surface-phase1-naming-design.md)
+  - [tool-surface-phase2-family-merge-design.md](./tool-surface-phase2-family-merge-design.md)
+  - [tool-surface-phase3-browser-rearrangement-design.md](./tool-surface-phase3-browser-rearrangement-design.md)
+  - [tool-surface-phase4-privatize-absorb-design.md](./tool-surface-phase4-privatize-absorb-design.md)
 
 ### Rust Native Engine — Data Flow
 
@@ -381,6 +381,9 @@ keyboard(action='press')(keys="alt+f4")
 keyboard(action='press')(keys="ctrl+shift+s")
 ```
 
+#### `keyboard(action='sequence')`
+Runs ordered key steps inside a single keyboard lock — use it for Alt+letter / letter-mnemonic chains (e.g. classic menu navigation) where an intermediate tool call between presses would close the menu. The steps execute atomically so the menu state survives across the chord.
+
 > **⚠️ Input routing gotcha (when `window_dock(action='dock')` is pinned)**
 > `keyboard(action='type')` / `keyboard(action='press')` send to **whichever window is currently focused**. If `window_dock(action='dock')(pin=true)` has pinned the Claude CLI topmost, keystrokes can land on the CLI instead of the target app.
 > Always call `focus_window(title=…)` first, then verify with `screenshot(detail='meta')` that `isActive=true` on the target. Canonical pattern: `focus_window → keyboard(action='press')/type → screenshot(diffMode=true)`.
@@ -529,9 +532,12 @@ Sends a command, waits for it to complete, and reads the output in one call. How
 
 `mode:'exit'` appends a completion marker whose *printed* form differs from its
 *typed* form, so it never matches the echoed command line (even for multi-line
-input). Pass `shell` explicitly (`'bash'` / `'powershell'`); `cmd.exe` is not yet
-supported. Unsafe input (unterminated quote / here-doc / `$(…)` / trailing `\` or
-backtick) is rejected up front rather than hanging.
+input). Pass `shell` explicitly (`'bash'` / `'powershell'`) — `shell:'auto'` reads
+the shell from the window, but it cannot see a shell running *inside* SSH / WSL and
+returns `ExitModeShellAmbiguous` when the process is genuinely unidentifiable (e.g.
+Windows Terminal). `cmd.exe` is not yet supported. Unsafe input (unterminated quote
+/ here-doc / `$(…)` / trailing `\` or backtick) is rejected up front rather than
+hanging.
 
 ```js
 terminal({ action:'run', windowTitle:'pwsh', input:'npm run build',
@@ -789,8 +795,10 @@ still safe.
 > `perception_forget` / `perception_list` tools were privatized in the Phase 1–4
 > consolidation — manual lens registration is no longer needed. The registry, hot
 > target cache, and sensor loop are unchanged; they are now driven automatically.
-> The `perception://lens/{id}/{summary|guards|debug|events}` MCP resources remain
-> available behind `DESKTOP_TOUCH_PERCEPTION_RESOURCES=1` for inspection.
+> The `perception://lens/{id}/...` MCP resources remain available for inspection:
+> the `summary` / `guards` views behind `DESKTOP_TOUCH_PERCEPTION_RESOURCES=1`, and
+> the `debug` / `events` views behind the additional
+> `DESKTOP_TOUCH_PERCEPTION_DEBUG_RESOURCES=1`.
 
 #### Fluents tracked per target
 
@@ -868,7 +876,7 @@ window bounds, not pixel-level occlusion.
 
 **SuggestedFix**: When a guard blocks with `unsafe_coordinates` / `identity_changed`, the response may carry a one-shot `suggestedFix.fixId` (expires in 15 s). Pass it back to `mouse_click`, `keyboard(action='type')`, `click_element`, or `browser_click` to approve the recovery; the server revalidates the stored target fingerprint (process pid + start-time for windows; a fresh guard for browser tabs) before executing.
 
-**Target-identity timeline**: The server maintains a per-target semantic event timeline (event kinds such as `target_bound`, `action_succeeded`, `action_blocked`, `title_changed`, `rect_changed`, `foreground_changed`, `navigation`, `modal_appeared`, `identity_changed`, `target_closed`). Storage is a per-target ring (32) plus a global cap (256); sensor events are 200 ms leading-edge debounced. It surfaces via the opt-in `include` envelope (`your_last_action` / `events` / the `episodic` memory layer) and the `perception://lens/{id}/events` resource (flag `DESKTOP_TOUCH_PERCEPTION_RESOURCES=1`).
+**Target-identity timeline**: The server maintains a per-target semantic event timeline (event kinds such as `target_bound`, `action_succeeded`, `action_blocked`, `title_changed`, `rect_changed`, `foreground_changed`, `navigation`, `modal_appeared`, `identity_changed`, `target_closed`). Storage is a per-target ring (32) plus a global cap (256); sensor events are 200 ms leading-edge debounced. It surfaces via the opt-in `include` envelope (`your_last_action` / `events` / the `episodic` memory layer) and the `perception://lens/{id}/events` resource (behind `DESKTOP_TOUCH_PERCEPTION_DEBUG_RESOURCES=1`).
 
 **Browser readiness policies**: `browser_click` passes with a warn-note when `readyState !== "complete"` but the selector is already in-viewport (policy: `selectorInViewport`). `browser_navigate` accepts `interactive` (policy: `navigationGate`). `browser_eval` remains strict.
 
@@ -953,6 +961,6 @@ screenshot(diffMode=true)
 
 Registered as `desktop-touch` under `mcpServers` in `~/.claude.json` (stdio). Auto-starts / stops with the Claude CLI.
 
-Build: `cd D:\git\desktop-touch-mcp && npm install` (the `prepare` hook runs `tsc` automatically).
+Build: `git clone` the repo, then `npm install` (the `prepare` hook runs `tsc` automatically).
 
 The Rust native engine (`@harusame64/desktop-touch-engine`) is included in the release zip. It loads as a `.node` addon at startup — no Rust toolchain required for end users. If the addon is missing or fails to load, all UIA and image-diff operations fall back to TypeScript/PowerShell transparently.

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -2,9 +2,9 @@
 
 MCP (Model Context Protocol) server that lets Claude CLI drive any Windows desktop application.
 
-> 現行の設計判断・残タスク・方針転換は、まず [README.md](D:/git/desktop-touch-mcp/docs/README.md) と
-> [todo-index.md](D:/git/desktop-touch-mcp/docs/todo-index.md) を参照してください。
-> この文書は **現行実装の概観** を説明する正本であり、tool surface 再編の将来案までは確定事項として扱いません。
+> This document is the canonical overview of the **current implementation**. For the
+> user-facing quick start and per-tool tables, see the top-level [README.md](../README.md);
+> for design notes and remaining work, see the files under [`docs/`](./).
 
 ---
 
@@ -70,7 +70,7 @@ desktop-touch-mcp (Node.js / TypeScript)
 
 ### Surface status
 
-- **Current public surface (v1.5.0)**: 29 tools — 27 stub catalog + 2 dynamic v2 (`desktop_discover` / `desktop_act`)
+- **Current public surface (v1.8.0)**: 29 tools — 27 stub catalog + 2 dynamic v2 (`desktop_discover` / `desktop_act`)
 - **Tool surface reduction (Phase 1–4) — shipped**: naming redesign, family merge dispatchers, browser rearrangement, privatize/absorb. Pre-Phase-1 surface was 65 tools.
 - Phase design references (all Implemented):
   - [tool-surface-phase1-naming-design.md](D:/git/desktop-touch-mcp/docs/tool-surface-phase1-naming-design.md)
@@ -180,6 +180,46 @@ For `keyboard(action='press')`, rich mode only fires for state-transitioning key
 
 ## Tool catalogue
 
+The 29 public tools group into six families. The **World-Graph V2** pair is the
+recommended dispatch path; the coordinate / UIA / browser tools remain for
+fallback and specialised work.
+
+### 🌐 World-Graph V2 — discover-then-act (primary path)
+
+The recommended way to operate any window, browser tab, or terminal. Instead of
+guessing screen coordinates, you *discover* interactive entities (each carrying a
+short-lived lease) and then *act* on an entity by its lease.
+
+#### `desktop_discover`
+Observe a target and return interactive entities with leases — no raw screen
+coordinates. One surface spans four lanes: UIA (native windows / dialogs), CDP
+(Chrome / Edge tabs), terminal, and a visual GPU lane (Set-of-Marks) for windows
+UIA cannot see. Each entity carries a lease (`expiresAtMs` is the correctness
+wall; `softExpiresAtMs` ≈ 60 % of TTL is the soft re-discover hint). TTL adapts
+to `view` mode (`action` / `explore` / `debug`), entity count, and payload size,
+capped at 60 s. Warnings (`visual_provider_unavailable`, `visual_provider_warming`,
+`cdp_provider_failed`, …) tell the caller when a lane is degraded.
+
+#### `desktop_act`
+Act on an entity returned by `desktop_discover` (`click` / `type` / `drag` /
+`select`, …). The lease is validated before execution, and the response carries a
+semantic diff (`entity_disappeared`, `modal_appeared`, `focus_shifted`, …) plus
+the `attention` signal — so the caller can decide the next step without another
+screenshot. On `ok:false` read `reason` and follow the recovery path:
+
+| `reason` | Recovery |
+|---|---|
+| `lease_expired` / `lease_generation_mismatch` / `lease_digest_mismatch` / `entity_not_found` | re-call `desktop_discover` |
+| `modal_blocking` | `response.blockingElement` names the blocker → `click_element(name=…)` then retry |
+| `entity_outside_viewport` | `scroll(action='to_element' | 'raw')` then re-call `desktop_discover` |
+| `executor_failed` | fall back to `click_element` / `mouse_click` / `browser_click` |
+
+> **Kill switch:** `DESKTOP_TOUCH_DISABLE_FUKUWARAI_V2=1` hides `desktop_discover` /
+> `desktop_act` from the catalogue and re-registers three V1 fallback tools
+> (`get_windows` / `get_ui_elements` / `set_element_value`) for troubleshooting.
+> The deprecated opt-in `DESKTOP_TOUCH_ENABLE_FUKUWARAI_V2` is still accepted but
+> no longer required (V2 is default-on).
+
 ### 📸 Screenshot family
 
 #### `screenshot`
@@ -235,10 +275,13 @@ Explicit Win32 PrintWindow capture, retained for back-compat and explicit select
 - `dotByDot=true` emits 1:1 WebP.
 - `PW_RENDERFULLCONTENT` is the default flag (set `fullContent=false` for the legacy flag-0 mode when a GPU game / video window hangs PrintWindow).
 
-#### `screenshot_ocr`
-Word-level text with on-screen coords via Windows OCR (`Windows.Media.Ocr`). Fallback for apps where UIA is sparse.
+> Word-level Windows OCR (`Windows.Media.Ocr`) is reached through `screenshot`
+> itself — `detail="text"` with `ocrFallback="auto"` (default) fires OCR when UIA
+> is sparse/empty or the foreground is Chromium; `ocrFallback="always"` forces it.
+> The standalone `screenshot_ocr` / `get_screen_info` tools were absorbed during
+> the Phase 1–4 surface consolidation.
 
-#### `screenshot(detail="text")` — SoM fallback (v0.15.4)
+#### `screenshot(detail="text")` — SoM fallback
 When `detectUiaBlind()` fires (fewer than 5 UIA elements, or a single Pane covering ≥ 90% of the window with fewer than 5 other actionable elements), `screenshot(detail="text")` automatically activates the Hybrid Non-CDP pipeline instead of returning an empty element list:
 
 1. Capture window via PrintWindow → RGBA buffer
@@ -250,22 +293,14 @@ When `detectUiaBlind()` fires (fewer than 5 UIA elements, or a single Pane cover
 
 Sharp library is the transparent fallback for `preprocessImage` if the native `.node` engine is unavailable (no feature loss, only performance difference). When `drawSomLabels` is unavailable (Rust engine not built), `somImage` is `null` — the `elements[]` list with `clickAt` coords is still returned, but without the visual annotation PNG. If the SoM pipeline fails at any stage, `screenshot(detail="text")` transparently falls back to the regular OCR word-list path.
 
-#### `get_screen_info`
-Monitor list: resolution, position, DPI, cursor position.
-
 ---
 
 ### 🖥️ Window management
 
-#### `get_windows`
-All windows in Z-order.
-```json
-{ "zOrder": 0, "title": "Notepad", "region": {"x":78,"y":78,"width":976,"height":618},
-  "isActive": true, "isMinimized": false, "isOnCurrentDesktop": true }
-```
-
-#### `get_active_window`
-Information about the currently-focused window.
+> The Z-order window list and active-window info that `get_windows` /
+> `get_active_window` used to return are now part of `desktop_state.windows`
+> (and `desktop_discover`). The two standalone getters were privatized in the
+> Phase 1–4 consolidation.
 
 #### `focus_window`
 Bring a window to the foreground by partial title match.
@@ -275,7 +310,7 @@ focus_window(title="Chrome", chromeTabUrlContains="github.com")  # activate a sp
 ```
 `chromeTabUrlContains` activates the matching Chrome/Edge tab by URL substring before focusing the HWND. If CDP is unavailable, the parameter is silently skipped and `hints.warnings` surfaces `"cdpUnavailable"`.
 
-#### `window_dock(action='pin')` / `unwindow_dock(action='pin')`
+#### `window_dock(action='pin')` / `window_dock(action='unpin')`
 Toggle always-on-top; `duration_ms` for an auto-release timer.
 
 #### `window_dock(action='dock')`
@@ -302,9 +337,6 @@ Parameters: `corner` (top-left / top-right / bottom-left / bottom-right), `width
 
 All mouse tools take `speed` plus `homing` / `windowTitle` / `elementName` / `elementId`. Success responses carry the `post` block (`narrate:"rich"` adds a UIA diff).
 
-#### `mouse_move`
-Move the cursor.
-
 #### `mouse_click`
 Click (`left` / `right` / `middle`). `doubleClick=true` for a double-click; `tripleClick=true` for a triple-click (selects a full line of text). If both are set, `tripleClick` wins.
 
@@ -321,16 +353,13 @@ mouse_click(x, y, windowTitle="Notepad")    # Tier 1 + 2
 mouse_click(x, y, homing=false)             # correction off
 ```
 
-The cache is refreshed automatically by `screenshot` / `get_windows` / `focus_window` / `workspace_snapshot`. A 60-second TTL keeps HWND reuse from steering the wrong window.
+The cache is refreshed automatically by `screenshot` / `desktop_discover` / `focus_window` / `workspace_snapshot`. A 60-second TTL keeps HWND reuse from steering the wrong window.
 
 #### `mouse_drag`
-Drag (startX,startY) → (endX,endY). When homing is active, the end-point gets the same delta as the start.
+Drag (startX,startY) → (endX,endY). When homing is active, the end-point gets the same delta as the start. Both endpoints are guarded; cross-window / desktop drags are blocked unless `allowCrossWindowDrag:true`.
 
 #### `scroll`
-`direction`: `up` / `down` / `left` / `right`; `amount` is the step count. Internally multiplied by 3 because nut-js's single step is tiny.
-
-#### `get_cursor_position`
-Current cursor coords.
+The unified scroll dispatcher. `scroll(action='raw')` takes `direction` (`up` / `down` / `left` / `right`) and `amount` (step count, internally multiplied by 3 because nut-js's single step is tiny). The richer `action='to_element'` / `'smart'` / `'capture'` modes are documented under **Macro / scroll** and **SmartScroll** below.
 
 ---
 
@@ -362,7 +391,7 @@ keyboard(action='press')(keys="ctrl+shift+s")
 
 > **v0.15:** All UIA operations route through the Rust native engine by default (direct COM calls, 2–100 ms). PowerShell fallback activates automatically if the native engine is unavailable.
 
-Action tools (`click_element` / `set_element_value`) return the `post` block; `narrate:"rich"` adds a UIA diff.
+`click_element` returns the `post` block; `narrate:"rich"` adds a UIA diff.
 
 #### `screenshot(detail="text")` ← recommended
 Action-oriented element extraction. Every entry carries `clickAt` coords.
@@ -382,23 +411,19 @@ Action-oriented element extraction. Every entry carries `clickAt` coords.
 }
 ```
 
-#### `get_ui_elements`
-The raw UIA tree. Use this when you need an `automationId`. Each element includes `viewportPosition` (`'in-view'|'above'|'below'|'left'|'right'`) relative to the window client region — use it to decide whether `scroll(action='to_element')` is needed before clicking. Results are capped at `maxElements` (default 80, max 200).
-
 #### `click_element`
 Click by name / ID via UIA `InvokePattern` — no coords needed.
 ```
 click_element(windowTitle="Notepad", name="Settings", controlType="Button")
 ```
 
-#### `set_element_value`
-Set a text field directly via UIA `ValuePattern`.
-```
-set_element_value(windowTitle="Notepad", name="Text editor", value="Hello!")
-```
-
-#### `scope_element`
-Zoomed (1280 px) capture of one element + its child tree.
+> The raw UIA tree (`get_ui_elements`), direct field setter (`set_element_value`),
+> and single-element zoom (`scope_element`) were privatized in the Phase 1–4
+> consolidation. `get_ui_elements` / `set_element_value` are re-registered as V1
+> fallback tools only when `DESKTOP_TOUCH_DISABLE_FUKUWARAI_V2=1` is set. For
+> normal automation, `desktop_discover` (entity tree with leases) and
+> `screenshot(detail="text")` (`actionable[]` with `clickAt` + `automationId`)
+> cover the same ground.
 
 ---
 
@@ -450,34 +475,16 @@ Lightweight OS + app context. See the current state without a screenshot.
 |---|---|
 | `focusedElement` | UIA `GetFocusedElement` — the element with keyboard focus (name / type / value) |
 | `cursorOverElement` | UIA `ElementFromPoint` — the UIA element directly under the cursor |
-| `windows` | Z-ordered window list (same shape as `get_windows`) |
+| `windows` | Z-ordered window list (the same `{title, region, isActive, …}` shape `desktop_discover` reports) |
 
 On Chromium windows UIA is sparse, so `focusedElement` / `cursorOverElement` can be `null` — reach for the CDP tools there.
 
-#### `get_history`
-Summaries of the most recent actions (default 5, max 20).
-
-```json
-[
-  { "tool": "mouse_click", "ok": true,
-    "post": { "focusedWindow": "Notepad", "windowChanged": false, "elapsedMs": 35 },
-    "tsMs": 1744600000000 }
-]
-```
-
-Useful inside loops / repeated operations to check what the previous step actually did. `post.rich` is not stored in the ring buffer (keeps it small).
-
-#### `get_document_state`
-CDP state for the active tab (Chrome / Edge).
-
-```json
-{
-  "title": "Google",
-  "url": "https://www.google.com/",
-  "readyState": "complete",
-  "activeTab": { "id": "abc123", "port": 9222 }
-}
-```
+> The standalone `get_history` (recent-action ring buffer) and
+> `get_document_state` (active CDP tab state) tools were privatized in the
+> Phase 1–4 consolidation. The same data is now opt-in on any response via the
+> `include` argument (`your_last_action` / `events` / the `working` /
+> `episodic` memory layers, since v1.2/v1.3), and active-tab state comes back
+> from `browser_open` / `browser_eval`.
 
 ---
 
@@ -508,6 +515,30 @@ wait_until(condition="element_matches",         target={windowTitle:"Notepad", s
 
 ### 🖥️ Terminal
 
+`terminal` is a unified dispatcher over `run` / `read` / `send`.
+
+#### `terminal(action='run')`
+Sends a command, waits for it to complete, and reads the output in one call. How
+"complete" is decided is controlled by `until`:
+
+| Mode | Waits for | Best for |
+|---|---|---|
+| `quiet` (default) | output to fall silent for `quietMs` | short interactive commands |
+| `pattern` | a string/regex you expect in the output (optional `quietMs` settle fallback) | long commands with a known final marker |
+| `exit` | the command to actually **finish** — returns the real process exit code | when you need completion or the exit code |
+
+`mode:'exit'` appends a completion marker whose *printed* form differs from its
+*typed* form, so it never matches the echoed command line (even for multi-line
+input). Pass `shell` explicitly (`'bash'` / `'powershell'`); `cmd.exe` is not yet
+supported. Unsafe input (unterminated quote / here-doc / `$(…)` / trailing `\` or
+backtick) is rejected up front rather than hanging.
+
+```js
+terminal({ action:'run', windowTitle:'pwsh', input:'npm run build',
+           until:{ mode:'exit', shell:'powershell' } })
+// → completion: { reason:'exited', exitCode:0, elapsedMs:… }, output: real output only
+```
+
 #### `terminal(action='read')`
 Reads the current buffer of PowerShell / cmd / Windows Terminal via UIA `TextPattern`, falling back to OCR.
 
@@ -516,25 +547,42 @@ Reads the current buffer of PowerShell / cmd / Windows Terminal via UIA `TextPat
 ```
 
 #### `terminal(action='send')`
-Sends input to a terminal (SendKeys). `waitForPrompt` blocks until the next prompt reappears.
+Sends raw input to a terminal. `waitForPrompt` blocks until the next prompt reappears.
 
 ---
 
-### 📡 Async events
+### 📊 Office (Excel)
 
-#### `events_subscribe`
-Subscribe to window / focus / browser-navigation changes. Returns a `subscriptionId`.
+#### `excel`
+Author and run Excel VBA macros over COM late binding — the headline differentiator
+against formula-only assistants that cannot execute VBA.
 
-#### `events_poll`
-Drain the queue for a subscription (up to `maxEvents`). Long-poll style.
+- `action='run_vba'` writes a `Sub` into a managed Trusted Location
+  (`%LOCALAPPDATA%\desktop-touch-mcp\trusted-vba`), opens it, and `Application.Run`s
+  the macro. `macroName` must appear as `Sub <name>(…)` in `code` (else
+  `VbaMacroNotFound`).
+- `action='check_access_vbom'` is a read-only preflight returning
+  `{ trusted, lockedByPolicy, scope }` — run it first so the remediation hint
+  pre-empts an opaque COM failure inside `run_vba`.
+- One-time setup: `node scripts/enable-access-vbom.mjs` registers the Trusted
+  Location and the required HKCU trust keys; Excel must be restarted afterwards.
+  Excel COM is single-threaded, so calls serialise through the bridge's worker
+  thread.
 
-#### `events_unsubscribe`
-Drop a subscription.
+```js
+excel({ action:'check_access_vbom' })                       // → { trusted:true, scope:'hkcu' }
+excel({ action:'run_vba',
+        code:'Sub Demo()\n  Range("A1").Value = "Hello"\nEnd Sub' })
+```
 
-#### `events_list`
-List active subscriptions.
+---
 
-**Event kinds:** `window_appeared` / `window_disappeared` / `window_moved` / `focus_changed` / `browser_navigated`
+### 🩺 Diagnostics
+
+#### `server_status`
+Reports native-engine health and feature activation — whether the Rust UIA / image
+engine loaded, which fallbacks are active, and version / capability flags. Use it to
+confirm the native path is live (vs the PowerShell fallback) when latency looks off.
 
 ---
 
@@ -576,7 +624,10 @@ Also **ARIA-aware**: surfaces `role=switch` / `checkbox` / `radio` / `tab` / `me
 **Form-state verification (preferred over screenshot for button/toggle state):** Call this after form submission to check button, checkbox, and ARIA toggle states — structured JSON, no image tokens. For inputs, `text` reflects the empty-field hint text when set (takes priority over any typed value); to read the actual typed content use `browser_eval('document.querySelector(sel).value')`.
 
 #### `browser_fill`
-Fill a React/Vue/Svelte controlled input via CDP without breaking framework state. Uses native prototype setter + `InputEvent` dispatch (not `execCommand`). Obtain `selector` from `browser_overview` or `browser_locate` first. `actual` in the response reflects what the element's `value` property reads after fill — verify it matches. Does not work on `contenteditable` rich-text editors.
+Fill a React/Vue/Svelte controlled input via CDP without breaking framework state. Uses native prototype setter + `InputEvent` dispatch (not `execCommand`). Obtain `selector` from `browser_form` / `browser_overview` / `browser_locate` first. `actual` in the response reflects what the element's `value` property reads after fill — verify it matches. Does not work on `contenteditable` rich-text editors.
+
+#### `browser_form`
+Inspect every form field (`input` / `select` / `textarea` / `button`) inside a CSS-selector container and return each field's name, type, id, current value, hint text, disabled / readOnly state, and resolved label (via `for[id]` → ancestor `<label>` → `aria-labelledby` → `aria-label`). Call this *before* `browser_fill` to discover exact selectors and avoid targeting the wrong input (e.g. a global search bar). `type=hidden` fields are excluded unless `includeHidden:true`.
 
 #### `browser_eval(action:'appState')`
 One CDP call that scans the well-known places SPAs stash their hydration payloads:
@@ -719,53 +770,29 @@ scroll(action='smart')({target: '#footer-nav'})  # detects and compensates autom
 
 ---
 
-### 👁️ Reactive Perception Graph (v0.11)
+### 👁️ Auto-Perception — attention signal & guards
 
-Low-cost situational awareness for repeated desktop actions. Register a perception lens on a target window or browser tab, then pass `lensId` to action tools. The server verifies target identity, focus, readiness, modal obstruction, and click safety before the action, then attaches a compact `post.perception` envelope after the action — without forcing another `screenshot` or `desktop_state` round trip.
+Low-cost situational awareness for repeated desktop actions. This is an **always-on
+internal layer**, not a tool family: every `desktop_state` and `desktop_act`
+response carries an `attention` signal, and action tools auto-guard whenever you
+pass a `windowTitle` / `tabId`. The server verifies target identity, focus,
+readiness, modal obstruction, and click safety *before* the action, then attaches
+a compact `post.perception` envelope *after* it — without forcing another
+`screenshot` or `desktop_state` round trip.
 
-The unit of tracking is a `PerceptionLens`: a live state tracker for one task-relevant target. It is not a screenshot cache and not a raw event stream. It maintains only the structured state needed to decide whether the next action is still safe.
+The internal unit of tracking is a `PerceptionLens`: a live state tracker for one
+task-relevant target. It is not a screenshot cache and not a raw event stream — it
+maintains only the structured state needed to decide whether the next action is
+still safe.
 
-#### `perception_register`
+> **Retired tools:** the explicit `perception_register` / `perception_read` /
+> `perception_forget` / `perception_list` tools were privatized in the Phase 1–4
+> consolidation — manual lens registration is no longer needed. The registry, hot
+> target cache, and sensor loop are unchanged; they are now driven automatically.
+> The `perception://lens/{id}/{summary|guards|debug|events}` MCP resources remain
+> available behind `DESKTOP_TOUCH_PERCEPTION_RESOURCES=1` for inspection.
 
-Register a live perception lens on a target window or browser tab. Returns a `lensId`.
-
-```
-perception_register({
-  name: "editor",
-  target: { kind: "window", match: { titleIncludes: "Notepad" } },
-  guards: ["target.identityStable", "safe.keyboardTarget"],
-  guardPolicy: "block",   // "warn" | "block" (default: "block")
-  maxEnvelopeTokens: 120,
-})
-→ { lensId: "perc-1", seq: 1, digest: "..." }
-```
-
-The server resolves the target (foreground-preferred for duplicate window titles), populates structured fluents, and keeps them fresh through Win32/CDP/UIA sensors. Subsequent action tool calls with `lensId` will:
-1. **Guard check** — refresh relevant state and evaluate guards before the action. If `guardPolicy:"block"` and a guard fails, the action fails closed with `{ok:false, code:"GuardFailed", suggest:[...]}`.
-2. **Envelope** — attach `post.perception` to the success response with attention, guard states, changed fields, and the latest known target state.
-
-#### `perception_read`
-
-Force-refresh a lens and return its current perception envelope. Use when `post.perception.attention` is `dirty`, `stale`, `settling`, `guard_failed`, or `identity_changed`, or when you want fresh structured state without performing an action.
-
-```
-perception_read({ lensId: "perc-1" })
-→ PerceptionEnvelope
-```
-
-#### `perception_forget`
-
-Deregister a lens. When all lenses are deregistered the sensor loop stops automatically.
-
-```
-perception_forget({ lensId: "perc-1" }) → { ok: true }
-```
-
-#### `perception_list`
-
-List all active lenses with their binding, seq, and attention state.
-
-#### Fluents maintained per lens
+#### Fluents tracked per target
 
 | Fluent | What it tracks |
 |---|---|
@@ -816,41 +843,38 @@ List all active lenses with their binding, seq, and attention state.
 #### Usage example
 
 ```
-# Register once
-perception_register({name:"editor", target:{kind:"window", match:{titleIncludes:"Notepad"}}})
-→ {lensId:"perc-1"}
-
-# Pass lensId to any action tool. Guards + envelope are automatic.
-keyboard(action='type')({text:"hello", windowTitle:"Notepad", lensId:"perc-1"})
+# Auto guard: just pass windowTitle. Guards + envelope are automatic.
+keyboard(action='type')({text:"hello", windowTitle:"Notepad"})
 → post.perception: {attention:"ok", guards:{...}, latest:{target:{title, rect, foreground}}}
 
-# When the app restarts (different pid), identity guard fires:
-keyboard(action='type')({text:"x", lensId:"perc-1"})
-→ {ok:false, code:"GuardFailed", suggest:["Re-register lens for the new process instance"]}
+# When the app restarts (different pid), the identity guard fires closed:
+keyboard(action='type')({text:"x", windowTitle:"Notepad"})
+→ {ok:false, code:"GuardFailed", suggest:[...]}
 ```
 
-`lensId` is opt-in on: `keyboard(action='type')`, `keyboard(action='press')`, `mouse_click`, `mouse_drag`, `click_element`, `set_element_value`, `browser_click`, `browser_navigate`, `browser_eval`. Omitting `lensId` preserves existing behavior exactly.
+For advanced pinned-target workflows the `lensId` parameter is still opt-in on:
+`keyboard(action='type')`, `keyboard(action='press')`, `mouse_click`, `mouse_drag`,
+`click_element`, `browser_click`, `browser_navigate`, `browser_eval`, `desktop_act`.
+Omitting `lensId` uses the normal Auto-Perception path.
 
-**Limits:** max 16 active lenses (LRU eviction — see below). Sensor work is staged by cost: cheap Win32/CDP state is refreshed first; UIA focus, OCR, and screenshots remain escalation paths rather than baseline perception. `safe.clickCoordinates` validates window bounds, not pixel-level occlusion.
+**Limits:** max 16 active lenses (LRU eviction). Sensor work is staged by cost:
+cheap Win32/CDP state is refreshed first; UIA focus, OCR, and screenshots remain
+escalation paths rather than baseline perception. `safe.clickCoordinates` validates
+window bounds, not pixel-level occlusion.
 
-#### v0.13 — Auto Perception (v3 closure)
+#### Capabilities surfaced through Auto-Perception
 
-**Auto guard (v0.12+)**: Action tools guard automatically when `windowTitle`/`tabId` is passed — no `perception_register` needed. The `lensId` path remains for advanced pinned-lens workflows.
+**Auto guard**: Action tools guard automatically when `windowTitle` / `tabId` is passed — no manual registration needed. The `lensId` path remains for advanced pinned-target workflows.
 
-**Manual Lens LRU (v0.13)**: Lens eviction is now LRU (least-recently-used). Using a lens via `perception_read`, evaluatePreToolGuards, or buildEnvelopeFor promotes it to MRU. Idle lenses are evicted first. Max 16 unchanged.
+**SuggestedFix**: When a guard blocks with `unsafe_coordinates` / `identity_changed`, the response may carry a one-shot `suggestedFix.fixId` (expires in 15 s). Pass it back to `mouse_click`, `keyboard(action='type')`, `click_element`, or `browser_click` to approve the recovery; the server revalidates the stored target fingerprint (process pid + start-time for windows; a fresh guard for browser tabs) before executing.
 
-**SuggestedFix — all 4 tools (v0.13)**: `fixId` approval is now supported by `mouse_click`, `keyboard(action='type')`, `click_element`, and `browser_click`. The server revalidates the stored target fingerprint (process pid + start-time for windows; subsequent guard for browser tabs) before executing.
+**Target-identity timeline**: The server maintains a per-target semantic event timeline (event kinds such as `target_bound`, `action_succeeded`, `action_blocked`, `title_changed`, `rect_changed`, `foreground_changed`, `navigation`, `modal_appeared`, `identity_changed`, `target_closed`). Storage is a per-target ring (32) plus a global cap (256); sensor events are 200 ms leading-edge debounced. It surfaces via the opt-in `include` envelope (`your_last_action` / `events` / the `episodic` memory layer) and the `perception://lens/{id}/events` resource (flag `DESKTOP_TOUCH_PERCEPTION_RESOURCES=1`).
 
-**Target-Identity Timeline (v0.13)**: The server maintains a per-target semantic event timeline. 13 event kinds (`target_bound`, `action_attempted`, `action_succeeded`, `action_blocked`, `title_changed`, `rect_changed`, `foreground_changed`, `navigation`, `modal_appeared`, `modal_dismissed`, `identity_changed`, `target_closed`, `compacted`). Storage: per-target ring (32), global FIFO cap (256). Sensor events are 200ms leading-edge debounced; action/post events are not. Exposed via:
-- `get_history` → `recentTargetKeys` (3 keys, no event bodies)
-- `perception_read(lensId)` → `recentEvents` (up to 10 per target)
-- `perception://target/{targetKey}/timeline` + `perception://targets/recent` (flag: `DESKTOP_TOUCH_PERCEPTION_RESOURCES=1`)
+**Browser readiness policies**: `browser_click` passes with a warn-note when `readyState !== "complete"` but the selector is already in-viewport (policy: `selectorInViewport`). `browser_navigate` accepts `interactive` (policy: `navigationGate`). `browser_eval` remains strict.
 
-**Browser readiness policies (v0.13)**: `browser_click` passes with a warn-note when `readyState !== "complete"` but the selector is already in-viewport (policy: `selectorInViewport`). `browser_navigate` accepts `interactive` (policy: `navigationGate`). `browser_eval` remains strict.
+**mouse_drag endpoint guard**: Both start and end coordinates are guarded. Cross-window / desktop drags are blocked by default; opt in with `allowCrossWindowDrag:true`.
 
-**mouse_drag endpoint guard (v0.13)**: Both start and end coordinates are guarded. Cross-window / desktop drags blocked by default; opt in with `allowCrossWindowDrag:true`.
-
-**browser_eval structured mode (v0.13)**: Pass `withPerception:true` to receive `{ok, result, post}` JSON instead of raw text. Circular references, functions, and BigInt in eval results are safely serialized via WeakSet-based replacer.
+**browser_eval structured mode**: Pass `withPerception:true` to receive `{ok, result, post}` JSON instead of raw text. Circular references, functions, and BigInt in eval results are safely serialized via a WeakSet-based replacer.
 
 ---
 

--- a/site/README.md
+++ b/site/README.md
@@ -34,6 +34,10 @@ site/
     v1.0-milestone.md
     v1.2-milestone.html
     v1.2-milestone.md
+    v1.4-milestone.html
+    v1.4-milestone.md
+    v1.8-milestone.html
+    v1.8-milestone.md
   assets/
     figures/
     eval/
@@ -71,6 +75,14 @@ site/
   - v1.2 milestone draft
 - `articles/v1.2-milestone.html`
   - published v1.2 milestone page
+- `articles/v1.4-milestone.md`
+  - v1.4 milestone draft
+- `articles/v1.4-milestone.html`
+  - published v1.4 milestone page
+- `articles/v1.8-milestone.md`
+  - v1.8 milestone draft (covers the v1.5–v1.8 arc)
+- `articles/v1.8-milestone.html`
+  - published v1.8 milestone page
 - `assets/figures/`
   - visual drafts and diagrams
 - `assets/eval/`

--- a/site/articles/beyond-coordinate-roulette.html
+++ b/site/articles/beyond-coordinate-roulette.html
@@ -28,7 +28,7 @@
           <a href="./beyond-coordinate-roulette.html">B-C-R</a>
           <a href="./planned-evaluation.html">Evaluation</a>
           <a href="./client-setup.html">Setup</a>
-          <a href="./v1.0-milestone.html">Milestones</a>
+          <a href="./v1.8-milestone.html">Milestones</a>
           <a href="https://github.com/Harusame64/desktop-touch-mcp">GitHub</a>
         </nav>
       </div>

--- a/site/articles/client-setup.html
+++ b/site/articles/client-setup.html
@@ -24,7 +24,7 @@
           <a href="./beyond-coordinate-roulette.html">B-C-R</a>
           <a href="./planned-evaluation.html">Evaluation</a>
           <a href="./client-setup.html">Setup</a>
-          <a href="./v1.0-milestone.html">Milestones</a>
+          <a href="./v1.8-milestone.html">Milestones</a>
           <a href="https://github.com/Harusame64/desktop-touch-mcp">GitHub</a>
         </nav>
       </div>

--- a/site/articles/planned-evaluation.html
+++ b/site/articles/planned-evaluation.html
@@ -24,7 +24,7 @@
           <a href="./beyond-coordinate-roulette.html">B-C-R</a>
           <a href="./planned-evaluation.html">Evaluation</a>
           <a href="./client-setup.html">Setup</a>
-          <a href="./v1.0-milestone.html">Milestones</a>
+          <a href="./v1.8-milestone.html">Milestones</a>
           <a href="https://github.com/Harusame64/desktop-touch-mcp">GitHub</a>
         </nav>
       </div>

--- a/site/articles/reactive-perception-graph.html
+++ b/site/articles/reactive-perception-graph.html
@@ -28,7 +28,7 @@
           <a href="./beyond-coordinate-roulette.html">B-C-R</a>
           <a href="./planned-evaluation.html">Evaluation</a>
           <a href="./client-setup.html">Setup</a>
-          <a href="./v1.0-milestone.html">Milestones</a>
+          <a href="./v1.8-milestone.html">Milestones</a>
           <a href="https://github.com/Harusame64/desktop-touch-mcp">GitHub</a>
         </nav>
       </div>

--- a/site/articles/v1.0-milestone.html
+++ b/site/articles/v1.0-milestone.html
@@ -28,7 +28,7 @@
           <a href="./beyond-coordinate-roulette.html">B-C-R</a>
           <a href="./planned-evaluation.html">Evaluation</a>
           <a href="./client-setup.html">Setup</a>
-          <a href="./v1.4-milestone.html">Milestones</a>
+          <a href="./v1.8-milestone.html">Milestones</a>
           <a href="https://github.com/Harusame64/desktop-touch-mcp">GitHub</a>
         </nav>
       </div>

--- a/site/articles/v1.2-milestone.html
+++ b/site/articles/v1.2-milestone.html
@@ -28,7 +28,7 @@
           <a href="./beyond-coordinate-roulette.html">B-C-R</a>
           <a href="./planned-evaluation.html">Evaluation</a>
           <a href="./client-setup.html">Setup</a>
-          <a href="./v1.4-milestone.html">Milestones</a>
+          <a href="./v1.8-milestone.html">Milestones</a>
           <a href="https://github.com/Harusame64/desktop-touch-mcp">GitHub</a>
         </nav>
       </div>

--- a/site/articles/v1.4-milestone.html
+++ b/site/articles/v1.4-milestone.html
@@ -28,7 +28,7 @@
           <a href="./beyond-coordinate-roulette.html">B-C-R</a>
           <a href="./planned-evaluation.html">Evaluation</a>
           <a href="./client-setup.html">Setup</a>
-          <a href="./v1.4-milestone.html">Milestones</a>
+          <a href="./v1.8-milestone.html">Milestones</a>
           <a href="https://github.com/Harusame64/desktop-touch-mcp">GitHub</a>
         </nav>
       </div>

--- a/site/articles/v1.8-milestone.html
+++ b/site/articles/v1.8-milestone.html
@@ -1,0 +1,167 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>v1.8 Milestone: From Delivery to Completion, and Reaching Deeper Into Apps</title>
+    <meta name="description" content="The v1.5–v1.8 series extend trustworthy delivery into real command completion (terminal exit codes), reach into apps with almost no clickable surface (Excel VBA), and harden how the agent acts and observes." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Manrope:wght@500;700;800&family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../assets/styles.css" />
+    <script defer src="../assets/site.js"></script>
+    <script type="module">
+      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+      mermaid.initialize({ startOnLoad: true, theme: "base", securityLevel: "loose", themeVariables: { primaryColor: "#e8f1ff", primaryTextColor: "#1d2433", primaryBorderColor: "#3141b7", lineColor: "#58657d", secondaryColor: "#f8dfd4", tertiaryColor: "#d7f2ed", fontFamily: "Manrope" } });
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="site-shell">
+        <a class="brand" href="../index.html">
+          <span class="brand-kicker">Milestone</span>
+          <span class="brand-title">v1.8: From Delivery to Completion, and Reaching Deeper Into Apps</span>
+        </a>
+        <nav class="nav-links" aria-label="Main">
+          <a href="../index.html">Home</a>
+          <a href="./reactive-perception-graph.html">RPG</a>
+          <a href="./beyond-coordinate-roulette.html">B-C-R</a>
+          <a href="./planned-evaluation.html">Evaluation</a>
+          <a href="./client-setup.html">Setup</a>
+          <a href="./v1.8-milestone.html">Milestones</a>
+          <a href="https://github.com/Harusame64/desktop-touch-mcp">GitHub</a>
+        </nav>
+      </div>
+    </header>
+
+    <main class="page">
+      <div class="site-shell">
+        <section class="hero-card">
+          <div class="article-hero">
+            <a class="breadcrumb" href="../index.html">← Back to project top</a>
+            <span class="eyebrow">Project Evolution</span>
+            <h1>The v1.8 Milestone</h1>
+            <p class="lead">v1.4 made delivery trustworthy — "did my input arrive?". The v1.5–v1.8 series push the same idea two steps further: from delivery to <em>completion</em> ("did the command actually finish, and did it succeed?"), and into apps that have almost no clickable surface at all.</p>
+          </div>
+          <div class="hero-visual" style="padding-top: 0;">
+            <div class="mermaid-wrap" style="width: 100%;">
+              <pre class="mermaid">graph LR
+    subgraph v120["v1.2: Response deepened"]
+        B[as_of, confidence]
+    end
+
+    subgraph v130["v1.3: Memory added"]
+        D[working / episodic]
+        E[semantic / procedural]
+    end
+
+    subgraph v140["v1.4: Delivery verified"]
+        G[Typed error codes]
+        I[Delivery verification]
+    end
+
+    subgraph v1518["v1.5–v1.8: Completion &amp; reach"]
+        J[excel VBA bridge]
+        K[terminal exit code]
+        L[race-free verify]
+        M[idle dormancy]
+    end
+
+    v120 --&gt; v130 --&gt; v140 --&gt; v1518
+
+    classDef stable fill:#e8f1ff,stroke:#3b6db3,color:#183257;
+    classDef fresh fill:#d7f2ed,stroke:#1f8a70,color:#0e3b30;
+    class B,D,E,G,I stable;
+    class J,K,L,M fresh;</pre>
+            </div>
+          </div>
+        </section>
+
+        <div class="article-layout">
+          <div class="article-main">
+            <section class="article-card">
+              <span class="label warm">The shift</span>
+              <h2>From "my input arrived" to "the work is done".</h2>
+              <p>v1.4 closed the silent-failure gaps in <em>sending</em>: a click reached a live listener, a fill landed its value, a background keystroke entered the target. But the input arriving is not the same as the work finishing. Sending <code>npm run build</code> is delivery; knowing it finished — and whether it exited 0 or 1 — is completion. And some applications, like a spreadsheet, keep their real logic in cells and macros, not in buttons you can click at all. The v1.5–v1.8 series address both.</p>
+            </section>
+
+            <section class="article-card">
+              <span class="label">Key Evolution: Reach (v1.5)</span>
+              <h2>The <code>excel</code> tool — run VBA, not just write formulas.</h2>
+              <p>v1.5 introduces the <code>excel</code> tool: author and run VBA macros against a live Excel instance over COM — the headline differentiator against assistants that write formulas but cannot execute VBA.</p>
+              <pre><code>excel({ action: "run_vba",
+        code: 'Sub Demo()\n  Range("A1").Value = "Hello"\nEnd Sub' })</code></pre>
+              <p><code>action='run_vba'</code> writes a <code>Sub</code> into a managed Trusted Location and runs it; <code>action='check_access_vbom'</code> is a read-only preflight for the one-time trust setup. The bridge <strong>structurally bypasses the VBA Editor UI</strong> — no UIA tree walk, no menu navigation, no coordinate clicks. After a one-time setup (<code>node scripts/enable-access-vbom.mjs</code>), macro execution is a single tool call. The point is reach: operate the application through the interface it actually exposes to code.</p>
+            </section>
+
+            <section class="article-card">
+              <span class="label">Key Evolution: Completion (v1.8)</span>
+              <h2><code>terminal until:{mode:'exit'}</code> — real completion, real exit code.</h2>
+              <p>The older completion modes infer the answer: <code>quiet</code> waits for output to fall silent, <code>pattern</code> waits for a marker you embed. Both struggle with the everyday idiom <code>some-task; echo DONE</code> matched by <code>DONE</code> — the marker also appears in the <em>echoed command line</em>, so a run could report "done" before the command produced a single byte.</p>
+              <pre><code>terminal({ action: "run", windowTitle: "pwsh", input: "npm run build",
+           until: { mode: "exit", shell: "powershell" } })
+// → completion: { reason: "exited", exitCode: 0, elapsedMs: … }</code></pre>
+              <p><code>mode:'exit'</code> removes the guesswork: the server appends a completion marker whose <em>printed</em> form differs from its <em>typed</em> form, so it can never match the echoed command (even across multiple lines), and it returns the real process exit code. Pass <code>shell</code> explicitly — auto-detection cannot see a shell inside SSH or WSL and returns <code>ExitModeShellAmbiguous</code> rather than guess wrong. On classic console (conhost) shells, exit mode now uses a native console paste instead of the clipboard, so your copied content is left intact and multi-line commands no longer drop characters.</p>
+            </section>
+
+            <section class="article-card">
+              <span class="label">Key Evolution: Acting reliably (v1.6–v1.7)</span>
+              <h2>Verification that does not race, and a direct keyboard path.</h2>
+              <ul>
+                <li><strong>Race-free visual verification.</strong> <code>desktop_act</code> confirms a touch by checking whether the target window repainted. When another visual tool ran on the same monitor, Windows could refuse the second concurrent capture and the signal degraded to indeterminate. All screen-capture now flows through one shared owner per monitor, so the verifier and browser/visual tools share a subscription instead of racing — and the observation now populates on the ordinary <code>desktop_discover</code> → <code>desktop_act</code> flow.</li>
+                <li><strong>A first-class <code>keyboard</code> executor.</strong> Text inputs that expose a value pattern advertise <code>keyboard</code> alongside <code>uia</code>, so the agent can inject text directly into RichEdit / Document controls where a name-based UIA requery would fail.</li>
+              </ul>
+            </section>
+
+            <section class="article-card">
+              <span class="label">Key Evolution: Operational trust (v1.7)</span>
+              <h2>Calmer to leave running.</h2>
+              <p><strong>Idle-aware dormancy and a diagnostic log (v1.7.1):</strong> when nothing is happening, background sensor work winds down to keep idle CPU (and fan noise) low, and a diagnostic event log makes sudden-death and slow-path issues observable after the fact.</p>
+              <p><strong>A deliberate-dwell emergency stop (v1.7.2):</strong> the move-to-corner failsafe now requires the cursor to <em>dwell</em>, so a fast drive-by no longer kills the server by accident — while the deliberate gesture still stops it instantly.</p>
+            </section>
+
+            <section class="article-card">
+              <span class="label">Key Evolution: A nudge toward the safer path (v1.8)</span>
+              <h2>A <code>desktop_act</code> hint after typing into native fields.</h2>
+              <p>Type into a native UI text field with <code>keyboard(action='type')</code> and the response now carries an additive <code>advisory</code> pointing at the lease-based <code>desktop_act</code> flow, with a ready-to-run example. <code>desktop_act</code> adds lease verification, modal-blocking detection, and an attention diff that a bare <code>keyboard:type</code> skips. The hint is suppressed for browser/web content and for surfaces where <code>keyboard</code> is genuinely the right tool, so it only appears when <code>desktop_act</code> is the better path — and it is purely additive.</p>
+            </section>
+
+            <section class="article-card">
+              <span class="label warm">Compatibility</span>
+              <h2>Existing callers stay untouched.</h2>
+              <p>Completion modes are opt-in on <code>terminal(action='run')</code>; the default behaviour is unchanged. The <code>desktop_act</code> advisory is additive — responses are identical when no hint applies. The <code>excel</code> tool is new surface, not a change to any existing tool. The new capabilities are paid for only by callers who ask for them.</p>
+              <div class="hero-actions">
+                <a class="button primary" href="https://github.com/Harusame64/desktop-touch-mcp/blob/main/CHANGELOG.md">View Full Changelog</a>
+                <a class="button secondary" href="./v1.4-milestone.html">Read the v1.4 Milestone</a>
+              </div>
+            </section>
+          </div>
+
+          <aside class="article-aside">
+            <div class="aside-card">
+              <h3>Why these together</h3>
+              <p>v1.4 made <em>sending</em> trustworthy. v1.5–v1.8 make <em>finishing</em> trustworthy and extend the agent's reach: a terminal command reports when it finished and what it returned; Excel is driven through VBA over COM, not by poking at the ribbon; visual verification stops racing; and idle dormancy plus a dwell-gated failsafe make the server calmer to leave running.</p>
+              <h3>Release span</h3>
+              <p>The work landed across v1.5.0, v1.6.0, the v1.7 series, and v1.8.0. The full sequence is in the changelog.</p>
+              <h3>Related pages</h3>
+              <ul>
+                <li><a href="../index.html">Project top</a></li>
+                <li><a href="./v1.4-milestone.html">v1.4 milestone</a></li>
+                <li><a href="./v1.2-milestone.html">v1.2 milestone</a></li>
+                <li><a href="./v1.0-milestone.html">v1.0 milestone</a></li>
+                <li><a href="./beyond-coordinate-roulette.html">Beyond Coordinate Roulette</a></li>
+              </ul>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </main>
+
+    <footer class="footer">
+      <div class="site-shell">
+        <span>v1.8 Milestone Article</span>
+        <span>&copy; <span data-year></span> experimental interface work</span>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/site/articles/v1.8-milestone.md
+++ b/site/articles/v1.8-milestone.md
@@ -1,0 +1,88 @@
+---
+title: "v1.8 Milestone — From Delivery to Completion, and Reaching Deeper Into Apps"
+description: "Why the v1.5–v1.8 series extend trustworthy delivery into real command completion (terminal exit codes), reach into apps that have almost no clickable surface (Excel VBA), and harden how the agent acts and observes."
+---
+
+# v1.8 Milestone — From Delivery to Completion, and Reaching Deeper Into Apps
+
+> v1.0 narrowed the surface. v1.2 deepened each response. v1.3 gave the agent a memory of its past calls, and v1.4 made delivery trustworthy — "did my input actually arrive?". The v1.5–v1.8 series push the same idea two steps further: from *delivery* to *completion* ("did the command actually finish, and did it succeed?"), and into apps that have almost no clickable surface at all.
+
+## Where v1.4 left things
+
+v1.4 closed the silent-failure gaps in *sending*. After it, an agent could trust that a click reached a live listener, that a fill landed the value it intended, and that a background keystroke actually entered the target.
+
+But "the input arrived" is not the same as "the work is done". Two gaps remained:
+
+- **Did the command finish?** Sending `npm run build` to a terminal is delivery. Knowing it finished — and whether it exited 0 or 1 — is completion. Until now the agent had to guess completion from output going quiet or from a marker it embedded in the command, and both heuristics misfire on the most common idiom.
+- **What about apps with no surface to click?** A spreadsheet's real logic lives in cells, names, and macros, not in buttons. Driving Excel by clicking the ribbon is slow and brittle, and writing formulas is not the same as *running code* inside the workbook.
+
+The v1.5 through v1.8 releases address both, and harden the act-and-observe loop around them.
+
+## What v1.5 adds — reaching into Excel with VBA
+
+v1.5 introduces the **`excel`** tool: author and run VBA macros against a live Excel instance over COM. This is the headline differentiator against assistants that can write formulas but cannot execute VBA.
+
+```
+excel({
+  action: "run_vba",
+  code: 'Sub Demo()\n  Range("A1").Value = "Hello"\nEnd Sub'
+})
+```
+
+`action='run_vba'` writes a `Sub` into a managed Trusted Location, opens it, and runs the macro; `action='check_access_vbom'` is a read-only preflight that tells you whether the one-time trust setup is in place before you depend on it. The bridge **structurally bypasses the VBA Editor UI** — no UIA tree walk, no menu navigation, no coordinate clicks — using the same COM API that desktop RPA tools use. One-time setup (`node scripts/enable-access-vbom.mjs`) configures the trust keys Excel requires; after that, macro execution is a single tool call.
+
+The point is reach: instead of pretending a spreadsheet is a picture of buttons, the agent operates the application through the interface the application actually exposes to code.
+
+## What v1.8 adds — knowing a command finished, with its exit code
+
+`terminal(action='run')` sends a command, waits, and reads the output in one call. The new piece in v1.8 is **how it decides "done"**:
+
+```
+terminal({ action: "run", windowTitle: "pwsh", input: "npm run build",
+           until: { mode: "exit", shell: "powershell" } })
+// → completion: { reason: "exited", exitCode: 0, elapsedMs: … }
+```
+
+The older completion modes infer the answer: `quiet` waits for output to fall silent, `pattern` waits for a marker you put in the command. Both struggle with the everyday idiom `some-task; echo DONE` matched by `DONE` — because the marker also appears in the *echoed command line*, and for multi-line commands there is no reliable way to tell that echo apart from real output. So a `run` could report "done" before the command had produced a single byte, and callers fell back to a separate `read` — defeating the whole point of `run`.
+
+`until:{mode:'exit'}` removes the guesswork. The server appends its own completion marker whose *printed* form differs from its *typed* form, so it can never match the echoed command (even across multiple lines), and it returns the **real process exit code**. Pass `shell` explicitly (`bash` or `powershell`): auto-detection cannot see a shell running inside SSH or WSL, so it returns `ExitModeShellAmbiguous` rather than guess wrong. `cmd.exe` is not supported yet, and a command that ends mid-construct (an unterminated quote, here-doc, `$(…)`, or a trailing backslash) is rejected up front instead of hanging.
+
+Two related fixes round out the terminal work: `mode:'pattern'` now anchors past the echoed command so a sentinel matches only when the command genuinely prints it, and it accepts an optional `quietMs` settle fallback so a command that finishes without ever printing the pattern no longer hangs until the timeout. Use `mode:'exit'` for completion and exit status; keep `mode:'pattern'` for matching output mid-run.
+
+On classic console (conhost) shells, sending the command in exit mode now uses a native console paste instead of routing text through the Windows clipboard — your copied content is left intact, and characters are no longer dropped from multi-line commands.
+
+## What v1.6 and v1.7 add — acting reliably, and watching the cost
+
+The middle of the series hardens the act-and-observe loop that everything else rides on.
+
+- **Race-free visual verification (v1.7).** `desktop_act` confirms a touch by checking whether the target window actually repainted. When another visual tool (a browser command, a screenshot) was running on the same monitor, Windows could refuse the second concurrent screen-capture and the "did the pixels change?" signal degraded to indeterminate. All screen-capture now flows through a single shared owner per monitor, so `desktop_act`'s verifier and the browser/visual tools share one subscription instead of racing. The same release also populates that observation on the ordinary `desktop_discover` → `desktop_act` flow, not only when the caller pinned a window handle.
+- **A first-class `keyboard` executor (v1.7).** Text inputs that expose a value pattern now advertise `keyboard` alongside `uia` as a preferred executor, so the agent can inject text directly into RichEdit / Document controls (such as Notepad's editor) where a name-based UIA requery would fail.
+- **Idle-aware dormancy and a diagnostic log (v1.7.1).** When nothing is happening, background sensor work winds down to keep idle CPU (and fan noise) low; a diagnostic event log makes sudden-death and slow-path issues observable after the fact.
+- **A deliberate-dwell emergency stop (v1.7.2).** The move-to-corner failsafe now requires the cursor to *dwell*, so a fast drive-by through the corner no longer kills the server by accident — while the deliberate gesture still stops it instantly.
+
+## What v1.8 adds — a nudge toward the safer path
+
+When you type into a native UI text field with `keyboard(action='type')`, the response now carries an additive **advisory** pointing at the lease-based `desktop_act` flow, with a ready-to-run example. `desktop_act` adds lease verification, modal-blocking detection, and an attention diff that a bare `keyboard:type` skips. The hint is suppressed for browser/web content and for surfaces where `keyboard` is genuinely the right tool, so it only appears when `desktop_act` is the better path. It is purely additive — responses are unchanged when no hint applies.
+
+## Why these together
+
+v1.4 made *sending* trustworthy. v1.5–v1.8 make *finishing* trustworthy and extend the agent's reach:
+
+- **Completion, not just delivery** — a terminal command reports when it actually finished and what it returned.
+- **Reach, not just clicks** — Excel is driven through VBA over COM, not by poking at the ribbon.
+- **Reliable acting** — visual verification stops racing, and a direct keyboard executor handles controls UIA cannot re-find.
+- **Operational trust** — idle dormancy, a diagnostic log, and a dwell-gated failsafe make the server calmer to leave running.
+
+The direction is the same one every release has followed: a little further from "infer, hope, retry" toward "observe, verify, decide".
+
+## Conclusion
+
+v1.0 narrowed the surface so each call meant more. v1.2 deepened the response. v1.3 made the agent's past calls a queryable resource. v1.4 closed the gaps where a send could appear to succeed while doing nothing. v1.5–v1.8 carry that promise from delivery through to completion — and reach into the parts of an application a screenshot can never click.
+
+## Next Steps
+
+- View the full [Changelog on GitHub](https://github.com/Harusame64/desktop-touch-mcp/blob/main/CHANGELOG.md)
+- Read the [v1.4 milestone article](./v1.4-milestone.html) — how delivery became trustworthy
+- Read the [v1.2 milestone article](./v1.2-milestone.html) — how the response was deepened
+- Read the [v1.0 milestone article](./v1.0-milestone.html) — how the surface was narrowed
+- Read [Beyond Coordinate Roulette](./beyond-coordinate-roulette.html) — why operating by meaning beats operating by pixels

--- a/site/index.html
+++ b/site/index.html
@@ -28,7 +28,7 @@
           <a href="./articles/beyond-coordinate-roulette.html">B-C-R</a>
           <a href="./articles/planned-evaluation.html">Evaluation</a>
           <a href="./articles/client-setup.html">Setup</a>
-          <a href="./articles/v1.4-milestone.html">Milestones</a>
+          <a href="./articles/v1.8-milestone.html">Milestones</a>
           <a href="https://github.com/Harusame64/desktop-touch-mcp">GitHub</a>
         </nav>
       </div>
@@ -102,6 +102,10 @@
             <h2>Project Milestones</h2>
             <p>As the project evolves, we document major architectural shifts and milestones here.</p>
             <div class="three-up">
+              <a class="mini-card" href="./articles/v1.8-milestone.html">
+                <h3>v1.8: From Delivery to Completion, and Reaching Deeper Into Apps</h3>
+                <p>Trustworthy delivery extends into trustworthy completion: <code>terminal(action='run')</code> can wait for a command to finish and report its real exit code, the new <code>excel</code> tool runs VBA over COM, and the act-and-observe loop gains race-free visual verification, idle-aware CPU dormancy, a diagnostic log, and a deliberate-dwell emergency stop.</p>
+              </a>
               <a class="mini-card" href="./articles/v1.4-milestone.html">
                 <h3>v1.4: From Observation to Memory and Trustworthy Delivery</h3>
                 <p>Four cognitive memory layers the agent can re-query (<code>working</code>, <code>episodic</code>, <code>semantic</code>, <code>procedural</code>) plus delivery verification that closes the silent-failure paths in browser, terminal, and keyboard sends. Plus typed error codes for refusals and a new opt-in <code>foreground_flash</code> channel for Windows Terminal.</p>
@@ -214,7 +218,7 @@ act</pre></div>
             <span class="label warm">Explore</span>
             <h2>Where to go next</h2>
             <div class="three-up">
-              <a class="mini-card" href="./articles/v1.4-milestone.html"><h3>v1.4 Milestone</h3><p>Cognitive memory layers and delivery verification — agents can re-query their past calls and trust the verdict on whether each one worked.</p></a>
+              <a class="mini-card" href="./articles/v1.8-milestone.html"><h3>v1.8 Milestone</h3><p>From delivery to completion: terminal exit codes, the Excel VBA bridge, and a hardened act-and-observe loop.</p></a>
               <a class="mini-card" href="./articles/reactive-perception-graph.html"><h3>RPG explainer</h3><p>A diagram-heavy walkthrough of why stale assumptions matter and how RPG responds.</p></a>
               <a class="mini-card" href="./articles/beyond-coordinate-roulette.html"><h3>Beyond Coordinate Roulette</h3><p>The philosophy piece behind entity-first, meaning-first UI interaction.</p></a>
             </div>

--- a/site/index.md
+++ b/site/index.md
@@ -98,6 +98,10 @@ It is trying to document an active line of engineering and research.
 
 As the project evolves, we document major architectural shifts and milestones here.
 
+### v1.8: From Delivery to Completion, and Reaching Deeper Into Apps
+The v1.5–v1.8 series extend trustworthy *delivery* into trustworthy *completion*. `terminal(action='run')` can now wait for a command to actually finish and report its real exit code (`until:{mode:'exit'}`), the new `excel` tool runs VBA macros over COM where formula-only tools can't, and the act-and-observe loop is hardened with race-free visual verification, idle-aware CPU dormancy, a diagnostic event log, and a deliberate-dwell emergency stop.
+- [Read the v1.8 Milestone Article](./articles/v1.8-milestone.html)
+
 ### v1.4: From Observation to Memory and Trustworthy Delivery
 The v1.3 and v1.4 series add two things on top of v1.2's per-response context: four cognitive memory layers the agent can re-query (`working`, `episodic`, `semantic`, `procedural`), and delivery verification that closes the silent-failure paths in browser, terminal, and keyboard sends. Plus typed error codes for refusals and a new opt-in `foreground_flash` channel for Windows Terminal.
 - [Read the v1.4 Milestone Article](./articles/v1.4-milestone.html)

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -30,6 +30,10 @@
   </url>
   <url>
     <loc>https://harusame64.github.io/desktop-touch-mcp/articles/v1.4-milestone.html</loc>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://harusame64.github.io/desktop-touch-mcp/articles/v1.8-milestone.html</loc>
     <priority>0.8</priority>
   </url>
 </urlset>


### PR DESCRIPTION
User-facing docs were stale relative to the shipped v1.8 surface. This brings README, the system-overview reference, the GitHub repo metadata, and the public site up to date. Docs-only; no code changes.

## What changed
- **README**: tool count 28 → 29, add the `excel` tool, headline discover-then-act + perception guards, and drop the v0.13-era sections that documented privatized `perception_*` / `get_history` tools as if public.
- **docs/system-overview.md**: rewrite the tool catalogue to the current 29-tool surface (add World-Graph V2, excel, server_status, browser_form; expand terminal `run`/`until`; reframe perception as the internal Auto-Perception layer; fix the architecture diagram, absolute paths, and internal jargon).
- **GitHub repo** (already applied): description + topics modernized (discover-then-act, leases, perception guards; added `cdp` / `claude-code`).
- **site/**: new v1.8 milestone (md + html) covering the v1.5–v1.8 arc, index milestone card, unified "Milestones" nav, sitemap, and site/README listing.

## Review
Each phase was reviewed by Opus (review-only); all findings resolved (system-overview took 2 rounds for the perception-resource flag gating + keyboard `sequence` gaps). Historical "28 tools" wording in the v1.0/v1.2 milestone articles is intentionally preserved (correct for those releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)