### PR TITLE
fix(e2e): focusWindow → restoreAndFocusWindow (undefined import, CodeQL #129)

### DIFF
--- a/tests/e2e/focus-integrity.test.ts
+++ b/tests/e2e/focus-integrity.test.ts
@@ -27,13 +27,13 @@ import { terminalSendHandler } from "../../src/tools/terminal.js";
 import { launchNotepad, type NpInstance } from "./helpers/notepad-launcher.js";
 import { launchPowerShell, type PsInstance } from "./helpers/powershell-launcher.js";
 import { parsePayload, sleep } from "./helpers/wait.js";
-import { focusWindow } from "../../src/engine/win32.js";
+import { restoreAndFocusWindow } from "../../src/engine/win32.js";
 
 let np: NpInstance;
 
 beforeAll(async () => {
   np = await launchNotepad();
-  try { focusWindow(np.hwnd); } catch { /* non-fatal */ }
+  try { restoreAndFocusWindow(np.hwnd); } catch { /* non-fatal */ }
   await sleep(400);
 }, 10_000);
 
@@ -45,7 +45,7 @@ afterAll(() => np?.kill());
 
 describe("A1-armed: keyboard_type with windowTitle arms focusLost detection", () => {
   it("returns ok:true and no focusLost when Notepad keeps focus", async () => {
-    try { focusWindow(np.hwnd); } catch { /* non-fatal */ }
+    try { restoreAndFocusWindow(np.hwnd); } catch { /* non-fatal */ }
     await sleep(200);
 
     const result = await keyboardTypeHandler({
@@ -221,7 +221,7 @@ describe("A2: terminal_send(restoreFocus:true) restores caller's focus", () => {
 
   it("focusRestored:true when Notepad was active before terminal_send", async ({ skip }) => {
     // Focus Notepad first (the window we want focus to return to)
-    try { focusWindow(np.hwnd); } catch { /* non-fatal */ }
+    try { restoreAndFocusWindow(np.hwnd); } catch { /* non-fatal */ }
     await sleep(300);
 
     // Verify Notepad is active
@@ -260,7 +260,7 @@ describe("A2: terminal_send(restoreFocus:true) restores caller's focus", () => {
 
   it("focusRestored:false when restoreFocus is disabled", async ({ skip }) => {
     // Focus Notepad first
-    try { focusWindow(np.hwnd); } catch { /* non-fatal */ }
+    try { restoreAndFocusWindow(np.hwnd); } catch { /* non-fatal */ }
     await sleep(300);
 
     const { enumWindowsInZOrder } = await import("../../src/engine/win32.js");

--- a/tests/e2e/rich-narration-edge.test.ts
+++ b/tests/e2e/rich-narration-edge.test.ts
@@ -12,7 +12,7 @@ import { keyboardTypeHandler } from "../../src/tools/keyboard.js";
 import { withRichNarration } from "../../src/tools/_narration.js";
 import { launchNotepad, type NpInstance } from "./helpers/notepad-launcher.js";
 import { parsePayload, sleep } from "./helpers/wait.js";
-import { focusWindow } from "../../src/engine/win32.js";
+import { restoreAndFocusWindow } from "../../src/engine/win32.js";
 
 // Wrap keyboard_press the same way the MCP server does
 const richKeyboardPress = withRichNarration("keyboard_press", keyboardPressHandler, {
@@ -189,7 +189,7 @@ describe("B4: consecutive narrate:rich calls have independent post.rich (no cach
 
   beforeAll(async () => {
     np = await launchNotepad();
-    try { focusWindow(np.hwnd); } catch { /* non-fatal */ }
+    try { restoreAndFocusWindow(np.hwnd); } catch { /* non-fatal */ }
     await sleep(400);
   }, 10_000);
 

--- a/tests/e2e/tool-chain.test.ts
+++ b/tests/e2e/tool-chain.test.ts
@@ -19,7 +19,7 @@ import { mouseClickHandler } from "../../src/tools/mouse.js";
 import { withPostState } from "../../src/tools/_post.js";
 import { launchNotepad, type NpInstance } from "./helpers/notepad-launcher.js";
 import { parsePayload, sleep } from "./helpers/wait.js";
-import { focusWindow } from "../../src/engine/win32.js";
+import { restoreAndFocusWindow } from "../../src/engine/win32.js";
 import { screenshotHandler } from "../../src/tools/screenshot.js";
 import { spawnBlankWindow } from "./helpers/blank-window.js";
 
@@ -36,7 +36,7 @@ const trackedKeyboardPress = withPostState("keyboard_press", keyboardPressHandle
 
 beforeAll(async () => {
   np = await launchNotepad();
-  try { focusWindow(np.hwnd); } catch { /* non-fatal */ }
+  try { restoreAndFocusWindow(np.hwnd); } catch { /* non-fatal */ }
   await sleep(400);
 }, 10_000);
 
@@ -165,7 +165,7 @@ describe("H3: mouse_click → get_context focus propagates within 300ms", () => 
 
   beforeAll(async () => {
     np3 = await launchNotepad();
-    try { focusWindow(np3.hwnd); } catch { /* non-fatal */ }
+    try { restoreAndFocusWindow(np3.hwnd); } catch { /* non-fatal */ }
     await sleep(400);
   }, 10_000);
 

--- a/tests/e2e/ui-elements-cache.test.ts
+++ b/tests/e2e/ui-elements-cache.test.ts
@@ -17,7 +17,7 @@ import { clickElementHandler, getUiElementsHandler } from "../../src/tools/ui-el
 import { keyboardPressHandler } from "../../src/tools/keyboard.js";
 import { launchNotepad, type NpInstance } from "./helpers/notepad-launcher.js";
 import { parsePayload, sleep } from "./helpers/wait.js";
-import { focusWindow } from "../../src/engine/win32.js";
+import { restoreAndFocusWindow } from "../../src/engine/win32.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // F1-base: ElementNotFound + suggest for a completely bogus automationId
@@ -87,7 +87,7 @@ describe("F1-dialog: stale automationId after dialog closes → ElementNotFound"
     np = await launchNotepad();
 
     try {
-      focusWindow(np.hwnd);
+      restoreAndFocusWindow(np.hwnd);
     } catch { /* non-fatal */ }
     await sleep(300);
 


### PR DESCRIPTION
## What
Fixes CodeQL **`js/call-to-non-callable`** alert **#129** (`tests/e2e/tool-chain.test.ts:39`, "Callee is not a function: type undefined") — and the same latent bug in 3 sibling e2e files.

## Root cause
Four e2e tests imported `focusWindow` from `src/engine/win32.ts`, which **exports no such symbol** (`restoreAndFocusWindow` / `forceSetForegroundWindow` exist instead). The import resolved to `undefined`; `focusWindow(np.hwnd)` threw *"focusWindow is not a function"* at runtime and was **swallowed by the surrounding `try/catch`** — so these tests silently never focused their window in `beforeAll`. `tsc` didn't catch it (the build tsconfig doesn't type-check e2e tests; vitest uses esbuild = no type-check). CodeQL did.

## Fix
Replace with the repo-wide window-focus helper `restoreAndFocusWindow(hwnd)` (SW_RESTORE + SetForegroundWindow — the same call the keyboard / mouse / dock / scroll tools use). `np.hwnd` is a `bigint`, which it accepts.

Files: `tests/e2e/{tool-chain,focus-integrity,rich-narration-edge,ui-elements-cache}.test.ts`.

## Notes
- Pre-existing on `main`; **unrelated to the ADR-023 modal work**.
- Test-only change (no production code). Not running these e2e here — they launch Notepad + focus real windows (live-desktop). The fix is a mechanical correction to a helper used throughout the codebase; `tsc --noEmit` clean.
- Alert #129 auto-closes when this merges (real fix, not a suppression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)