### PR TITLE
fix(browser): detectModal — exclude low-coverage backdrop drawers (real GSC shape)

### DIFF
--- a/src/tools/browser-resolver.ts
+++ b/src/tools/browser-resolver.ts
@@ -1170,6 +1170,19 @@ export interface ModalVerdict {
 export const MODAL_COVERAGE_THRESHOLD = 0.5;
 /** K — minimum modal-BEHAVIOR signals (scroll-lock / inert / focus-inside) for rule 4 rescue. */
 export const MODAL_RESCUE_MIN_BEHAVIOR_SIGNALS = 1;
+/**
+ * A backdrop-backed `role=dialog` candidate whose viewport coverage is below this
+ * is treated as a drawer/side-panel (drawer-exclusion), not a modal — so
+ * `drawerExcluded` correctly reflects the exclusion. Real GSC dogfood (2026-05-24):
+ * its `role="dialog"` "navigational drawer" has `hasBackdrop:true` but only ~0.18
+ * coverage, `aria-modal:false`, `landmark:null` — it slipped past the landmark
+ * drawer signals and was only declined by the rescue coverage gate, so
+ * `drawerExcluded` read false. A non-strong, backdrop-backed, low-coverage dialog
+ * is a side panel (a real modal with a backdrop covers far more). Strong-signal
+ * modals (aria-modal / alertdialog / native showModal) are unaffected — rule 2
+ * classifies them before drawer exclusion. Below the rescue threshold (0.5).
+ */
+export const MODAL_DRAWER_MAX_COVERAGE = 0.35;
 
 /**
  * Self-contained injected-JS IIFE (no outer-helper dependency — embeds verbatim
@@ -1318,8 +1331,17 @@ export function detectModal(facts: ModalFacts): ModalVerdict {
   const scrollLock = facts.bodyScrollLock;
 
   const isStrong = (c: DialogFacts): boolean => c.ariaModal || c.role === "alertdialog" || c.nativeDialogOpen;
+  // Drawer / side-panel evidence (only consulted in the no-strong-signal branch):
+  // a navigation/complementary landmark, an offscreen-parked transform, OR a
+  // backdrop-backed dialog whose coverage is too small to be a real modal (real
+  // GSC dogfood — its role=dialog "navigational drawer" has a backdrop but ~0.18
+  // coverage, no aria-modal, no landmark). A strong-signal modal never reaches
+  // here (rule 2), so this never suppresses a real modal.
   const isDrawer = (c: DialogFacts): boolean =>
-    c.landmarkRole === "navigation" || c.landmarkRole === "complementary" || c.offscreenTransform;
+    c.landmarkRole === "navigation" ||
+    c.landmarkRole === "complementary" ||
+    c.offscreenTransform ||
+    (c.hasBackdrop && c.viewportCoverage < MODAL_DRAWER_MAX_COVERAGE);
   const behaviorCount = (c: DialogFacts): number =>
     (scrollLock ? 1 : 0) + (c.siblingsInert ? 1 : 0) + (focusInside ? 1 : 0);
 

--- a/tests/fixtures/browser-modal/gsc-real-drawer.json
+++ b/tests/fixtures/browser-modal/gsc-real-drawer.json
@@ -1,0 +1,26 @@
+{
+  "_note": "ADR-023 Phase 2: REAL Google Search Console 'navigational drawer' captured via dogfood (2026-05-24). role=dialog with a backdrop but only ~0.18 viewport coverage, no aria-modal, no landmark — the exact 課題③ shape. Must be isModal:false AND drawerExcluded:true (the low-coverage backdrop drawer signal). Resolves OQ-P2-d.",
+  "facts": {
+    "viewport": { "innerWidth": 1536, "innerHeight": 730 },
+    "bodyScrollLock": false,
+    "activeElement": { "tag": "body", "role": null, "inDialogCandidate": false },
+    "dialogCandidates": [
+      {
+        "role": "dialog",
+        "tag": "div",
+        "ariaModal": false,
+        "nativeDialogOpen": false,
+        "name": "navigational drawer",
+        "visible": true,
+        "rect": { "x": 0, "y": 0, "w": 320, "h": 730 },
+        "viewportCoverage": 0.18,
+        "offscreenTransform": false,
+        "zIndex": 100,
+        "landmarkRole": null,
+        "hasBackdrop": true,
+        "siblingsInert": false
+      }
+    ]
+  },
+  "expect": { "isModal": false, "drawerExcluded": true }
+}

--- a/tests/unit/browser-resolver-modal.test.ts
+++ b/tests/unit/browser-resolver-modal.test.ts
@@ -112,6 +112,23 @@ describe("ADR-023 Phase 2 (PR-2a): detectModal — rule branches", () => {
     expect(v.signals.drawerExcluded).toBe(true);
   });
 
+  it("rule 3 drawer exclusion: low-coverage backdrop dialog (real GSC drawer shape) → not modal, drawerExcluded", () => {
+    // GSC's role=dialog "navigational drawer": backdrop but only ~0.18 coverage,
+    // no aria-modal, no landmark. Must be excluded as a drawer (dogfood 2026-05-24).
+    const v = detectModal(
+      mkFacts([mkDialog({ role: "dialog", ariaModal: false, hasBackdrop: true, viewportCoverage: 0.18, landmarkRole: null })]),
+    );
+    expect(v.isModal).toBe(false);
+    expect(v.signals.drawerExcluded).toBe(true);
+  });
+
+  it("low-coverage WITHOUT backdrop is NOT a drawer (avoids over-firing drawerExcluded)", () => {
+    // a small non-modal popover with no backdrop → not modal, but not attributed to a drawer.
+    const v = detectModal(mkFacts([mkDialog({ hasBackdrop: false, viewportCoverage: 0.1, landmarkRole: null })]));
+    expect(v.isModal).toBe(false);
+    expect(v.signals.drawerExcluded).toBe(false);
+  });
+
   it("rule 4 rescue: no strong + backdrop + scroll-lock + coverage → isModal", () => {
     const v = detectModal(
       mkFacts([mkDialog({ hasBackdrop: true, viewportCoverage: 0.6 })], { bodyScrollLock: true }),


### PR DESCRIPTION
## What
Follow-up from the **real GSC dogfood** (2026-05-24). GSC's `role="dialog"` *"navigational drawer"* has a **backdrop** but only **~0.18 viewport coverage**, no `aria-modal`, no landmark. `detectModal` already returned `isModal:false` (the rescue coverage gate rejected it), but `signals.drawerExcluded` read **false** because it slipped past the landmark drawer signals.

## Fix
Add a drawer signal: a **backdrop-backed dialog below `MODAL_DRAWER_MAX_COVERAGE` (0.35)** is a side panel, not a modal → `drawerExcluded` now correctly fires.
- `< 0.35` is well below the `0.5` rescue gate, so the two don't overlap.
- Strong-signal modals (`aria-modal` / `alertdialog` / native `showModal`) are **unaffected** — rule 2 precedes drawer exclusion.
- A low-coverage dialog **without** a backdrop is NOT treated as a drawer (avoids over-firing `drawerExcluded` on plain popovers).
- **`isModal` verdict is unchanged for every existing case** — this only improves the diagnostic `drawerExcluded` attribution.

## Tests
- Unit: GSC-shape drawer (backdrop + 0.18 cov + no landmark) → `isModal:false` + `drawerExcluded:true`; low-cov *without* backdrop → `drawerExcluded:false`.
- Adds the **dogfood-captured** fixture `tests/fixtures/browser-modal/gsc-real-drawer.json` (resolves plan **OQ-P2-d**).
- 62 resolver unit pass; gather JS / snapshot **unchanged** (pure-decision tweak).

## Plan
desktop-touch-mcp-internal@f77db46 `docs/adr-023-phase-2-modal-plan.md` (§2.3 / OQ-P2-d).

🤖 Generated with [Claude Code](https://claude.com/claude-code)