### PR TITLE
feat(desktop_act): S3a — surface DXGI dirty Rect[] from the motion poll (ADR-024 Seed-2)

### DIFF
--- a/src/engine/any-change.ts
+++ b/src/engine/any-change.ts
@@ -34,6 +34,7 @@
  */
 
 import type { VisualMotionObservation } from "../tools/_input-pipeline.js";
+import type { Rect } from "./vision-gpu/types.js";
 import {
   BROKER_CONSTANTS,
   type CacheAcquireState,
@@ -171,6 +172,15 @@ export interface VerifyAnyChangeOpts {
   broker?: DirtyRectBroker | null;
   /** @internal — test-only override for `enumMonitors`. */
   enumerate?: () => Array<{ bounds: { x: number; y: number; width: number; height: number } }>;
+  /**
+   * ADR-024 Seed-2 S3a — opt-in to surface the raw DXGI dirty `Rect[]` on the
+   * returned `VisualMotionObservation.dirtyRects` (screen-absolute, per-output,
+   * NOT yet window-rect filtered). Reuses the same poll that produces `motion`,
+   * so it adds **zero** extra DXGI acquires. Default `false` (omitted) — every
+   * existing caller (keyboard / mouse-verify Stage-5 fallback) keeps a
+   * byte-equal observation. Only the `desktop_act` visual-only ROI path opts in.
+   */
+  includeDirtyRects?: boolean;
 }
 
 /**
@@ -334,6 +344,23 @@ export async function verifyAnyChange(
       };
     }
 
+    // ADR-024 Seed-2 S3a — surface the raw per-output dirty rects (screen-abs,
+    // NOT window-rect filtered — that lands in S3b) only when the caller opts
+    // in. Mapped to plain `Rect` objects so we never hand back a reference to
+    // the native poll array. Reuses the `rects` drained above → zero extra
+    // DXGI polls. Omitted (spread of `{}`) on the default path so existing
+    // callers' observations stay byte-equal.
+    const dirtyRectsField: { dirtyRects?: Rect[] } = opts.includeDirtyRects
+      ? {
+          dirtyRects: rects.map((r) => ({
+            x: r.x,
+            y: r.y,
+            width: r.width,
+            height: r.height,
+          })),
+        }
+      : {};
+
     if (ratioOfTargetArea >= STAGE5_MIN_INTERSECTED_AREA_RATIO) {
       return {
         motion: "any_change",
@@ -344,6 +371,7 @@ export async function verifyAnyChange(
           totalIntersectedAreaPx,
           ratioOfTargetArea,
         },
+        ...dirtyRectsField,
         framesSampled,
         totalElapsedMs,
         cacheState: acquireState,
@@ -361,6 +389,7 @@ export async function verifyAnyChange(
         totalIntersectedAreaPx,
         ratioOfTargetArea,
       },
+      ...dirtyRectsField,
       framesSampled,
       totalElapsedMs,
       cacheState: acquireState,

--- a/src/tools/_input-pipeline.ts
+++ b/src/tools/_input-pipeline.ts
@@ -45,6 +45,7 @@ import {
   readScrollPositionInTab,
 } from "../engine/cdp-bridge.js";
 import { getCdpPort } from "../utils/desktop-config.js";
+import type { Rect } from "../engine/vision-gpu/types.js";
 
 /**
  * Win32 class name of a Chrome / Edge **top-level** window. Used as the gate
@@ -445,6 +446,29 @@ export interface VisualMotionObservation {
      */
     ratioOfTargetArea?: number;
   };
+  /**
+   * ADR-024 Seed-2 Stage 5 (S3a) — the raw DXGI dirty rectangles observed
+   * during the post-action poll, in **desktop screen-absolute coordinates**
+   * (per-output, translated via `DXGI_OUTPUT_DESC.DesktopCoordinates` — PR
+   * #322). Surfaced from the **same** `sub.next()` poll that produced
+   * `motion`, so the visual-only ROI-capture path (ADR-024 Seed-2) reuses
+   * the gate's poll with **no second DXGI acquire** (sub-plan §2 S3a, OQ-11).
+   *
+   * **Opt-in**: only populated when the caller passes
+   * `VerifyAnyChangeOpts.includeDirtyRects === true` (the `desktop_act` ROI
+   * path). Every other `verifyAnyChange` caller (keyboard / mouse-verify
+   * Stage-5 fallback) leaves it `undefined`, so their serialized observation
+   * stays byte-equal (additive optional field — CLAUDE.md §3.2 carry-over).
+   * Only populated for `source: "dxgi_dirty_rect"` and only when ≥1 rect was
+   * observed; omitted on the empty-rect / `indeterminate` / non-DXGI paths.
+   *
+   * **NOT yet window-rect filtered**: these are per-output rects that may
+   * include dirty regions outside the target window (other windows, the
+   * cursor, notifications). The window-rect intersection filter that turns
+   * them into a window-relative ROI lands in S3b; the ROI-aware OCR + fold
+   * into `roiCapture` land in S4/S5. Until then no consumer reads this field.
+   */
+  dirtyRects?: Rect[];
   /**
    * Algorithm that produced this observation. Stage 1 emits
    * `"uia_scroll_percent"` (success) or `"chain_trust_unverified"`

--- a/tests/unit/any-change-orchestrator.test.ts
+++ b/tests/unit/any-change-orchestrator.test.ts
@@ -165,6 +165,97 @@ describe("verifyAnyChange orchestrator", () => {
     expect(obs.residual?.totalIntersectedAreaPx).toBe(2500);
   });
 
+  // ── ADR-024 Seed-2 S3a — opt-in dirty-rect surface ────────────────────────
+  // The visual-only ROI-capture path reuses the SAME poll that produces
+  // `motion` to also surface the raw dirty `Rect[]` (sub-plan §2 S3a). These
+  // tests pin: (a) opt-in → rects surfaced from a single poll; (b) default →
+  // field absent (byte-equal for existing callers); (c) the rects are the raw
+  // per-output rects, NOT yet window-rect filtered.
+
+  it("S3a: includeDirtyRects surfaces the raw rects on any_change from the same observation", async () => {
+    const sub = buildSub(async () => [{ x: 10, y: 10, width: 50, height: 60 }]);
+    const obs = await verifyAnyChange({
+      hwnd: 1n,
+      windowRect: WINDOW_RECT,
+      broker: brokerReturning(sub),
+      enumerate: () => [PRIMARY_MONITOR],
+      budgetMs: FAST_BUDGET_MS,
+      includeDirtyRects: true,
+    });
+    // A SINGLE verifyAnyChange call (= one broker acquire + drain) yields BOTH
+    // the motion verdict and the rect[]. The ROI path never makes a second
+    // verifyAnyChange call, so the rects cost zero extra DXGI acquires
+    // (sub-plan §2 S3a — "single-poll で motion + rect[] 両取り").
+    expect(obs.motion).toBe("any_change");
+    expect(obs.dirtyRects).toEqual([{ x: 10, y: 10, width: 50, height: 60 }]);
+    // The scalar residual is unchanged (additive — both populated together).
+    expect(obs.residual?.dirtyRectCount).toBe(1);
+  });
+
+  it("S3a: includeDirtyRects surfaces sub-threshold rects on no_change too", async () => {
+    // 30x70 = 2100 px < 2400 px gate → no_change, but the rect is still real
+    // dirty pixels the ROI path may want to crop.
+    const sub = buildSub(async () => [{ x: 5, y: 5, width: 30, height: 70 }]);
+    const obs = await verifyAnyChange({
+      hwnd: 1n,
+      windowRect: WINDOW_RECT,
+      broker: brokerReturning(sub),
+      enumerate: () => [PRIMARY_MONITOR],
+      budgetMs: FAST_BUDGET_MS,
+      includeDirtyRects: true,
+    });
+    expect(obs.motion).toBe("no_change");
+    expect(obs.dirtyRects).toEqual([{ x: 5, y: 5, width: 30, height: 70 }]);
+  });
+
+  it("S3a: includeDirtyRects surfaces RAW per-output rects (not window-rect filtered)", async () => {
+    // One rect inside the window, one entirely outside it. S3a is the surface
+    // phase — BOTH must come through verbatim; the window-rect intersection
+    // filter is S3b, not here.
+    const inside = { x: 10, y: 10, width: 50, height: 60 };
+    const outside = { x: 2000, y: 100, width: 100, height: 100 };
+    const sub = buildSub(async () => [inside, outside]);
+    const obs = await verifyAnyChange({
+      hwnd: 1n,
+      windowRect: WINDOW_RECT,
+      broker: brokerReturning(sub),
+      enumerate: () => [PRIMARY_MONITOR],
+      budgetMs: FAST_BUDGET_MS,
+      includeDirtyRects: true,
+    });
+    expect(obs.dirtyRects).toEqual([inside, outside]);
+    // The returned array is a fresh copy, not the native poll array reference.
+    expect(obs.dirtyRects?.[0]).not.toBe(inside);
+  });
+
+  it("S3a: default (no includeDirtyRects) omits dirtyRects → byte-equal for existing callers", async () => {
+    const sub = buildSub(async () => [{ x: 10, y: 10, width: 50, height: 60 }]);
+    const obs = await verifyAnyChange({
+      hwnd: 1n,
+      windowRect: WINDOW_RECT,
+      broker: brokerReturning(sub),
+      enumerate: () => [PRIMARY_MONITOR],
+      budgetMs: FAST_BUDGET_MS,
+    });
+    expect(obs.motion).toBe("any_change");
+    expect(obs.dirtyRects).toBeUndefined();
+    expect("dirtyRects" in obs).toBe(false);
+  });
+
+  it("S3a: empty rects omit dirtyRects even when opted in (nothing to surface)", async () => {
+    const sub = buildSub(async () => []);
+    const obs = await verifyAnyChange({
+      hwnd: 1n,
+      windowRect: WINDOW_RECT,
+      broker: brokerReturning(sub),
+      enumerate: () => [PRIMARY_MONITOR],
+      budgetMs: FAST_BUDGET_MS,
+      includeDirtyRects: true,
+    });
+    expect(obs.motion).toBe("no_change");
+    expect(obs.dirtyRects).toBeUndefined();
+  });
+
   it("DXGI Unsupported at acquire → motion: indeterminate, source: dxgi_dirty_rect_unavailable", async () => {
     const obs = await verifyAnyChange({
       hwnd: 1n,

--- a/tests/unit/any-change-orchestrator.test.ts
+++ b/tests/unit/any-change-orchestrator.test.ts
@@ -72,6 +72,24 @@ function brokerReturning(sub: SubscriptionLike | null): DirtyRectBroker {
   );
 }
 
+/** Like `brokerReturning` but also hands back the factory spy so a test can
+ *  assert the DXGI subscription was acquired exactly once — substantiating the
+ *  S3a "+0 extra acquire" acceptance with a measurement, not just structure. */
+function brokerWithFactorySpy(
+  sub: SubscriptionLike,
+): { broker: DirtyRectBroker; factory: ReturnType<typeof vi.fn> } {
+  const factory = vi.fn(() => sub);
+  const broker = new DirtyRectBroker(
+    factory,
+    () => 0,
+    BROKER_CONSTANTS.BROKER_CACHE_IDLE_TIMEOUT_MS,
+    BROKER_CONSTANTS.BROKER_UNAVAILABLE_TTL_MS,
+    FAST_FANOUT_POLL_MS,
+    BROKER_CONSTANTS.BROKER_NEGATIVE_BACKOFF_MS,
+  );
+  return { broker, factory };
+}
+
 describe("verifyAnyChange orchestrator", () => {
   it("empty rects → motion: no_change, residual omitted", async () => {
     const sub = buildSub(async () => []);
@@ -190,6 +208,26 @@ describe("verifyAnyChange orchestrator", () => {
     expect(obs.dirtyRects).toEqual([{ x: 10, y: 10, width: 50, height: 60 }]);
     // The scalar residual is unchanged (additive — both populated together).
     expect(obs.residual?.dirtyRectCount).toBe(1);
+  });
+
+  it("S3a: includeDirtyRects acquires the DXGI subscription exactly once (+0 extra acquire)", async () => {
+    // Acceptance ① "DXGI poll 回数が現状 +0" — surfacing the rects must NOT
+    // trigger a second broker acquire. The factory is invoked once per
+    // first-touch acquire of an output; reusing the drained `rects` keeps it
+    // at one even with the opt-in on.
+    const { broker, factory } = brokerWithFactorySpy(
+      buildSub(async () => [{ x: 10, y: 10, width: 50, height: 60 }]),
+    );
+    const obs = await verifyAnyChange({
+      hwnd: 1n,
+      windowRect: WINDOW_RECT,
+      broker,
+      enumerate: () => [PRIMARY_MONITOR],
+      budgetMs: FAST_BUDGET_MS,
+      includeDirtyRects: true,
+    });
+    expect(obs.dirtyRects).toEqual([{ x: 10, y: 10, width: 50, height: 60 }]);
+    expect(factory).toHaveBeenCalledTimes(1);
   });
 
   it("S3a: includeDirtyRects surfaces sub-threshold rects on no_change too", async () => {


### PR DESCRIPTION
## ADR-024 Seed-2 — S3a (ROI source, part 1: dirty-rect surface)

Walking-skeleton phase **S3a** for visual-only post-action ROI auto-crop. Stacks on S1 (#424) + S2 (#425, both merged).

**Goal (sub-plan §2 S3a, OQ-11):** let the single `verifyAnyChange` DXGI poll that already produces the post-act `motion` verdict ALSO surface the raw dirty `Rect[]`, so the ROI-capture path reuses that poll with **zero extra DXGI acquires** (no double-poll).

### Changes (additive, opt-in, byte-equal by default)
- **`VisualMotionObservation.dirtyRects?: Rect[]`** — raw per-output dirty rects in **desktop screen-absolute coords**, **NOT yet window-rect filtered** (that lands in S3b). Populated only for `source: "dxgi_dirty_rect"` with ≥1 rect.
- **`VerifyAnyChangeOpts.includeDirtyRects?: boolean`** (default `false`). Reuses the `rects` already drained in the same poll → +0 DXGI acquire.

### Why opt-in (key design decision — please scrutinize)
`verifyAnyChange` has **three** consumers: the `desktop_act` ROI path (this PR), plus the keyboard Stage-4 and mouse-verify Stage-5 DXGI fallbacks. The latter two **serialize the full observation** into their tool responses. Unconditional population would therefore **leak `dirtyRects` into those responses** and break their byte-equality. The opt-in flag confines the rects to the `desktop_act` ROI path, so **every response stays byte-equal until S5** folds the crop into `roiCapture`.

### Scope discipline
Orchestrator capability **only**. The handler / `buildRoiCapture` wiring is deferred to **S3b**, where the window-rect intersection filter that actually *consumes* the rects lands — so there is no dead code or wiring-ahead here (same incremental pattern as S1/S2). In S3a the rects are surfaced + unit-proven; no production consumer reads the field yet.

### Tests
5 new `any-change-orchestrator` cases:
- opt-in → rects surfaced on `any_change` from the same observation
- opt-in → sub-threshold `no_change` still surfaces rects
- opt-in → RAW per-output rects (in-window + out-of-window both pass verbatim; filtering is S3b)
- default (no flag) → `dirtyRects` absent (byte-equal for existing callers)
- empty rects → omitted even when opted in

Local: full suite **4170 passed / 0 failed**; `check:failwith-fixtures` + `check:stub-catalog` clean; `tsc` clean.

Plan: `desktop-touch-mcp-internal@39bfe346:docs/adr-024-seed2-plan.md` (§2 S3a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)