### PR TITLE
fix(browser): ADR-023 role filter matches the climb target, not the matched leaf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,9 @@
   `code:'BrowserAmbiguousTarget'` with a short candidate list and hints for
   narrowing down; when matches exist but none is clickable it returns
   `code:'BrowserNoActionableTarget'`. It never guesses between look-alikes.
-  - Narrow further with `role` (`by:'text', pattern:'Save', role:'button'`) or a
+  - Narrow further with `role` (`by:'text', pattern:'Save', role:'button'`) — the
+    `role` is matched against the real clickable target, so it still works when the
+    visible text sits inside a child element of the button (common in SPAs) — or a
     `scope` CSS container.
   - The existing `selector` mode is unchanged — pass either `selector` **or**
     `by`+`pattern`, not both.

--- a/src/tools/browser-resolver.ts
+++ b/src/tools/browser-resolver.ts
@@ -390,6 +390,14 @@ export function buildActionCandidateFactsJs(args: ActionFactsArgs): string {
       visible: vis,
       enabled: enabled,
       receivesEvents: receivesEvents,
+      // Role-filter match for THIS node (uses the same roleMatches predicate that
+      // builds the pool, so input type is available). true when no role filter is
+      // set. decideActionTarget gates the climb-resolved clickable on this so a
+      // role-constrained action never resolves to a wrong-role ancestor (the climb
+      // picks the NEAREST strong clickable, which the chain-aware pool filter may
+      // have admitted via a FARTHER role-matching ancestor — e.g. role:'button'
+      // with an <a> nested in a div[role=button]).
+      roleMatch: roleFilter ? roleMatches(el) : true,
       rect: { x: Math.round(r.left), y: Math.round(r.top), w: Math.round(r.width), h: Math.round(r.height) },
     };
   }
@@ -601,6 +609,19 @@ export interface ClickableNode {
   enabled: boolean;
   /** `document.elementFromPoint(center)` hit is this node or a descendant (not occluded) */
   receivesEvents: boolean;
+  /**
+   * Role-filter match for this node: `false` ONLY when a `role` filter was given
+   * AND this node's role does not satisfy it (computed in the gatherer via the
+   * same `roleMatches` predicate that builds the pool, so input `type` is
+   * available). `undefined`/`true` otherwise (no filter, or a match).
+   * `decideActionTarget` gates the climb-resolved clickable on `roleMatch !==
+   * false`, so a role-constrained action never resolves to a wrong-role ancestor:
+   * the chain-aware pool filter admits a candidate when ANY ancestor within D
+   * matches the role, but the climb resolves to the NEAREST strong clickable —
+   * which may be a different-role element (an `<a>` nested in a div[role=button]).
+   * Without the gate, role:'button' could silently click that link.
+   */
+  roleMatch?: boolean;
   /** viewport rect (CSS px), rounded */
   rect: RectXYWH;
 }
@@ -821,7 +842,14 @@ export function decideActionTarget(
       f,
       clickable: c?.node ?? null,
       depth: c?.depth ?? -1,
-      actionable: c ? isActionable(c.node, requireReceivesEvents) : false,
+      // Role gate: the climb resolves to the nearest strong clickable, but the
+      // chain-aware pool filter may have admitted this candidate via a FARTHER
+      // role-matching ancestor. If the resolved clickable does not itself satisfy
+      // the role filter (roleMatch === false), it is NOT actionable — a role-
+      // constrained action must stop (noActionable) rather than silently act on a
+      // wrong-role element (e.g. role:'button' resolving to an <a> nested in a
+      // div[role=button]). roleMatch is undefined when no role filter was set.
+      actionable: c ? isActionable(c.node, requireReceivesEvents) && c.node.roleMatch !== false : false,
     };
   });
 

--- a/src/tools/browser-resolver.ts
+++ b/src/tools/browser-resolver.ts
@@ -38,7 +38,12 @@ export interface ActionFactsArgs {
    * Optional ARIA/implicit-role filter combined (AND) with the by-axis match —
    * `browser_click({by:'text', pattern:'Save', role:'button'})` keeps only Save
    * matches whose role is button. Applied to the full sorted match set before the
-   * top-N cap, so the count + candidates reflect the role-filtered pool.
+   * top-N cap, so the count + candidates reflect the role-filtered pool. The role
+   * is checked against the matched element OR any ancestor within CLIMB_MAX_DEPTH
+   * (the same climb the decision performs), so a button whose visible label is
+   * wrapped in a child element (`<div role="button"><span>Save</span></div>`,
+   * the common SPA shape) still matches — the filter targets the climb's
+   * actionable target, not the matched leaf.
    */
   role?: string;
 }
@@ -322,7 +327,25 @@ function candidatePoolJs(args: ActionFactsArgs): string {
     if (roleFilter === 'heading') return /^h[1-6]$/.test(tg);
     return false;
   }
-  const pool = roleFilter ? filtered.filter(function(e) { return roleMatches(e.el); }) : filtered;
+  // The role filter targets the ACTIONABLE element (the climb resolves to a
+  // clickable ancestor up to D), NOT the matched leaf. by:'text'/'regex' record
+  // the element whose DIRECT text node matches — for a SPA button that wraps its
+  // label in a child (<div role="button"><span>Save</span></div>) that leaf is a
+  // role-less span, so a leaf-only role check drops every such button (real GSC
+  // dogfood: by:'text'+role:'button' returned total:0). Match the role against the
+  // leaf OR any ancestor within the SAME CLIMB_MAX_DEPTH the decision climbs, so
+  // the role filter and the climb agree. The decision/climb logic is unchanged —
+  // this only widens the pre-top-N pool (decideActionTarget still resolves /
+  // dedupes by the climbed clickable's rect).
+  function roleMatchesChain(el) {
+    let node = el;
+    for (let d = 0; node && d <= D; d++) {
+      if (roleMatches(node)) return true;
+      node = node.parentElement;
+    }
+    return false;
+  }
+  const pool = roleFilter ? filtered.filter(function(e) { return roleMatchesChain(e.el); }) : filtered;
   const top = pool.slice(0, N);`;
 }
 

--- a/tests/e2e/browser-resolver.test.ts
+++ b/tests/e2e/browser-resolver.test.ts
@@ -124,15 +124,50 @@ describe.skipIf(!CHROME_AVAILABLE)("resolveBrowserActionTarget — ambiguity & s
   });
 });
 
-describe.skipIf(!CHROME_AVAILABLE)("resolveBrowserActionTarget — role filter (plan §S4)", () => {
+describe.skipIf(!CHROME_AVAILABLE)("resolveBrowserActionTarget — role filter (plan §S4 + climb-fix)", () => {
   it("role:'button' keeps the in-viewport button → resolved", async () => {
     const r = await resolve({ by: "text", pattern: "Open Settings", role: "button", action: "click" });
     expect(r.kind, JSON.stringify(r)).toBe("resolved");
   });
 
-  it("role:'link' keeps only the off-viewport drawer link → noActionable", async () => {
+  it("role:'link' keeps only the off-viewport drawer link → noActionable (axis unchanged)", async () => {
+    // The drawer <a href> is the matched leaf and self-matches role:'link', so it
+    // stays in the (chain-aware) pool; it is non-actionable (off-viewport) → the
+    // outcome is unchanged by the climb-fix. Guards the ariaLabel/role-axis path.
     const r = await resolve({ by: "text", pattern: "Open Settings", role: "link", action: "click" });
     expect(r.kind, JSON.stringify(r)).toBe("noActionable");
+  });
+
+  // ── ADR-023 role-filter climb-fix (real GSC dogfood P1) ──
+  // The role filter must match the climb's actionable target, not the matched
+  // leaf. A button whose visible label is wrapped in a child span used to return
+  // total:0 for by:'text'+role:'button' (GSC's `<div role=button><span>送信`).
+  it("role:'button' resolves a <button> whose label is a child span (regression)", async () => {
+    const r = await resolve({ by: "text", pattern: "Compose Email", role: "button", action: "click" });
+    expect(r.kind, JSON.stringify(r)).toBe("resolved");
+    if (r.kind === "resolved") expect(r.climbDepth).toBe(1);
+  });
+
+  it("role:'button' resolves a div[role=button] with a nested-span label (GSC-faithful; doubles as dedup sanity)", async () => {
+    // Resolved (not ambiguous) confirms the single leaf span climbs to one
+    // distinct role=button rect — the chain-aware filter does not inflate the pool
+    // into a false ambiguity.
+    const r = await resolve({ by: "text", pattern: "Submit Order", role: "button", action: "click" });
+    expect(r.kind, JSON.stringify(r)).toBe("resolved");
+    if (r.kind === "resolved") expect(r.climbDepth).toBe(1);
+  });
+
+  it("role:'button' + by:'regex' resolves the nested-span button (same root bug)", async () => {
+    const r = await resolve({ by: "regex", pattern: "Compose", role: "button", action: "click" });
+    expect(r.kind, JSON.stringify(r)).toBe("resolved");
+  });
+
+  it("by:'ariaLabel' + role:'textbox' still resolves the input (textbox not broken by the fix)", async () => {
+    // role:'textbox' is NOT in STRONG_ROLES; it resolves via the existing tag
+    // predicate. The chain-aware filter must not regress this (Layer-2 would have).
+    const r = await resolve({ by: "ariaLabel", pattern: "Email address", role: "textbox", action: "fill" });
+    expect(r.kind, JSON.stringify(r)).toBe("resolved");
+    if (r.kind === "resolved") expect(r.climbDepth).toBe(0);
   });
 });
 

--- a/tests/e2e/browser-resolver.test.ts
+++ b/tests/e2e/browser-resolver.test.ts
@@ -169,6 +169,22 @@ describe.skipIf(!CHROME_AVAILABLE)("resolveBrowserActionTarget — role filter (
     expect(r.kind, JSON.stringify(r)).toBe("resolved");
     if (r.kind === "resolved") expect(r.climbDepth).toBe(0);
   });
+
+  // Role gate (Codex P1): the chain-aware pool filter admits a candidate when ANY
+  // ancestor within D matches the role, but the climb resolves to the NEAREST
+  // strong clickable. For an <a> nested in a div[role=button], by:'text'+
+  // role:'button' must NOT silently click the link — the gate rejects the
+  // wrong-role resolution → noActionable.
+  it("role:'button' on a link nested in a div[role=button] → noActionable (no wrong-role click)", async () => {
+    const r = await resolve({ by: "text", pattern: "Linky Action", role: "button", action: "click" });
+    expect(r.kind, JSON.stringify(r)).toBe("noActionable");
+  });
+
+  it("role:'link' on that same nested link → resolved (the link IS the requested role)", async () => {
+    const r = await resolve({ by: "text", pattern: "Linky Action", role: "link", action: "click" });
+    expect(r.kind, JSON.stringify(r)).toBe("resolved");
+    if (r.kind === "resolved") expect(r.climbDepth).toBe(1);
+  });
 });
 
 describe.skipIf(!CHROME_AVAILABLE)("resolveBrowserActionTarget — fill path (AC-4)", () => {

--- a/tests/e2e/fixtures/resolver-gsc-like.html
+++ b/tests/e2e/fixtures/resolver-gsc-like.html
@@ -48,6 +48,14 @@
          (ADR-023 role-filter climb-fix; before the fix this returned total:0). -->
     <div role="button" id="composed-div-btn"><span class="inner">Submit Order</span></div>
 
+    <!-- Nested-mixed-role: a real <a href> (strong link) nested inside a
+         div[role=button]. by:'text'+role:'button' admits this candidate (a
+         role=button ancestor is within climb depth), but the climb resolves to the
+         NEAREST strong clickable = the <a> (a link, NOT a button). The role gate
+         must reject it → noActionable, never a silent wrong-role click. With
+         role:'link' it resolves (the link is the requested role). -->
+    <div role="button" id="linky-btn"><a href="#linky"><span class="inner">Linky Action</span></a></div>
+
     <!-- Occluded: a higher z-index overlay covers the button center. -->
     <div class="overlay-host">
       <button id="covered-btn">Covered Action</button>

--- a/tests/e2e/fixtures/resolver-gsc-like.html
+++ b/tests/e2e/fixtures/resolver-gsc-like.html
@@ -41,6 +41,13 @@
     <!-- Climb test: matched text lives in a child span; resolves to the button (depth 1). -->
     <button id="composed-btn"><span class="inner">Compose Email</span></button>
 
+    <!-- GSC-faithful: a div[role=button] whose label is wrapped in a child span
+         (mirrors GSC's `<div role="button"><span><span>送信</span></span></div>`).
+         by:'text'+role:'button' must resolve here even though the matched leaf is
+         the role-less span — the role filter climbs to the role=button ancestor
+         (ADR-023 role-filter climb-fix; before the fix this returned total:0). -->
+    <div role="button" id="composed-div-btn"><span class="inner">Submit Order</span></div>
+
     <!-- Occluded: a higher z-index overlay covers the button center. -->
     <div class="overlay-host">
       <button id="covered-btn">Covered Action</button>

--- a/tests/unit/__snapshots__/browser-resolver-candidate-collection.test.ts.snap
+++ b/tests/unit/__snapshots__/browser-resolver-candidate-collection.test.ts.snap
@@ -386,7 +386,25 @@ exports[`ADR-023 Phase 1 PR2: buildActionCandidateFactsJs — gather tail (snaps
     if (roleFilter === 'heading') return /^h[1-6]$/.test(tg);
     return false;
   }
-  const pool = roleFilter ? filtered.filter(function(e) { return roleMatches(e.el); }) : filtered;
+  // The role filter targets the ACTIONABLE element (the climb resolves to a
+  // clickable ancestor up to D), NOT the matched leaf. by:'text'/'regex' record
+  // the element whose DIRECT text node matches — for a SPA button that wraps its
+  // label in a child (<div role="button"><span>Save</span></div>) that leaf is a
+  // role-less span, so a leaf-only role check drops every such button (real GSC
+  // dogfood: by:'text'+role:'button' returned total:0). Match the role against the
+  // leaf OR any ancestor within the SAME CLIMB_MAX_DEPTH the decision climbs, so
+  // the role filter and the climb agree. The decision/climb logic is unchanged —
+  // this only widens the pre-top-N pool (decideActionTarget still resolves /
+  // dedupes by the climbed clickable's rect).
+  function roleMatchesChain(el) {
+    let node = el;
+    for (let d = 0; node && d <= D; d++) {
+      if (roleMatches(node)) return true;
+      node = node.parentElement;
+    }
+    return false;
+  }
+  const pool = roleFilter ? filtered.filter(function(e) { return roleMatchesChain(e.el); }) : filtered;
   const top = pool.slice(0, N);
 
   // Physical-coord conversion constants (getElementScreenCoords formula,
@@ -702,7 +720,25 @@ exports[`ADR-023 Phase 1 PR4: buildFillActJs — by-axis fill act (snapshot) > e
     if (roleFilter === 'heading') return /^h[1-6]$/.test(tg);
     return false;
   }
-  const pool = roleFilter ? filtered.filter(function(e) { return roleMatches(e.el); }) : filtered;
+  // The role filter targets the ACTIONABLE element (the climb resolves to a
+  // clickable ancestor up to D), NOT the matched leaf. by:'text'/'regex' record
+  // the element whose DIRECT text node matches — for a SPA button that wraps its
+  // label in a child (<div role="button"><span>Save</span></div>) that leaf is a
+  // role-less span, so a leaf-only role check drops every such button (real GSC
+  // dogfood: by:'text'+role:'button' returned total:0). Match the role against the
+  // leaf OR any ancestor within the SAME CLIMB_MAX_DEPTH the decision climbs, so
+  // the role filter and the climb agree. The decision/climb logic is unchanged —
+  // this only widens the pre-top-N pool (decideActionTarget still resolves /
+  // dedupes by the climbed clickable's rect).
+  function roleMatchesChain(el) {
+    let node = el;
+    for (let d = 0; node && d <= D; d++) {
+      if (roleMatches(node)) return true;
+      node = node.parentElement;
+    }
+    return false;
+  }
+  const pool = roleFilter ? filtered.filter(function(e) { return roleMatchesChain(e.el); }) : filtered;
   const top = pool.slice(0, N);
   // ── ADR-023 Phase 1 PR4: by-axis fill ACT (deterministic re-gather + index). ──
   // IDENTITY GATE (Codex P1): the re-gather assumes the DOM is unchanged since the

--- a/tests/unit/__snapshots__/browser-resolver-candidate-collection.test.ts.snap
+++ b/tests/unit/__snapshots__/browser-resolver-candidate-collection.test.ts.snap
@@ -445,6 +445,14 @@ exports[`ADR-023 Phase 1 PR2: buildActionCandidateFactsJs — gather tail (snaps
       visible: vis,
       enabled: enabled,
       receivesEvents: receivesEvents,
+      // Role-filter match for THIS node (uses the same roleMatches predicate that
+      // builds the pool, so input type is available). true when no role filter is
+      // set. decideActionTarget gates the climb-resolved clickable on this so a
+      // role-constrained action never resolves to a wrong-role ancestor (the climb
+      // picks the NEAREST strong clickable, which the chain-aware pool filter may
+      // have admitted via a FARTHER role-matching ancestor — e.g. role:'button'
+      // with an <a> nested in a div[role=button]).
+      roleMatch: roleFilter ? roleMatches(el) : true,
       rect: { x: Math.round(r.left), y: Math.round(r.top), w: Math.round(r.width), h: Math.round(r.height) },
     };
   }

--- a/tests/unit/browser-resolver-candidate-collection.test.ts
+++ b/tests/unit/browser-resolver-candidate-collection.test.ts
@@ -121,7 +121,10 @@ describe("ADR-023 Phase 1 PR2: buildActionCandidateFactsJs — gather tail (snap
     expect(noRole).toContain("const roleFilter = null;");
     const withRole = buildActionCandidateFactsJs({ by: "text", pattern: "Save", role: "Button", caseSensitive: false });
     expect(withRole).toContain('const roleFilter = "button";'); // lowercased
-    expect(withRole).toContain("filtered.filter(function(e) { return roleMatches(e.el); })");
+    // climb-fix: the role filter matches the leaf OR an ancestor within D, so a
+    // button whose label is wrapped in a child element still matches (GSC dogfood).
+    expect(withRole).toContain("function roleMatchesChain(el)");
+    expect(withRole).toContain("filtered.filter(function(e) { return roleMatchesChain(e.el); })");
   });
 
   it("shares the collection error returns (ScopeNotFound / Timeout) via the body", () => {

--- a/tests/unit/browser-resolver-decision.test.ts
+++ b/tests/unit/browser-resolver-decision.test.ts
@@ -199,3 +199,47 @@ describe("decideActionTarget (ADR §1.2 D3 uniqueness contract)", () => {
     }
   });
 });
+
+describe("decideActionTarget — role gate (Codex P1: never resolve to a wrong-role ancestor)", () => {
+  it("undefined roleMatch (no role filter) does not gate → resolved", () => {
+    const d = decideActionTarget([facts({ index: 0, chain: [node({ tag: "button" })] })], 1);
+    expect(d.kind).toBe("resolved");
+  });
+
+  it("roleMatch:true on the climbed strong clickable → resolved", () => {
+    const d = decideActionTarget(
+      [facts({ index: 0, chain: [node({ tag: "span" }), node({ tag: "div", role: "button", roleMatch: true })] })],
+      1,
+    );
+    expect(d.kind).toBe("resolved");
+    if (d.kind === "resolved") expect(d.target.climbDepth).toBe(1);
+  });
+
+  it("roleMatch:false on the climbed strong clickable → noActionable (not a wrong-role resolve)", () => {
+    const d = decideActionTarget(
+      [facts({ index: 0, chain: [node({ tag: "span" }), node({ tag: "div", role: "button", roleMatch: false })] })],
+      1,
+    );
+    expect(d.kind).toBe("noActionable");
+  });
+
+  it("nested-mixed-role: climb resolves to the nearest strong link (roleMatch:false for button) → noActionable", () => {
+    // role:'button' admits this candidate via the farther div[role=button] ancestor
+    // (chain-aware pool filter), but the climb stops at the nearer <a href> link,
+    // whose roleMatch is false for a button filter → must NOT resolve to the link.
+    const d = decideActionTarget(
+      [
+        facts({
+          index: 0,
+          chain: [
+            node({ tag: "span" }),
+            node({ tag: "a", hasHref: true, roleMatch: false }), // nearest strong = link, wrong role
+            node({ tag: "div", role: "button", roleMatch: true }), // farther, matches — but not the climb target
+          ],
+        }),
+      ],
+      1,
+    );
+    expect(d.kind).toBe("noActionable");
+  });
+});


### PR DESCRIPTION
## 背景（実 GSC dogfood で検出した P1）
ADR-023 Phase 1 持ち越し②（AC-1 検証）の実 GSC dogfood で **P1** を検出。

`browser_click({by:'text', pattern:'送信', role:'button'})` が GSC の送信ボタン（`<div role="button"><span><span>送信</span></span></div>`）に対し **`total:0` / `BrowserNoActionableTarget`** を返す。tool description が推奨する曖昧性回避形 `by:'text'+role:'button'`（= AC-1/AC-2 の本命）が、テキストを子要素で包む最も一般的な SPA ボタン構造で全滅していた。

| dogfood 呼び出し | 結果 |
|---|---|
| `browser_fill({by:'ariaLabel', ...})` | ✅ delivered（AC-4） |
| `browser_click({by:'text', pattern:'送信', role:'button'})` | ❌ total:0（**本 PR で修正**） |
| `browser_click({by:'text', pattern:'送信'})`（role 無し） | ✅ resolved, climbDepth 2, delivered（core 健全） |

## root cause
`candidatePoolJs` が role filter を **climb 前の matched leaf**（`e.el`）に適用。`by:'text'`/`'regex'` は **direct text node** が一致する要素（= nested-span 構造では role 無しの末端 span）を record するため、`roleMatches(span)=false` で pool が空になり、climb（`decideActionTarget`）に到達する前に候補が消えていた。

## fix（Layer 1: chain-aware role filter）
`roleMatchesChain` が leaf + `CLIMB_MAX_DEPTH` 祖先まで（= decision が climb するのと同じ深さ）を走査し、role filter と climb を一致させる。**decision/climb 論理は不変**（pre-top-N pool を広げるのみ。`decideActionTarget` は climbed rect で resolve/dedup 継続）。by-axis fill も共有 `candidatePoolJs` 経由で同時に修正。

**Layer 2（role-aware climb）は見送り**: fill act path（depth ベース再 climb）との乖離 + `role:'textbox'`（STRONG_ROLES 外）の regression を持ち込むため。詳細は plan §3 Deferred。

## tests
- e2e regression: `composed-btn`（`<button><span>Compose Email</span>`）+ `role:'button'` → resolved (climbDepth 1)
- e2e GSC-faithful: 新 fixture `<div role="button"><span>Submit Order</span></div>` + `role:'button'` → resolved
- e2e `by:'regex'` 軸 / `by:'ariaLabel'`+`role:'textbox'` 不変 / negative `role:'link'` 維持
- snapshot: `buildActionCandidateFactsJs` + `buildFillActJs` のみ regen。**`buildCandidateCollectionJs`（browser_search）snapshot は不変 = AC-9 bit-equal**

## review status
- Opus design review 2 round 済（plan PR `desktop-touch-mcp-internal#11`）: Layer 2 見送り判断 + Layer 1 安全性論証 GO、P1/P2 ゼロ。
- 本 impl PR で Opus（アーキ/bit-equality）+ Codex（write path side-effect wave）review loop を回す。

Plan: `desktop-touch-mcp-internal@0318dd6:docs/adr-023-phase-1-role-filter-climb-fix.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)