### PR TITLE
refactor(browser): ADR-023 Phase 1 trunk — extract resolver candidate-collection (bit-equal)

### DIFF
--- a/src/tools/browser-resolver.ts
+++ b/src/tools/browser-resolver.ts
@@ -1,0 +1,228 @@
+/**
+ * browser-resolver.ts — ADR-023 Phase 1 resolver core.
+ *
+ * The shared injected-JS builder for semantic element resolution. Phase 1 trunk
+ * (S1/S7) extracts the candidate-collection IIFE VERBATIM from browser_search so
+ * `browser_search` stays bit-equal (snapshot-pinned by
+ * tests/unit/browser-resolver-candidate-collection.test.ts) while later phases
+ * layer actionability / ancestor climb / physical-coord resolution on top for
+ * browser_click({by}) / browser_fill({by}).
+ *
+ * The IIFE returns `{ total, returned, truncated, results[] }` (each result:
+ * type / text / selector / role / ariaLabel / matchedBy / confidence /
+ * inViewport / rect) or `{ __error }` (ScopeNotFound / InvalidRegex / Timeout).
+ *
+ * Plan: desktop-touch-mcp-internal:docs/adr-023-phase-1-resolver-plan.md S1/S7.
+ */
+
+export interface CandidateCollectionArgs {
+  by: "text" | "regex" | "role" | "ariaLabel" | "selector";
+  pattern: string;
+  scope?: string;
+  maxResults: number;
+  offset: number;
+  visibleOnly: boolean;
+  inViewportOnly: boolean;
+  caseSensitive: boolean;
+}
+
+/**
+ * Build the injected-JS IIFE that collects, scores, filters and shapes candidate
+ * elements for `browser_search`. This is a VERBATIM extraction of the former
+ * inline template in `browserSearchHandler` — the generated string is byte-equal
+ * (pinned by snapshot) so the public `browser_search` contract is unchanged
+ * (NFR-1 / AC-9). Do not change the emitted JS without updating the snapshot.
+ */
+export function buildCandidateCollectionJs(args: CandidateCollectionArgs): string {
+  const { by, pattern, scope, maxResults, offset, visibleOnly, inViewportOnly, caseSensitive } = args;
+  return `
+(function() {
+  const root = ${scope ? `document.querySelector(${JSON.stringify(scope)})` : "document"};
+  if (!root) return { __error: "ScopeNotFound" };
+
+  const by = ${JSON.stringify(by)};
+  const pat = ${JSON.stringify(pattern)};
+  const cs  = ${JSON.stringify(caseSensitive)};
+  const visibleOnly = ${JSON.stringify(visibleOnly)};
+  const viewportOnly = ${JSON.stringify(inViewportOnly)};
+  const maxN = ${JSON.stringify(maxResults + offset)};
+  const offN = ${JSON.stringify(offset)};
+
+  function isVisible(el) {
+    const s = window.getComputedStyle(el);
+    if (s.display === 'none' || s.visibility === 'hidden' || s.opacity === '0') return false;
+    const r = el.getBoundingClientRect();
+    return r.width > 0 && r.height > 0;
+  }
+  function inViewportRect(rect) {
+    return rect.top < window.innerHeight && rect.bottom > 0 &&
+           rect.left < window.innerWidth && rect.right > 0;
+  }
+  function bestSelector(el) {
+    if (el.id) return '#' + CSS.escape(el.id);
+    const name = el.getAttribute('name');
+    if (name) return el.tagName.toLowerCase() + '[name=' + JSON.stringify(name) + ']';
+    const aria = el.getAttribute('aria-label');
+    if (aria && aria.length < 80)
+      return el.tagName.toLowerCase() + '[aria-label=' + JSON.stringify(aria) + ']';
+    for (const attr of ['data-testid', 'data-asin']) {
+      const v = el.getAttribute(attr);
+      if (v && v.length < 60) return el.tagName.toLowerCase() + '[' + attr + '=' + JSON.stringify(v) + ']';
+    }
+    let node = el; let path = '';
+    for (let depth = 0; depth < 2 && node.parentElement; depth++) {
+      const p = node.parentElement;
+      const idx = Array.from(p.children).indexOf(node) + 1;
+      const seg = node.tagName.toLowerCase() + ':nth-child(' + idx + ')';
+      path = path ? seg + ' > ' + path : seg;
+      if (p.id) { path = '#' + CSS.escape(p.id) + ' > ' + path; break; }
+      node = p;
+    }
+    return path || el.tagName.toLowerCase();
+  }
+  function classify(el) {
+    const tag = el.tagName.toLowerCase();
+    if (tag === 'a') return 'link';
+    if (tag === 'button' || el.getAttribute('role') === 'button') return 'button';
+    if (tag === 'input' || tag === 'textarea' || tag === 'select') return 'input';
+    if (/^h[1-6]$/.test(tag)) return 'heading';
+    if (tag === 'p' || tag === 'span' || tag === 'div') return 'text';
+    return 'other';
+  }
+  function elText(el) {
+    const t = (el.textContent || '').trim().replace(/\\s+/g, ' ').slice(0, 80);
+    if (!t && el.tagName === 'INPUT')
+      return (el.placeholder || el.value || el.getAttribute('aria-label') || '').slice(0, 80);
+    return t;
+  }
+  function score(matched, visible) {
+    let s = matched;
+    if (!visible) s = Math.max(0, s - 0.3);
+    return Math.round(s * 100) / 100;
+  }
+
+  // Bound the scan — pages can have 10k+ nodes and CDP timeout is 15s.
+  const SCAN_BUDGET_MS = 3000;
+  const nowFn = (typeof performance !== 'undefined' ? () => performance.now() : () => Date.now());
+  const startTs = nowFn();
+  const deadline = startTs + SCAN_BUDGET_MS;
+  let aborted = false;
+  // Sample the clock every 1024 iterations — cheap but keeps latency bounded.
+  function overBudget(i) { return (i & 0x3FF) === 0 && nowFn() > deadline; }
+
+  // IIFE-local match-state stores. WeakMap is essential: DOM elements persist
+  // across Runtime.evaluate calls, so any expando we set (e.g. el.__matchScore)
+  // would leak into the next search and contaminate scores / matchedBy / dedupe.
+  // WeakMap is GC'd at IIFE end so each call starts clean.
+  const matchScore = new WeakMap();
+  const matchedByMap = new WeakMap();
+  const pushed = new Set();
+  function record(el, score, by) {
+    const prev = matchScore.get(el) || 0;
+    if (score > prev) { matchScore.set(el, score); matchedByMap.set(el, by); }
+    if (!pushed.has(el)) { candidates.push(el); pushed.add(el); }
+  }
+
+  const all = root.querySelectorAll('*');
+  let candidates = [];
+
+  if (by === 'selector') {
+    const selectorMatches = Array.from(root.querySelectorAll(pat));
+    for (let i = 0; i < selectorMatches.length; i++) {
+      if (overBudget(i)) { aborted = true; break; }
+      record(selectorMatches[i], 1.0, 'selector');
+    }
+  } else if (by === 'text') {
+    const needle = cs ? pat : pat.toLowerCase();
+    let i = 0;
+    for (const el of all) {
+      if (overBudget(i++)) { aborted = true; break; }
+      // Direct child text only (avoid double-counting parent matches via descendants)
+      const direct = Array.from(el.childNodes)
+        .filter(n => n.nodeType === 3)
+        .map(n => n.textContent || '')
+        .join('').trim();
+      if (!direct) continue;
+      const hay = cs ? direct : direct.toLowerCase();
+      if (hay === needle) record(el, 1.0, 'text');
+      else if (hay.includes(needle)) record(el, 0.8, 'text');
+    }
+  } else if (by === 'regex') {
+    let re;
+    try { re = new RegExp(pat, (cs ? '' : 'i') + 'u'); }
+    catch (e) { return { __error: "InvalidRegex", message: String(e) }; }
+    let i = 0;
+    for (const el of all) {
+      if (overBudget(i++)) { aborted = true; break; }
+      const direct = Array.from(el.childNodes).filter(n => n.nodeType === 3).map(n => n.textContent || '').join('').trim();
+      if (!direct) continue;
+      if (re.test(direct)) record(el, 0.9, 'regex');
+    }
+  } else if (by === 'role') {
+    const needle = cs ? pat : pat.toLowerCase();
+    let i = 0;
+    for (const el of all) {
+      if (overBudget(i++)) { aborted = true; break; }
+      const role = el.getAttribute('role') || '';
+      const cmp = cs ? role : role.toLowerCase();
+      if (cmp === needle) record(el, 0.75, 'role');
+    }
+    // Implicit roles — score slightly higher because they're guaranteed by tag.
+    if (!aborted && needle === 'button')  for (const el of root.querySelectorAll('button')) record(el, 0.85, 'roleImplicit');
+    if (!aborted && needle === 'link')    for (const el of root.querySelectorAll('a[href]')) record(el, 0.85, 'roleImplicit');
+    if (!aborted && needle === 'heading') for (const el of root.querySelectorAll('h1,h2,h3,h4,h5,h6')) record(el, 0.85, 'roleImplicit');
+  } else if (by === 'ariaLabel') {
+    const needle = cs ? pat : pat.toLowerCase();
+    let i = 0;
+    for (const el of all) {
+      if (overBudget(i++)) { aborted = true; break; }
+      const aria = el.getAttribute('aria-label') || '';
+      if (!aria) continue;
+      const cmp = cs ? aria : aria.toLowerCase();
+      if (cmp === needle) record(el, 0.95, 'ariaLabel');
+      else if (cmp.includes(needle)) record(el, 0.7, 'ariaLabel');
+    }
+  }
+
+  // candidates already de-duplicated via the pushed Set in record()
+
+  if (aborted && candidates.length === 0) {
+    return { __error: "Timeout", message: "Scan budget exceeded with no matches; narrow scope or maxResults." };
+  }
+
+  const filtered = [];
+  for (const el of candidates) {
+    const visible = isVisible(el);
+    if (visibleOnly && !visible) continue;
+    const rect = el.getBoundingClientRect();
+    const inVp = inViewportRect(rect);
+    if (viewportOnly && !inVp) continue;
+    filtered.push({ el, visible, rect, inVp });
+  }
+
+  // Score and sort by confidence desc
+  filtered.sort((a, b) => {
+    const sa = score(matchScore.get(a.el) || 0, a.visible);
+    const sb = score(matchScore.get(b.el) || 0, b.visible);
+    return sb - sa;
+  });
+
+  const total = filtered.length;
+  const sliced = filtered.slice(offN, offN + (maxN - offN));
+
+  const results = sliced.map(({ el, visible, rect, inVp }) => ({
+    type: classify(el),
+    text: elText(el),
+    selector: bestSelector(el),
+    role: el.getAttribute('role') || undefined,
+    ariaLabel: el.getAttribute('aria-label') || undefined,
+    matchedBy: matchedByMap.get(el),
+    confidence: score(matchScore.get(el) || 0, visible),
+    inViewport: inVp,
+    rect: { x: Math.round(rect.left), y: Math.round(rect.top), w: Math.round(rect.width), h: Math.round(rect.height) },
+  }));
+
+  return { total, returned: results.length, truncated: total > offN + results.length, results };
+})()
+`;
+}

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -28,6 +28,7 @@ import type { RichBlock } from "../engine/uia-diff.js";
 import { evaluatePreToolGuards, buildEnvelopeFor } from "../engine/perception/registry.js";
 import { runActionGuard, isAutoGuardEnabled, validateAndPrepareFix, consumeFix } from "./_action-guard.js";
 import { prepareBrowserEvalExpression } from "./browser-eval-helpers.js";
+import { buildCandidateCollectionJs } from "./browser-resolver.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Schemas
@@ -2062,196 +2063,14 @@ export const browserSearchHandler = async ({
   port: number;
 }): Promise<ToolResult> => {
   try {
-    const expression = `
-(function() {
-  const root = ${scope ? `document.querySelector(${JSON.stringify(scope)})` : "document"};
-  if (!root) return { __error: "ScopeNotFound" };
-
-  const by = ${JSON.stringify(by)};
-  const pat = ${JSON.stringify(pattern)};
-  const cs  = ${JSON.stringify(caseSensitive)};
-  const visibleOnly = ${JSON.stringify(visibleOnly)};
-  const viewportOnly = ${JSON.stringify(inViewportOnly)};
-  const maxN = ${JSON.stringify(maxResults + offset)};
-  const offN = ${JSON.stringify(offset)};
-
-  function isVisible(el) {
-    const s = window.getComputedStyle(el);
-    if (s.display === 'none' || s.visibility === 'hidden' || s.opacity === '0') return false;
-    const r = el.getBoundingClientRect();
-    return r.width > 0 && r.height > 0;
-  }
-  function inViewportRect(rect) {
-    return rect.top < window.innerHeight && rect.bottom > 0 &&
-           rect.left < window.innerWidth && rect.right > 0;
-  }
-  function bestSelector(el) {
-    if (el.id) return '#' + CSS.escape(el.id);
-    const name = el.getAttribute('name');
-    if (name) return el.tagName.toLowerCase() + '[name=' + JSON.stringify(name) + ']';
-    const aria = el.getAttribute('aria-label');
-    if (aria && aria.length < 80)
-      return el.tagName.toLowerCase() + '[aria-label=' + JSON.stringify(aria) + ']';
-    for (const attr of ['data-testid', 'data-asin']) {
-      const v = el.getAttribute(attr);
-      if (v && v.length < 60) return el.tagName.toLowerCase() + '[' + attr + '=' + JSON.stringify(v) + ']';
-    }
-    let node = el; let path = '';
-    for (let depth = 0; depth < 2 && node.parentElement; depth++) {
-      const p = node.parentElement;
-      const idx = Array.from(p.children).indexOf(node) + 1;
-      const seg = node.tagName.toLowerCase() + ':nth-child(' + idx + ')';
-      path = path ? seg + ' > ' + path : seg;
-      if (p.id) { path = '#' + CSS.escape(p.id) + ' > ' + path; break; }
-      node = p;
-    }
-    return path || el.tagName.toLowerCase();
-  }
-  function classify(el) {
-    const tag = el.tagName.toLowerCase();
-    if (tag === 'a') return 'link';
-    if (tag === 'button' || el.getAttribute('role') === 'button') return 'button';
-    if (tag === 'input' || tag === 'textarea' || tag === 'select') return 'input';
-    if (/^h[1-6]$/.test(tag)) return 'heading';
-    if (tag === 'p' || tag === 'span' || tag === 'div') return 'text';
-    return 'other';
-  }
-  function elText(el) {
-    const t = (el.textContent || '').trim().replace(/\\s+/g, ' ').slice(0, 80);
-    if (!t && el.tagName === 'INPUT')
-      return (el.placeholder || el.value || el.getAttribute('aria-label') || '').slice(0, 80);
-    return t;
-  }
-  function score(matched, visible) {
-    let s = matched;
-    if (!visible) s = Math.max(0, s - 0.3);
-    return Math.round(s * 100) / 100;
-  }
-
-  // Bound the scan — pages can have 10k+ nodes and CDP timeout is 15s.
-  const SCAN_BUDGET_MS = 3000;
-  const nowFn = (typeof performance !== 'undefined' ? () => performance.now() : () => Date.now());
-  const startTs = nowFn();
-  const deadline = startTs + SCAN_BUDGET_MS;
-  let aborted = false;
-  // Sample the clock every 1024 iterations — cheap but keeps latency bounded.
-  function overBudget(i) { return (i & 0x3FF) === 0 && nowFn() > deadline; }
-
-  // IIFE-local match-state stores. WeakMap is essential: DOM elements persist
-  // across Runtime.evaluate calls, so any expando we set (e.g. el.__matchScore)
-  // would leak into the next search and contaminate scores / matchedBy / dedupe.
-  // WeakMap is GC'd at IIFE end so each call starts clean.
-  const matchScore = new WeakMap();
-  const matchedByMap = new WeakMap();
-  const pushed = new Set();
-  function record(el, score, by) {
-    const prev = matchScore.get(el) || 0;
-    if (score > prev) { matchScore.set(el, score); matchedByMap.set(el, by); }
-    if (!pushed.has(el)) { candidates.push(el); pushed.add(el); }
-  }
-
-  const all = root.querySelectorAll('*');
-  let candidates = [];
-
-  if (by === 'selector') {
-    const selectorMatches = Array.from(root.querySelectorAll(pat));
-    for (let i = 0; i < selectorMatches.length; i++) {
-      if (overBudget(i)) { aborted = true; break; }
-      record(selectorMatches[i], 1.0, 'selector');
-    }
-  } else if (by === 'text') {
-    const needle = cs ? pat : pat.toLowerCase();
-    let i = 0;
-    for (const el of all) {
-      if (overBudget(i++)) { aborted = true; break; }
-      // Direct child text only (avoid double-counting parent matches via descendants)
-      const direct = Array.from(el.childNodes)
-        .filter(n => n.nodeType === 3)
-        .map(n => n.textContent || '')
-        .join('').trim();
-      if (!direct) continue;
-      const hay = cs ? direct : direct.toLowerCase();
-      if (hay === needle) record(el, 1.0, 'text');
-      else if (hay.includes(needle)) record(el, 0.8, 'text');
-    }
-  } else if (by === 'regex') {
-    let re;
-    try { re = new RegExp(pat, (cs ? '' : 'i') + 'u'); }
-    catch (e) { return { __error: "InvalidRegex", message: String(e) }; }
-    let i = 0;
-    for (const el of all) {
-      if (overBudget(i++)) { aborted = true; break; }
-      const direct = Array.from(el.childNodes).filter(n => n.nodeType === 3).map(n => n.textContent || '').join('').trim();
-      if (!direct) continue;
-      if (re.test(direct)) record(el, 0.9, 'regex');
-    }
-  } else if (by === 'role') {
-    const needle = cs ? pat : pat.toLowerCase();
-    let i = 0;
-    for (const el of all) {
-      if (overBudget(i++)) { aborted = true; break; }
-      const role = el.getAttribute('role') || '';
-      const cmp = cs ? role : role.toLowerCase();
-      if (cmp === needle) record(el, 0.75, 'role');
-    }
-    // Implicit roles — score slightly higher because they're guaranteed by tag.
-    if (!aborted && needle === 'button')  for (const el of root.querySelectorAll('button')) record(el, 0.85, 'roleImplicit');
-    if (!aborted && needle === 'link')    for (const el of root.querySelectorAll('a[href]')) record(el, 0.85, 'roleImplicit');
-    if (!aborted && needle === 'heading') for (const el of root.querySelectorAll('h1,h2,h3,h4,h5,h6')) record(el, 0.85, 'roleImplicit');
-  } else if (by === 'ariaLabel') {
-    const needle = cs ? pat : pat.toLowerCase();
-    let i = 0;
-    for (const el of all) {
-      if (overBudget(i++)) { aborted = true; break; }
-      const aria = el.getAttribute('aria-label') || '';
-      if (!aria) continue;
-      const cmp = cs ? aria : aria.toLowerCase();
-      if (cmp === needle) record(el, 0.95, 'ariaLabel');
-      else if (cmp.includes(needle)) record(el, 0.7, 'ariaLabel');
-    }
-  }
-
-  // candidates already de-duplicated via the pushed Set in record()
-
-  if (aborted && candidates.length === 0) {
-    return { __error: "Timeout", message: "Scan budget exceeded with no matches; narrow scope or maxResults." };
-  }
-
-  const filtered = [];
-  for (const el of candidates) {
-    const visible = isVisible(el);
-    if (visibleOnly && !visible) continue;
-    const rect = el.getBoundingClientRect();
-    const inVp = inViewportRect(rect);
-    if (viewportOnly && !inVp) continue;
-    filtered.push({ el, visible, rect, inVp });
-  }
-
-  // Score and sort by confidence desc
-  filtered.sort((a, b) => {
-    const sa = score(matchScore.get(a.el) || 0, a.visible);
-    const sb = score(matchScore.get(b.el) || 0, b.visible);
-    return sb - sa;
-  });
-
-  const total = filtered.length;
-  const sliced = filtered.slice(offN, offN + (maxN - offN));
-
-  const results = sliced.map(({ el, visible, rect, inVp }) => ({
-    type: classify(el),
-    text: elText(el),
-    selector: bestSelector(el),
-    role: el.getAttribute('role') || undefined,
-    ariaLabel: el.getAttribute('aria-label') || undefined,
-    matchedBy: matchedByMap.get(el),
-    confidence: score(matchScore.get(el) || 0, visible),
-    inViewport: inVp,
-    rect: { x: Math.round(rect.left), y: Math.round(rect.top), w: Math.round(rect.width), h: Math.round(rect.height) },
-  }));
-
-  return { total, returned: results.length, truncated: total > offN + results.length, results };
-})()
-`;
+    // ADR-023 Phase 1 (S1/S7): the candidate-collection IIFE is now built by the
+    // shared resolver module (verbatim extraction; bit-equal output pinned by
+    // tests/unit/browser-resolver-candidate-collection.test.ts). Later phases
+    // layer actionability / climb / coords onto the same builder for by-axis
+    // browser_click / browser_fill.
+    const expression = buildCandidateCollectionJs({
+      by, pattern, scope, maxResults, offset, visibleOnly, inViewportOnly, caseSensitive,
+    });
     const result = await evaluateInTab(expression, tabId ?? null, port);
     if (result && typeof result === "object" && "__error" in (result as object)) {
       const r = result as { __error: string; message?: string };

--- a/tests/fixtures/failwith-callsite-shapes.json
+++ b/tests/fixtures/failwith-callsite-shapes.json
@@ -79,112 +79,112 @@
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 607,
+      "line": 608,
       "tool": "browser_fill",
       "errKind": "member",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 743,
+      "line": 744,
       "tool": "browser_fill",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 849,
+      "line": 850,
       "tool": "browser_form",
       "errKind": "string-literal",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 863,
+      "line": 864,
       "tool": "browser_form",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 915,
+      "line": 916,
       "tool": "browser_open",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 967,
+      "line": 968,
       "tool": "browser_locate",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1040,
+      "line": 1041,
       "tool": "browser_click",
       "errKind": "new-error",
       "contextShape": "object-hoisted"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1076,
+      "line": 1077,
       "tool": "browser_click",
       "errKind": "new-error",
       "contextShape": "object-hoisted"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1410,
+      "line": 1411,
       "tool": "browser_eval",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1493,
+      "line": 1494,
       "tool": "browser_eval",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1520,
+      "line": 1521,
       "tool": "browser_navigate",
       "errKind": "new-error",
       "contextShape": "object-hoisted"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1537,
+      "line": 1538,
       "tool": "browser_navigate",
       "errKind": "new-error",
       "contextShape": "object-hoisted"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1829,
+      "line": 1830,
       "tool": "browser_overview",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1981,
+      "line": 1982,
       "tool": "browser_open",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 2294,
+      "line": 2113,
       "tool": "browser_search",
       "errKind": "identifier",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 2442,
+      "line": 2261,
       "tool": "browser_disconnect",
       "errKind": "identifier",
       "contextShape": "none"

--- a/tests/unit/__snapshots__/browser-resolver-candidate-collection.test.ts.snap
+++ b/tests/unit/__snapshots__/browser-resolver-candidate-collection.test.ts.snap
@@ -1,0 +1,194 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ADR-023 Phase 1 (S1/S7): buildCandidateCollectionJs — bit-equal extraction > emits the full IIFE for a representative by:text + scope query (snapshot) 1`] = `
+"
+(function() {
+  const root = document.querySelector("#checkout");
+  if (!root) return { __error: "ScopeNotFound" };
+
+  const by = "text";
+  const pat = "Submit";
+  const cs  = false;
+  const visibleOnly = true;
+  const viewportOnly = false;
+  const maxN = 20;
+  const offN = 0;
+
+  function isVisible(el) {
+    const s = window.getComputedStyle(el);
+    if (s.display === 'none' || s.visibility === 'hidden' || s.opacity === '0') return false;
+    const r = el.getBoundingClientRect();
+    return r.width > 0 && r.height > 0;
+  }
+  function inViewportRect(rect) {
+    return rect.top < window.innerHeight && rect.bottom > 0 &&
+           rect.left < window.innerWidth && rect.right > 0;
+  }
+  function bestSelector(el) {
+    if (el.id) return '#' + CSS.escape(el.id);
+    const name = el.getAttribute('name');
+    if (name) return el.tagName.toLowerCase() + '[name=' + JSON.stringify(name) + ']';
+    const aria = el.getAttribute('aria-label');
+    if (aria && aria.length < 80)
+      return el.tagName.toLowerCase() + '[aria-label=' + JSON.stringify(aria) + ']';
+    for (const attr of ['data-testid', 'data-asin']) {
+      const v = el.getAttribute(attr);
+      if (v && v.length < 60) return el.tagName.toLowerCase() + '[' + attr + '=' + JSON.stringify(v) + ']';
+    }
+    let node = el; let path = '';
+    for (let depth = 0; depth < 2 && node.parentElement; depth++) {
+      const p = node.parentElement;
+      const idx = Array.from(p.children).indexOf(node) + 1;
+      const seg = node.tagName.toLowerCase() + ':nth-child(' + idx + ')';
+      path = path ? seg + ' > ' + path : seg;
+      if (p.id) { path = '#' + CSS.escape(p.id) + ' > ' + path; break; }
+      node = p;
+    }
+    return path || el.tagName.toLowerCase();
+  }
+  function classify(el) {
+    const tag = el.tagName.toLowerCase();
+    if (tag === 'a') return 'link';
+    if (tag === 'button' || el.getAttribute('role') === 'button') return 'button';
+    if (tag === 'input' || tag === 'textarea' || tag === 'select') return 'input';
+    if (/^h[1-6]$/.test(tag)) return 'heading';
+    if (tag === 'p' || tag === 'span' || tag === 'div') return 'text';
+    return 'other';
+  }
+  function elText(el) {
+    const t = (el.textContent || '').trim().replace(/\\s+/g, ' ').slice(0, 80);
+    if (!t && el.tagName === 'INPUT')
+      return (el.placeholder || el.value || el.getAttribute('aria-label') || '').slice(0, 80);
+    return t;
+  }
+  function score(matched, visible) {
+    let s = matched;
+    if (!visible) s = Math.max(0, s - 0.3);
+    return Math.round(s * 100) / 100;
+  }
+
+  // Bound the scan — pages can have 10k+ nodes and CDP timeout is 15s.
+  const SCAN_BUDGET_MS = 3000;
+  const nowFn = (typeof performance !== 'undefined' ? () => performance.now() : () => Date.now());
+  const startTs = nowFn();
+  const deadline = startTs + SCAN_BUDGET_MS;
+  let aborted = false;
+  // Sample the clock every 1024 iterations — cheap but keeps latency bounded.
+  function overBudget(i) { return (i & 0x3FF) === 0 && nowFn() > deadline; }
+
+  // IIFE-local match-state stores. WeakMap is essential: DOM elements persist
+  // across Runtime.evaluate calls, so any expando we set (e.g. el.__matchScore)
+  // would leak into the next search and contaminate scores / matchedBy / dedupe.
+  // WeakMap is GC'd at IIFE end so each call starts clean.
+  const matchScore = new WeakMap();
+  const matchedByMap = new WeakMap();
+  const pushed = new Set();
+  function record(el, score, by) {
+    const prev = matchScore.get(el) || 0;
+    if (score > prev) { matchScore.set(el, score); matchedByMap.set(el, by); }
+    if (!pushed.has(el)) { candidates.push(el); pushed.add(el); }
+  }
+
+  const all = root.querySelectorAll('*');
+  let candidates = [];
+
+  if (by === 'selector') {
+    const selectorMatches = Array.from(root.querySelectorAll(pat));
+    for (let i = 0; i < selectorMatches.length; i++) {
+      if (overBudget(i)) { aborted = true; break; }
+      record(selectorMatches[i], 1.0, 'selector');
+    }
+  } else if (by === 'text') {
+    const needle = cs ? pat : pat.toLowerCase();
+    let i = 0;
+    for (const el of all) {
+      if (overBudget(i++)) { aborted = true; break; }
+      // Direct child text only (avoid double-counting parent matches via descendants)
+      const direct = Array.from(el.childNodes)
+        .filter(n => n.nodeType === 3)
+        .map(n => n.textContent || '')
+        .join('').trim();
+      if (!direct) continue;
+      const hay = cs ? direct : direct.toLowerCase();
+      if (hay === needle) record(el, 1.0, 'text');
+      else if (hay.includes(needle)) record(el, 0.8, 'text');
+    }
+  } else if (by === 'regex') {
+    let re;
+    try { re = new RegExp(pat, (cs ? '' : 'i') + 'u'); }
+    catch (e) { return { __error: "InvalidRegex", message: String(e) }; }
+    let i = 0;
+    for (const el of all) {
+      if (overBudget(i++)) { aborted = true; break; }
+      const direct = Array.from(el.childNodes).filter(n => n.nodeType === 3).map(n => n.textContent || '').join('').trim();
+      if (!direct) continue;
+      if (re.test(direct)) record(el, 0.9, 'regex');
+    }
+  } else if (by === 'role') {
+    const needle = cs ? pat : pat.toLowerCase();
+    let i = 0;
+    for (const el of all) {
+      if (overBudget(i++)) { aborted = true; break; }
+      const role = el.getAttribute('role') || '';
+      const cmp = cs ? role : role.toLowerCase();
+      if (cmp === needle) record(el, 0.75, 'role');
+    }
+    // Implicit roles — score slightly higher because they're guaranteed by tag.
+    if (!aborted && needle === 'button')  for (const el of root.querySelectorAll('button')) record(el, 0.85, 'roleImplicit');
+    if (!aborted && needle === 'link')    for (const el of root.querySelectorAll('a[href]')) record(el, 0.85, 'roleImplicit');
+    if (!aborted && needle === 'heading') for (const el of root.querySelectorAll('h1,h2,h3,h4,h5,h6')) record(el, 0.85, 'roleImplicit');
+  } else if (by === 'ariaLabel') {
+    const needle = cs ? pat : pat.toLowerCase();
+    let i = 0;
+    for (const el of all) {
+      if (overBudget(i++)) { aborted = true; break; }
+      const aria = el.getAttribute('aria-label') || '';
+      if (!aria) continue;
+      const cmp = cs ? aria : aria.toLowerCase();
+      if (cmp === needle) record(el, 0.95, 'ariaLabel');
+      else if (cmp.includes(needle)) record(el, 0.7, 'ariaLabel');
+    }
+  }
+
+  // candidates already de-duplicated via the pushed Set in record()
+
+  if (aborted && candidates.length === 0) {
+    return { __error: "Timeout", message: "Scan budget exceeded with no matches; narrow scope or maxResults." };
+  }
+
+  const filtered = [];
+  for (const el of candidates) {
+    const visible = isVisible(el);
+    if (visibleOnly && !visible) continue;
+    const rect = el.getBoundingClientRect();
+    const inVp = inViewportRect(rect);
+    if (viewportOnly && !inVp) continue;
+    filtered.push({ el, visible, rect, inVp });
+  }
+
+  // Score and sort by confidence desc
+  filtered.sort((a, b) => {
+    const sa = score(matchScore.get(a.el) || 0, a.visible);
+    const sb = score(matchScore.get(b.el) || 0, b.visible);
+    return sb - sa;
+  });
+
+  const total = filtered.length;
+  const sliced = filtered.slice(offN, offN + (maxN - offN));
+
+  const results = sliced.map(({ el, visible, rect, inVp }) => ({
+    type: classify(el),
+    text: elText(el),
+    selector: bestSelector(el),
+    role: el.getAttribute('role') || undefined,
+    ariaLabel: el.getAttribute('aria-label') || undefined,
+    matchedBy: matchedByMap.get(el),
+    confidence: score(matchScore.get(el) || 0, visible),
+    inViewport: inVp,
+    rect: { x: Math.round(rect.left), y: Math.round(rect.top), w: Math.round(rect.width), h: Math.round(rect.height) },
+  }));
+
+  return { total, returned: results.length, truncated: total > offN + results.length, results };
+})()
+"
+`;

--- a/tests/unit/browser-resolver-candidate-collection.test.ts
+++ b/tests/unit/browser-resolver-candidate-collection.test.ts
@@ -1,0 +1,75 @@
+/**
+ * tests/unit/browser-resolver-candidate-collection.test.ts
+ * — ADR-023 Phase 1 (S1/S7), R-P1-1 (snapshot-first, bit-equal extraction).
+ *
+ * `buildCandidateCollectionJs` is a VERBATIM extraction of the injected-JS IIFE
+ * that `browser_search` used to build inline. browser_search now delegates to it,
+ * so its public contract is unchanged ONLY IF the generated JS stays byte-equal.
+ * The full-template snapshot pins that: any change to the emitted JS (which would
+ * alter browser_search behavior) shows up as an explicit snapshot diff. The
+ * targeted assertions document the interpolation contract + the per-axis scoring
+ * constants the extraction must preserve.
+ *
+ * @see src/tools/browser-resolver.ts  buildCandidateCollectionJs
+ */
+
+import { describe, it, expect } from "vitest";
+import { buildCandidateCollectionJs } from "../../src/tools/browser-resolver.js";
+
+describe("ADR-023 Phase 1 (S1/S7): buildCandidateCollectionJs — bit-equal extraction", () => {
+  it("emits the full IIFE for a representative by:text + scope query (snapshot)", () => {
+    const js = buildCandidateCollectionJs({
+      by: "text", pattern: "Submit", scope: "#checkout",
+      maxResults: 20, offset: 0, visibleOnly: true, inViewportOnly: false, caseSensitive: false,
+    });
+    expect(js).toMatchSnapshot();
+  });
+
+  it("interpolates scope into document.querySelector, omits to document when absent", () => {
+    const withScope = buildCandidateCollectionJs({
+      by: "text", pattern: "x", scope: "#s",
+      maxResults: 5, offset: 0, visibleOnly: true, inViewportOnly: false, caseSensitive: false,
+    });
+    expect(withScope).toContain('const root = document.querySelector("#s");');
+
+    const noScope = buildCandidateCollectionJs({
+      by: "text", pattern: "x",
+      maxResults: 5, offset: 0, visibleOnly: true, inViewportOnly: false, caseSensitive: false,
+    });
+    expect(noScope).toContain("const root = document;");
+  });
+
+  it("JSON-encodes by / pattern / caseSensitive and derives maxN=maxResults+offset, offN=offset", () => {
+    const js = buildCandidateCollectionJs({
+      by: "ariaLabel", pattern: 'a"b', scope: undefined,
+      maxResults: 10, offset: 5, visibleOnly: false, inViewportOnly: true, caseSensitive: true,
+    });
+    expect(js).toContain('const by = "ariaLabel";');
+    expect(js).toContain('const pat = "a\\"b";'); // JSON.stringify escapes the embedded quote
+    expect(js).toContain("const cs  = true;");
+    expect(js).toContain("const visibleOnly = false;");
+    expect(js).toContain("const viewportOnly = true;");
+    expect(js).toContain("const maxN = 15;"); // 10 + 5
+    expect(js).toContain("const offN = 5;");
+  });
+
+  it("preserves the per-axis scoring constants + scan budget (verbatim extraction guard)", () => {
+    const js = buildCandidateCollectionJs({
+      by: "role", pattern: "button",
+      maxResults: 5, offset: 0, visibleOnly: true, inViewportOnly: false, caseSensitive: false,
+    });
+    for (const frag of [
+      "record(el, 1.0, 'text')",
+      "record(el, 0.8, 'text')",
+      "record(el, 0.9, 'regex')",
+      "record(el, 0.75, 'role')",
+      "record(el, 0.85, 'roleImplicit')",
+      "record(el, 0.95, 'ariaLabel')",
+      "record(el, 0.7, 'ariaLabel')",
+      "record(selectorMatches[i], 1.0, 'selector')",
+      "const SCAN_BUDGET_MS = 3000;",
+    ]) {
+      expect(js).toContain(frag);
+    }
+  });
+});


### PR DESCRIPTION
## What (ADR-023 Phase 1 trunk — S1 + S7)

The foundation for semantic by-axis targeting. **Pure refactor, no public behavior change.**

- **S1** — new `src/tools/browser-resolver.ts` exports `buildCandidateCollectionJs`, a **verbatim extraction** of the candidate-collection IIFE that `browser_search` used to build inline. This is the shared resolver core that later Phase 1 PRs layer actionability / ancestor climb / physical-coord resolution onto (for `browser_click({by})` / `browser_fill({by})`).
- **S7** — `browser_search` now delegates to `buildCandidateCollectionJs`. The generated JS is **byte-equal**, so the public `browser_search` contract is unchanged (NFR-1 / AC-9).

## Why isolated first (R-P1-1)
Extracting the IIFE is the highest-risk step (browser_search must stay bit-equal). Landing it alone, snapshot-pinned, de-risks the foundation before by-axis click/fill build on it (snapshot-first discipline).

## Verification
- `npm run build` — clean
- `npm run lint` — 0 errors
- `npx vitest run --project=unit` — all green (1 pre-existing flaky timer test in `ui-pattern-store-persistence`, unrelated, passes in isolation; tracked in backlog)
- New `tests/unit/browser-resolver-candidate-collection.test.ts`: full-template snapshot + interpolation contract (scope / by / pattern / caseSensitive / maxN / offN) + per-axis scoring-constant guards
- `browser.ts` −181 lines; `failwith-callsite-shapes.json` regenerated (line shifts only); `stub-tool-catalog.ts` unchanged (no schema/surface change)

## Plan
`desktop-touch-mcp-internal@aa6fcd3:docs/adr-023-phase-1-resolver-plan.md` S1/S7 (sub-plan, Opus Round 1 applied). Next PRs: S2 actionability+climb, S3 uniqueness, S6 ambiguity, then S4/S5 by-axis click/fill.

## Scope
`browser.ts` + new resolver module + tests. No Rust, no schema change, no new public tool/param.

🤖 Generated with [Claude Code](https://claude.com/claude-code)