### PR TITLE
feat(desktop_act): S1 contract lock for ADR-024 Seed-2 roiCapture

### DIFF
--- a/src/engine/world-graph/guarded-touch.ts
+++ b/src/engine/world-graph/guarded-touch.ts
@@ -1,6 +1,7 @@
 import type { UiEntity, EntityLease, ExecutorKind, ExecutorOutcome, UiAffordance } from "./types.js";
 import type { LeaseStore } from "./lease-store.js";
 import type { VisualMotionObservation } from "../../tools/_input-pipeline.js";
+import type { Rect } from "../vision-gpu/types.js";
 import { classifyModal } from "./session-registry.js";
 
 export type TouchAction = "auto" | "invoke" | "click" | "type" | "setValue" | "select";
@@ -45,6 +46,49 @@ export interface BlockingElementInfo {
   automationId?: string;
 }
 
+/**
+ * ADR-024 Seed-2 (S1 contract lock) — a lease-less entity preview carried inside
+ * a post-action `roiCapture`. Distinct from a discovered `UiEntity`: it has NO
+ * lease and therefore cannot be passed to `desktop_act` (MVP = ADR-024 OQ-8
+ * option (b)); re-run `desktop_discover` to obtain an actionable lease.
+ */
+export interface RoiPreviewEntity {
+  /** Best-effort label from OCR / visual recognition (may be "" for icon-only). */
+  label: string;
+  /** Coarse role hint (e.g. "label", "button"); "unknown" when unclassified. */
+  role: string;
+  /** Screen-absolute bounding rect of the entity. */
+  rect: Rect;
+  /** Affordances the entity is believed to support (e.g. ["click"]). */
+  actionability: string[];
+}
+
+/**
+ * ADR-024 Seed-2 (S1 contract lock) — post-action ROI capture attached to a
+ * successful `desktop_act` in the *visual-only regime* (UIA-blind / RDP / canvas
+ * targets where structured observation is unavailable). Folds "confirm the act
+ * result" and "rediscover the next target" into a single round-trip: instead of
+ * `act → desktop_state → screenshot`, the act response itself carries a
+ * diff-region crop plus a lease-less entity preview.
+ *
+ * Populated by the registration wrapper (`desktop-register.ts`), NOT the bare
+ * `GuardedTouchLoop` — same layering as `observation?` (the loop stays
+ * capture-agnostic). Absent on every non-visual-only / no-change path, so
+ * existing `{ok, executor, diff, next}` destructures are unaffected (additive,
+ * CLAUDE.md §3.2 carry-over). S1 locks the shape; the value stays `undefined`
+ * until the ROI source (S3) and ROI-aware OCR (S4) phases wire population.
+ */
+export interface RoiCapture {
+  /** Window-relative crop rect the `somImage` covers (the diff region, not the full window). */
+  roi: Rect;
+  /** Base64 PNG of the cropped diff region. */
+  somImage: string;
+  /** Lease-less observation preview (re-run `desktop_discover` for actionable leases). */
+  entities: RoiPreviewEntity[];
+  /** ROI source: DXGI dirty-rect (local UIA-blind) or software frame-diff (RDP). */
+  source: "dxgi" | "frame_diff";
+}
+
 export type TouchResult =
   | {
       ok: true;
@@ -73,6 +117,14 @@ export type TouchResult =
        * undefined) when no fallback happened.
        */
       downgrade?: ExecutorOutcome["downgrade"];
+      /**
+       * ADR-024 Seed-2 — post-action ROI capture (diff-region crop + lease-less
+       * entity preview) attached by the registration wrapper when the target is
+       * visual-only and the act produced a visible change. Absent otherwise
+       * (additive — existing destructures unaffected). See {@link RoiCapture}.
+       * S1 locks the shape; population lands in S3/S4.
+       */
+      roiCapture?: RoiCapture;
     }
   | {
       ok: false;

--- a/src/engine/world-graph/guarded-touch.ts
+++ b/src/engine/world-graph/guarded-touch.ts
@@ -76,7 +76,8 @@ export interface RoiPreviewEntity {
  * capture-agnostic). Absent on every non-visual-only / no-change path, so
  * existing `{ok, executor, diff, next}` destructures are unaffected (additive,
  * CLAUDE.md §3.2 carry-over). S1 locks the shape; the value stays `undefined`
- * until the ROI source (S3) and ROI-aware OCR (S4) phases wire population.
+ * until the ROI source (S3) and ROI-aware OCR (S4) phases are built and S5
+ * folds the result into the act response.
  */
 export interface RoiCapture {
   /** Window-relative crop rect the `somImage` covers (the diff region, not the full window). */
@@ -122,7 +123,7 @@ export type TouchResult =
        * entity preview) attached by the registration wrapper when the target is
        * visual-only and the act produced a visible change. Absent otherwise
        * (additive — existing destructures unaffected). See {@link RoiCapture}.
-       * S1 locks the shape; population lands in S3/S4.
+       * S1 locks the shape; population is built in S3/S4 and folded in S5.
        */
       roiCapture?: RoiCapture;
     }

--- a/src/tools/_roi-capture-gate.ts
+++ b/src/tools/_roi-capture-gate.ts
@@ -1,0 +1,67 @@
+/**
+ * _roi-capture-gate.ts — ADR-024 Seed-2 (S1 contract lock).
+ *
+ * Pure decision function: should a successful `desktop_act` fold a post-action
+ * `roiCapture` (diff-region crop + lease-less entity preview) into its response?
+ *
+ * S1 locks the gate logic and the opt-in surface; the registration wrapper wires
+ * this in S2 and the ROI/OCR population lands in S3/S4. Keeping the decision pure
+ * lets it be exhaustively unit-tested over the 5-valued motion enum without any
+ * capture machinery.
+ */
+
+import type { VisualMotionObservation } from "./_input-pipeline.js";
+
+/**
+ * Caller opt-in for post-action ROI capture. `undefined` (the default) behaves
+ * as the automatic regime gate (= "on-change" semantics, hard-gated on
+ * visual-only). Surfaced as the optional `returnCapture` param on `desktop_act`.
+ */
+export type ReturnCaptureMode = "on-change" | "always" | "never";
+
+/**
+ * Motion verdicts that count as a real visual change (ADR-024 §2 trigger).
+ * `no_change` / `indeterminate` (and an absent observation) are excluded — the
+ * former means nothing happened, the latter means we cannot verify (e.g. DXGI
+ * unavailable over RDP), and an unverifiable change must not trigger a crop.
+ */
+const CHANGED_MOTIONS: ReadonlySet<VisualMotionObservation["motion"]> = new Set([
+  "translation",
+  "local_repaint",
+  "any_change",
+]);
+
+export interface RoiCaptureGateInput {
+  /** Did the act succeed? */
+  ok: boolean;
+  /** Is the act target visual-only (UIA-blind / RDP / canvas)? Hard gate. */
+  visualOnly: boolean;
+  /** Motion verdict from the post-act observation, or `undefined` if none. */
+  motion: VisualMotionObservation["motion"] | undefined;
+  /** Caller opt-in. */
+  returnCapture: ReturnCaptureMode | undefined;
+}
+
+/**
+ * Decide whether to attach a `roiCapture` to a `desktop_act` response.
+ *
+ * Hard guards (enforced regardless of `returnCapture`):
+ *   1. the act must have succeeded, and
+ *   2. the target must be visual-only. On structured targets (browser/CDP,
+ *      UIA-rich native) structured observation via `desktop_state` is strictly
+ *      better, so attaching a screenshot would regress
+ *      `feedback_minimize_screenshot_reliance`.
+ *
+ * Within those guards:
+ *   - "never"               → never attach;
+ *   - "always"              → attach on any successful visual-only act (motion ignored);
+ *   - "on-change" / undefined → attach only when the post-act motion shows a real
+ *                               change (translation / local_repaint / any_change).
+ */
+export function shouldReturnRoiCapture(input: RoiCaptureGateInput): boolean {
+  if (!input.ok) return false;
+  if (input.returnCapture === "never") return false;
+  if (!input.visualOnly) return false;
+  if (input.returnCapture === "always") return true;
+  return input.motion !== undefined && CHANGED_MOTIONS.has(input.motion);
+}

--- a/src/tools/desktop-register.ts
+++ b/src/tools/desktop-register.ts
@@ -482,14 +482,15 @@ export const desktopTouchSchema = {
   ),
   text:   z.string().optional().describe("Text to type or set (required when action='type' or action='setValue')."),
   returnCapture: z.enum(["on-change", "always", "never"]).optional().describe(
-    "[EXPERIMENTAL] ADR-024 Seed-2 — control post-action ROI capture on visual-only targets " +
-    "(UIA-blind / RDP / canvas). When the act succeeds on such a target, the response may carry " +
-    "a 'roiCapture' { roi, somImage, entities } (diff-region crop + lease-less entity preview) so " +
-    "you can confirm the result and find the next target without a separate desktop_state / screenshot. " +
-    "'on-change' (default behaviour) attaches it only when the act produced a visible change; 'always' " +
-    "attaches it on any successful visual-only act; 'never' suppresses it. Has no effect on structured " +
-    "targets (browser/CDP, UIA-rich native) — use desktop_state there. Preview entities have no lease; " +
-    "re-call desktop_discover to act on them."
+    "[EXPERIMENTAL — RESERVED, NOT YET ACTIVE] ADR-024 Seed-2 — will control post-action ROI capture on " +
+    "visual-only targets (UIA-blind / RDP / canvas). Accepted now so clients can adopt the option, but " +
+    "the capture is still being rolled out: this version NEVER attaches 'roiCapture', for any value. Do " +
+    "not depend on a capture yet. When active, a successful act on a visual-only target will carry a " +
+    "'roiCapture' { roi, somImage, entities } (diff-region crop + lease-less entity preview) so you can " +
+    "confirm the result and find the next target without a separate desktop_state / screenshot. Planned " +
+    "semantics: 'on-change' (default) attaches only on a visible change; 'always' on any successful " +
+    "visual-only act; 'never' suppresses it. No effect on structured targets (browser/CDP, UIA-rich " +
+    "native) — use desktop_state there."
   ),
 };
 
@@ -825,10 +826,9 @@ export function registerDesktopTools(server: McpServer): void {
       "  executor_failed → fall back to V1 tools (click_element / mouse_click / browser_click);",
       "  executor_failed on terminal textbox (action=type) → use V1 terminal(action='send') instead.",
       "Check desktop_discover response.constraints for pre-emptive fallback hints before calling desktop_act.",
-      "[EXPERIMENTAL] On visual-only targets (UIA-blind / RDP / canvas), pass returnCapture to fold a post-action",
-      "'roiCapture' { roi, somImage, entities } (diff-region crop + lease-less entity preview) into the response —",
-      "confirm the result and find the next target without a separate desktop_state/screenshot. Preview entities",
-      "have no lease; re-call desktop_discover to act on them.",
+      "[EXPERIMENTAL — RESERVED] returnCapture is accepted but NOT YET ACTIVE: this version never attaches a",
+      "'roiCapture' for any value. When rolled out it will fold a post-action diff-region crop + lease-less",
+      "entity preview into the response on visual-only targets (UIA-blind / RDP / canvas). Do not depend on it yet.",
     ].join(" "),
     desktopActRegistrationSchema,
     desktopActRegistrationHandler as (input: unknown) => Promise<ToolResult>,

--- a/src/tools/desktop-register.ts
+++ b/src/tools/desktop-register.ts
@@ -65,6 +65,7 @@ import { computeViewportPosition } from "../utils/viewport-position.js";
 import { verifyAnyChange } from "../engine/any-change.js";
 import { disposeSharedDirtyRectBroker } from "../engine/dxgi-broker.js";
 import type { VisualMotionObservation } from "./_input-pipeline.js";
+import type { ReturnCaptureMode } from "./_roi-capture-gate.js";
 import { createDefaultCapabilityRegistry } from "../capabilities/registry.js";
 
 // ── Advisory registry singleton (PR-SR1-3) ────────────────────────────────────
@@ -480,6 +481,16 @@ export const desktopTouchSchema = {
     "'setValue' (Phase 4: absorbs former set_element_value) sets a UIA ValuePattern value or fills a CDP controlled input — pass the new value via text."
   ),
   text:   z.string().optional().describe("Text to type or set (required when action='type' or action='setValue')."),
+  returnCapture: z.enum(["on-change", "always", "never"]).optional().describe(
+    "[EXPERIMENTAL] ADR-024 Seed-2 — control post-action ROI capture on visual-only targets " +
+    "(UIA-blind / RDP / canvas). When the act succeeds on such a target, the response may carry " +
+    "a 'roiCapture' { roi, somImage, entities } (diff-region crop + lease-less entity preview) so " +
+    "you can confirm the result and find the next target without a separate desktop_state / screenshot. " +
+    "'on-change' (default behaviour) attaches it only when the act produced a visible change; 'always' " +
+    "attaches it on any successful visual-only act; 'never' suppresses it. Has no effect on structured " +
+    "targets (browser/CDP, UIA-rich native) — use desktop_state there. Preview entities have no lease; " +
+    "re-call desktop_discover to act on them."
+  ),
 };
 
 /**
@@ -541,7 +552,11 @@ const desktopDiscoverRawHandler = async (input: unknown): Promise<ToolResult> =>
  *  to `"0"`). Failures degrade silently — observation absence is
  *  bit-equal to the pre-Stage-5 envelope. */
 export const desktopActRawHandler = async (
-  input: { lease: EntityLease; action?: TouchAction; text?: string },
+  // ADR-024 Seed-2 S1: `returnCapture` is accepted (and advertised in the schema)
+  // so callers can start opting in; population of `result.roiCapture` is wired in
+  // S2+ (gate plumbing). In S1 the field is always absent — existing responses are
+  // bit-equal.
+  input: { lease: EntityLease; action?: TouchAction; text?: string; returnCapture?: ReturnCaptureMode },
 ): Promise<ToolResult> => {
   const validationError = validateDesktopTouchTextRequirement(input.action, input.text);
   if (validationError) {
@@ -810,6 +825,10 @@ export function registerDesktopTools(server: McpServer): void {
       "  executor_failed → fall back to V1 tools (click_element / mouse_click / browser_click);",
       "  executor_failed on terminal textbox (action=type) → use V1 terminal(action='send') instead.",
       "Check desktop_discover response.constraints for pre-emptive fallback hints before calling desktop_act.",
+      "[EXPERIMENTAL] On visual-only targets (UIA-blind / RDP / canvas), pass returnCapture to fold a post-action",
+      "'roiCapture' { roi, somImage, entities } (diff-region crop + lease-less entity preview) into the response —",
+      "confirm the result and find the next target without a separate desktop_state/screenshot. Preview entities",
+      "have no lease; re-call desktop_discover to act on them.",
     ].join(" "),
     desktopActRegistrationSchema,
     desktopActRegistrationHandler as (input: unknown) => Promise<ToolResult>,

--- a/tests/unit/roi-capture-gate.test.ts
+++ b/tests/unit/roi-capture-gate.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import {
+  shouldReturnRoiCapture,
+  type ReturnCaptureMode,
+  type RoiCaptureGateInput,
+} from "../../src/tools/_roi-capture-gate.js";
+import type { VisualMotionObservation } from "../../src/tools/_input-pipeline.js";
+
+// The full 5-valued motion enum (ADR-024 §2.5.3 — type SSOT is
+// _input-pipeline.ts, NOT the 3-valued any-change.ts docstring) plus `undefined`
+// (no observation attached, e.g. Stage 5 DXGI disabled).
+const ALL_MOTIONS: Array<VisualMotionObservation["motion"] | undefined> = [
+  "translation",
+  "local_repaint",
+  "any_change",
+  "no_change",
+  "indeterminate",
+  undefined,
+];
+const CHANGED = new Set(["translation", "local_repaint", "any_change"]);
+const ALL_MODES: Array<ReturnCaptureMode | undefined> = ["on-change", "always", "never", undefined];
+
+const gate = (over: Partial<RoiCaptureGateInput>): boolean =>
+  shouldReturnRoiCapture({
+    ok: true,
+    visualOnly: true,
+    motion: "any_change",
+    returnCapture: undefined,
+    ...over,
+  });
+
+describe("shouldReturnRoiCapture", () => {
+  describe("hard guard: ok", () => {
+    it("never attaches when the act failed, for any mode/motion", () => {
+      for (const returnCapture of ALL_MODES) {
+        for (const motion of ALL_MOTIONS) {
+          expect(gate({ ok: false, returnCapture, motion })).toBe(false);
+        }
+      }
+    });
+  });
+
+  describe("hard guard: visualOnly", () => {
+    it("never attaches on a non-visual-only target, even for 'always'", () => {
+      for (const returnCapture of ALL_MODES) {
+        for (const motion of ALL_MOTIONS) {
+          expect(gate({ visualOnly: false, returnCapture, motion })).toBe(false);
+        }
+      }
+    });
+  });
+
+  describe("returnCapture = 'never'", () => {
+    it("suppresses capture regardless of motion", () => {
+      for (const motion of ALL_MOTIONS) {
+        expect(gate({ returnCapture: "never", motion })).toBe(false);
+      }
+    });
+  });
+
+  describe("returnCapture = 'always'", () => {
+    it("attaches on any successful visual-only act, ignoring motion", () => {
+      for (const motion of ALL_MOTIONS) {
+        expect(gate({ returnCapture: "always", motion })).toBe(true);
+      }
+    });
+  });
+
+  describe("auto regime gate (undefined) and 'on-change'", () => {
+    for (const returnCapture of [undefined, "on-change"] as const) {
+      describe(`returnCapture = ${String(returnCapture)}`, () => {
+        for (const motion of ALL_MOTIONS) {
+          const expected = motion !== undefined && CHANGED.has(motion);
+          it(`motion=${String(motion)} → ${expected}`, () => {
+            expect(gate({ returnCapture, motion })).toBe(expected);
+          });
+        }
+      });
+    }
+
+    it("excludes 'indeterminate' (unverifiable, e.g. DXGI unavailable over RDP)", () => {
+      expect(gate({ returnCapture: "on-change", motion: "indeterminate" })).toBe(false);
+    });
+
+    it("excludes 'no_change' (nothing happened)", () => {
+      expect(gate({ returnCapture: "on-change", motion: "no_change" })).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## What (ADR-024 Seed-2, Phase S1 — contract lock)

Locks the post-action **`roiCapture`** contract surface for the **visual-only regime** (UIA-blind / RDP / canvas targets). **Value is not yet populated** — this PR only fixes the shape so later phases can fill it without a breaking change.

- `TouchResult` success variant gains optional `roiCapture { roi, somImage, entities, source }` + `RoiPreviewEntity` (lease-less preview, MVP = OQ-8 option **(b)**). Mirrors the existing additive `observation?` layering (populated by the registration wrapper, not the bare loop). Absent today → existing `{ok, executor, diff, next}` responses are **bit-equal**.
- `desktop_act` input schema + tool description gain optional `returnCapture` (`on-change | always | never`). Accepted now so callers can opt in; **wired in S2**.
- New **pure** gate `shouldReturnRoiCapture()` with hard guards (`ok` + `visualOnly`; the visual-only guard protects `feedback_minimize_screenshot_reliance`). **Exhaustively unit-tested over the 5-valued motion enum** (18 tests, `tests/unit/roi-capture-gate.test.ts`).

## Verification
- `npm run build` clean; new gate suite 18/18; full unit suite green except one **pre-existing environmental flake** (`ui-pattern-store-persistence` temp-dir rename ENOENT — passes in isolation, unrelated subsystem).
- `check:failwith-fixtures` clean (no failWith callsites added).

## ⚠ Phase-boundary note for review
The sub-plan put the **visual-only-flag session persistence** in S1. I **deferred it to S2**: its only consumer is the S2 gate wiring, so persisting it here would be unconsumed infra (dead code). The pure gate takes `visualOnly` as a param and is fully testable without it. **Please confirm this phase-boundary refinement** or push back.

## Review
production change → Opus + Codex per CLAUDE.md §3.3. Additive only (new optional field + new optional param + new pure fn).

Plan: `desktop-touch-mcp-internal@plan/adr-024-seed2:docs/adr-024-seed2-plan.md` (S1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)