### PR TITLE
fix(browser): guard browser_click against a minimized/off-screen window (+ browser-cdp e2e readiness)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,19 @@
   `'url_matches'` for an SPA route change, or `'ready_state'` for page load —
   rather than a generic timeout error.
 
+### Fixed
+
+- **`browser_click` no longer mis-fires at the screen corner when the browser
+  window is minimized.** A minimized Chrome/Edge window reports an off-screen
+  position for its content, so `browser_click` could compute a click point the OS
+  clamps to the top-left corner (0,0) — moving the cursor there and tripping the
+  built-in safety stop, which closed the connection. `browser_click` now detects a
+  minimized/off-screen window up front and stops with a typed
+  `BrowserTargetMinimized` error (with a hint to restore the window and retry)
+  instead of clicking. This applies to both the `selector` and the `by`+`pattern`
+  paths. `browser_fill` is unaffected — it types into the page directly and works
+  even when the window is minimized.
+
 ## [1.8.0] - 2026-05-23 — Terminal `run` can wait for a command to finish (exit code) + a `desktop_act` hint after typing into native fields
 
 ### Added

--- a/src/engine/cdp-bridge.ts
+++ b/src/engine/cdp-bridge.ts
@@ -18,6 +18,29 @@ export const DEFAULT_CDP_PORT = 9222;
 export const CMD_TIMEOUT_MS = 15_000;
 const CONNECT_TIMEOUT_MS = 5_000;
 
+/**
+ * Windows parks a minimized (or pathologically off-screen) top-level window's
+ * origin at (-32000, -32000). When a CDP target Chrome/Edge is minimized,
+ * `window.screenX` / `window.screenY` return that marker while the page layout
+ * (innerWidth, getBoundingClientRect) stays valid — so a viewport→screen
+ * conversion (getElementScreenCoords / browser-resolver physicalPoint) produces a
+ * large negative screen point that the OS clamps to (0,0). An OS mouse click
+ * there parks the cursor in the top-left failsafe zone and the dwell watchdog
+ * kills the server (`src/utils/failsafe.ts`). Detect this from the window origin
+ * BEFORE converting/clicking and stop with a typed error instead.
+ *
+ * The exact parking marker (-32000) is far beyond any real multi-monitor layout
+ * (that would be a 32000px-negative origin), so a legitimately left/top-positioned
+ * secondary monitor is never mis-flagged — only the click path guards on this; a
+ * CDP-eval write (browser_fill) is unaffected by a minimized window.
+ */
+export const MINIMIZED_WINDOW_SCREEN_COORD = -32_000;
+
+/** True when a window's CSS-px origin is at/below the Windows minimized-parking marker. */
+export function isOffscreenMinimized(screenX: number, screenY: number): boolean {
+  return screenX <= MINIMIZED_WINDOW_SCREEN_COORD || screenY <= MINIMIZED_WINDOW_SCREEN_COORD;
+}
+
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 export interface CdpTab {
@@ -43,6 +66,10 @@ export interface ElementCoords {
   height: number;
   /** Whether the element is fully within the viewport */
   inViewport: boolean;
+  /** Window origin X (window.screenX, CSS px) — lets the click path detect a minimized/off-screen window before clicking (isOffscreenMinimized). */
+  screenX: number;
+  /** Window origin Y (window.screenY, CSS px). See screenX. */
+  screenY: number;
 }
 
 // ─── CDP Session ──────────────────────────────────────────────────────────────
@@ -435,6 +462,11 @@ export async function getElementScreenCoords(
     height: Math.round(rect.height * dpr),
     x:      Math.round((physLeft + physRight)  / 2),
     y:      Math.round((physTop  + physBottom) / 2),
+    // Raw window origin (CSS px) so the click caller can detect a minimized /
+    // off-screen-parked window (window.screenX/Y === -32000) before issuing an
+    // OS click that the OS would clamp to (0,0). See isOffscreenMinimized.
+    screenX: sx,
+    screenY: sy,
     inViewport: (function() {
       var cx = rect.left + rect.width / 2;
       var cy = rect.top  + rect.height / 2;

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -16,6 +16,7 @@ import {
   getDomHtml,
   disconnectAll,
   getTabContext,
+  isOffscreenMinimized,
   CMD_TIMEOUT_MS,
   type TabContext,
 } from "../engine/cdp-bridge.js";
@@ -1266,6 +1267,32 @@ function browserResolveStopToFailure(
 }
 
 /**
+ * Typed failure for a click against a minimized / off-screen-parked browser
+ * window (window.screenX/screenY at the Windows -32000 marker). Returned by BOTH
+ * click paths BEFORE the OS click so the cursor never lands at the OS-clamped
+ * (0,0) corner — which would trip the top-left failsafe dwell and kill the
+ * server. Shared so the message/suggest stay identical across selector + by-axis.
+ *
+ * `browser_fill` is deliberately exempt: it writes via a CDP eval on the page,
+ * not an OS click, so a minimized window is harmless there. Inline failCode (the
+ * BrowserAmbiguousTarget / ElementNotInViewport precedent) — no SUGGESTS entry,
+ * so no catalog-drift cascade.
+ */
+function browserMinimizedFailure(ctx: Record<string, unknown>): ToolResult {
+  return failCode(
+    "BrowserTargetMinimized",
+    "browser_click: the target Chrome/Edge window is minimized, so its element coordinates resolve off-screen — clicking would mis-fire at the screen corner. Restore the window and retry.",
+    {
+      suggest: [
+        "Restore / bring the browser window to the foreground (click its taskbar icon, or focus_window by its title), then retry browser_click.",
+        "If you only need to enter text, browser_fill works on a minimized window — it sets the value via the page without an OS click.",
+      ],
+      context: ctx,
+    },
+  );
+}
+
+/**
  * by-axis browser_click: resolve a single actionable target semantically, then
  * OS-click at its resolved physical coords (no second querySelector — coords come
  * from the same gather eval, ADR §1.2 D1). Ambiguous / non-actionable / error
@@ -1336,6 +1363,14 @@ async function handleBrowserClickByAxis(args: {
   const ctx = { by, pattern, ...(role ? { role } : {}), ...(scope ? { scope } : {}) };
   if (outcome.kind === "error") return browserResolveErrorToFailure(outcome, "browser_click", ctx);
   if (outcome.kind !== "resolved") return browserResolveStopToFailure(outcome, "browser_click", ctx);
+
+  // Minimized-window guard: the gather eval's viewport origin is the Windows
+  // -32000 parking marker → outcome.physical is a large negative point the OS
+  // would clamp to (0,0). Stop before the OS click so we never trip the failsafe
+  // (the resolve gather above is a pure CDP eval — no click happened yet).
+  if (isOffscreenMinimized(outcome.viewport.screenX, outcome.viewport.screenY)) {
+    return browserMinimizedFailure(ctx);
+  }
 
   // Resolved: OS-click at the physical point (probe with null selector — the
   // resolver located the element by coords; document-level mutation probe).
@@ -1492,6 +1527,14 @@ export const browserClickElementHandler = async ({
       effectiveTabId ?? null,
       port
     );
+    // Minimized-window guard (same as the by-axis path): when the window origin
+    // is the Windows -32000 marker, coords.{x,y} are off-screen negatives the OS
+    // would clamp to (0,0). Checked before the inViewport gate because a
+    // minimized window still reports its elements as in-viewport (the viewport
+    // layout is intact) — so without this it falls through to the OS click.
+    if (isOffscreenMinimized(coords.screenX, coords.screenY)) {
+      return browserMinimizedFailure({ selector: effectiveSelector });
+    }
     if (!coords.inViewport) {
       return failCode(
         "ElementNotInViewport",

--- a/tests/e2e/browser-cdp.test.ts
+++ b/tests/e2e/browser-cdp.test.ts
@@ -51,23 +51,31 @@ afterAll(() => {
   chrome?.kill();
 });
 
-async function waitForLoad(expectedTitle?: string, maxMs = 8_000): Promise<void> {
+// Readiness gate. The original version only checked readyState + document.title,
+// which passes the instant the <head> commits — before the <body> is parsed and
+// laid out. Under full-suite load (many Chrome instances launched first, plus the
+// default component-extension targets that share the CDP /json list), that early
+// pass let DOM tests run against a not-yet-populated document → flaky
+// "#btn-submit not found" / "document.body is null" failures (the body wasn't
+// there yet). We now poll for the actual fixture element to exist AND be laid out
+// (getBoundingClientRect().width > 0) — the same element-level readiness the other
+// browser e2e suites use, which do not flake. 15s headroom for a loaded machine.
+async function waitForLoad(expectedTitle?: string, maxMs = 15_000): Promise<void> {
+  const titleClause = expectedTitle ? ` && document.title === ${JSON.stringify(expectedTitle)}` : "";
+  const ready = `document.readyState === 'complete'${titleClause}` +
+    ` && !!document.body && document.getElementById('btn-submit') !== null` +
+    ` && document.getElementById('btn-submit').getBoundingClientRect().width > 0`;
   const deadline = Date.now() + maxMs;
   while (Date.now() < deadline) {
     try {
-      const state = await evaluateInTab("document.readyState", null, TEST_PORT);
-      if (state === "complete") {
-        if (!expectedTitle) return;
-        const title = await evaluateInTab("document.title", null, TEST_PORT);
-        if (title === expectedTitle) return;
-      }
+      if (await evaluateInTab(ready, null, TEST_PORT) === true) return;
     } catch {
       // session may not be ready yet
     }
     await sleep(300);
   }
   throw new Error(
-    `Page did not finish loading${expectedTitle ? ` with title "${expectedTitle}"` : ""} within ${maxMs}ms`
+    `Page did not finish loading${expectedTitle ? ` with title "${expectedTitle}"` : ""} (with #btn-submit laid out) within ${maxMs}ms`
   );
 }
 

--- a/tests/e2e/browser-click-minimized.test.ts
+++ b/tests/e2e/browser-click-minimized.test.ts
@@ -1,0 +1,121 @@
+/**
+ * browser-click-minimized.test.ts — E2E for the minimized-window click guard.
+ *
+ * Repro of the dogfood bug: a CDP target Chrome that is MINIMIZED reports
+ * window.screenX/screenY === -32000 (the Windows parking marker) while the page
+ * layout stays valid, so browser_click's viewport→screen conversion yields an
+ * off-screen-negative point the OS clamps to (0,0). The resulting top-left click
+ * trips the failsafe dwell and kills the server (Connection closed).
+ *
+ * We reproduce the exact signal headless by overriding window.screenX/screenY to
+ * -32000 (a real minimize is not observable in --headless=new), then assert BOTH
+ * click paths STOP with code:'BrowserTargetMinimized' BEFORE any OS click — so the
+ * test itself never moves the cursor to (0,0) and never trips the failsafe. The
+ * fill path is exempt (it writes via a CDP eval, no OS click) and must still work.
+ *
+ * Own Chrome instance + port so the screenX override never leaks into other suites.
+ *
+ * @see src/tools/browser.ts  browserMinimizedFailure / handleBrowserClickByAxis
+ * @see src/engine/cdp-bridge.ts  isOffscreenMinimized
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+import { launchChrome, tryFindChrome, type ChromeInstance } from "./helpers/chrome-launcher.js";
+import { sleep } from "./helpers/wait.js";
+import { evaluateInTab, disconnectAll } from "../../src/engine/cdp-bridge.js";
+import { browserClickElementHandler, browserFillInputHandler } from "../../src/tools/browser.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = join(__dirname, "fixtures", "resolver-gsc-like.html");
+const TEST_PORT = 9232; // distinct from other browser suites (9224–9231)
+const FIXTURE_URL = `file:///${FIXTURE_PATH.replace(/\\/g, "/")}`;
+const CHROME_AVAILABLE = tryFindChrome() !== null;
+
+let chrome: ChromeInstance;
+let overrideApplied: unknown = false;
+
+beforeAll(async () => {
+  if (!CHROME_AVAILABLE) return;
+  chrome = await launchChrome(TEST_PORT, true /* headless */, FIXTURE_URL);
+  const deadline = Date.now() + 15_000;
+  let laidOut = false;
+  while (Date.now() < deadline) {
+    try {
+      const ready = await evaluateInTab(
+        `document.readyState === 'complete' && document.querySelector('#bound-btn') !== null && ` +
+        `document.querySelector('#bound-btn').getBoundingClientRect().width > 0`,
+        null, TEST_PORT);
+      if (ready === true) { laidOut = true; break; }
+    } catch { /* ignore */ }
+    await sleep(250);
+  }
+  if (!laidOut) throw new Error("Fixture did not lay out within 15s");
+
+  // Reproduce the minimized signal: shadow window.screenX/screenY with the
+  // Windows -32000 parking value. This is what a real minimized window reports;
+  // both the by-axis gather eval and getElementScreenCoords read window.screenX,
+  // so this drives both click paths through the guard. Persists on the page's
+  // window object across CDP evals (no navigation in this fixture).
+  overrideApplied = await evaluateInTab(
+    `(function(){
+       try {
+         Object.defineProperty(window, 'screenX', { configurable: true, get: function(){ return -32000; } });
+         Object.defineProperty(window, 'screenY', { configurable: true, get: function(){ return -32000; } });
+         return window.screenX === -32000 && window.screenY === -32000;
+       } catch (e) { return 'ERR:' + (e && e.message ? e.message : String(e)); }
+     })()`,
+    null, TEST_PORT);
+}, 20_000);
+
+afterAll(() => {
+  disconnectAll(TEST_PORT);
+  chrome?.kill();
+});
+
+function payload(r: { content: Array<{ type: string; text?: string }> }): Record<string, unknown> {
+  const text = r.content[0]?.type === "text" ? r.content[0].text ?? "{}" : "{}";
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+async function click(args: Record<string, unknown>) {
+  return payload(await browserClickElementHandler({ port: TEST_PORT, ...args } as Parameters<typeof browserClickElementHandler>[0]));
+}
+async function fill(args: Record<string, unknown>) {
+  return payload(await browserFillInputHandler({ value: "", includeContext: false, port: TEST_PORT, ...args } as Parameters<typeof browserFillInputHandler>[0]));
+}
+
+describe.skipIf(!CHROME_AVAILABLE)("browser_click — minimized-window guard (headless)", () => {
+  it("the screenX/screenY override took effect (sanity)", () => {
+    expect(overrideApplied, `override result: ${JSON.stringify(overrideApplied)}`).toBe(true);
+  });
+
+  it("by-axis click on a minimized window STOPS with BrowserTargetMinimized (no OS click)", async () => {
+    await evaluateInTab("document.getElementById('bound-out').textContent = ''", null, TEST_PORT);
+    const r = await click({ by: "text", pattern: "Bound Action" });
+    expect(r.ok, JSON.stringify(r)).toBe(false);
+    expect(r.code).toBe("BrowserTargetMinimized");
+    expect(Array.isArray(r.suggest)).toBe(true);
+    // The onclick side effect proves whether an OS click was actually delivered.
+    const out = await evaluateInTab("document.getElementById('bound-out').textContent", null, TEST_PORT);
+    expect(out).toBe(""); // guard fired before the click — nothing happened
+  });
+
+  it("selector click on a minimized window STOPS with BrowserTargetMinimized", async () => {
+    // #real-settings is at the top of the fixture → always in-viewport, so it
+    // passes the inViewport gate and reaches the minimized guard (which a
+    // minimized window does NOT escape via inViewport — the layout is intact).
+    const r = await click({ selector: "#real-settings" });
+    expect(r.ok, JSON.stringify(r)).toBe(false);
+    expect(r.code).toBe("BrowserTargetMinimized");
+  });
+
+  it("browser_fill is EXEMPT — it writes via CDP eval, so a minimized window still fills", async () => {
+    await evaluateInTab("document.querySelector('#email-input').value = ''", null, TEST_PORT);
+    const r = await fill({ by: "ariaLabel", pattern: "Email address", value: "minimized-ok" });
+    expect(r.ok, JSON.stringify(r)).toBe(true);
+    const domVal = await evaluateInTab("document.querySelector('#email-input').value", null, TEST_PORT);
+    expect(domVal).toBe("minimized-ok");
+  });
+});

--- a/tests/fixtures/failwith-callsite-shapes.json
+++ b/tests/fixtures/failwith-callsite-shapes.json
@@ -79,112 +79,112 @@
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 718,
+      "line": 719,
       "tool": "browser_fill",
       "errKind": "member",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 725,
+      "line": 726,
       "tool": "browser_fill",
       "errKind": "new-error",
       "contextShape": "object-hoisted"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1047,
+      "line": 1048,
       "tool": "browser_form",
       "errKind": "string-literal",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1061,
+      "line": 1062,
       "tool": "browser_form",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1113,
+      "line": 1114,
       "tool": "browser_open",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1165,
+      "line": 1166,
       "tool": "browser_locate",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1423,
+      "line": 1458,
       "tool": "browser_click",
       "errKind": "new-error",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1434,
+      "line": 1469,
       "tool": "browser_click",
       "errKind": "new-error",
       "contextShape": "object-hoisted"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1635,
+      "line": 1678,
       "tool": "browser_eval",
       "errKind": "new-error",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1787,
+      "line": 1830,
       "tool": "browser_eval",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1814,
+      "line": 1857,
       "tool": "browser_navigate",
       "errKind": "new-error",
       "contextShape": "object-hoisted"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 1831,
+      "line": 1874,
       "tool": "browser_navigate",
       "errKind": "new-error",
       "contextShape": "object-hoisted"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 2123,
+      "line": 2166,
       "tool": "browser_overview",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 2275,
+      "line": 2318,
       "tool": "browser_open",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 2406,
+      "line": 2449,
       "tool": "browser_search",
       "errKind": "identifier",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/browser.ts",
-      "line": 2554,
+      "line": 2597,
       "tool": "browser_disconnect",
       "errKind": "identifier",
       "contextShape": "none"

--- a/tests/unit/browser-minimized-guard.test.ts
+++ b/tests/unit/browser-minimized-guard.test.ts
@@ -1,0 +1,52 @@
+/**
+ * browser-minimized-guard.test.ts — unit boundary tests for the minimized /
+ * off-screen-parked window predicate that gates browser_click.
+ *
+ * A minimized Chrome/Edge window reports window.screenX/screenY === -32000 (the
+ * Windows parking marker) while the page layout stays valid, so a viewport→screen
+ * conversion yields an off-screen-negative point the OS clamps to (0,0); an OS
+ * click there trips the top-left failsafe and kills the server. `isOffscreenMinimized`
+ * detects this from the window origin so the click paths can stop with a typed
+ * BrowserTargetMinimized failure instead. The threshold is the EXACT parking
+ * marker so a legitimately negative-origin secondary monitor is never mis-flagged.
+ *
+ * @see src/engine/cdp-bridge.ts  isOffscreenMinimized / MINIMIZED_WINDOW_SCREEN_COORD
+ */
+
+import { describe, it, expect } from "vitest";
+import { isOffscreenMinimized, MINIMIZED_WINDOW_SCREEN_COORD } from "../../src/engine/cdp-bridge.js";
+
+describe("isOffscreenMinimized — minimized-window detection", () => {
+  it("the marker constant is the Windows -32000 parking value", () => {
+    expect(MINIMIZED_WINDOW_SCREEN_COORD).toBe(-32000);
+  });
+
+  it("flags a minimized window (both axes at -32000, the dogfood signal)", () => {
+    // Live dogfood: {"screenX":-32000,"screenY":-32000,...} on a minimized GSC tab.
+    expect(isOffscreenMinimized(-32000, -32000)).toBe(true);
+  });
+
+  it("flags when EITHER axis hits the marker", () => {
+    expect(isOffscreenMinimized(-32000, 0)).toBe(true);
+    expect(isOffscreenMinimized(100, -32000)).toBe(true);
+  });
+
+  it("flags values beyond the marker (defensive ≤, not ===)", () => {
+    expect(isOffscreenMinimized(-32001, 0)).toBe(true);
+    expect(isOffscreenMinimized(0, -40000)).toBe(true);
+  });
+
+  it("does NOT flag a normal on-screen window", () => {
+    expect(isOffscreenMinimized(0, 0)).toBe(false);
+    expect(isOffscreenMinimized(1920, 0)).toBe(false);
+    expect(isOffscreenMinimized(120, 80)).toBe(false);
+  });
+
+  it("does NOT flag a legitimate left/top secondary monitor (negative but far above the marker)", () => {
+    // A second display positioned to the left/top has a negative origin (e.g.
+    // -1920, -1080) that is NOT a minimized window — must stay clickable.
+    expect(isOffscreenMinimized(-1920, 0)).toBe(false);
+    expect(isOffscreenMinimized(-2560, -1440)).toBe(false);
+    expect(isOffscreenMinimized(-31999, -31999)).toBe(false); // just inside the marker
+  });
+});


### PR DESCRIPTION
## What & why

Two browser-robustness fixes (separate commits), the second discovered while verifying the first.

### 1. `browser_click` minimized-window guard (production fix)
A minimized Chrome/Edge window reports its origin at the Windows `-32000` parking marker (`window.screenX/screenY`) while the page layout stays valid. `browser_click`'s viewport→screen conversion then yields an off-screen-negative point the OS clamps to **(0,0)** — the cursor lands in the top-left failsafe zone and the dwell watchdog kills the server (`Connection closed`). Found during real GSC dogfooding.

Now both click paths (`selector` and `by`+`pattern`) detect a minimized/off-screen window from the window origin **before** the OS click and stop with a typed **`BrowserTargetMinimized`** error (restore-and-retry hint) instead of mis-firing. `browser_fill` is **exempt** — it writes via a CDP eval, not an OS click, so it still works on a minimized window.

- engine: `MINIMIZED_WINDOW_SCREEN_COORD` + `isOffscreenMinimized()` (`cdp-bridge.ts`); `getElementScreenCoords` now returns `screenX/screenY`.
- tools: `browserMinimizedFailure()` shared by both click paths (inline `failCode`, no SUGGESTS/catalog drift — `BrowserAmbiguousTarget` precedent).
- tests: unit predicate boundaries (incl. legitimate negative-origin secondary monitor is **not** flagged) + headless e2e that overrides `window.screenX=-32000`, asserts both paths stop **without clicking** (the `onclick` side effect stays empty) and that `fill` still succeeds.

### 2. `browser-cdp.test.ts` flaky readiness (test-only fix)
Verifying #1 surfaced a pre-existing flake: under full-suite load the CDP test file failed ~1-in-4 with `#btn-submit not found` / `document.body is null`. Root cause = a **startup timing race**: `waitForLoad` only checked `readyState`+`title`, which passes the instant `<head>` commits — before `<body>` is parsed. `resolveTab(null)` was resolving the fixture correctly on every probe, so **no production change** is needed. Now it polls for the fixture element to exist **and** be laid out (`getBoundingClientRect().width > 0`), the same element-level readiness the other (non-flaky) browser e2e suites use. **Verified: 12-file browser e2e set 6/6 green.**

## Test
- `tests/unit/browser-minimized-guard.test.ts` — 6/6
- `tests/e2e/browser-click-minimized.test.ts` — 4/4 (headless)
- existing browser suites (cdp / click-by-axis / fill-by-axis / cdp-verification) green; `check:failwith-fixtures` regenerated (line-number only).

## Plan / design (private repo)
`desktop-touch-mcp-internal@ac8751b:docs/browser-click-minimized-window-followup.md` — option B (typed-error guard) locked, with carry-over (A) restore-first as a future opt-in.

## Follow-up (separate PR)
opt-in gate for real-OS-input e2e (`mouse-*` / `force-focus` / `tool-chain` clicks) so a normal `test:capture` never moves the physical cursor on a live desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)