### PR TITLE
test(e2e): emergency stop for the live-desktop e2e suite (npm run e2e:stop)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ tests/repros/
 # Per-ADR PowerShell investigation spikes (Windows Terminal, RDP, etc.).
 # Findings live in the private companion repo's ADR docs.
 scripts/spikes/
+
+# e2e emergency-stop sentinel (runtime, never commit)
+.e2e-stop

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "test:capture": "node scripts/test-capture.mjs",
     "test:unit": "vitest run --project=unit",
     "test:e2e": "vitest run --project=e2e",
+    "e2e:stop": "node scripts/e2e-stop.mjs",
     "test:headed": "HEADED=1 vitest run --project=e2e",
     "test:e2e:browser": "vitest run --project=e2e \"tests/e2e/browser-*.test.ts\"",
     "test:e2e:window": "vitest run --project=e2e tests/e2e/dock-window.test.ts tests/e2e/dock-auto.test.ts tests/e2e/focus-integrity.test.ts tests/e2e/force-focus.test.ts tests/e2e/screenshot-electron.test.ts tests/e2e/ui-elements-cache.test.ts",

--- a/scripts/e2e-stop.mjs
+++ b/scripts/e2e-stop.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+/**
+ * e2e-stop.mjs — request an emergency stop of a running e2e suite.
+ *
+ * Drops the `.e2e-stop` sentinel that tests/e2e/abort-check.ts watches; the run
+ * then skips every remaining test at its next boundary (afterAll/afterEach still
+ * run, so Chrome / spawned windows are cleaned up). Run this from ANY terminal —
+ * it never touches the desktop, so it works even while a test is driving the
+ * cursor via SendInput.
+ *
+ *   npm run e2e:stop
+ *
+ * The sentinel is auto-cleared at the start and end of every e2e run
+ * (tests/e2e/global-setup.ts), so a leftover file never skips a fresh run.
+ */
+import { writeFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const sentinel = join(dirname(fileURLToPath(import.meta.url)), "..", ".e2e-stop");
+writeFileSync(sentinel, `stop ${new Date().toISOString()}\n`, "utf8");
+console.log(`[e2e:stop] requested — the e2e run will halt at the next test boundary.\n  sentinel: ${sentinel}`);

--- a/tests/e2e/abort-check.ts
+++ b/tests/e2e/abort-check.ts
@@ -1,0 +1,20 @@
+/**
+ * abort-check.ts — vitest `setupFiles` for the e2e project (runs in each worker).
+ *
+ * Registers a global `beforeEach` that honours the emergency-stop sentinel: once
+ * `npm run e2e:stop` drops `.e2e-stop`, every remaining test skips at its next
+ * boundary. `ctx.skip()` (not process.exit /
+ * throw) is deliberate — it halts the run promptly while letting each file's
+ * afterEach/afterAll still run, so Chrome instances and spawned windows are torn
+ * down cleanly rather than orphaned. The check is a single existsSync per test
+ * (microseconds) and adds no UI surface, so it never destabilises screenshot /
+ * window-enumeration / focus tests.
+ */
+import { beforeEach } from "vitest";
+import { isStopRequested } from "./helpers/stop-sentinel.js";
+
+beforeEach((ctx) => {
+  if (isStopRequested()) {
+    ctx.skip();
+  }
+});

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -2,18 +2,24 @@
  * global-setup.ts — vitest `globalSetup` for the e2e project (runs ONCE in the
  * main process, before any worker, and once on teardown).
  *
- * Clears any stale `.e2e-stop` emergency-stop sentinel at the start of a run (so a
- * leftover file from a crashed/aborted run never silently skips a fresh one) and
- * again on teardown. The stop itself is requested with `npm run e2e:stop` from any
- * terminal — that drops the sentinel, and abort-check.ts then skips every
- * remaining test at the next boundary. A terminal command (not a clickable window)
- * is deliberate: it works even while a test is driving the cursor via SendInput
- * (when a STOP button would be unclickable), and it adds no on-screen window that
- * could perturb screenshot / window-enumeration / focus tests.
+ * Clears a STALE `.e2e-stop` emergency-stop sentinel at the start of a run (so a
+ * leftover file from a crashed/aborted run never silently skips a fresh one), and
+ * clears the sentinel on teardown. The startup clear is staleness-gated on the
+ * process launch time: a stop fired during THIS run's boot window (before any
+ * worker's beforeEach runs) is preserved so the run still halts (Codex PR #408 P1).
+ *
+ * The stop itself is requested with `npm run e2e:stop` from any terminal — that
+ * drops the sentinel, and abort-check.ts then skips every remaining test at the
+ * next boundary. A terminal command (not a clickable window) is deliberate: it
+ * works even while a test is driving the cursor via SendInput (when a STOP button
+ * would be unclickable), and it adds no on-screen window that could perturb
+ * screenshot / window-enumeration / focus tests.
  */
-import { clearStop } from "./helpers/stop-sentinel.js";
+import { clearStaleStop, clearStop } from "./helpers/stop-sentinel.js";
 
 export default function setup(): () => void {
-  clearStop(); // drop any stale sentinel from a prior run
+  // process launch time = now - uptime. A sentinel older than this is from a prior
+  // run (stale → clear); a newer one was issued during our boot (keep → honour it).
+  clearStaleStop(Date.now() - Math.floor(process.uptime() * 1000));
   return () => clearStop();
 }

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,0 +1,19 @@
+/**
+ * global-setup.ts — vitest `globalSetup` for the e2e project (runs ONCE in the
+ * main process, before any worker, and once on teardown).
+ *
+ * Clears any stale `.e2e-stop` emergency-stop sentinel at the start of a run (so a
+ * leftover file from a crashed/aborted run never silently skips a fresh one) and
+ * again on teardown. The stop itself is requested with `npm run e2e:stop` from any
+ * terminal — that drops the sentinel, and abort-check.ts then skips every
+ * remaining test at the next boundary. A terminal command (not a clickable window)
+ * is deliberate: it works even while a test is driving the cursor via SendInput
+ * (when a STOP button would be unclickable), and it adds no on-screen window that
+ * could perturb screenshot / window-enumeration / focus tests.
+ */
+import { clearStop } from "./helpers/stop-sentinel.js";
+
+export default function setup(): () => void {
+  clearStop(); // drop any stale sentinel from a prior run
+  return () => clearStop();
+}

--- a/tests/e2e/helpers/stop-sentinel.ts
+++ b/tests/e2e/helpers/stop-sentinel.ts
@@ -1,0 +1,48 @@
+/**
+ * stop-sentinel.ts — emergency-stop sentinel for the e2e suite.
+ *
+ * The e2e suite drives real OS input (mouse / keyboard) on the live desktop. If a
+ * run misbehaves (cursor hijacked, foreground churn) you need a reliable way to
+ * halt it WITHOUT racing the test for the cursor. The mechanism is a plain file
+ * on disk: any process can drop it, and the per-test `beforeEach` (abort-check.ts)
+ * checks for it and skips every remaining test at the next boundary — so the run
+ * stops promptly while afterAll/afterEach hooks still clean up (Chrome, windows).
+ *
+ * Drop the sentinel with `npm run e2e:stop` from any terminal — reliable even
+ * while a test owns the cursor (it does not touch the desktop), and it adds no
+ * on-screen window that could perturb screenshot / window-enumeration tests.
+ *
+ * A file (not an env var / in-process flag) is deliberate: env vars cannot change
+ * after the worker starts, and the test worker is a separate process from the
+ * terminal you'd type the stop into. The filesystem is the one channel both share.
+ */
+import { existsSync, writeFileSync, rmSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// Repo root: tests/e2e/helpers → ../../../
+export const STOP_SENTINEL_PATH = join(__dirname, "..", "..", "..", ".e2e-stop");
+
+// The `path` arg defaults to STOP_SENTINEL_PATH for all callers; it exists so the
+// unit test can exercise the round-trip against a temp file WITHOUT touching the
+// real repo-root sentinel (which would abort a concurrent e2e run).
+
+/** True when an emergency stop has been requested (sentinel file present). */
+export function isStopRequested(path: string = STOP_SENTINEL_PATH): boolean {
+  return existsSync(path);
+}
+
+/** Request an emergency stop (drop the sentinel). Used by `npm run e2e:stop` + the STOP window. */
+export function requestStop(path: string = STOP_SENTINEL_PATH): void {
+  writeFileSync(path, `stop ${new Date().toISOString()}\n`, "utf8");
+}
+
+/** Remove the sentinel (stale-cleanup at run start + teardown). Never throws. */
+export function clearStop(path: string = STOP_SENTINEL_PATH): void {
+  try {
+    rmSync(path, { force: true });
+  } catch {
+    /* ignore — best effort */
+  }
+}

--- a/tests/e2e/helpers/stop-sentinel.ts
+++ b/tests/e2e/helpers/stop-sentinel.ts
@@ -16,7 +16,7 @@
  * after the worker starts, and the test worker is a separate process from the
  * terminal you'd type the stop into. The filesystem is the one channel both share.
  */
-import { existsSync, writeFileSync, rmSync } from "fs";
+import { existsSync, writeFileSync, rmSync, statSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 
@@ -33,16 +33,34 @@ export function isStopRequested(path: string = STOP_SENTINEL_PATH): boolean {
   return existsSync(path);
 }
 
-/** Request an emergency stop (drop the sentinel). Used by `npm run e2e:stop` + the STOP window. */
+/** Request an emergency stop by dropping the sentinel — the importable equivalent of `npm run e2e:stop` (which writes the same file directly). Exercised by the unit test. */
 export function requestStop(path: string = STOP_SENTINEL_PATH): void {
   writeFileSync(path, `stop ${new Date().toISOString()}\n`, "utf8");
 }
 
-/** Remove the sentinel (stale-cleanup at run start + teardown). Never throws. */
+/** Remove the sentinel (teardown cleanup). Never throws. */
 export function clearStop(path: string = STOP_SENTINEL_PATH): void {
   try {
     rmSync(path, { force: true });
   } catch {
     /* ignore — best effort */
+  }
+}
+
+/**
+ * Clear the sentinel at run start ONLY if it is STALE — left over from a previous,
+ * crashed run (its mtime predates `launchedAtMs`, this run's process launch). A
+ * sentinel written at/after launch — a `npm run e2e:stop` fired during this run's
+ * boot window, before any worker's beforeEach runs — is PRESERVED so the run still
+ * halts (Codex PR #408 P1: an unconditional startup clear would erase a stop
+ * issued in the exact "abort immediately after launch" case). Never throws.
+ */
+export function clearStaleStop(launchedAtMs: number, path: string = STOP_SENTINEL_PATH): void {
+  try {
+    if (statSync(path).mtimeMs < launchedAtMs) {
+      rmSync(path, { force: true });
+    }
+  } catch {
+    /* absent / stat failed → nothing to clear */
   }
 }

--- a/tests/unit/e2e-stop-sentinel.test.ts
+++ b/tests/unit/e2e-stop-sentinel.test.ts
@@ -1,0 +1,53 @@
+/**
+ * e2e-stop-sentinel.test.ts — unit coverage for the e2e emergency-stop sentinel
+ * helpers (tests/e2e/helpers/stop-sentinel.ts). Exercised against a TEMP path so
+ * the real repo-root `.e2e-stop` is never touched (touching it could abort a
+ * concurrent e2e run).
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { existsSync, mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  isStopRequested,
+  requestStop,
+  clearStop,
+  STOP_SENTINEL_PATH,
+} from "../e2e/helpers/stop-sentinel.js";
+
+const tmp = mkdtempSync(join(tmpdir(), "e2e-stop-"));
+const SENTINEL = join(tmp, ".e2e-stop");
+
+afterEach(() => clearStop(SENTINEL));
+
+describe("e2e stop sentinel", () => {
+  it("round-trips request → detected → cleared", () => {
+    expect(isStopRequested(SENTINEL)).toBe(false);
+    requestStop(SENTINEL);
+    expect(isStopRequested(SENTINEL)).toBe(true);
+    expect(existsSync(SENTINEL)).toBe(true);
+    clearStop(SENTINEL);
+    expect(isStopRequested(SENTINEL)).toBe(false);
+  });
+
+  it("clearStop is idempotent and never throws when the sentinel is absent", () => {
+    expect(() => {
+      clearStop(SENTINEL);
+      clearStop(SENTINEL);
+    }).not.toThrow();
+    expect(isStopRequested(SENTINEL)).toBe(false);
+  });
+
+  it("the default sentinel lives at the repo root as .e2e-stop", () => {
+    expect(STOP_SENTINEL_PATH.replace(/\\/g, "/").endsWith("/.e2e-stop")).toBe(true);
+  });
+});
+
+// One-time cleanup of the temp dir when the process exits.
+process.on("exit", () => {
+  try {
+    rmSync(tmp, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});

--- a/tests/unit/e2e-stop-sentinel.test.ts
+++ b/tests/unit/e2e-stop-sentinel.test.ts
@@ -5,13 +5,14 @@
  * concurrent e2e run).
  */
 import { describe, it, expect, afterEach } from "vitest";
-import { existsSync, mkdtempSync, rmSync } from "fs";
+import { existsSync, mkdtempSync, rmSync, utimesSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
   isStopRequested,
   requestStop,
   clearStop,
+  clearStaleStop,
   STOP_SENTINEL_PATH,
 } from "../e2e/helpers/stop-sentinel.js";
 
@@ -40,6 +41,30 @@ describe("e2e stop sentinel", () => {
 
   it("the default sentinel lives at the repo root as .e2e-stop", () => {
     expect(STOP_SENTINEL_PATH.replace(/\\/g, "/").endsWith("/.e2e-stop")).toBe(true);
+  });
+});
+
+describe("clearStaleStop — preserve a stop issued during boot, clear a prior-run leftover", () => {
+  it("CLEARS a sentinel older than the launch time (stale prior-run leftover)", () => {
+    requestStop(SENTINEL);
+    // Age the sentinel to 60s ago; launch happened 'now' → it predates launch → stale.
+    const old = Date.now() / 1000 - 60;
+    utimesSync(SENTINEL, old, old);
+    clearStaleStop(Date.now(), SENTINEL);
+    expect(isStopRequested(SENTINEL)).toBe(false);
+  });
+
+  it("PRESERVES a sentinel newer than the launch time (stop fired during boot)", () => {
+    // Launch time is 60s in the past; the sentinel is written 'now' → newer → kept.
+    const launchedAtMs = Date.now() - 60_000;
+    requestStop(SENTINEL);
+    clearStaleStop(launchedAtMs, SENTINEL);
+    expect(isStopRequested(SENTINEL)).toBe(true);
+  });
+
+  it("is a no-op (no throw) when the sentinel is absent", () => {
+    expect(() => clearStaleStop(Date.now(), SENTINEL)).not.toThrow();
+    expect(isStopRequested(SENTINEL)).toBe(false);
   });
 });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -42,6 +42,11 @@ export default defineConfig({
         test: {
           name: "e2e",
           include: ["tests/e2e/**/*.test.ts"],
+          // Emergency stop: globalSetup clears a stale `.e2e-stop` sentinel;
+          // abort-check.ts skips remaining tests once the sentinel is dropped by
+          // `npm run e2e:stop` from any terminal. See tests/e2e/helpers/stop-sentinel.ts.
+          globalSetup: ["./tests/e2e/global-setup.ts"],
+          setupFiles: ["./tests/e2e/abort-check.ts"],
           // E2E tests share OS-level resources (windows, focus, clipboard)
           // and must run serially.
           fileParallelism: false,


### PR DESCRIPTION
## What & why

The e2e suite drives **real OS input** (mouse/keyboard) on the live desktop. If a run misbehaves (cursor hijacked, foreground churn) you currently can only Ctrl+C the runner. This adds a clean way to halt a run **without racing the test for the cursor**.

`npm run e2e:stop` (from any terminal) drops a `.e2e-stop` sentinel file; a global `beforeEach` then **skips every remaining test at the next boundary** via `ctx.skip()`. Because it's `ctx.skip()` (not `process.exit`/throw), each file's `afterEach`/`afterAll` still run, so Chrome instances and spawned windows are **torn down cleanly** (no orphans), and the run ends with exit 0.

### Why a terminal command, not a STOP-button window
A clickable window is **unclickable while a test is driving the cursor via SendInput** (it fights you for the pointer), and a persistent top-most window would show up in screenshot / window-enumeration / focus tests and make *their* results waver. The filesystem sentinel sidesteps both — it never touches the desktop. (I prototyped an opt-in STOP window but it did not render reliably when spawned from vitest's globalSetup context, and added no value over the terminal command, so it was dropped.)

## Pieces
- `tests/e2e/helpers/stop-sentinel.ts` — sentinel path + `is/request/clear` helpers (path arg defaults to the real sentinel; overridable for the unit test).
- `tests/e2e/abort-check.ts` — `setupFiles` `beforeEach` that `ctx.skip()`s when the sentinel exists.
- `tests/e2e/global-setup.ts` — `globalSetup` clears a **stale** sentinel at start + on teardown (so a leftover from a crashed run never bricks a fresh one).
- `scripts/e2e-stop.mjs` + `package.json` `"e2e:stop"`.
- `vitest.config.ts` e2e project: `globalSetup` + `setupFiles`.
- `tests/unit/e2e-stop-sentinel.test.ts` — helper round-trip against a temp path (never touches the real sentinel).
- `.gitignore` — `.e2e-stop`.

## Test / verification
- unit 3/3.
- **mid-run stop**: started a 3-file browser e2e run, ran `npm run e2e:stop` ~6s in → 27 ran, **39 skipped**, exit 0, `afterAll` cleanup ran, sentinel auto-cleared by teardown.
- **normal run unaffected**: `browser-cdp.test.ts` → 27 passed / 2 skipped (headed-gated baseline), no spurious skips.
- No production / user-facing change (dev test-infra only) → no CHANGELOG entry.

## Context
Follow-up to #407 (browser_click minimized-window guard). The user is fine running real-input e2e on the live desktop; this just gives a reliable way to abort a run when needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)