### PR TITLE
feat(desktop_act): S2 gate plumbing + visual-only flag persistence (ADR-024 Seed-2)

### DIFF
--- a/src/engine/world-graph/session-registry.ts
+++ b/src/engine/world-graph/session-registry.ts
@@ -143,6 +143,14 @@ export interface SessionState {
   readonly leaseStore: LeaseStore;
   readonly loop: GuardedTouchLoop;
   lastAccessMs: number;
+  /**
+   * ADR-024 Seed-2 — was the most recent `desktop_discover` on this session a
+   * visual-only target (UIA-blind: PWA/Electron/canvas/RDP)? Written by
+   * `DesktopFacade.see()` from the discover `warnings` (UIA_BLIND_WARNINGS), read
+   * by the `desktop_act` wrapper to gate post-action `roiCapture`. Undefined until
+   * the first discover; treated as `false` (no capture) when absent.
+   */
+  lastDiscoverVisualOnly?: boolean;
 }
 
 // ── Session creation options ──────────────────────────────────────────────────
@@ -302,6 +310,7 @@ export class SessionRegistry {
       leaseStore: new LeaseStore({ defaultTtlMs: opts.defaultTtlMs, nowFn: opts.nowFn }),
       loop: null!,  // assigned immediately below
       lastAccessMs: opts.nowFn?.() ?? Date.now(),
+      lastDiscoverVisualOnly: undefined,
     };
 
     const env: TouchEnvironment = {

--- a/src/tools/desktop-providers/compose-providers.ts
+++ b/src/tools/desktop-providers/compose-providers.ts
@@ -109,7 +109,14 @@ function addWarningIfPartial(result: ProviderResult, primaryCount: number): Prov
 // there, and uia is additive. Even if uia is blind, the terminal buffer is the
 // authoritative source — visual escalation would add noise, not signal.
 
-const UIA_BLIND_WARNINGS   = new Set(["uia_blind_single_pane", "uia_blind_too_few_elements"]);
+/**
+ * UIA-blind warning codes (PWA/Electron/canvas/RDP — UIA tree unusable). The
+ * single SSOT predicate for "is this target visual-only": both the OCR lane gate
+ * (`uiaBlindForOcr` below) and the ADR-024 Seed-2 session flag
+ * (`SessionState.lastDiscoverVisualOnly`, set in desktop.ts from the same
+ * `rawResult.warnings`) test membership in this set, so they never diverge.
+ */
+export const UIA_BLIND_WARNINGS = new Set(["uia_blind_single_pane", "uia_blind_too_few_elements"]);
 const VISUAL_UNREADY_WARNINGS = new Set(["visual_provider_unavailable", "visual_provider_warming"]);
 
 function applyVisualEscalation(

--- a/src/tools/desktop-register.ts
+++ b/src/tools/desktop-register.ts
@@ -38,7 +38,7 @@ import type { NativeLeaseTokenSummary } from "../engine/native-types.js";
 import type { ToolResult } from "./_types.js";
 import { Err } from "../types/result.js";
 import { ExecutorFailedError } from "../errors/typed-errors.js";
-import type { TouchAction } from "../engine/world-graph/guarded-touch.js";
+import type { TouchAction, RoiCapture } from "../engine/world-graph/guarded-touch.js";
 import {
   SnapshotIngress,
   combineEventSources,
@@ -65,7 +65,7 @@ import { computeViewportPosition } from "../utils/viewport-position.js";
 import { verifyAnyChange } from "../engine/any-change.js";
 import { disposeSharedDirtyRectBroker } from "../engine/dxgi-broker.js";
 import type { VisualMotionObservation } from "./_input-pipeline.js";
-import type { ReturnCaptureMode } from "./_roi-capture-gate.js";
+import { shouldReturnRoiCapture, type ReturnCaptureMode } from "./_roi-capture-gate.js";
 import { createDefaultCapabilityRegistry } from "../capabilities/registry.js";
 
 // ── Advisory registry singleton (PR-SR1-3) ────────────────────────────────────
@@ -581,6 +581,18 @@ export const desktopActRawHandler = async (
     }
   }
 
+  // ADR-024 Seed-2 S2 — gate post-action ROI capture on the visual-only regime.
+  // Reuses the motion verdict from the observation poll above (no extra DXGI
+  // poll). `buildRoiCapture` is the S3/S4/S5 seam: in S2 it returns undefined
+  // whenever the gate passes (ROI source not yet wired), so responses stay
+  // bit-equal with the pre-Seed-2 shape.
+  if (result.ok) {
+    const roiCapture = buildRoiCapture(facade, input.lease.viewId, result.observation, input.returnCapture);
+    if (roiCapture !== undefined) {
+      (result as { roiCapture?: RoiCapture }).roiCapture = roiCapture;
+    }
+  }
+
   // Issue #327 item G: GuardedTouchLoop.touch returns {ok:false,
   // reason:"executor_failed", diff:[]} on executor exception. Because the handler
   // RETURNS this (does not throw), the L5 makeCommitWrapper treats it as a normal
@@ -649,6 +661,40 @@ async function tryVerifyAnyChange(
     // not break the envelope.
     return null;
   }
+}
+
+/**
+ * ADR-024 Seed-2 — gate + population seam for the post-action `roiCapture`.
+ *
+ * Returns the capture to attach to a successful `desktop_act`, or `undefined`
+ * when either (a) the gate declines (non-visual-only target / no change / opt-out)
+ * or (b) the ROI pipeline is not yet wired.
+ *
+ * S2 (this commit): the gate is live — it reads the session's visual-only flag
+ * (persisted at discover) and reuses the `observation` motion verdict already
+ * computed above, so it adds **no** extra DXGI poll. Population is a stub: even
+ * when the gate passes there is no ROI source yet (lands in S3), so this returns
+ * `undefined` and the act response stays bit-equal with the pre-Seed-2 shape.
+ * S3 (ROI source) → S4 (ROI-aware OCR) → S5 (fold) replace the stub tail with the
+ * real `{ roi, somImage, entities, source }`.
+ */
+function buildRoiCapture(
+  facade: DesktopFacade,
+  viewId: string,
+  observation: VisualMotionObservation | undefined,
+  returnCapture: ReturnCaptureMode | undefined,
+): RoiCapture | undefined {
+  const gatePassed = shouldReturnRoiCapture({
+    ok: true, // only called on the success path
+    visualOnly: facade.resolveVisualOnlyForViewId(viewId),
+    motion: observation?.motion,
+    returnCapture,
+  });
+  if (!gatePassed) return undefined;
+  // S3 (ROI source via single-poll dirty-rect surface) → S4 (ROI-aware OCR) →
+  // S5 (fold) populate `{ roi, somImage, entities, source }` here. Until S3
+  // lands there is no ROI source, so nothing is attached.
+  return undefined;
 }
 
 /** Pre-flight lease validation closure used by the commit wrapper

--- a/src/tools/desktop.ts
+++ b/src/tools/desktop.ts
@@ -16,6 +16,7 @@ import type { CandidateIngress } from "../engine/world-graph/candidate-ingress.j
 import { createDesktopExecutor, type ExecutorDeps } from "./desktop-executor.js";
 import type { TouchAction, TouchResult } from "../engine/world-graph/guarded-touch.js";
 import { deriveViewConstraints, type ViewConstraints, type EntityCapabilities } from "./desktop-constraints.js";
+import { UIA_BLIND_WARNINGS } from "./desktop-providers/compose-providers.js";
 import { deriveEntityCapabilities } from "./desktop-capabilities.js";
 import { bakeEntityCapabilities } from "../capabilities/registry.js";
 import { isUiaCacheStale } from "../engine/identity-tracker.js";
@@ -377,6 +378,12 @@ export class DesktopFacade {
     resolved = resolved.slice(0, max);
 
     session.entities = resolved;
+    // ADR-024 Seed-2 — persist whether this discover saw a visual-only (UIA-blind:
+    // PWA/Electron/canvas/RDP) target, for the desktop_act wrapper to gate
+    // post-action roiCapture. Same SSOT predicate as the OCR lane's
+    // `uiaBlindForOcr` (membership in UIA_BLIND_WARNINGS over the discover
+    // warnings), so the two signals never diverge.
+    session.lastDiscoverVisualOnly = rawResult.warnings.some((w) => UIA_BLIND_WARNINGS.has(w));
     this.registry.replaceViewId(prevViewId, newViewId, key);
 
     // Phase 4 (Codex PR #41 round 5 P1): top-level windows enumeration.
@@ -598,6 +605,17 @@ export class DesktopFacade {
     } catch {
       return null;
     }
+  }
+
+  /**
+   * ADR-024 Seed-2 — read the visual-only flag persisted at the most recent
+   * `desktop_discover` for this session's view, used by the `desktop_act` wrapper
+   * to gate post-action `roiCapture`. Returns `false` when the session is gone or
+   * no discover has run yet (safe default = no capture).
+   */
+  resolveVisualOnlyForViewId(viewId: string): boolean {
+    const session = this.registry.getByViewId(viewId, this.opts.nowFn);
+    return session?.lastDiscoverVisualOnly ?? false;
   }
 
   validateLeaseOnly(lease: EntityLease): LeaseValidationResult {

--- a/src/tools/desktop.ts
+++ b/src/tools/desktop.ts
@@ -378,12 +378,22 @@ export class DesktopFacade {
     resolved = resolved.slice(0, max);
 
     session.entities = resolved;
-    // ADR-024 Seed-2 — persist whether this discover saw a visual-only (UIA-blind:
-    // PWA/Electron/canvas/RDP) target, for the desktop_act wrapper to gate
-    // post-action roiCapture. Same SSOT predicate as the OCR lane's
-    // `uiaBlindForOcr` (membership in UIA_BLIND_WARNINGS over the discover
-    // warnings), so the two signals never diverge.
-    session.lastDiscoverVisualOnly = rawResult.warnings.some((w) => UIA_BLIND_WARNINGS.has(w));
+    // ADR-024 Seed-2 — persist whether this discover saw a *visual-only* target
+    // for the desktop_act wrapper to gate post-action roiCapture. Visual-only =
+    // UIA-blind (PWA/Electron/canvas/RDP) AND no structured observation source.
+    // UIA-blindness ALONE is not sufficient: the terminal route runs UIA as an
+    // *additive* provider (compose-providers.ts), so a terminal whose UIA tree
+    // looks blind still surfaces uia_blind_* warnings — but the terminal buffer is
+    // a structured source, so a post-action screenshot must be suppressed there
+    // (feedback_minimize_screenshot_reliance; Codex PR #425 P2). Browser (CDP) is
+    // likewise structured. So require a blind warning AND the absence of any
+    // terminal/cdp candidate. The blind predicate stays the same SSOT set as the
+    // OCR lane's `uiaBlindForOcr` (UIA_BLIND_WARNINGS).
+    const uiaBlind = rawResult.warnings.some((w) => UIA_BLIND_WARNINGS.has(w));
+    const hasStructuredSource = rawResult.candidates.some(
+      (c) => c.source === "terminal" || c.source === "cdp",
+    );
+    session.lastDiscoverVisualOnly = uiaBlind && !hasStructuredSource;
     this.registry.replaceViewId(prevViewId, newViewId, key);
 
     // Phase 4 (Codex PR #41 round 5 P1): top-level windows enumeration.

--- a/tests/unit/roi-capture-flag-persistence.test.ts
+++ b/tests/unit/roi-capture-flag-persistence.test.ts
@@ -4,14 +4,15 @@ import type { UiEntityCandidate } from "../../src/engine/vision-gpu/types.js";
 import type { ProviderResult } from "../../src/engine/world-graph/candidate-ingress.js";
 
 // ADR-024 Seed-2 S2 — the visual-only flag (SessionState.lastDiscoverVisualOnly)
-// is written by see() from the discover warnings and read by the desktop_act
+// is written by see() from the discover snapshot and read by the desktop_act
 // wrapper via resolveVisualOnlyForViewId(). This pins the write→read contract
-// (sub-plan §2 S2 acceptance ⑤). The flag must derive from the SAME predicate as
-// the OCR lane (membership in UIA_BLIND_WARNINGS), so we drive it through warnings.
+// (sub-plan §2 S2 acceptance ⑤). Visual-only = UIA-blind warning AND no
+// structured (terminal/cdp) candidate source (Codex PR #425 P2), so we drive
+// the flag through both warnings and candidate sources.
 
-function cand(label: string): UiEntityCandidate {
+function cand(label: string, source: UiEntityCandidate["source"] = "ocr"): UiEntityCandidate {
   return {
-    source: "ocr",
+    source,
     target: { kind: "window", id: "win-1" },
     label,
     role: "label",
@@ -19,18 +20,20 @@ function cand(label: string): UiEntityCandidate {
     confidence: 0.8,
     observedAtMs: 1000,
     provisional: false,
-    digest: `digest-${label}`,
+    digest: `digest-${label}-${source}`,
     rect: { x: 10, y: 20, width: 80, height: 30 },
   };
 }
 
+interface Snapshot { candidates: UiEntityCandidate[]; warnings: string[] }
+
 /** Minimal ingress that returns a snapshot (candidates + warnings) so we control
- *  the discover `warnings` the facade derives the flag from. `warnings` is read
- *  live on each getSnapshot, so a test can mutate it to simulate a regime change
- *  across two discovers on the same session. */
-function mutableIngress(warningsRef: { current: string[] }): CandidateIngress {
+ *  both the discover `warnings` and candidate sources the facade derives the flag
+ *  from. The snapshot is read live on each getSnapshot, so a test can mutate it to
+ *  simulate a regime change across two discovers on the same session. */
+function mutableIngress(ref: { current: Snapshot }): CandidateIngress {
   return {
-    getSnapshot: async (): Promise<ProviderResult> => ({ candidates: [cand("Foo")], warnings: warningsRef.current }),
+    getSnapshot: async (): Promise<ProviderResult> => ({ ...ref.current }),
     invalidate: () => {},
     subscribe: () => () => {},
     dispose: () => {},
@@ -42,8 +45,8 @@ const discover = async (facade: DesktopFacade): Promise<string> => {
   return out.entities[0].lease.viewId;
 };
 
-const facadeWith = (warnings: string[]): DesktopFacade =>
-  new DesktopFacade(() => [], { ingress: mutableIngress({ current: warnings }) });
+const facadeWith = (warnings: string[], candidates: UiEntityCandidate[] = [cand("Foo")]): DesktopFacade =>
+  new DesktopFacade(() => [], { ingress: mutableIngress({ current: { candidates, warnings } }) });
 
 describe("ADR-024 Seed-2 — visual-only flag persistence (discover → act)", () => {
   it("sets the flag when discover reports a UIA-blind warning (single-giant-pane)", async () => {
@@ -66,18 +69,30 @@ describe("ADR-024 Seed-2 — visual-only flag persistence (discover → act)", (
     expect(facade.resolveVisualOnlyForViewId(await discover(facade))).toBe(false);
   });
 
+  it("does NOT set the flag for a terminal target even when UIA looks blind (structured buffer; Codex #425 P2)", async () => {
+    // The terminal route runs UIA additively, so a terminal can surface uia_blind_*
+    // warnings — but the terminal buffer is structured, so roiCapture must be suppressed.
+    const facade = facadeWith(["uia_blind_single_pane"], [cand("$ npm test", "terminal")]);
+    expect(facade.resolveVisualOnlyForViewId(await discover(facade))).toBe(false);
+  });
+
+  it("does NOT set the flag when a cdp candidate is present even with a blind warning", async () => {
+    const facade = facadeWith(["uia_blind_single_pane"], [cand("Search", "cdp")]);
+    expect(facade.resolveVisualOnlyForViewId(await discover(facade))).toBe(false);
+  });
+
   it("returns false (safe default) for an unknown viewId — no session / no discover", () => {
     const facade = new DesktopFacade(() => []);
     expect(facade.resolveVisualOnlyForViewId("never-issued-view-id")).toBe(false);
   });
 
   it("re-evaluates the flag on each discover (blind → structured flips it back to false)", async () => {
-    const ref = { current: ["uia_blind_single_pane"] };
+    const ref = { current: { candidates: [cand("Foo")], warnings: ["uia_blind_single_pane"] } };
     const facade = new DesktopFacade(() => [], { ingress: mutableIngress(ref) });
     const v1 = await discover(facade);
     expect(facade.resolveVisualOnlyForViewId(v1)).toBe(true);
     // Same target → same session key; the next discover updates the same session.
-    ref.current = [];
+    ref.current = { candidates: [cand("Foo")], warnings: [] };
     const v2 = await discover(facade);
     expect(facade.resolveVisualOnlyForViewId(v2)).toBe(false);
   });

--- a/tests/unit/roi-capture-flag-persistence.test.ts
+++ b/tests/unit/roi-capture-flag-persistence.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { DesktopFacade, type CandidateIngress } from "../../src/tools/desktop.js";
+import type { UiEntityCandidate } from "../../src/engine/vision-gpu/types.js";
+import type { ProviderResult } from "../../src/engine/world-graph/candidate-ingress.js";
+
+// ADR-024 Seed-2 S2 — the visual-only flag (SessionState.lastDiscoverVisualOnly)
+// is written by see() from the discover warnings and read by the desktop_act
+// wrapper via resolveVisualOnlyForViewId(). This pins the write→read contract
+// (sub-plan §2 S2 acceptance ⑤). The flag must derive from the SAME predicate as
+// the OCR lane (membership in UIA_BLIND_WARNINGS), so we drive it through warnings.
+
+function cand(label: string): UiEntityCandidate {
+  return {
+    source: "ocr",
+    target: { kind: "window", id: "win-1" },
+    label,
+    role: "label",
+    actionability: ["click"],
+    confidence: 0.8,
+    observedAtMs: 1000,
+    provisional: false,
+    digest: `digest-${label}`,
+    rect: { x: 10, y: 20, width: 80, height: 30 },
+  };
+}
+
+/** Minimal ingress that returns a snapshot (candidates + warnings) so we control
+ *  the discover `warnings` the facade derives the flag from. `warnings` is read
+ *  live on each getSnapshot, so a test can mutate it to simulate a regime change
+ *  across two discovers on the same session. */
+function mutableIngress(warningsRef: { current: string[] }): CandidateIngress {
+  return {
+    getSnapshot: async (): Promise<ProviderResult> => ({ candidates: [cand("Foo")], warnings: warningsRef.current }),
+    invalidate: () => {},
+    subscribe: () => () => {},
+    dispose: () => {},
+  };
+}
+
+const discover = async (facade: DesktopFacade): Promise<string> => {
+  const out = await facade.see({ target: { windowTitle: "Canvas" } });
+  return out.entities[0].lease.viewId;
+};
+
+const facadeWith = (warnings: string[]): DesktopFacade =>
+  new DesktopFacade(() => [], { ingress: mutableIngress({ current: warnings }) });
+
+describe("ADR-024 Seed-2 — visual-only flag persistence (discover → act)", () => {
+  it("sets the flag when discover reports a UIA-blind warning (single-giant-pane)", async () => {
+    const facade = facadeWith(["uia_blind_single_pane"]);
+    expect(facade.resolveVisualOnlyForViewId(await discover(facade))).toBe(true);
+  });
+
+  it("sets the flag for the too-few-elements blind reason", async () => {
+    const facade = facadeWith(["uia_blind_too_few_elements"]);
+    expect(facade.resolveVisualOnlyForViewId(await discover(facade))).toBe(true);
+  });
+
+  it("leaves the flag false when discover has no blind warning (structured target)", async () => {
+    const facade = facadeWith([]);
+    expect(facade.resolveVisualOnlyForViewId(await discover(facade))).toBe(false);
+  });
+
+  it("ignores unrelated warnings (e.g. visual_provider_unavailable) — flag stays false", async () => {
+    const facade = facadeWith(["visual_provider_unavailable"]);
+    expect(facade.resolveVisualOnlyForViewId(await discover(facade))).toBe(false);
+  });
+
+  it("returns false (safe default) for an unknown viewId — no session / no discover", () => {
+    const facade = new DesktopFacade(() => []);
+    expect(facade.resolveVisualOnlyForViewId("never-issued-view-id")).toBe(false);
+  });
+
+  it("re-evaluates the flag on each discover (blind → structured flips it back to false)", async () => {
+    const ref = { current: ["uia_blind_single_pane"] };
+    const facade = new DesktopFacade(() => [], { ingress: mutableIngress(ref) });
+    const v1 = await discover(facade);
+    expect(facade.resolveVisualOnlyForViewId(v1)).toBe(true);
+    // Same target → same session key; the next discover updates the same session.
+    ref.current = [];
+    const v2 = await discover(facade);
+    expect(facade.resolveVisualOnlyForViewId(v2)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What (ADR-024 Seed-2, Phase S2 — gate plumbing + visual-only flag persistence)

> **Stacked on #424 (S1).** Base = `feature/adr-024-s1-roicapture-contract`. Review/merge after S1. Still **bit-equal** — population is a stub until S3.

- **Visual-only flag persistence (discover → act)**: `SessionState.lastDiscoverVisualOnly`, written by `DesktopFacade.see()` from the discover `warnings` (membership in `UIA_BLIND_WARNINGS`, now **exported** from `compose-providers` so it's the *same SSOT predicate* as the OCR lane's `uiaBlindForOcr` — they cannot diverge). `resolveVisualOnlyForViewId()` reads it with a safe `false` default.
- **Gate wiring**: `desktopActRawHandler` calls `buildRoiCapture()` on success → runs `shouldReturnRoiCapture` **reusing the motion verdict from the observation poll already done above (no extra DXGI poll, acceptance ④)**. `buildRoiCapture` is the **S3/S4/S5 population seam**: in S2 it returns `undefined` whenever the gate passes (no ROI source yet) → responses stay bit-equal.

## Verification
- `npm run build` clean; flag-persistence suite **6/6** (`tests/unit/roi-capture-flag-persistence.test.ts`).
- Full unit suite green except **3 pre-existing load-sensitive timing flakes** (benchmark idle / ui-pattern debounce / winevent sidecar) — all pass in isolation, unrelated subsystems.

## Scope notes for review
- **Byte-equality**: structurally guaranteed in S2 — `buildRoiCapture` returns `undefined` unconditionally (stub tail). End-to-end act-handler roiCapture-absence gets real coverage in S5 when population lands.
- The visual-only flag derives from the **same `rawResult.warnings`** that the existing (shipped) `deriveViewConstraints` consumes, so it's exactly as correct as the production `constraints.uia` signal.
- This PR contains the **visual-only persistence that the sub-plan moved S1 → S2** (per #424 Opus R1).

## Review
production change → Opus + Codex per CLAUDE.md §3.3 (session-contract extension = Codex axis).

Plan: `desktop-touch-mcp-internal@plan/adr-024-seed2:docs/adr-024-seed2-plan.md` (S2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)