### PR TITLE
fix(terminal): send Enter as a real key event so conhost PowerShell executes the command

### DIFF
--- a/src/engine/bg-input.ts
+++ b/src/engine/bg-input.ts
@@ -229,8 +229,8 @@ export function postKeyToHwnd(hwnd: unknown, vk: number): boolean {
  * (the command is typed but not run), whereas a VK_RETURN key event is
  * recognized as accept-line. bash / cmd accept the key-event Enter as CR exactly
  * as they did the WM_CHAR form, so terminal command execution is preserved.
- * Functionally equivalent to the native console-paste Enter (`console_paste.rs`)
- * — identical low-32 keystroke lParam (Win32 reads a keystroke lParam as 32-bit).
+ * Bit-identical lParam with the native console-paste Enter (`console_paste.rs`),
+ * which sign-extends its keyup lParam to match this path.
  */
 export function postEnterToHwnd(hwnd: unknown): boolean {
   return postKeyToHwnd(hwnd, VK_RETURN);

--- a/src/engine/bg-input.ts
+++ b/src/engine/bg-input.ts
@@ -229,7 +229,8 @@ export function postKeyToHwnd(hwnd: unknown, vk: number): boolean {
  * (the command is typed but not run), whereas a VK_RETURN key event is
  * recognized as accept-line. bash / cmd accept the key-event Enter as CR exactly
  * as they did the WM_CHAR form, so terminal command execution is preserved.
- * Bit-equal with the native console-paste Enter (`console_paste.rs`).
+ * Functionally equivalent to the native console-paste Enter (`console_paste.rs`)
+ * — identical low-32 keystroke lParam (Win32 reads a keystroke lParam as 32-bit).
  */
 export function postEnterToHwnd(hwnd: unknown): boolean {
   return postKeyToHwnd(hwnd, VK_RETURN);

--- a/src/engine/bg-input.ts
+++ b/src/engine/bg-input.ts
@@ -223,12 +223,16 @@ export function postKeyToHwnd(hwnd: unknown, vk: number): boolean {
 }
 
 /**
- * Send Enter to `hwnd` via WM_CHAR '\r'.
- * Preferred over postKeyToHwnd(VK_RETURN) for terminals (WT/conhost normalise '\r').
+ * Send Enter to `hwnd` as a real KEY EVENT (WM_KEYDOWN + WM_KEYUP VK_RETURN),
+ * NOT WM_CHAR '\r'. A WM_CHAR 0x0D is the Ctrl+M control code: conhost
+ * PowerShell's PSReadLine renders it as a LITERAL 'm' and never accepts the line
+ * (the command is typed but not run), whereas a VK_RETURN key event is
+ * recognized as accept-line. bash / cmd accept the key-event Enter as CR exactly
+ * as they did the WM_CHAR form, so terminal command execution is preserved.
+ * Bit-equal with the native console-paste Enter (`console_paste.rs`).
  */
 export function postEnterToHwnd(hwnd: unknown): boolean {
-  const target = resolveTarget(hwnd);
-  return postMessageToHwnd(target, WM_CHAR, VK_RETURN, 0);
+  return postKeyToHwnd(hwnd, VK_RETURN);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/win32/console_paste.rs
+++ b/src/win32/console_paste.rs
@@ -41,10 +41,9 @@ const ID_CONSOLE_PASTE: usize = 0xFFF1;
 const WM_KEYDOWN: u32 = 0x0100;
 const WM_KEYUP: u32 = 0x0101;
 /// VK_RETURN. Enter is sent as a real KEY EVENT (WM_KEYDOWN + WM_KEYUP), NOT
-/// WM_CHAR 0x0D — functionally equivalent to the TS `postEnterToHwnd`: the LOW
-/// 32 bits of the keystroke lParam are identical (Win32 reads a keystroke lParam
-/// as 32-bit, so the keyup high bits — which differ from the TS path's
-/// sign-extended JS-32-bit value — are ignored). conhost
+/// WM_CHAR 0x0D — the lParam is built to be BIT-IDENTICAL to the TS
+/// `postEnterToHwnd`/`postKeyToHwnd` path (keyup sign-extended; see the send
+/// site). conhost
 /// PowerShell's PSReadLine treats WM_CHAR 0x0D (= Ctrl+M) as a LITERAL 'm' and
 /// never accepts the line (the command is typed but not run); a VK_RETURN key
 /// event IS recognized as accept-line. bash / cmd accept the key-event Enter as
@@ -199,8 +198,16 @@ pub fn win32_console_paste_no_focus(
                     // line; a VK_RETURN key event is accept-line in PowerShell and
                     // CR in bash/cmd. lParam carries the Enter scan code; keyup sets
                     // the previous-state (bit 30) + transition (bit 31) bits.
-                    let down = (ENTER_SCANCODE & 0xFF) << 16;
-                    let up = down | (1isize << 30) | (1isize << 31);
+                    //
+                    // Build the lParam as i32 then widen to isize so it is
+                    // BIT-IDENTICAL to the TS postKeyToHwnd path: the keyup flags
+                    // set bit 31, making the low-32 value negative, which the TS
+                    // path sign-extends (JS 32-bit bitwise -> i64 in
+                    // win32_post_message). Win32 reads only the low 32 bits, but
+                    // matching keeps TS/native parity exact (Codex P2).
+                    let scan = (ENTER_SCANCODE & 0xFF) as u32;
+                    let down = ((scan << 16) as i32) as isize;
+                    let up = (((scan << 16) | (1u32 << 30) | (1u32 << 31)) as i32) as isize;
                     let _ = post_message(target, WM_KEYDOWN, WPARAM(VK_RETURN), LPARAM(down));
                     let _ = post_message(target, WM_KEYUP, WPARAM(VK_RETURN), LPARAM(up));
                     std::thread::sleep(Duration::from_millis(ENTER_GAP_DELAY_MS));

--- a/src/win32/console_paste.rs
+++ b/src/win32/console_paste.rs
@@ -38,10 +38,19 @@ const WM_COMMAND: u32 = 0x0111;
 /// Legacy console context-menu "Paste" command id (conhost). Mirrors
 /// `ID_CONSOLE_PASTE` in `bg-input.ts`.
 const ID_CONSOLE_PASTE: usize = 0xFFF1;
-const WM_CHAR: u32 = 0x0102;
-/// VK_RETURN. Enter is sent as WM_CHAR only (bit-equal with the TS
-/// `postEnterToHwnd`, not WM_KEYDOWN/KEYUP).
+const WM_KEYDOWN: u32 = 0x0100;
+const WM_KEYUP: u32 = 0x0101;
+/// VK_RETURN. Enter is sent as a real KEY EVENT (WM_KEYDOWN + WM_KEYUP), NOT
+/// WM_CHAR 0x0D — kept bit-equal with the TS `postEnterToHwnd`. conhost
+/// PowerShell's PSReadLine treats WM_CHAR 0x0D (= Ctrl+M) as a LITERAL 'm' and
+/// never accepts the line (the command is typed but not run); a VK_RETURN key
+/// event IS recognized as accept-line. bash / cmd accept the key-event Enter as
+/// CR just as they did the WM_CHAR form, so the original conhost-bash fix is
+/// preserved (verified by the SSH-WSL load gate + cross-shell dogfood).
 const VK_RETURN: usize = 0x0D;
+/// Enter key scan code (scan-code set 1). Carried in the WM_KEYDOWN/UP lParam so
+/// conhost builds a faithful key record (matches a physically pressed Enter).
+const ENTER_SCANCODE: isize = 0x1C;
 /// Let conhost drain the pasted clipboard into its input buffer before Enter.
 const PASTE_DRAIN_DELAY_MS: u64 = 200;
 /// Gap after Enter before restoring the clipboard.
@@ -181,8 +190,16 @@ pub fn win32_console_paste_no_focus(
                     post_paste_failed = true;
                 } else {
                     std::thread::sleep(Duration::from_millis(PASTE_DRAIN_DELAY_MS));
-                    // Enter — WM_CHAR VK_RETURN only (bit-equal with TS postEnterToHwnd).
-                    let _ = post_message(target, WM_CHAR, WPARAM(VK_RETURN), LPARAM(0));
+                    // Enter — real KEY EVENT (WM_KEYDOWN + WM_KEYUP VK_RETURN),
+                    // NOT WM_CHAR 0x0D. PSReadLine (conhost PowerShell) renders a
+                    // WM_CHAR 0x0D (Ctrl+M) as a literal 'm' and never accepts the
+                    // line; a VK_RETURN key event is accept-line in PowerShell and
+                    // CR in bash/cmd. lParam carries the Enter scan code; keyup sets
+                    // the previous-state (bit 30) + transition (bit 31) bits.
+                    let down = (ENTER_SCANCODE & 0xFF) << 16;
+                    let up = down | (1isize << 30) | (1isize << 31);
+                    let _ = post_message(target, WM_KEYDOWN, WPARAM(VK_RETURN), LPARAM(down));
+                    let _ = post_message(target, WM_KEYUP, WPARAM(VK_RETURN), LPARAM(up));
                     std::thread::sleep(Duration::from_millis(ENTER_GAP_DELAY_MS));
                 }
             }

--- a/src/win32/console_paste.rs
+++ b/src/win32/console_paste.rs
@@ -41,7 +41,10 @@ const ID_CONSOLE_PASTE: usize = 0xFFF1;
 const WM_KEYDOWN: u32 = 0x0100;
 const WM_KEYUP: u32 = 0x0101;
 /// VK_RETURN. Enter is sent as a real KEY EVENT (WM_KEYDOWN + WM_KEYUP), NOT
-/// WM_CHAR 0x0D — kept bit-equal with the TS `postEnterToHwnd`. conhost
+/// WM_CHAR 0x0D — functionally equivalent to the TS `postEnterToHwnd`: the LOW
+/// 32 bits of the keystroke lParam are identical (Win32 reads a keystroke lParam
+/// as 32-bit, so the keyup high bits — which differ from the TS path's
+/// sign-extended JS-32-bit value — are ignored). conhost
 /// PowerShell's PSReadLine treats WM_CHAR 0x0D (= Ctrl+M) as a LITERAL 'm' and
 /// never accepts the line (the command is typed but not run); a VK_RETURN key
 /// event IS recognized as accept-line. bash / cmd accept the key-event Enter as

--- a/tests/e2e/keyboard-bg-verification.test.ts
+++ b/tests/e2e/keyboard-bg-verification.test.ts
@@ -222,11 +222,12 @@ describe("keyboard({action:'press', method:'background'}) — issue #177 verific
       expect(r.hints?.verifyDelivery).toBeDefined();
       // We accept "delivered" (read-back saw the new line) or "unverifiable"
       // (TextPattern not available on this build) — bare ok:true is the
-      // regression. enter is dispatched as WM_CHAR '\r' (postEnterToHwnd),
-      // so channel reflects that on the unverifiable branch; on the
-      // delivered branch the press handler classifies the channel as
-      // wm_keydown by default. Don't pin the channel on this case to keep
-      // the assertion focused on the matrix-doc invariant.
+      // regression. enter is now dispatched as a real key event (WM_KEYDOWN/UP
+      // VK_RETURN via postEnterToHwnd; it used to be WM_CHAR '\r' but that is
+      // Ctrl+M, which PowerShell's PSReadLine renders as a literal 'm' instead
+      // of accepting the line), so the channel classification varies. Don't pin
+      // the channel on this case to keep the assertion focused on the matrix-doc
+      // invariant.
       expect(["delivered", "unverifiable"]).toContain(r.hints.verifyDelivery.status);
     }, 10_000);
   });

--- a/tests/e2e/terminal.test.ts
+++ b/tests/e2e/terminal.test.ts
@@ -269,21 +269,31 @@ describe.each(SCENARIOS)("[$label] terminal", ({ host, label, expectedClassPatte
     }, 20_000);
 
     // Console-paste regression guard: conhost auto-send of a MULTILINE command
-    // must deliver every line byte-intact via the native console paste
-    // (channel:"console_paste"). This is the headline fix — the legacy chunked
-    // WM_CHAR path drops characters when conhost executes at each embedded
-    // newline (bg-input.ts char-drop). conhost-only: the WT host swallows
-    // WM_CHAR and never routes through console-paste. Native-gated: an older
-    // .node build falls through to wm_char (skip — env condition, not a bug).
-    it("delivers a MULTILINE command byte-intact via console-paste [conhost]", async ({ skip }) => {
+    // must EXECUTE every line via the native console paste (channel:
+    // "console_paste"), not merely type it. This is the headline fix — the
+    // legacy chunked WM_CHAR path drops characters when conhost executes at each
+    // embedded newline (bg-input.ts char-drop). conhost-only: the WT host
+    // swallows WM_CHAR and never routes through console-paste. Native-gated: an
+    // older .node build falls through to wm_char (skip — env condition).
+    //
+    // CRITICAL (dogfood 2026-05-25): assert EXECUTION, not delivery. The first
+    // revision only checked `toContain(marker)`, which matches the *typed but
+    // un-executed* command echo (`PS> echo <marker>`) just as well as the run
+    // output — so it passed even though the final Enter (WM_CHAR 0x0D = Ctrl+M)
+    // was rendered as a literal 'm' by PowerShell's PSReadLine and never accepted
+    // the line. A run marker therefore appears TWICE (the `echo <marker>` line +
+    // the `<marker>` output line); a typed-but-not-run marker appears ONCE. We
+    // require >=2 for the LAST line specifically, which is the one that depends
+    // on the synthetic final Enter (intermediate lines run via the pasted CRLFs).
+    it("EXECUTES every line of a MULTILINE command via console-paste [conhost]", async ({ skip }) => {
       if (host !== "conhost") skip("console-paste routing is conhost-only");
-      const a = `mlA-${Date.now().toString(36)}`;
-      const b = `mlB-${Date.now().toString(36)}`;
+      const a = `mlA${Date.now().toString(36)}`;
+      const b = `mlB${Date.now().toString(36)}`;
       const sendRes = parsePayload(await terminalSendHandler({
         windowTitle: ps.title,
         // Two distinct echo lines on one logical send. The native paste
-        // CRLF-normalises the embedded \n so conhost runs both lines; the
-        // legacy WM_CHAR path would drop chars across the line boundary.
+        // CRLF-normalises the embedded \n so conhost runs the first line, and the
+        // synthetic final Enter must run the LAST line (the regression target).
         input: `echo ${a}\necho ${b}`,
         method: "auto",
         pressEnter: true,
@@ -309,9 +319,11 @@ describe.each(SCENARIOS)("[$label] terminal", ({ host, label, expectedClassPatte
         windowTitle: ps.title, lines: 200, stripAnsi: true, source: "auto", ocrLanguage: "ja",
       }));
       expect(readRes.ok, JSON.stringify(readRes)).toBe(true);
-      // BOTH lines must have run byte-intact — the multiline drop this PR fixes.
-      expect(readRes.text).toContain(a);
-      expect(readRes.text).toContain(b);
+      const occurrences = (s: string) => readRes.text.split(s).length - 1;
+      // Each marker must appear at least twice: the `echo <marker>` command line
+      // AND the `<marker>` execution output. >=2 proves the line actually RAN.
+      expect(occurrences(a), `first line not executed; buffer tail: ${readRes.text.slice(-300)}`).toBeGreaterThanOrEqual(2);
+      expect(occurrences(b), `LAST line not executed (synthetic Enter regression); buffer tail: ${readRes.text.slice(-300)}`).toBeGreaterThanOrEqual(2);
     }, 20_000);
   });
 

--- a/tests/unit/bg-input.test.ts
+++ b/tests/unit/bg-input.test.ts
@@ -148,10 +148,19 @@ describe("postKeyToHwnd", () => {
 describe("postEnterToHwnd", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("sends WM_CHAR with CR (0x0D)", () => {
+  it("sends VK_RETURN as a real key event (KEYDOWN then KEYUP), NOT WM_CHAR", () => {
     vi.mocked(postMessageToHwnd).mockReturnValue(true);
     postEnterToHwnd(HWND);
-    expect(postMessageToHwnd).toHaveBeenCalledWith(expect.anything(), 0x0102, 0x0D, 0);
+    // A WM_CHAR 0x0D is the Ctrl+M control code: conhost PowerShell's PSReadLine
+    // renders it as a literal 'm' and never accepts the line. A real VK_RETURN
+    // key event IS accept-line (and CR in bash/cmd), so postEnterToHwnd now
+    // delegates to postKeyToHwnd → KEYDOWN + KEYUP VK_RETURN with a scan-code
+    // lParam (matching the native console-paste Enter).
+    expect(postMessageToHwnd).toHaveBeenCalledTimes(2);
+    expect(postMessageToHwnd).toHaveBeenNthCalledWith(1, expect.anything(), 0x0100, 0x0D, expect.any(Number));
+    expect(postMessageToHwnd).toHaveBeenNthCalledWith(2, expect.anything(), 0x0101, 0x0D, expect.any(Number));
+    // Regression guard: Enter must NEVER go back to WM_CHAR 0x0D (the PSReadLine 'm' bug).
+    expect(postMessageToHwnd).not.toHaveBeenCalledWith(expect.anything(), 0x0102, 0x0D, expect.anything());
   });
 });
 


### PR DESCRIPTION
## Problem (found by dogfood of v1.9.1)

Sending into a **conhost (`ConsoleWindowClass`) PowerShell** window via `terminal action=send method:auto` (the v1.9.1 console-paste path) **typed the command but never ran it**, leaving a stray `m` on the input line:

```
PS C:\> echo hi_world_m        ← typed, NOT executed, trailing 'm'
```

Confirmed against ground truth (screenshot + a real foreground Enter that then executed the pending line; both UIA and OCR read-back showed the literal `m`).

## Root cause

The final Enter was sent as `WM_CHAR 0x0D`. **`0x0D` is the Ctrl+M control code** — PowerShell's **PSReadLine renders a `WM_CHAR 0x0D` as a literal `m`** and never treats it as accept-line. `bash`/`cmd` read it as CR and execute, which is why the original conhost-**bash** fix and the SSH-WSL gates passed while **PowerShell silently failed**.

The same `WM_CHAR` Enter is shared by the WM_CHAR path (`postEnterToHwnd`) and was **also the cause of the previously "flaky" local PowerShell exit-mode timeout** — the `until:{mode:'exit'}` epilogue never executed, so the sentinel never rendered and the run timed out. It was a real bug masquerading as a flake.

## Fix

Send Enter as a real **KEY EVENT** (`WM_KEYDOWN` + `WM_KEYUP` `VK_RETURN` with the Enter scan code), in both:
- the native console-paste (`src/win32/console_paste.rs`), and
- the TS `postEnterToHwnd` (`src/engine/bg-input.ts`, now delegates to the existing `postKeyToHwnd` helper).

PSReadLine accepts a `VK_RETURN` key event as accept-line; `bash`/`cmd` still see CR, so the original conhost-bash fix **and** exit-mode are preserved. Works in the background (`PostMessage`, no foreground steal).

The mechanism was de-risked before the native change: a background `WM_KEYDOWN/WM_KEYUP VK_RETURN` executed a pending line in conhost PowerShell with no stray char.

## Test hardening

The conhost multiline e2e now asserts **EXECUTION**, not delivery: a run marker appears **twice** (the `echo <marker>` command echo **+** the `<marker>` output line). The previous `toContain(marker)` matched the *typed-but-un-executed* echo and masked this exact bug — the dogfood gate caught what the test could not.

## Verification (local conhost + SSH-WSL, native rebuilt)

| Gate | Result |
|---|---|
| `terminal.test.ts` conhost "EXECUTES every line" | ✅ (was masking the bug) |
| `terminal-exit-mode.test.ts` | ✅ 12/12 — `[powershell]` now passes (the "flake"), `[bash@wsl-ssh]` still passes (no regression) |
| `terminal-console-paste-load.test.ts` | ✅ 4/4 (bash send under load/contention) |
| `terminal.test.ts` full | ✅ 31 passed / 1 skipped |
| console-paste routing unit | ✅ 16/16 |

## Scope / regression
- Native console-paste Enter + TS `postEnterToHwnd` only. No routing/contract change.
- bash/cmd behaviour preserved (CR via key event = canonical Enter); also fixes the pre-existing conhost-PowerShell exit-mode timeout.
- Native binary is rebuilt by CI from source (`console_paste.rs`); the `.node` is gitignored.

Targets a v1.9.2 patch. The v1.9.1 CHANGELOG "conhost windows reliably" claim becomes accurate for PowerShell with this fix.

Plan: [`desktop-touch-mcp-internal@3dd30bd:docs/terminal-send-conhost-console-paste-plan.md`](https://github.com/Harusame64/desktop-touch-mcp-internal/blob/3dd30bd5626fb0104602afdd1308a33bd3108f56/docs/terminal-send-conhost-console-paste-plan.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)