### PR TITLE
feat(browser): ADR-023 Phase 1 PR4 — browser_fill({by,pattern,value,role})

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ### Added
 
+- **`browser_fill` can target inputs by meaning, not just CSS selectors.** Like
+  `browser_click`, you can now pass `by` + `pattern` instead of a `selector` to
+  fill a field by what identifies it — most useful with `by:'ariaLabel'`
+  (`browser_fill({by:'ariaLabel', pattern:'Email address', value:'a@b.com'})`).
+  The server resolves to a **single** field and fills it through the same
+  React/Vue-compatible path as selector mode (native setter + input/change
+  events, with post-fill value verification). It refuses to guess: when several
+  fields match it stops with `code:'BrowserAmbiguousTarget'` (candidate list +
+  hints); when the match resolves to something that is not a fillable
+  input/textarea/contenteditable it stops with `code:'BrowserNoActionableTarget'`.
+  Optionally add `role` and `scope` to narrow. Provide EITHER `selector` OR
+  `by`+`pattern` (not both); selector mode is unchanged.
+
 - **`browser_click` can target elements by meaning, not just CSS selectors.**
   Instead of a `selector`, you can now pass `by` + `pattern` to click an element
   by what it *is* — handy for dynamic-class single-page apps where stable CSS

--- a/src/stub-tool-catalog.ts
+++ b/src/stub-tool-catalog.ts
@@ -185,13 +185,39 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
   },
   {
     "name": "browser_fill",
-    "description": "Fill a form input with a value via CDP — works on React/Vue/Svelte controlled inputs that reject browser_eval value assignment. Use browser_overview or browser_locate first to obtain a stable selector. Use this over browser_eval when setting a controlled input's value via JS does not update the framework state. Caveats: Requires browser_open (CDP active). Does not work on contenteditable rich-text editors — use keyboard(action='type') for those. actual in response shows what the element's value property reads after fill; verify it matches the intended value. Typed errors: code:'BrowserFillNotDelivered' on post-fill value mismatch — note the false-positive case where a React controlled input's onChange transforms the value (delivery actually succeeded; SUGGESTS context surfaces hints.verifyDelivery.subReason:'controlled_input_transform' for that case). When detected, the actual value in the response is authoritative.",
+    "description": "Fill a form input with a value via CDP — works on React/Vue/Svelte controlled inputs that reject browser_eval value assignment. Two ways to target: (1) selector — a CSS selector (use browser_overview / browser_locate to find one); or (2) by-axis (semantic) — by:'text'|'regex'|'role'|'ariaLabel' + pattern (e.g. by:'ariaLabel', pattern:'Email address', or by:'role', pattern:'textbox'), so you do not have to build a CSS selector. by-axis resolves to a SINGLE fillable element and STOPS with code:'BrowserAmbiguousTarget' (candidates[] + next[] hints) when 2+ match, or code:'BrowserNoActionableTarget' when the match is not a fillable input/textarea/contenteditable — it never guesses. Optionally add role to filter and scope to narrow. Provide EITHER selector OR by+pattern (not both). Use this over browser_eval when setting a controlled input's value via JS does not update framework state. Caveats: Requires browser_open (CDP active). actual in the response shows the element's value after fill; verify it matches the intended value. Typed errors: code:'BrowserFillNotDelivered' on post-fill value mismatch — note the false-positive case where a React controlled input's onChange transforms the value (delivery actually succeeded; hints.verifyDelivery.subReason:'controlled_input_transform' for that case; the actual value is authoritative).",
     "inputSchema": {
       "type": "object",
       "properties": {
         "selector": {
+          "description": "CSS selector for the input element. Provide EITHER selector OR by+pattern.",
+          "type": "string"
+        },
+        "by": {
           "type": "string",
-          "description": "CSS selector for the target element (e.g. '#submit', '.btn', 'button[type=submit]')."
+          "enum": [
+            "text",
+            "regex",
+            "role",
+            "ariaLabel"
+          ],
+          "description": "Semantic axis to target by INSTEAD of a CSS selector: 'text' (visible text), 'regex', 'role' (ARIA/implicit role), 'ariaLabel'. Pair with pattern. Resolves to a SINGLE actionable element and STOPS with candidates when ambiguous."
+        },
+        "pattern": {
+          "type": "string",
+          "description": "Value matched against the chosen by axis (required when by is set)."
+        },
+        "role": {
+          "type": "string",
+          "description": "Optional ARIA/implicit-role filter AND-combined with by (e.g. by:'text', pattern:'Save', role:'button')."
+        },
+        "scope": {
+          "type": "string",
+          "description": "Optional CSS selector to limit the by-axis search scope (disambiguation)."
+        },
+        "caseSensitive": {
+          "type": "boolean",
+          "description": "Case-sensitive matching for by:'text'/'regex' (default false)."
         },
         "value": {
           "description": "Text to fill into the input element",
@@ -224,7 +250,6 @@ export const STUB_TOOL_CATALOG: StubToolCatalogEntry[] = [
       },
       "additionalProperties": false,
       "required": [
-        "selector",
         "value"
       ]
     }

--- a/src/tools/browser-resolver.ts
+++ b/src/tools/browser-resolver.ts
@@ -285,14 +285,24 @@ export function buildCandidateCollectionJs(args: CandidateCollectionArgs): strin
  * candidates: CandidateFacts[] }` or the shared `{ __error }` shape on
  * ScopeNotFound / InvalidRegex / Timeout. Pinned by snapshot.
  */
-export function buildActionCandidateFactsJs(args: ActionFactsArgs): string {
+/**
+ * Shared injected-JS fragment: candidate matching body + score-desc top-N pool
+ * (role-filtered). Emits through `const top = pool.slice(0, N)`, leaving
+ * `filtered` / `matchScore` / `matchedByMap` / `N` / `D` / `pool` / `top` in
+ * scope. Both the gather builder (buildActionCandidateFactsJs) and the fill-act
+ * builder (buildFillActJs) embed this verbatim then append their own tail — a
+ * single source for the role filter + top-N cap. Re-running it in the fill-act
+ * eval re-selects the SAME top[index] deterministically (same querySelectorAll
+ * order + scoring), so by-axis fill needs no selector/coordinate re-identification
+ * (avoids re-non-uniqueness; plan §S5).
+ */
+function candidatePoolJs(args: ActionFactsArgs): string {
   const { by, pattern, scope, caseSensitive, role } = args;
-  // maxResults/offset are unused by the gather tail (it takes top-N of the full
-  // sorted set); fixed values keep the shared body's interpolation total. The
-  // resolver always collects visible elements and lets receivesEvents gate the
-  // viewport (so off-viewport candidates fall out as non-actionable, not unseen).
+  // maxResults/offset are unused by the tails (they take top-N of the full sorted
+  // set); fixed values keep the shared body's interpolation total. The resolver
+  // always collects visible elements and lets receivesEvents gate the viewport.
   return `${candidateMatchingBodyJs({ by, pattern, scope, maxResults: 200, offset: 0, visibleOnly: true, inViewportOnly: false, caseSensitive })}
-  // ── ADR-023 Phase 1 PR2: action-target fact gathering (top-N only, §2.bis). ──
+  // ── ADR-023 Phase 1: action-target candidate pool (top-N, role-filtered). ──
   const N = ${AMBIGUITY_CANDIDATE_CAP};
   const D = ${CLIMB_MAX_DEPTH};
 
@@ -313,7 +323,11 @@ export function buildActionCandidateFactsJs(args: ActionFactsArgs): string {
     return false;
   }
   const pool = roleFilter ? filtered.filter(function(e) { return roleMatches(e.el); }) : filtered;
-  const top = pool.slice(0, N);
+  const top = pool.slice(0, N);`;
+}
+
+export function buildActionCandidateFactsJs(args: ActionFactsArgs): string {
+  return `${candidatePoolJs(args)}
 
   // Physical-coord conversion constants (getElementScreenCoords formula,
   // cdp-bridge.ts) — computed once so browser_click({by}) converts the resolved
@@ -431,6 +445,59 @@ export function buildActionCandidateFactsJs(args: ActionFactsArgs): string {
     viewport: { screenX: sx, screenY: sy, dpr: dpr, chromeH: chromeH, chromeW: chromeW, innerWidth: window.innerWidth, innerHeight: window.innerHeight },
     candidates: factsList,
   };
+})()
+`;
+}
+
+/**
+ * Build the injected-JS IIFE that ACTS on a by-axis fill target (browser_fill
+ * by-axis, plan §S5 — the 2nd eval: gather→decide ran in node, this acts). It
+ * re-runs the SAME candidate matching/pool as the gather eval (deterministic —
+ * identical querySelectorAll order + scoring), re-selects `top[index]`, climbs
+ * `climbDepth` ancestors to the resolved element, verifies it is fillable
+ * (input / textarea / contenteditable), focuses it, sets the value via the native
+ * prototype setter + dispatches InputEvent/'change' (React/Vue-compatible — the
+ * same path as the selector fill), and reads `element.value` back.
+ *
+ * Re-gather+index is used (NOT a fresh querySelector or an elementFromPoint
+ * coordinate re-find) so a GSC dynamic class cannot re-match differently
+ * (re-non-uniqueness) and an overlay cannot be mis-targeted (occlusion). Returns
+ * `{ ok:true, actual, fullActualLen, fullMatches }` or `{ ok:false, error }`
+ * (index_out_of_range / resolved_element_lost / not_fillable). Pinned by snapshot.
+ */
+export function buildFillActJs(args: ActionFactsArgs, index: number, climbDepth: number, value: string): string {
+  return `${candidatePoolJs(args)}
+  // ── ADR-023 Phase 1 PR4: by-axis fill ACT (deterministic re-gather + index). ──
+  if (top.length <= ${index}) return { ok: false, error: 'index_out_of_range' };
+  let el = top[${index}].el;
+  for (let d = 0; d < ${climbDepth} && el; d++) el = el.parentElement;
+  if (!el) return { ok: false, error: 'resolved_element_lost' };
+
+  const tag = el.tagName;
+  const isInput = tag === 'INPUT' || tag === 'TEXTAREA';
+  const isEditable = el.isContentEditable === true;
+  if (!isInput && !isEditable) return { ok: false, error: 'not_fillable', tag: tag.toLowerCase() };
+
+  el.focus();
+  const val = ${JSON.stringify(value)};
+  if (isInput) {
+    if (typeof el.select === 'function') el.select();
+    let proto = null;
+    if (tag === 'INPUT') proto = HTMLInputElement.prototype;
+    else if (tag === 'TEXTAREA') proto = HTMLTextAreaElement.prototype;
+    const descriptor = proto ? Object.getOwnPropertyDescriptor(proto, 'value') : null;
+    if (descriptor && descriptor.set) descriptor.set.call(el, val);
+    else el.value = val;
+    el.dispatchEvent(new InputEvent('input', { bubbles: true, cancelable: true, inputType: 'insertText', data: val }));
+    el.dispatchEvent(new Event('change', { bubbles: true }));
+    const fullActual = el.value !== undefined ? el.value : '';
+    return { ok: true, actual: (fullActual || '').slice(0, 100), fullActualLen: fullActual.length, fullMatches: fullActual === val };
+  }
+  // contenteditable
+  el.textContent = val;
+  el.dispatchEvent(new InputEvent('input', { bubbles: true, cancelable: true, inputType: 'insertText', data: val }));
+  const fullActual = el.textContent || '';
+  return { ok: true, actual: (fullActual || '').slice(0, 100), fullActualLen: fullActual.length, fullMatches: fullActual === val };
 })()
 `;
 }

--- a/src/tools/browser-resolver.ts
+++ b/src/tools/browser-resolver.ts
@@ -465,11 +465,32 @@ export function buildActionCandidateFactsJs(args: ActionFactsArgs): string {
  * `{ ok:true, actual, fullActualLen, fullMatches }` or `{ ok:false, error }`
  * (index_out_of_range / resolved_element_lost / not_fillable). Pinned by snapshot.
  */
-export function buildFillActJs(args: ActionFactsArgs, index: number, climbDepth: number, value: string): string {
+export function buildFillActJs(
+  args: ActionFactsArgs,
+  index: number,
+  climbDepth: number,
+  value: string,
+  expect: { name: string; role: string | null; ariaLabel: string | null; tag: string; total: number },
+): string {
   return `${candidatePoolJs(args)}
   // ── ADR-023 Phase 1 PR4: by-axis fill ACT (deterministic re-gather + index). ──
+  // IDENTITY GATE (Codex P1): the re-gather assumes the DOM is unchanged since the
+  // resolve eval. If it mutated (a matching field inserted/removed/reordered),
+  // top[index] could be a DIFFERENT field — a silent mis-fill. Verify the matched
+  // element's identity (pool count + name/role/ariaLabel/tag of top[index] before
+  // climb) against what resolve saw; on mismatch fail (the agent re-resolves) and
+  // NEVER write.
+  if (pool.length !== ${expect.total}) return { ok: false, error: 'identity_changed', detail: 'candidate_count' };
   if (top.length <= ${index}) return { ok: false, error: 'index_out_of_range' };
-  let el = top[${index}].el;
+  const matched = top[${index}].el;
+  const mName = elText(matched);
+  const mRole = matched.getAttribute('role') || null;
+  const mAria = matched.getAttribute('aria-label') || null;
+  const mTag = matched.tagName.toLowerCase();
+  if (mName !== ${JSON.stringify(expect.name)} || mRole !== ${JSON.stringify(expect.role)} || mAria !== ${JSON.stringify(expect.ariaLabel)} || mTag !== ${JSON.stringify(expect.tag)}) {
+    return { ok: false, error: 'identity_changed', detail: 'signature' };
+  }
+  let el = matched;
   for (let d = 0; d < ${climbDepth} && el; d++) el = el.parentElement;
   if (!el) return { ok: false, error: 'resolved_element_lost' };
 
@@ -839,6 +860,14 @@ export type ResolveActionOutcome =
       /** 0 = matched element, 1..D = ancestor distance climbed */
       climbDepth: number;
       viewport: ViewportMetrics;
+      /**
+       * Identity of the MATCHED element (chain[0], i.e. top[index] before climb) +
+       * the candidate-pool total. A by-axis fill re-gathers in a 2nd eval and must
+       * verify this identity still holds at top[index] before writing — otherwise a
+       * DOM mutation between resolve and act could silently mis-fill a different
+       * field (Codex PR4 P1). Click does not need it (it acts by physical coords).
+       */
+      matched: { name: string; role: string | null; ariaLabel: string | null; tag: string; total: number };
     }
   | { kind: "ambiguous"; total: number; returned: number; truncated: boolean; candidates: AmbiguityCandidate[]; next: string[] }
   | { kind: "noActionable"; total: number; returned: number; truncated: boolean; candidates: AmbiguityCandidate[]; next: string[] }
@@ -902,6 +931,11 @@ export async function resolveBrowserActionTarget(args: ResolveActionArgs): Promi
     requireReceivesEvents: args.action !== "fill",
   });
   if (decision.kind === "resolved") {
+    // Identity of the matched element (chain[0] = top[index] before climb) so a
+    // by-axis fill can verify the 2nd-eval re-gather still points at the same
+    // field before writing (Codex PR4 P1). decideActionTarget.target.index is a
+    // facts index, so gathered.candidates[index] is that matched candidate.
+    const f = gathered.candidates[decision.target.index];
     return {
       kind: "resolved",
       index: decision.target.index,
@@ -909,6 +943,13 @@ export async function resolveBrowserActionTarget(args: ResolveActionArgs): Promi
       physical: physicalPoint(decision.target.rect, gathered.viewport),
       climbDepth: decision.target.climbDepth,
       viewport: gathered.viewport,
+      matched: {
+        name: f?.name ?? "",
+        role: f?.role ?? null,
+        ariaLabel: f?.ariaLabel ?? null,
+        tag: f?.chain?.[0]?.tag ?? "",
+        total: gathered.total,
+      },
     };
   }
   return decision;

--- a/src/tools/browser-resolver.ts
+++ b/src/tools/browser-resolver.ts
@@ -474,13 +474,21 @@ export function buildFillActJs(args: ActionFactsArgs, index: number, climbDepth:
   if (!el) return { ok: false, error: 'resolved_element_lost' };
 
   const tag = el.tagName;
-  const isInput = tag === 'INPUT' || tag === 'TEXTAREA';
+  const ty = (el.getAttribute('type') || '').toLowerCase();
+  // Text-entry controls only. Exclude non-text input types (Codex P1): type=file
+  // THROWS on a non-empty .value assignment; checkbox/radio/button/submit/reset/
+  // image/range/color/hidden ignore a value string (a false-positive "filled") or
+  // are not text targets. Same exclusion as the 'textbox' role filter.
+  const isTextInput = tag === 'INPUT' && !/^(button|submit|reset|checkbox|radio|range|color|file|image|hidden)$/.test(ty);
+  const isTextArea = tag === 'TEXTAREA';
   const isEditable = el.isContentEditable === true;
-  if (!isInput && !isEditable) return { ok: false, error: 'not_fillable', tag: tag.toLowerCase() };
+  if (!isTextInput && !isTextArea && !isEditable) {
+    return { ok: false, error: 'not_fillable', tag: tag.toLowerCase() + (ty ? '[type=' + ty + ']' : '') };
+  }
 
   el.focus();
   const val = ${JSON.stringify(value)};
-  if (isInput) {
+  if (isTextInput || isTextArea) {
     if (typeof el.select === 'function') el.select();
     let proto = null;
     if (tag === 'INPUT') proto = HTMLInputElement.prototype;

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -28,7 +28,7 @@ import type { RichBlock } from "../engine/uia-diff.js";
 import { evaluatePreToolGuards, buildEnvelopeFor } from "../engine/perception/registry.js";
 import { runActionGuard, isAutoGuardEnabled, validateAndPrepareFix, consumeFix } from "./_action-guard.js";
 import { prepareBrowserEvalExpression } from "./browser-eval-helpers.js";
-import { buildCandidateCollectionJs, resolveBrowserActionTarget, type ResolveActionOutcome } from "./browser-resolver.js";
+import { buildCandidateCollectionJs, resolveBrowserActionTarget, buildFillActJs, type ResolveActionOutcome } from "./browser-resolver.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Schemas
@@ -285,7 +285,15 @@ export const browserSearchSchema = {
 };
 
 export const browserFillInputSchema = {
-  selector: selectorParam,
+  selector: z
+    .string()
+    .optional()
+    .describe("CSS selector for the input element. Provide EITHER selector OR by+pattern."),
+  by: byAxisParam,
+  pattern: byPatternParam,
+  role: byRoleParam,
+  scope: byScopeParam,
+  caseSensitive: byCaseSensitiveParam,
   value: z.string().max(10_000).describe("Text to fill into the input element"),
   tabId: tabIdParam,
   port: portParam,
@@ -687,20 +695,173 @@ async function osClickAndVerify(
 // Handlers
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * Shape a fill act result into the tool response — shared by the selector path
+ * and the by-axis path. `identity` is spread into BOTH the failure context and
+ * the success payload (selector mode passes `{ selector }` to keep its wire shape
+ * bit-equal; by-axis passes `{ filled: { by, pattern, role? } }`).
+ *
+ * fullMatches===false → BrowserFillNotDelivered (Issue #181 matrix doc §3.1/§5.2):
+ * the bytes reached the page but the framework's onChange rewrote them. The
+ * subReason heuristic distinguishes a controlled-input transform (actual non-empty
+ * and ≤ requested) from outright rejection.
+ */
+async function finalizeFillResult(
+  actResult: { ok: boolean; error?: string; actual?: string; fullActualLen?: number; fullMatches?: boolean },
+  value: string,
+  identity: Record<string, unknown>,
+  includeContext: boolean,
+  tabId: string | undefined,
+  port: number,
+): Promise<ToolResult> {
+  if (!actResult.ok) {
+    return failWith(actResult.error ?? "browser_fill: fill failed", "browser_fill");
+  }
+  if (actResult.fullMatches === false) {
+    const requestedLen = value.length;
+    const actualLen = actResult.fullActualLen ?? 0;
+    const subReason =
+      actualLen > 0 && actualLen <= requestedLen ? "controlled_input_transform" : "value_not_retained";
+    return failWith(new Error("BrowserFillNotDelivered"), "browser_fill", {
+      ...identity,
+      requested: value.slice(0, 100),
+      requestedLen,
+      actual: actResult.actual,
+      actualLen,
+      subReason,
+      note:
+        subReason === "controlled_input_transform"
+          ? "False-positive watch: React/Vue controlled inputs may rewrite the value in onChange (numbers-only filter, max-length, format mask). The bytes reached the page but the framework chose not to keep them. Treat actual as authoritative."
+          : "The DOM did not retain the requested value after fill — input may be readOnly, disabled, or guarded by a synthetic-event proxy that rejects programmatic writes.",
+      hints: {
+        verifyDelivery: {
+          status: "unverifiable",
+          channel: "cdp",
+          reason: "value_mismatch",
+          subReason,
+          actualLen,
+          requestedLen,
+        },
+      },
+    });
+  }
+  const lines = [
+    JSON.stringify({
+      ok: true,
+      ...identity,
+      value,
+      actual: actResult.actual,
+      // matrix doc §4.2 規範 hint shape — always emit `delivered` on success.
+      hints: { verifyDelivery: { status: "delivered", channel: "cdp" } },
+    }),
+  ];
+  if (includeContext) {
+    const tabCtx = await getCachedTabContext(tabId ?? null, port);
+    lines.push(
+      "",
+      `activeTab: ${JSON.stringify({ id: tabCtx.id, title: tabCtx.title, url: tabCtx.url })}`,
+      `readyState: "${tabCtx.readyState}"`,
+    );
+  }
+  return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+}
+
+/**
+ * by-axis browser_fill: resolve a single actionable target semantically (fill
+ * actionability = visible + enabled, NOT receivesEvents — fill acts via CDP eval,
+ * plan §S5), then ACT in a 2nd eval (deterministic re-gather + index + climb +
+ * native-setter fill). Ambiguous / non-actionable / error stop with a typed
+ * failure. Selector mode stays on its bit-equal 2-eval path.
+ */
+async function handleBrowserFillByAxis(args: {
+  by: "text" | "regex" | "role" | "ariaLabel";
+  pattern: string;
+  role?: string;
+  scope?: string;
+  caseSensitive?: boolean;
+  value: string;
+  tabId?: string;
+  port: number;
+  includeContext: boolean;
+}): Promise<ToolResult> {
+  const { by, pattern, role, scope, caseSensitive, value, tabId, port, includeContext } = args;
+  const outcome = await resolveBrowserActionTarget({
+    by, pattern, role, scope, caseSensitive, action: "fill", tabId: tabId ?? null, port,
+  });
+  const ctx = { by, pattern, ...(role ? { role } : {}), ...(scope ? { scope } : {}) };
+  if (outcome.kind === "error") return browserResolveErrorToFailure(outcome, "browser_fill", ctx);
+  if (outcome.kind !== "resolved") return browserResolveStopToFailure(outcome, "browser_fill", ctx);
+
+  // Resolved → act (2nd eval): re-gather the same pool, re-select top[index],
+  // climb to the resolved element, fill via the native setter. No second
+  // querySelector / coordinate re-find (avoids re-non-uniqueness / occlusion).
+  const actExpr = buildFillActJs({ by, pattern, role, scope, caseSensitive: caseSensitive ?? false }, outcome.index, outcome.climbDepth, value);
+  const actResult = await evaluateInTab(actExpr, tabId ?? null, port) as
+    { ok: boolean; error?: string; tag?: string; actual?: string; fullActualLen?: number; fullMatches?: boolean };
+
+  if (!actResult.ok) {
+    if (actResult.error === "not_fillable") {
+      return failCode(
+        "BrowserNoActionableTarget",
+        `browser_fill: the resolved <${actResult.tag ?? "element"}> is not a fillable input/textarea/contenteditable.`,
+        {
+          suggest: [
+            "Target the input directly with by:'ariaLabel' or by:'role' (role:'textbox')",
+            "Or pass a precise CSS selector",
+          ],
+          context: ctx,
+        },
+      );
+    }
+    // index_out_of_range / resolved_element_lost: the DOM changed between the
+    // resolve gather and the act re-gather.
+    return failCode(
+      "ToolError",
+      `browser_fill: the page changed between resolving and filling (${actResult.error ?? "unknown"}).`,
+      { suggest: ["Retry — the resolver re-resolves against the current DOM"], context: ctx },
+    );
+  }
+
+  return await finalizeFillResult(actResult, value, { filled: { by, pattern, ...(role ? { role } : {}) } }, includeContext, tabId, port);
+}
+
 export const browserFillInputHandler = async ({
   selector,
+  by,
+  pattern,
+  role,
+  scope,
+  caseSensitive,
   value,
   tabId,
   port,
   includeContext,
 }: {
-  selector: string;
+  selector?: string;
+  by?: "text" | "regex" | "role" | "ariaLabel";
+  pattern?: string;
+  role?: string;
+  scope?: string;
+  caseSensitive?: boolean;
   value: string;
   tabId?: string;
   port: number;
   includeContext: boolean;
 }): Promise<ToolResult> => {
   try {
+    // ADR-023 Phase 1: by-axis (semantic) fill path. The registration schema's
+    // .refine() guarantees exactly-one-of(selector | by+pattern), so a present
+    // `by` means selector is absent → resolver path. Selector mode below is
+    // unchanged (bit-equal 2-eval, AC-9).
+    if (by && pattern) {
+      return await handleBrowserFillByAxis({ by, pattern, role, scope, caseSensitive, value, tabId, port, includeContext });
+    }
+    if (!selector) {
+      return failCode("InvalidArgs", "browser_fill: provide either selector or by+pattern.", {
+        suggest: ["Pass a CSS selector, or by+pattern (e.g. by:'ariaLabel', pattern:'Email')."],
+      });
+    }
+
     // Fill sequence: focus the element first, then update its value from page context
     // using the native prototype setter and dispatch InputEvent/change so frameworks
     // such as React/Vue observe the same DOM updates they listen for in normal input flows.
@@ -766,90 +927,10 @@ export const browserFillInputHandler = async ({
 })()`;
     const fillResult = await evaluateInTab(fillExpr, tabId ?? null, port) as
       { ok: boolean; error?: string; actual?: string; fullActualLen?: number; fullMatches?: boolean };
-    if (!fillResult.ok) {
-      return failWith(fillResult.error ?? "browser_fill: fill failed", "browser_fill");
-    }
-
-    // ── Issue #181: post-fill element.value verification (matrix doc §3.1) ──
-    // fullMatches=false means the DOM did not retain the value we sent.
-    // matrix doc §5.2 flags React controlled inputs as a known false-positive
-    // source: the value was *delivered*, but the framework's onChange handler
-    // rewrote it (numbers-only filter, max-length, format mask). We surface
-    // this as a typed failure (BrowserFillNotDelivered) with a sub-reason on
-    // the hint so the caller can disambiguate without resorting to retry.
-    if (fillResult.fullMatches === false) {
-      const requestedLen = value.length;
-      const actualLen = fillResult.fullActualLen ?? 0;
-      // Heuristic: if the actual length is *non-zero and shorter than
-      // requested*, the framework most likely transformed the value
-      // (truncation, character-class filter, format mask). Length ≥ requested
-      // suggests the framework rejected the value entirely (e.g. type=email
-      // with sanitization that prepends a default). Either way the value did
-      // not land cleanly.
-      const subReason =
-        actualLen > 0 && actualLen <= requestedLen
-          ? "controlled_input_transform"
-          : "value_not_retained";
-      // failWith treats every key in the third arg as a context entry except
-      // those listed in ROOT_HOISTED_KEYS (`hints`, etc.). The diagnostic
-      // fields below land under failure.context.* and `hints` lands at the
-      // failure root — matching the success-path envelope shape (matrix doc
-      // §4.2) so callers can read failure.hints.verifyDelivery and
-      // success.hints.verifyDelivery from the same path.
-      return failWith(
-        new Error("BrowserFillNotDelivered"),
-        "browser_fill",
-        {
-          selector,
-          requested: value.slice(0, 100),
-          requestedLen,
-          actual: fillResult.actual,
-          actualLen,
-          subReason,
-          note:
-            subReason === "controlled_input_transform"
-              ? "False-positive watch: React/Vue controlled inputs may rewrite the value in onChange (numbers-only filter, max-length, format mask). The bytes reached the page but the framework chose not to keep them. Treat actual as authoritative."
-              : "The DOM did not retain the requested value after fill — input may be readOnly, disabled, or guarded by a synthetic-event proxy that rejects programmatic writes.",
-          hints: {
-            verifyDelivery: {
-              status: "unverifiable",
-              channel: "cdp",
-              reason: "value_mismatch",
-              subReason,
-              actualLen,
-              requestedLen,
-            },
-          },
-        }
-      );
-    }
-
-    const lines = [
-      JSON.stringify({
-        ok: true,
-        selector,
-        value,
-        actual: fillResult.actual,
-        // matrix doc §4.2 規範 hint shape — always emit `delivered` on success
-        // path so callers can pin verification end-to-end without conditionally
-        // checking `hints` presence.
-        hints: {
-          verifyDelivery: {
-            status: "delivered",
-            channel: "cdp",
-          },
-        },
-      }),
-    ];
-    if (includeContext) {
-      const tabCtx = await getCachedTabContext(tabId ?? null, port);
-      lines.push(
-        "",
-        `activeTab: ${JSON.stringify({ id: tabCtx.id, title: tabCtx.title, url: tabCtx.url })}`,
-        `readyState: "${tabCtx.readyState}"`,
-      );
-    }
-    return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    // Verify + shape the result (shared with the by-axis path). `identity` =
+    // { selector } so the failure context + success response keep the exact
+    // selector-mode keys/order (bit-equal, AC-9).
+    return await finalizeFillResult(fillResult, value, { selector }, includeContext, tabId, port);
   } catch (err) {
     return failWith(err, "browser_fill");
   }
@@ -2647,7 +2728,19 @@ export const browserClickRegistrationHandler = makeCommitWrapper(
  * `browserFillInputHandler` 直接渡しだったため post.* block も追加される
  * behavior 変化あり (additive、互換維持)。
  */
-export const browserFillRegistrationSchema = withEnvelopeIncludeSchema(browserFillInputSchema);
+// ADR-023 Phase 1: exactly-one-of(selector | by+pattern) via .refine() — same
+// zod-4/SDK pattern as browser_click (registerTool, not server.tool's 3-arg form
+// which throws on a ZodObject).
+export const browserFillRegistrationSchema = z
+  .object(withEnvelopeIncludeSchema(browserFillInputSchema))
+  .refine(
+    (a) => {
+      const hasSelector = typeof a.selector === "string" && a.selector.length > 0;
+      const hasBy = typeof a.by === "string" && typeof a.pattern === "string" && a.pattern.length > 0;
+      return hasSelector !== hasBy; // exactly one (XOR)
+    },
+    { message: "browser_fill: provide EITHER selector OR (by + pattern), not both or neither." },
+  );
 
 export const browserFillRegistrationHandler = makeCommitWrapper(
   withRichNarration(
@@ -2871,10 +2964,13 @@ export function registerBrowserTools(server: McpServer): void {
     browserNavigateRegistrationHandler as typeof browserNavigateHandler
   );
 
-  server.tool(
+  server.registerTool(
     "browser_fill",
-    "Fill a form input with a value via CDP — works on React/Vue/Svelte controlled inputs that reject browser_eval value assignment. Use browser_overview or browser_locate first to obtain a stable selector. Use this over browser_eval when setting a controlled input's value via JS does not update the framework state. Caveats: Requires browser_open (CDP active). Does not work on contenteditable rich-text editors — use keyboard(action='type') for those. actual in response shows what the element's value property reads after fill; verify it matches the intended value. Typed errors: code:'BrowserFillNotDelivered' on post-fill value mismatch — note the false-positive case where a React controlled input's onChange transforms the value (delivery actually succeeded; SUGGESTS context surfaces hints.verifyDelivery.subReason:'controlled_input_transform' for that case). When detected, the actual value in the response is authoritative.",
-    browserFillRegistrationSchema,
+    {
+      description:
+        "Fill a form input with a value via CDP — works on React/Vue/Svelte controlled inputs that reject browser_eval value assignment. Two ways to target: (1) selector — a CSS selector (use browser_overview / browser_locate to find one); or (2) by-axis (semantic) — by:'text'|'regex'|'role'|'ariaLabel' + pattern (e.g. by:'ariaLabel', pattern:'Email address', or by:'role', pattern:'textbox'), so you do not have to build a CSS selector. by-axis resolves to a SINGLE fillable element and STOPS with code:'BrowserAmbiguousTarget' (candidates[] + next[] hints) when 2+ match, or code:'BrowserNoActionableTarget' when the match is not a fillable input/textarea/contenteditable — it never guesses. Optionally add role to filter and scope to narrow. Provide EITHER selector OR by+pattern (not both). Use this over browser_eval when setting a controlled input's value via JS does not update framework state. Caveats: Requires browser_open (CDP active). actual in the response shows the element's value after fill; verify it matches the intended value. Typed errors: code:'BrowserFillNotDelivered' on post-fill value mismatch — note the false-positive case where a React controlled input's onChange transforms the value (delivery actually succeeded; hints.verifyDelivery.subReason:'controlled_input_transform' for that case; the actual value is authoritative).",
+      inputSchema: browserFillRegistrationSchema,
+    },
     browserFillRegistrationHandler as typeof browserFillInputHandler
   );
 

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -792,12 +792,17 @@ async function handleBrowserFillByAxis(args: {
   if (outcome.kind === "error") return browserResolveErrorToFailure(outcome, "browser_fill", ctx);
   if (outcome.kind !== "resolved") return browserResolveStopToFailure(outcome, "browser_fill", ctx);
 
-  // Resolved → act (2nd eval): re-gather the same pool, re-select top[index],
-  // climb to the resolved element, fill via the native setter. No second
-  // querySelector / coordinate re-find (avoids re-non-uniqueness / occlusion).
-  const actExpr = buildFillActJs({ by, pattern, role, scope, caseSensitive: caseSensitive ?? false }, outcome.index, outcome.climbDepth, value);
+  // Resolved → act (2nd eval): re-gather the same pool, verify the matched
+  // element's identity is unchanged (Codex P1 — never silently mis-fill a field
+  // the DOM moved under us), re-select top[index], climb, fill via the native
+  // setter. No second querySelector / coordinate re-find (avoids re-non-uniqueness
+  // / occlusion).
+  const actExpr = buildFillActJs(
+    { by, pattern, role, scope, caseSensitive: caseSensitive ?? false },
+    outcome.index, outcome.climbDepth, value, outcome.matched,
+  );
   const actResult = await evaluateInTab(actExpr, tabId ?? null, port) as
-    { ok: boolean; error?: string; tag?: string; actual?: string; fullActualLen?: number; fullMatches?: boolean };
+    { ok: boolean; error?: string; detail?: string; tag?: string; actual?: string; fullActualLen?: number; fullMatches?: boolean };
 
   if (!actResult.ok) {
     if (actResult.error === "not_fillable") {
@@ -813,11 +818,12 @@ async function handleBrowserFillByAxis(args: {
         },
       );
     }
-    // index_out_of_range / resolved_element_lost: the DOM changed between the
-    // resolve gather and the act re-gather.
+    // identity_changed / index_out_of_range / resolved_element_lost: the DOM
+    // mutated between the resolve gather and the act re-gather — fail WITHOUT
+    // writing so we never fill the wrong field.
     return failCode(
       "ToolError",
-      `browser_fill: the page changed between resolving and filling (${actResult.error ?? "unknown"}).`,
+      `browser_fill: the page changed between resolving and filling (${actResult.error ?? "unknown"}${actResult.detail ? ": " + actResult.detail : ""}) — not filled.`,
       { suggest: ["Retry — the resolver re-resolves against the current DOM"], context: ctx },
     );
   }

--- a/tests/e2e/browser-fill-by-axis.test.ts
+++ b/tests/e2e/browser-fill-by-axis.test.ts
@@ -103,4 +103,12 @@ describe.skipIf(!CHROME_AVAILABLE)("browser_fill by-axis — stops (headless)", 
     expect(r.ok, JSON.stringify(r)).toBe(false);
     expect(r.code).toBe("ScopeNotFound");
   });
+
+  it("a non-text input (checkbox) is not fillable → BrowserNoActionableTarget (Codex P1)", async () => {
+    // <input type=checkbox> is strong+visible+enabled so it RESOLVES, but the act
+    // eval must reject it (setting .value would be a false-positive 'filled').
+    const r = await fill({ by: "ariaLabel", pattern: "Accept terms", value: "x" });
+    expect(r.ok, JSON.stringify(r)).toBe(false);
+    expect(r.code).toBe("BrowserNoActionableTarget");
+  });
 });

--- a/tests/e2e/browser-fill-by-axis.test.ts
+++ b/tests/e2e/browser-fill-by-axis.test.ts
@@ -16,6 +16,7 @@ import { launchChrome, tryFindChrome, type ChromeInstance } from "./helpers/chro
 import { sleep } from "./helpers/wait.js";
 import { evaluateInTab, disconnectAll } from "../../src/engine/cdp-bridge.js";
 import { browserFillInputHandler } from "../../src/tools/browser.js";
+import { buildFillActJs } from "../../src/tools/browser-resolver.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURE_PATH = join(__dirname, "fixtures", "resolver-gsc-like.html");
@@ -110,5 +111,38 @@ describe.skipIf(!CHROME_AVAILABLE)("browser_fill by-axis — stops (headless)", 
     const r = await fill({ by: "ariaLabel", pattern: "Accept terms", value: "x" });
     expect(r.ok, JSON.stringify(r)).toBe(false);
     expect(r.code).toBe("BrowserNoActionableTarget");
+  });
+});
+
+describe.skipIf(!CHROME_AVAILABLE)("browser_fill by-axis — identity gate reject path (Codex P1)", () => {
+  // Drive the act eval directly with a STALE `expect` to prove the identity gate
+  // fires against a real DOM and never writes (the handler runs the two evals
+  // back-to-back, so a real mutation between them cannot be staged end-to-end).
+  it("rejects a stale pool-count expectation (identity_changed/candidate_count, no write)", async () => {
+    await evaluateInTab("document.querySelector('#email-input').value = 'keep'", null, TEST_PORT);
+    const js = buildFillActJs(
+      { by: "ariaLabel", pattern: "Email address", caseSensitive: false }, 0, 0, "MUST-NOT-WRITE",
+      { name: "Email address", role: null, ariaLabel: "Email address", tag: "input", total: 999 },
+    );
+    const r = await evaluateInTab(js, null, TEST_PORT) as { ok: boolean; error?: string; detail?: string };
+    expect(r.ok, JSON.stringify(r)).toBe(false);
+    expect(r.error).toBe("identity_changed");
+    expect(r.detail).toBe("candidate_count");
+    const domVal = await evaluateInTab("document.querySelector('#email-input').value", null, TEST_PORT);
+    expect(domVal).toBe("keep"); // gate prevented the write
+  });
+
+  it("rejects a signature mismatch (identity_changed/signature, no write)", async () => {
+    await evaluateInTab("document.querySelector('#email-input').value = 'keep'", null, TEST_PORT);
+    const js = buildFillActJs(
+      { by: "ariaLabel", pattern: "Email address", caseSensitive: false }, 0, 0, "MUST-NOT-WRITE",
+      { name: "WRONG NAME", role: null, ariaLabel: "Email address", tag: "input", total: 1 },
+    );
+    const r = await evaluateInTab(js, null, TEST_PORT) as { ok: boolean; error?: string; detail?: string };
+    expect(r.ok, JSON.stringify(r)).toBe(false);
+    expect(r.error).toBe("identity_changed");
+    expect(r.detail).toBe("signature");
+    const domVal = await evaluateInTab("document.querySelector('#email-input').value", null, TEST_PORT);
+    expect(domVal).toBe("keep"); // gate prevented the write
   });
 });

--- a/tests/e2e/browser-fill-by-axis.test.ts
+++ b/tests/e2e/browser-fill-by-axis.test.ts
@@ -1,0 +1,106 @@
+/**
+ * browser-fill-by-axis.test.ts — E2E for ADR-023 Phase 1 PR4 browser_fill({by}).
+ *
+ * by-axis fill is fully headless-testable end to end: BOTH the resolve gather and
+ * the act (focus + native-setter value + dispatch) run via CDP eval — no physical
+ * mouse — so the resolved-fill success path is covered here against real Chrome,
+ * along with the ambiguous / not-fillable / no-actionable / error stops.
+ *
+ * @see src/tools/browser.ts  handleBrowserFillByAxis
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+import { launchChrome, tryFindChrome, type ChromeInstance } from "./helpers/chrome-launcher.js";
+import { sleep } from "./helpers/wait.js";
+import { evaluateInTab, disconnectAll } from "../../src/engine/cdp-bridge.js";
+import { browserFillInputHandler } from "../../src/tools/browser.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = join(__dirname, "fixtures", "resolver-gsc-like.html");
+const TEST_PORT = 9231;
+const FIXTURE_URL = `file:///${FIXTURE_PATH.replace(/\\/g, "/")}`;
+const CHROME_AVAILABLE = tryFindChrome() !== null;
+
+let chrome: ChromeInstance;
+
+beforeAll(async () => {
+  if (!CHROME_AVAILABLE) return;
+  chrome = await launchChrome(TEST_PORT, true /* headless */, FIXTURE_URL);
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    try {
+      const ready = await evaluateInTab(
+        `document.readyState === 'complete' && document.querySelector('#email-input') !== null && ` +
+        `document.querySelector('#email-input').getBoundingClientRect().width > 0`,
+        null, TEST_PORT);
+      if (ready === true) return;
+    } catch { /* ignore */ }
+    await sleep(250);
+  }
+  throw new Error("Fixture did not lay out within 15s");
+}, 20_000);
+
+afterAll(() => {
+  disconnectAll(TEST_PORT);
+  chrome?.kill();
+});
+
+function payload(r: { content: Array<{ type: string; text?: string }> }): Record<string, unknown> {
+  const text = r.content[0]?.type === "text" ? r.content[0].text ?? "{}" : "{}";
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+async function fill(args: Record<string, unknown>) {
+  return payload(await browserFillInputHandler({
+    value: "", includeContext: false, port: TEST_PORT, ...args,
+  } as Parameters<typeof browserFillInputHandler>[0]));
+}
+
+describe.skipIf(!CHROME_AVAILABLE)("browser_fill by-axis — resolved fill (AC-4, headless)", () => {
+  it("resolves an input by aria-label and fills it (value lands in the DOM)", async () => {
+    await evaluateInTab("document.querySelector('#email-input').value = ''", null, TEST_PORT);
+    const r = await fill({ by: "ariaLabel", pattern: "Email address", value: "user@example.com" });
+    expect(r.ok, JSON.stringify(r)).toBe(true);
+    expect(r.actual).toBe("user@example.com");
+    const domVal = await evaluateInTab("document.querySelector('#email-input').value", null, TEST_PORT);
+    expect(domVal).toBe("user@example.com");
+  });
+
+  it("overwrites an existing value (select-all + native setter)", async () => {
+    await evaluateInTab("document.querySelector('#email-input').value = 'old text'", null, TEST_PORT);
+    const r = await fill({ by: "ariaLabel", pattern: "Email address", value: "fresh" });
+    expect(r.ok, JSON.stringify(r)).toBe(true);
+    const domVal = await evaluateInTab("document.querySelector('#email-input').value", null, TEST_PORT);
+    expect(domVal).toBe("fresh");
+  });
+});
+
+describe.skipIf(!CHROME_AVAILABLE)("browser_fill by-axis — stops (headless)", () => {
+  it("ambiguous match → BrowserAmbiguousTarget (no fill)", async () => {
+    const r = await fill({ by: "text", pattern: "Save", value: "x" });
+    expect(r.ok, JSON.stringify(r)).toBe(false);
+    expect(r.code).toBe("BrowserAmbiguousTarget");
+  });
+
+  it("resolves uniquely to a non-fillable element → BrowserNoActionableTarget (act-stage gate)", async () => {
+    // "Compose Email" matches the inner span; resolves (climbs) to the <button>,
+    // which is not fillable → the act eval returns not_fillable.
+    const r = await fill({ by: "text", pattern: "Compose Email", value: "x" });
+    expect(r.ok, JSON.stringify(r)).toBe(false);
+    expect(r.code).toBe("BrowserNoActionableTarget");
+  });
+
+  it("matched text with no strong clickable → BrowserNoActionableTarget (resolve-stage)", async () => {
+    const r = await fill({ by: "text", pattern: "Just a label Foobar", value: "x" });
+    expect(r.ok, JSON.stringify(r)).toBe(false);
+    expect(r.code).toBe("BrowserNoActionableTarget");
+  });
+
+  it("invalid scope → ScopeNotFound", async () => {
+    const r = await fill({ by: "ariaLabel", pattern: "Email address", scope: "#no-such-scope", value: "x" });
+    expect(r.ok, JSON.stringify(r)).toBe(false);
+    expect(r.code).toBe("ScopeNotFound");
+  });
+});

--- a/tests/e2e/fixtures/resolver-gsc-like.html
+++ b/tests/e2e/fixtures/resolver-gsc-like.html
@@ -60,6 +60,9 @@
 
     <!-- Fill target: an input identified by aria-label. -->
     <input id="email-input" type="text" aria-label="Email address" />
+
+    <!-- Non-text input: must NOT be fillable by by-axis fill (Codex P1). -->
+    <input id="terms-checkbox" type="checkbox" aria-label="Accept terms" />
   </main>
 </body>
 </html>

--- a/tests/fixtures/failwith-callsite-shapes.json
+++ b/tests/fixtures/failwith-callsite-shapes.json
@@ -86,105 +86,105 @@
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 770,
+      "line": 725,
       "tool": "browser_fill",
-      "errKind": "member",
-      "contextShape": "none"
+      "errKind": "new-error",
+      "contextShape": "object-hoisted"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 960,
+      "line": 1041,
       "tool": "browser_form",
       "errKind": "string-literal",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 974,
+      "line": 1055,
       "tool": "browser_form",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1026,
+      "line": 1107,
       "tool": "browser_open",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1078,
+      "line": 1159,
       "tool": "browser_locate",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1336,
+      "line": 1417,
       "tool": "browser_click",
       "errKind": "new-error",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1347,
+      "line": 1428,
       "tool": "browser_click",
       "errKind": "new-error",
       "contextShape": "object-hoisted"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1548,
+      "line": 1629,
       "tool": "browser_eval",
       "errKind": "new-error",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1700,
+      "line": 1781,
       "tool": "browser_eval",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1727,
+      "line": 1808,
       "tool": "browser_navigate",
       "errKind": "new-error",
       "contextShape": "object-hoisted"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1744,
+      "line": 1825,
       "tool": "browser_navigate",
       "errKind": "new-error",
       "contextShape": "object-hoisted"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 2036,
+      "line": 2117,
       "tool": "browser_overview",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 2188,
+      "line": 2269,
       "tool": "browser_open",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 2319,
+      "line": 2400,
       "tool": "browser_search",
       "errKind": "identifier",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 2467,
+      "line": 2548,
       "tool": "browser_disconnect",
       "errKind": "identifier",
       "contextShape": "none"

--- a/tests/fixtures/failwith-callsite-shapes.json
+++ b/tests/fixtures/failwith-callsite-shapes.json
@@ -93,98 +93,98 @@
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1041,
+      "line": 1047,
       "tool": "browser_form",
       "errKind": "string-literal",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1055,
+      "line": 1061,
       "tool": "browser_form",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1107,
+      "line": 1113,
       "tool": "browser_open",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1159,
+      "line": 1165,
       "tool": "browser_locate",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1417,
+      "line": 1423,
       "tool": "browser_click",
       "errKind": "new-error",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1428,
+      "line": 1434,
       "tool": "browser_click",
       "errKind": "new-error",
       "contextShape": "object-hoisted"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1629,
+      "line": 1635,
       "tool": "browser_eval",
       "errKind": "new-error",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1781,
+      "line": 1787,
       "tool": "browser_eval",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1808,
+      "line": 1814,
       "tool": "browser_navigate",
       "errKind": "new-error",
       "contextShape": "object-hoisted"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1825,
+      "line": 1831,
       "tool": "browser_navigate",
       "errKind": "new-error",
       "contextShape": "object-hoisted"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 2117,
+      "line": 2123,
       "tool": "browser_overview",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 2269,
+      "line": 2275,
       "tool": "browser_open",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 2400,
+      "line": 2406,
       "tool": "browser_search",
       "errKind": "identifier",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 2548,
+      "line": 2554,
       "tool": "browser_disconnect",
       "errKind": "identifier",
       "contextShape": "none"

--- a/tests/unit/__snapshots__/browser-resolver-candidate-collection.test.ts.snap
+++ b/tests/unit/__snapshots__/browser-resolver-candidate-collection.test.ts.snap
@@ -366,7 +366,7 @@ exports[`ADR-023 Phase 1 PR2: buildActionCandidateFactsJs — gather tail (snaps
     return sb - sa;
   });
 
-  // ── ADR-023 Phase 1 PR2: action-target fact gathering (top-N only, §2.bis). ──
+  // ── ADR-023 Phase 1: action-target candidate pool (top-N, role-filtered). ──
   const N = 8;
   const D = 3;
 
@@ -505,6 +505,236 @@ exports[`ADR-023 Phase 1 PR2: buildActionCandidateFactsJs — gather tail (snaps
     viewport: { screenX: sx, screenY: sy, dpr: dpr, chromeH: chromeH, chromeW: chromeW, innerWidth: window.innerWidth, innerHeight: window.innerHeight },
     candidates: factsList,
   };
+})()
+"
+`;
+
+exports[`ADR-023 Phase 1 PR4: buildFillActJs — by-axis fill act (snapshot) > emits the full fill-act IIFE for a representative by:ariaLabel target (snapshot) 1`] = `
+"
+(function() {
+  const root = document;
+  if (!root) return { __error: "ScopeNotFound" };
+
+  const by = "ariaLabel";
+  const pat = "Email address";
+  const cs  = false;
+  const visibleOnly = true;
+  const viewportOnly = false;
+  const maxN = 200;
+  const offN = 0;
+
+  function isVisible(el) {
+    const s = window.getComputedStyle(el);
+    if (s.display === 'none' || s.visibility === 'hidden' || s.opacity === '0') return false;
+    const r = el.getBoundingClientRect();
+    return r.width > 0 && r.height > 0;
+  }
+  function inViewportRect(rect) {
+    return rect.top < window.innerHeight && rect.bottom > 0 &&
+           rect.left < window.innerWidth && rect.right > 0;
+  }
+  function bestSelector(el) {
+    if (el.id) return '#' + CSS.escape(el.id);
+    const name = el.getAttribute('name');
+    if (name) return el.tagName.toLowerCase() + '[name=' + JSON.stringify(name) + ']';
+    const aria = el.getAttribute('aria-label');
+    if (aria && aria.length < 80)
+      return el.tagName.toLowerCase() + '[aria-label=' + JSON.stringify(aria) + ']';
+    for (const attr of ['data-testid', 'data-asin']) {
+      const v = el.getAttribute(attr);
+      if (v && v.length < 60) return el.tagName.toLowerCase() + '[' + attr + '=' + JSON.stringify(v) + ']';
+    }
+    let node = el; let path = '';
+    for (let depth = 0; depth < 2 && node.parentElement; depth++) {
+      const p = node.parentElement;
+      const idx = Array.from(p.children).indexOf(node) + 1;
+      const seg = node.tagName.toLowerCase() + ':nth-child(' + idx + ')';
+      path = path ? seg + ' > ' + path : seg;
+      if (p.id) { path = '#' + CSS.escape(p.id) + ' > ' + path; break; }
+      node = p;
+    }
+    return path || el.tagName.toLowerCase();
+  }
+  function classify(el) {
+    const tag = el.tagName.toLowerCase();
+    if (tag === 'a') return 'link';
+    if (tag === 'button' || el.getAttribute('role') === 'button') return 'button';
+    if (tag === 'input' || tag === 'textarea' || tag === 'select') return 'input';
+    if (/^h[1-6]$/.test(tag)) return 'heading';
+    if (tag === 'p' || tag === 'span' || tag === 'div') return 'text';
+    return 'other';
+  }
+  function elText(el) {
+    const t = (el.textContent || '').trim().replace(/\\s+/g, ' ').slice(0, 80);
+    if (!t && el.tagName === 'INPUT')
+      return (el.placeholder || el.value || el.getAttribute('aria-label') || '').slice(0, 80);
+    return t;
+  }
+  function score(matched, visible) {
+    let s = matched;
+    if (!visible) s = Math.max(0, s - 0.3);
+    return Math.round(s * 100) / 100;
+  }
+
+  // Bound the scan — pages can have 10k+ nodes and CDP timeout is 15s.
+  const SCAN_BUDGET_MS = 3000;
+  const nowFn = (typeof performance !== 'undefined' ? () => performance.now() : () => Date.now());
+  const startTs = nowFn();
+  const deadline = startTs + SCAN_BUDGET_MS;
+  let aborted = false;
+  // Sample the clock every 1024 iterations — cheap but keeps latency bounded.
+  function overBudget(i) { return (i & 0x3FF) === 0 && nowFn() > deadline; }
+
+  // IIFE-local match-state stores. WeakMap is essential: DOM elements persist
+  // across Runtime.evaluate calls, so any expando we set (e.g. el.__matchScore)
+  // would leak into the next search and contaminate scores / matchedBy / dedupe.
+  // WeakMap is GC'd at IIFE end so each call starts clean.
+  const matchScore = new WeakMap();
+  const matchedByMap = new WeakMap();
+  const pushed = new Set();
+  function record(el, score, by) {
+    const prev = matchScore.get(el) || 0;
+    if (score > prev) { matchScore.set(el, score); matchedByMap.set(el, by); }
+    if (!pushed.has(el)) { candidates.push(el); pushed.add(el); }
+  }
+
+  const all = root.querySelectorAll('*');
+  let candidates = [];
+
+  if (by === 'selector') {
+    const selectorMatches = Array.from(root.querySelectorAll(pat));
+    for (let i = 0; i < selectorMatches.length; i++) {
+      if (overBudget(i)) { aborted = true; break; }
+      record(selectorMatches[i], 1.0, 'selector');
+    }
+  } else if (by === 'text') {
+    const needle = cs ? pat : pat.toLowerCase();
+    let i = 0;
+    for (const el of all) {
+      if (overBudget(i++)) { aborted = true; break; }
+      // Direct child text only (avoid double-counting parent matches via descendants)
+      const direct = Array.from(el.childNodes)
+        .filter(n => n.nodeType === 3)
+        .map(n => n.textContent || '')
+        .join('').trim();
+      if (!direct) continue;
+      const hay = cs ? direct : direct.toLowerCase();
+      if (hay === needle) record(el, 1.0, 'text');
+      else if (hay.includes(needle)) record(el, 0.8, 'text');
+    }
+  } else if (by === 'regex') {
+    let re;
+    try { re = new RegExp(pat, (cs ? '' : 'i') + 'u'); }
+    catch (e) { return { __error: "InvalidRegex", message: String(e) }; }
+    let i = 0;
+    for (const el of all) {
+      if (overBudget(i++)) { aborted = true; break; }
+      const direct = Array.from(el.childNodes).filter(n => n.nodeType === 3).map(n => n.textContent || '').join('').trim();
+      if (!direct) continue;
+      if (re.test(direct)) record(el, 0.9, 'regex');
+    }
+  } else if (by === 'role') {
+    const needle = cs ? pat : pat.toLowerCase();
+    let i = 0;
+    for (const el of all) {
+      if (overBudget(i++)) { aborted = true; break; }
+      const role = el.getAttribute('role') || '';
+      const cmp = cs ? role : role.toLowerCase();
+      if (cmp === needle) record(el, 0.75, 'role');
+    }
+    // Implicit roles — score slightly higher because they're guaranteed by tag.
+    if (!aborted && needle === 'button')  for (const el of root.querySelectorAll('button')) record(el, 0.85, 'roleImplicit');
+    if (!aborted && needle === 'link')    for (const el of root.querySelectorAll('a[href]')) record(el, 0.85, 'roleImplicit');
+    if (!aborted && needle === 'heading') for (const el of root.querySelectorAll('h1,h2,h3,h4,h5,h6')) record(el, 0.85, 'roleImplicit');
+  } else if (by === 'ariaLabel') {
+    const needle = cs ? pat : pat.toLowerCase();
+    let i = 0;
+    for (const el of all) {
+      if (overBudget(i++)) { aborted = true; break; }
+      const aria = el.getAttribute('aria-label') || '';
+      if (!aria) continue;
+      const cmp = cs ? aria : aria.toLowerCase();
+      if (cmp === needle) record(el, 0.95, 'ariaLabel');
+      else if (cmp.includes(needle)) record(el, 0.7, 'ariaLabel');
+    }
+  }
+
+  // candidates already de-duplicated via the pushed Set in record()
+
+  if (aborted && candidates.length === 0) {
+    return { __error: "Timeout", message: "Scan budget exceeded with no matches; narrow scope or maxResults." };
+  }
+
+  const filtered = [];
+  for (const el of candidates) {
+    const visible = isVisible(el);
+    if (visibleOnly && !visible) continue;
+    const rect = el.getBoundingClientRect();
+    const inVp = inViewportRect(rect);
+    if (viewportOnly && !inVp) continue;
+    filtered.push({ el, visible, rect, inVp });
+  }
+
+  // Score and sort by confidence desc
+  filtered.sort((a, b) => {
+    const sa = score(matchScore.get(a.el) || 0, a.visible);
+    const sb = score(matchScore.get(b.el) || 0, b.visible);
+    return sb - sa;
+  });
+
+  // ── ADR-023 Phase 1: action-target candidate pool (top-N, role-filtered). ──
+  const N = 8;
+  const D = 3;
+
+  // Optional role filter (AND with the by-axis match) applied BEFORE the top-N
+  // cap so total/candidates reflect the role-filtered pool (plan §S4 role combine).
+  const roleFilter = null;
+  function roleMatches(el) {
+    const explicit = (el.getAttribute('role') || '').toLowerCase();
+    if (explicit === roleFilter) return true;
+    const tg = el.tagName.toLowerCase();
+    const ty = (el.getAttribute('type') || '').toLowerCase();
+    if (roleFilter === 'button') return tg === 'button' || (tg === 'input' && /^(button|submit|reset)$/.test(ty));
+    if (roleFilter === 'link') return tg === 'a' && el.hasAttribute('href');
+    if (roleFilter === 'textbox') return tg === 'textarea' || (tg === 'input' && !/^(button|submit|reset|checkbox|radio|range|color|file|image|hidden)$/.test(ty));
+    if (roleFilter === 'checkbox') return tg === 'input' && ty === 'checkbox';
+    if (roleFilter === 'radio') return tg === 'input' && ty === 'radio';
+    if (roleFilter === 'heading') return /^h[1-6]$/.test(tg);
+    return false;
+  }
+  const pool = roleFilter ? filtered.filter(function(e) { return roleMatches(e.el); }) : filtered;
+  const top = pool.slice(0, N);
+  // ── ADR-023 Phase 1 PR4: by-axis fill ACT (deterministic re-gather + index). ──
+  if (top.length <= 0) return { ok: false, error: 'index_out_of_range' };
+  let el = top[0].el;
+  for (let d = 0; d < 0 && el; d++) el = el.parentElement;
+  if (!el) return { ok: false, error: 'resolved_element_lost' };
+
+  const tag = el.tagName;
+  const isInput = tag === 'INPUT' || tag === 'TEXTAREA';
+  const isEditable = el.isContentEditable === true;
+  if (!isInput && !isEditable) return { ok: false, error: 'not_fillable', tag: tag.toLowerCase() };
+
+  el.focus();
+  const val = "user@example.com";
+  if (isInput) {
+    if (typeof el.select === 'function') el.select();
+    let proto = null;
+    if (tag === 'INPUT') proto = HTMLInputElement.prototype;
+    else if (tag === 'TEXTAREA') proto = HTMLTextAreaElement.prototype;
+    const descriptor = proto ? Object.getOwnPropertyDescriptor(proto, 'value') : null;
+    if (descriptor && descriptor.set) descriptor.set.call(el, val);
+    else el.value = val;
+    el.dispatchEvent(new InputEvent('input', { bubbles: true, cancelable: true, inputType: 'insertText', data: val }));
+    el.dispatchEvent(new Event('change', { bubbles: true }));
+    const fullActual = el.value !== undefined ? el.value : '';
+    return { ok: true, actual: (fullActual || '').slice(0, 100), fullActualLen: fullActual.length, fullMatches: fullActual === val };
+  }
+  // contenteditable
+  el.textContent = val;
+  el.dispatchEvent(new InputEvent('input', { bubbles: true, cancelable: true, inputType: 'insertText', data: val }));
+  const fullActual = el.textContent || '';
+  return { ok: true, actual: (fullActual || '').slice(0, 100), fullActualLen: fullActual.length, fullMatches: fullActual === val };
 })()
 "
 `;

--- a/tests/unit/__snapshots__/browser-resolver-candidate-collection.test.ts.snap
+++ b/tests/unit/__snapshots__/browser-resolver-candidate-collection.test.ts.snap
@@ -705,8 +705,23 @@ exports[`ADR-023 Phase 1 PR4: buildFillActJs — by-axis fill act (snapshot) > e
   const pool = roleFilter ? filtered.filter(function(e) { return roleMatches(e.el); }) : filtered;
   const top = pool.slice(0, N);
   // ── ADR-023 Phase 1 PR4: by-axis fill ACT (deterministic re-gather + index). ──
+  // IDENTITY GATE (Codex P1): the re-gather assumes the DOM is unchanged since the
+  // resolve eval. If it mutated (a matching field inserted/removed/reordered),
+  // top[index] could be a DIFFERENT field — a silent mis-fill. Verify the matched
+  // element's identity (pool count + name/role/ariaLabel/tag of top[index] before
+  // climb) against what resolve saw; on mismatch fail (the agent re-resolves) and
+  // NEVER write.
+  if (pool.length !== 1) return { ok: false, error: 'identity_changed', detail: 'candidate_count' };
   if (top.length <= 0) return { ok: false, error: 'index_out_of_range' };
-  let el = top[0].el;
+  const matched = top[0].el;
+  const mName = elText(matched);
+  const mRole = matched.getAttribute('role') || null;
+  const mAria = matched.getAttribute('aria-label') || null;
+  const mTag = matched.tagName.toLowerCase();
+  if (mName !== "Email address" || mRole !== null || mAria !== "Email address" || mTag !== "input") {
+    return { ok: false, error: 'identity_changed', detail: 'signature' };
+  }
+  let el = matched;
   for (let d = 0; d < 0 && el; d++) el = el.parentElement;
   if (!el) return { ok: false, error: 'resolved_element_lost' };
 

--- a/tests/unit/__snapshots__/browser-resolver-candidate-collection.test.ts.snap
+++ b/tests/unit/__snapshots__/browser-resolver-candidate-collection.test.ts.snap
@@ -711,13 +711,21 @@ exports[`ADR-023 Phase 1 PR4: buildFillActJs — by-axis fill act (snapshot) > e
   if (!el) return { ok: false, error: 'resolved_element_lost' };
 
   const tag = el.tagName;
-  const isInput = tag === 'INPUT' || tag === 'TEXTAREA';
+  const ty = (el.getAttribute('type') || '').toLowerCase();
+  // Text-entry controls only. Exclude non-text input types (Codex P1): type=file
+  // THROWS on a non-empty .value assignment; checkbox/radio/button/submit/reset/
+  // image/range/color/hidden ignore a value string (a false-positive "filled") or
+  // are not text targets. Same exclusion as the 'textbox' role filter.
+  const isTextInput = tag === 'INPUT' && !/^(button|submit|reset|checkbox|radio|range|color|file|image|hidden)$/.test(ty);
+  const isTextArea = tag === 'TEXTAREA';
   const isEditable = el.isContentEditable === true;
-  if (!isInput && !isEditable) return { ok: false, error: 'not_fillable', tag: tag.toLowerCase() };
+  if (!isTextInput && !isTextArea && !isEditable) {
+    return { ok: false, error: 'not_fillable', tag: tag.toLowerCase() + (ty ? '[type=' + ty + ']' : '') };
+  }
 
   el.focus();
   const val = "user@example.com";
-  if (isInput) {
+  if (isTextInput || isTextArea) {
     if (typeof el.select === 'function') el.select();
     let proto = null;
     if (tag === 'INPUT') proto = HTMLInputElement.prototype;

--- a/tests/unit/browser-click-by-axis-schema.test.ts
+++ b/tests/unit/browser-click-by-axis-schema.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { browserClickRegistrationSchema } from "../../src/tools/browser.js";
+import { browserClickRegistrationSchema, browserFillRegistrationSchema } from "../../src/tools/browser.js";
 
 describe("browser_click registration schema — exactly-one-of(selector | by+pattern)", () => {
   it("accepts selector alone", () => {
@@ -53,6 +53,38 @@ describe("browser_click registration schema — exactly-one-of(selector | by+pat
     expect(def?.type).toBe("object");
     const shape = def?.shape ?? {};
     for (const key of ["selector", "by", "pattern", "role", "scope", "include"]) {
+      expect(Object.keys(shape)).toContain(key);
+    }
+  });
+});
+
+describe("browser_fill registration schema — exactly-one-of(selector | by+pattern)", () => {
+  it("accepts selector + value", () => {
+    expect(browserFillRegistrationSchema.safeParse({ selector: "#email", value: "x" }).success).toBe(true);
+  });
+
+  it("accepts by + pattern + value", () => {
+    expect(browserFillRegistrationSchema.safeParse({ by: "ariaLabel", pattern: "Email", value: "x" }).success).toBe(true);
+  });
+
+  it("rejects BOTH selector and by+pattern", () => {
+    expect(browserFillRegistrationSchema.safeParse({ selector: "#e", by: "ariaLabel", pattern: "Email", value: "x" }).success).toBe(false);
+  });
+
+  it("rejects NEITHER", () => {
+    expect(browserFillRegistrationSchema.safeParse({ value: "x" }).success).toBe(false);
+  });
+
+  it("requires value", () => {
+    expect(browserFillRegistrationSchema.safeParse({ by: "ariaLabel", pattern: "Email" }).success).toBe(false);
+  });
+
+  it("survives the refine as a ZodObject with all by-axis + value properties", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const def = (browserFillRegistrationSchema as any)._zod?.def;
+    expect(def?.type).toBe("object");
+    const shape = def?.shape ?? {};
+    for (const key of ["selector", "by", "pattern", "role", "scope", "value", "include"]) {
       expect(Object.keys(shape)).toContain(key);
     }
   });

--- a/tests/unit/browser-resolver-candidate-collection.test.ts
+++ b/tests/unit/browser-resolver-candidate-collection.test.ts
@@ -132,14 +132,16 @@ describe("ADR-023 Phase 1 PR2: buildActionCandidateFactsJs — gather tail (snap
   });
 });
 
+const EXPECT = { name: "Email address", role: null, ariaLabel: "Email address", tag: "input", total: 1 };
+
 describe("ADR-023 Phase 1 PR4: buildFillActJs — by-axis fill act (snapshot)", () => {
   it("emits the full fill-act IIFE for a representative by:ariaLabel target (snapshot)", () => {
-    const js = buildFillActJs({ by: "ariaLabel", pattern: "Email address", caseSensitive: false }, 0, 0, "user@example.com");
+    const js = buildFillActJs({ by: "ariaLabel", pattern: "Email address", caseSensitive: false }, 0, 0, "user@example.com", EXPECT);
     expect(js).toMatchSnapshot();
   });
 
   it("reuses the shared candidate pool (same matching body + role filter + top-N)", () => {
-    const js = buildFillActJs({ by: "ariaLabel", pattern: "X", role: "textbox", caseSensitive: false }, 0, 0, "v");
+    const js = buildFillActJs({ by: "ariaLabel", pattern: "X", role: "textbox", caseSensitive: false }, 0, 0, "v", EXPECT);
     for (const frag of [
       "filtered.sort((a, b) =>",          // shared matching body
       "const top = pool.slice(0, N);",    // shared pool fragment
@@ -150,10 +152,23 @@ describe("ADR-023 Phase 1 PR4: buildFillActJs — by-axis fill act (snapshot)", 
     }
   });
 
+  it("identity gate (Codex P1): verifies pool count + matched signature before writing", () => {
+    const js = buildFillActJs(
+      { by: "ariaLabel", pattern: "X", caseSensitive: false }, 2, 1, "hi",
+      { name: "Email address", role: null, ariaLabel: "Email address", tag: "input", total: 3 },
+    );
+    expect(js).toContain("if (pool.length !== 3) return { ok: false, error: 'identity_changed', detail: 'candidate_count' };");
+    expect(js).toContain('if (mName !== "Email address" || mRole !== null || mAria !== "Email address" || mTag !== "input")');
+    expect(js).toContain("error: 'identity_changed', detail: 'signature'");
+    // the gate runs BEFORE any focus/setter write
+    expect(js.indexOf("identity_changed")).toBeLessThan(js.indexOf("descriptor.set.call(el, val)"));
+  });
+
   it("act tail: re-select top[index], climb climbDepth, fillable gate, native setter + events", () => {
-    const js = buildFillActJs({ by: "ariaLabel", pattern: "X", caseSensitive: false }, 2, 1, "hi");
+    const js = buildFillActJs({ by: "ariaLabel", pattern: "X", caseSensitive: false }, 2, 1, "hi", EXPECT);
     expect(js).toContain("if (top.length <= 2) return { ok: false, error: 'index_out_of_range' };");
-    expect(js).toContain("let el = top[2].el;");
+    expect(js).toContain("const matched = top[2].el;");
+    expect(js).toContain("let el = matched;");
     expect(js).toContain("for (let d = 0; d < 1 && el; d++) el = el.parentElement;");
     expect(js).toContain("const isTextInput = tag === 'INPUT' && !/^(button|submit|reset|checkbox|radio|range|color|file|image|hidden)$/.test(ty);");
     expect(js).toContain("el.isContentEditable === true");
@@ -165,7 +180,7 @@ describe("ADR-023 Phase 1 PR4: buildFillActJs — by-axis fill act (snapshot)", 
   });
 
   it("JSON-encodes the value (escapes embedded quotes) and interpolates index/climbDepth as numbers", () => {
-    const js = buildFillActJs({ by: "ariaLabel", pattern: "X", caseSensitive: false }, 0, 0, 'a"b');
+    const js = buildFillActJs({ by: "ariaLabel", pattern: "X", caseSensitive: false }, 0, 0, 'a"b', EXPECT);
     expect(js).toContain('const val = "a\\"b";');
   });
 });

--- a/tests/unit/browser-resolver-candidate-collection.test.ts
+++ b/tests/unit/browser-resolver-candidate-collection.test.ts
@@ -17,6 +17,7 @@ import { describe, it, expect } from "vitest";
 import {
   buildCandidateCollectionJs,
   buildActionCandidateFactsJs,
+  buildFillActJs,
 } from "../../src/tools/browser-resolver.js";
 
 describe("ADR-023 Phase 1 (S1/S7): buildCandidateCollectionJs — bit-equal extraction", () => {
@@ -128,5 +129,43 @@ describe("ADR-023 Phase 1 PR2: buildActionCandidateFactsJs — gather tail (snap
     expect(js).toContain('document.querySelector("#nope")');
     expect(js).toContain('return { __error: "ScopeNotFound" };');
     expect(js).toContain('__error: "Timeout"');
+  });
+});
+
+describe("ADR-023 Phase 1 PR4: buildFillActJs — by-axis fill act (snapshot)", () => {
+  it("emits the full fill-act IIFE for a representative by:ariaLabel target (snapshot)", () => {
+    const js = buildFillActJs({ by: "ariaLabel", pattern: "Email address", caseSensitive: false }, 0, 0, "user@example.com");
+    expect(js).toMatchSnapshot();
+  });
+
+  it("reuses the shared candidate pool (same matching body + role filter + top-N)", () => {
+    const js = buildFillActJs({ by: "ariaLabel", pattern: "X", role: "textbox", caseSensitive: false }, 0, 0, "v");
+    for (const frag of [
+      "filtered.sort((a, b) =>",          // shared matching body
+      "const top = pool.slice(0, N);",    // shared pool fragment
+      'const roleFilter = "textbox";',    // role filter shared
+      "record(el, 0.95, 'ariaLabel')",    // shared per-axis scoring
+    ]) {
+      expect(js).toContain(frag);
+    }
+  });
+
+  it("act tail: re-select top[index], climb climbDepth, fillable gate, native setter + events", () => {
+    const js = buildFillActJs({ by: "ariaLabel", pattern: "X", caseSensitive: false }, 2, 1, "hi");
+    expect(js).toContain("if (top.length <= 2) return { ok: false, error: 'index_out_of_range' };");
+    expect(js).toContain("let el = top[2].el;");
+    expect(js).toContain("for (let d = 0; d < 1 && el; d++) el = el.parentElement;");
+    expect(js).toContain("const isInput = tag === 'INPUT' || tag === 'TEXTAREA';");
+    expect(js).toContain("el.isContentEditable === true");
+    expect(js).toContain("error: 'not_fillable'");
+    expect(js).toContain("descriptor.set.call(el, val)");        // React-compatible native setter
+    expect(js).toContain("new InputEvent('input'");
+    expect(js).toContain("new Event('change'");
+    expect(js).toContain("fullMatches: fullActual === val");
+  });
+
+  it("JSON-encodes the value (escapes embedded quotes) and interpolates index/climbDepth as numbers", () => {
+    const js = buildFillActJs({ by: "ariaLabel", pattern: "X", caseSensitive: false }, 0, 0, 'a"b');
+    expect(js).toContain('const val = "a\\"b";');
   });
 });

--- a/tests/unit/browser-resolver-candidate-collection.test.ts
+++ b/tests/unit/browser-resolver-candidate-collection.test.ts
@@ -155,7 +155,7 @@ describe("ADR-023 Phase 1 PR4: buildFillActJs — by-axis fill act (snapshot)", 
     expect(js).toContain("if (top.length <= 2) return { ok: false, error: 'index_out_of_range' };");
     expect(js).toContain("let el = top[2].el;");
     expect(js).toContain("for (let d = 0; d < 1 && el; d++) el = el.parentElement;");
-    expect(js).toContain("const isInput = tag === 'INPUT' || tag === 'TEXTAREA';");
+    expect(js).toContain("const isTextInput = tag === 'INPUT' && !/^(button|submit|reset|checkbox|radio|range|color|file|image|hidden)$/.test(ty);");
     expect(js).toContain("el.isContentEditable === true");
     expect(js).toContain("error: 'not_fillable'");
     expect(js).toContain("descriptor.set.call(el, val)");        // React-compatible native setter


### PR DESCRIPTION
## What

ADR-023 Phase 1 — **`browser_fill` by-axis (semantic) targeting**, the final Phase 1 PR, built on the resolver core (#402) and mirroring `browser_click` by-axis (#403). Pass `by:'text'|'regex'|'role'|'ariaLabel'` + `pattern` instead of a CSS selector to fill a field by what identifies it (most useful: `by:'ariaLabel'`).

- **gather → decide → act** (plan §S5): `resolveBrowserActionTarget({action:'fill'})` gathers + decides in node (fill actionability = visible + enabled, **not** `receivesEvents` — fill acts via a CDP eval, not an OS click). On resolve, a 2nd **act eval** (`buildFillActJs`) **deterministically re-gathers** the same pool, re-selects `top[index]`, climbs to the resolved element, gates fillability (input / textarea / contenteditable), and sets the value via the same React/Vue-compatible native-setter path as selector mode. Re-gather-by-index avoids selector re-non-uniqueness *and* `elementFromPoint` occlusion mis-targeting.
- Ambiguous → `BrowserAmbiguousTarget`; resolve-stage non-actionable or act-stage non-fillable → `BrowserNoActionableTarget`; gather errors via the shared mappers. Never guesses.

## DRY (shared, not duplicated)

- `candidatePoolJs` — matching body + role filter + top-N — reused by `buildActionCandidateFactsJs` (gather) and `buildFillActJs` (fill act).
- `finalizeFillResult` — `BrowserFillNotDelivered` + success shaping — reused by the selector path and the by-axis path.

## Selector mode unchanged (AC-9)

`finalizeFillResult` takes `identity={selector}` for selector mode, preserving the exact failure-context + success wire shape. `browser-cdp-verification.test.ts` confirms the selector fill is bit-equal.

## Schema / registration

`selector` optional + `by`/`pattern`/`role`/`scope`/`caseSensitive` + `value`; exactly-one-of via `.refine()` on a `z.object(...)` registered with `server.registerTool` (the verified zod-4/SDK pattern). Stub-catalog generator already handles the refined wire schema (from #403); the `browser_fill` stub now lists every by-axis param + `value`.

## Tests

- **unit** — fill schema refine (exactly-one-of + requires value + zod-4 wire transparency); `buildFillActJs` snapshot + asserts (re-select top[index], climb, fillable gate, native setter, value escaping).
- **e2e (real headless Chrome — fully end-to-end, since the fill act is a CDP eval, no OS mouse)** — resolved fill value lands in the DOM (AC-4), overwrite existing value, ambiguous stop, act-stage not-fillable → `BrowserNoActionableTarget`, resolve-stage no-actionable, `ScopeNotFound`.

Full unit suite green (3737); all touched browser e2e green.

Plan: `desktop-touch-mcp-internal@ac4d389:docs/adr-023-phase-1-resolver-plan.md` (S5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
