### PR TITLE
docs(site): add v1.9 milestone entry (browser semantic targeting + modal)

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -102,6 +102,10 @@
             <h2>Project Milestones</h2>
             <p>As the project evolves, we document major architectural shifts and milestones here.</p>
             <div class="three-up">
+              <a class="mini-card" href="https://github.com/Harusame64/desktop-touch-mcp/releases/tag/v1.9.0">
+                <h3>v1.9: Semantic Targeting Reaches the Browser</h3>
+                <p><code>browser_click</code> and <code>browser_fill</code> can target an element by what it <em>means</em> (<code>by:'text'|'role'|'ariaLabel'</code> + a <code>pattern</code>), resolving to a single actionable target and stopping — not guessing — when the match is ambiguous. The browser also learns to tell a real modal dialog from a navigation drawer: <code>browser_overview</code> reports a machine-readable <code>modal</code> state and <code>browser_click</code> refuses to click <em>through</em> a blocking dialog onto its backdrop. "See entities, not coordinates," applied to the web.</p>
+              </a>
               <a class="mini-card" href="./articles/v1.8-milestone.html">
                 <h3>v1.8: From Delivery to Completion, and Reaching Deeper Into Apps</h3>
                 <p>Trustworthy delivery extends into trustworthy completion: <code>terminal(action='run')</code> can wait for a command to finish and report its real exit code, the new <code>excel</code> tool runs VBA over COM, and the act-and-observe loop gains race-free visual verification, idle-aware CPU dormancy, a diagnostic log, and a deliberate-dwell emergency stop.</p>

--- a/site/index.md
+++ b/site/index.md
@@ -98,6 +98,10 @@ It is trying to document an active line of engineering and research.
 
 As the project evolves, we document major architectural shifts and milestones here.
 
+### v1.9: Semantic Targeting Reaches the Browser
+The browser tools stop leaning on brittle CSS selectors. `browser_click` and `browser_fill` can now target an element by what it *means* (`by:'text' | 'role' | 'ariaLabel'` + a `pattern`), resolving to a single actionable target and **stopping** — rather than guessing — when the match is ambiguous. The same release teaches the browser to tell a real modal dialog from a navigation drawer: `browser_overview` reports a machine-readable `modal` state, and `browser_click` refuses to click *through* a blocking dialog instead of landing on its backdrop. It is "see entities, not coordinates" applied to the web.
+- [See the v1.9.0 release notes](https://github.com/Harusame64/desktop-touch-mcp/releases/tag/v1.9.0)
+
 ### v1.8: From Delivery to Completion, and Reaching Deeper Into Apps
 The v1.5–v1.8 series extend trustworthy *delivery* into trustworthy *completion*. `terminal(action='run')` can now wait for a command to actually finish and report its real exit code (`until:{mode:'exit'}`), the new `excel` tool runs VBA macros over COM where formula-only tools can't, and the act-and-observe loop is hardened with race-free visual verification, idle-aware CPU dormancy, a diagnostic event log, and a deliberate-dwell emergency stop.
 - [Read the v1.8 Milestone Article](./articles/v1.8-milestone.html)


### PR DESCRIPTION
## What
Light-touch site update for **v1.9.0**: a Milestones entry on the landing page (`site/index.md` + `site/index.html`) framing the new **browser by-axis semantic targeting** + **modal detection** as *"see entities, not coordinates"* applied to the web — linking to the v1.9.0 release notes.

## Why light-touch (no full article)
Milestone articles are selective (v1.0 / v1.2 / v1.4 / v1.8 — not every minor). v1.9 is a focused release; a full article right after v1.8 would be too dense. The entry surfaces the thematically-central capability without a new article.

## Notes
- `site/` is hand-maintained md + html (Pages serves html) — both updated, kept in sync.
- nav "Milestones" still points at the latest in-site **article** (v1.8); `sitemap.xml` unchanged (v1.9 links to release notes, not a new in-site page).
- No internal jargon (public tool/param names only) — user-facing English.

🤖 Generated with [Claude Code](https://claude.com/claude-code)