### PR TITLE
docs(release): note npx smoke test must run outside project dir

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -455,6 +455,14 @@ rm -rf "$USERPROFILE/.desktop-touch-mcp/releases/vX.Y.Z"
 npm cache clean --force
 
 # 2. Download via npx and verify --help
+#    ⚠️ Run this from a cwd OUTSIDE the project source dir (e.g. `cd $env:TEMP` first).
+#    The project's own package.json has name=@harusame64/desktop-touch-mcp; once its
+#    version equals the just-published X.Y.Z, running npx from the project root makes
+#    npx resolve the LOCAL (uninstalled) package instead of the registry one and fail
+#    with "'desktop-touch-mcp' is not recognized as an internal or external command".
+#    That is a false negative (wrong cwd), NOT a release bug — re-run from $env:TEMP.
+#    (`npx @...@<older-version>` works from the project root because the local version
+#    no longer satisfies the spec, which is why a 1.7.2 cross-check can mislead.)
 npx -y @harusame64/desktop-touch-mcp@X.Y.Z --help
 # Expected: "desktop-touch-mcp vX.Y.Z" and usage text
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -455,12 +455,13 @@ rm -rf "$USERPROFILE/.desktop-touch-mcp/releases/vX.Y.Z"
 npm cache clean --force
 
 # 2. Download via npx and verify --help
-#    ⚠️ Run this from a cwd OUTSIDE the project source dir (e.g. `cd $env:TEMP` first).
+#    ⚠️ Run this from a cwd OUTSIDE the project source dir first
+#    (PowerShell: `cd $env:TEMP`  |  bash: `cd /tmp`).
 #    The project's own package.json has name=@harusame64/desktop-touch-mcp; once its
 #    version equals the just-published X.Y.Z, running npx from the project root makes
 #    npx resolve the LOCAL (uninstalled) package instead of the registry one and fail
 #    with "'desktop-touch-mcp' is not recognized as an internal or external command".
-#    That is a false negative (wrong cwd), NOT a release bug — re-run from $env:TEMP.
+#    That is a false negative (wrong cwd), NOT a release bug — re-run from a temp dir.
 #    (`npx @...@<older-version>` works from the project root because the local version
 #    no longer satisfies the spec, which is why a 1.7.2 cross-check can mislead.)
 npx -y @harusame64/desktop-touch-mcp@X.Y.Z --help


### PR DESCRIPTION
## What
Adds a note to the Smoke Test section of `docs/release-process.md`: the post-publish `npx` smoke test must be run from a cwd **outside** the project source dir (e.g. `cd \$env:TEMP` first).

## Why
During the v1.8.0 release, the smoke test failed with `"'desktop-touch-mcp' is not recognized as an internal or external command"`. Root cause: once the project's own `package.json` version equals the just-published `X.Y.Z`, running `npx` from the project root resolves the **local (uninstalled)** package instead of the registry one. This is a false negative caused by cwd, not a release bug — re-running from `\$env:TEMP` succeeds.

This was the leftover learning from the v1.8.0 release that hadn't been committed yet.

## Scope
Docs-only, single self-contained note. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)