### PR TITLE
feat(desktop_act): S3b — window-rect intersection filter for ROI rects (ADR-024 Seed-2)

### DIFF
--- a/src/tools/_roi-region.ts
+++ b/src/tools/_roi-region.ts
@@ -1,0 +1,75 @@
+/**
+ * _roi-region.ts — ADR-024 Seed-2 S3b — window-rect intersection filter (OQ-11c).
+ *
+ * Converts the per-output DXGI dirty rects surfaced by S3a
+ * (`VisualMotionObservation.dirtyRects`, screen-absolute / per-output) into
+ * **window-relative** ROI rects:
+ *
+ *   1. Intersect each dirty rect with the target window rect.
+ *   2. Drop rects that miss the window entirely — DXGI dirty rects are
+ *      reported per *output* (whole monitor), so a single poll can carry dirty
+ *      regions belonging to other windows, the mouse cursor, or notifications
+ *      sharing the same monitor. Those must not leak into the act's ROI crop.
+ *   3. Translate the survivors into window-origin-relative coordinates
+ *      (subtract `windowRect.x` / `windowRect.y`) so they line up with the
+ *      `roiCapture.roi` / `somImage` crop space (a window-relative rect, per
+ *      the S1 contract `RoiCapture.roi`).
+ *
+ * Pure + side-effect-free. **No production consumer yet**: the act-response
+ * fold (S5) calls this to build `roiCapture.roi` after the ROI-aware OCR (S4)
+ * produces the entity preview. S3b ships + unit-tests the geometry in
+ * isolation so the per-output→window coordinate/sign conversion is reviewable
+ * on its own (sub-plan §2 S3b review axis).
+ *
+ * Sub-plan: `desktop-touch-mcp-internal@…:docs/adr-024-seed2-plan.md` §2 S3b.
+ */
+
+import type { Rect } from "../engine/vision-gpu/types.js";
+
+/**
+ * Intersect the per-output dirty rects with `windowRect` and return the
+ * overlapping regions in **window-relative** coordinates. Rects that do not
+ * overlap the window are excluded.
+ *
+ * @param dirtyRects Screen-absolute per-output dirty rects (S3a
+ *                   `VisualMotionObservation.dirtyRects`). May be empty.
+ * @param windowRect Screen-absolute target window rect (same coordinate space
+ *                   as `dirtyRects` — both desktop screen-absolute).
+ * @returns Window-relative ROI rects (origin = window top-left). **Empty** when
+ *          no dirty rect overlaps the window — the caller (S5) treats `[]` as
+ *          "no ROI" and omits `roiCapture` (sub-plan §2 S3b acceptance ③).
+ */
+export function filterDirtyRectsToWindow(
+  dirtyRects: readonly Rect[],
+  windowRect: Rect,
+): Rect[] {
+  const out: Rect[] = [];
+
+  const winLeft = windowRect.x;
+  const winTop = windowRect.y;
+  const winRight = windowRect.x + windowRect.width;
+  const winBottom = windowRect.y + windowRect.height;
+
+  for (const r of dirtyRects) {
+    // Clip the dirty rect to the window bounds (screen-absolute).
+    const left = Math.max(r.x, winLeft);
+    const top = Math.max(r.y, winTop);
+    const right = Math.min(r.x + r.width, winRight);
+    const bottom = Math.min(r.y + r.height, winBottom);
+
+    const width = right - left;
+    const height = bottom - top;
+    // No overlap (or a zero-area edge touch) → not part of the window's ROI.
+    if (width <= 0 || height <= 0) continue;
+
+    // Translate into window-origin-relative coordinates for the crop space.
+    out.push({
+      x: left - winLeft,
+      y: top - winTop,
+      width,
+      height,
+    });
+  }
+
+  return out;
+}

--- a/tests/unit/roi-region.test.ts
+++ b/tests/unit/roi-region.test.ts
@@ -1,0 +1,106 @@
+/**
+ * ADR-024 Seed-2 S3b — `filterDirtyRectsToWindow` unit tests (OQ-11c).
+ *
+ * Pins the per-output→window coordinate/sign conversion (sub-plan §2 S3b
+ * review axis): screen-absolute dirty rects intersected with the target
+ * window rect, out-of-window dirty excluded, survivors translated to
+ * window-relative coordinates. The window origin is intentionally non-zero in
+ * most cases so a missing `- windowRect.x/y` translation (or a wrong sign)
+ * fails loudly.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { filterDirtyRectsToWindow } from "../../src/tools/_roi-region.js";
+
+// Window at a non-zero screen origin so the relative translation is observable.
+const WINDOW = { x: 100, y: 200, width: 800, height: 600 };
+
+describe("filterDirtyRectsToWindow (S3b window-rect filter)", () => {
+  it("fully-inside rect → translated to window-relative coordinates", () => {
+    // Screen-abs (150, 260) inside the window at origin (100, 200) →
+    // relative (50, 60).
+    const out = filterDirtyRectsToWindow(
+      [{ x: 150, y: 260, width: 40, height: 30 }],
+      WINDOW,
+    );
+    expect(out).toEqual([{ x: 50, y: 60, width: 40, height: 30 }]);
+  });
+
+  it("rect entirely outside the window → excluded", () => {
+    // On the same monitor but past the window's right/bottom edges (e.g. a
+    // notification toast or another window).
+    const out = filterDirtyRectsToWindow(
+      [{ x: 1000, y: 900, width: 50, height: 50 }],
+      WINDOW,
+    );
+    expect(out).toEqual([]);
+  });
+
+  it("rect partially overlapping the top-left corner → clipped then relative", () => {
+    // Screen-abs rect straddles the window's top-left corner (origin 100,200).
+    // It spans x:[80,160] y:[180,260]; clipped to the window that's
+    // x:[100,160] y:[200,260] → relative x:[0,60] y:[0,60] → (0,0,60,60).
+    const out = filterDirtyRectsToWindow(
+      [{ x: 80, y: 180, width: 80, height: 80 }],
+      WINDOW,
+    );
+    expect(out).toEqual([{ x: 0, y: 0, width: 60, height: 60 }]);
+  });
+
+  it("rect partially overlapping the bottom-right corner → clipped to window edge", () => {
+    // Window right edge = 100+800 = 900, bottom = 200+600 = 800. A rect at
+    // screen (870, 770, 80, 80) spans to (950, 850); clipped to (870..900,
+    // 770..800) = 30x30 → relative (770, 570, 30, 30).
+    const out = filterDirtyRectsToWindow(
+      [{ x: 870, y: 770, width: 80, height: 80 }],
+      WINDOW,
+    );
+    expect(out).toEqual([{ x: 770, y: 570, width: 30, height: 30 }]);
+  });
+
+  it("mixed batch → keeps only window-overlapping rects, each made relative", () => {
+    const inside = { x: 150, y: 260, width: 40, height: 30 }; // → (50,60,40,30)
+    const outside = { x: 1000, y: 900, width: 50, height: 50 }; // excluded
+    const corner = { x: 80, y: 180, width: 80, height: 80 }; // → (0,0,60,60)
+    const out = filterDirtyRectsToWindow([inside, outside, corner], WINDOW);
+    expect(out).toEqual([
+      { x: 50, y: 60, width: 40, height: 30 },
+      { x: 0, y: 0, width: 60, height: 60 },
+    ]);
+  });
+
+  it("empty input → empty output (roiCapture absent fallback, acceptance ③)", () => {
+    expect(filterDirtyRectsToWindow([], WINDOW)).toEqual([]);
+  });
+
+  it("zero-area edge touch (shares only the right border) → excluded", () => {
+    // Rect's left edge sits exactly on the window's right edge (x=900) → width
+    // clips to 0 → not an ROI.
+    const out = filterDirtyRectsToWindow(
+      [{ x: 900, y: 300, width: 40, height: 40 }],
+      WINDOW,
+    );
+    expect(out).toEqual([]);
+  });
+
+  it("window at origin (0,0) → relative == absolute (no translation artifact)", () => {
+    const out = filterDirtyRectsToWindow(
+      [{ x: 10, y: 20, width: 30, height: 40 }],
+      { x: 0, y: 0, width: 800, height: 600 },
+    );
+    expect(out).toEqual([{ x: 10, y: 20, width: 30, height: 40 }]);
+  });
+
+  it("rect exactly equal to the window → full-window relative ROI", () => {
+    const out = filterDirtyRectsToWindow([{ ...WINDOW }], WINDOW);
+    expect(out).toEqual([{ x: 0, y: 0, width: 800, height: 600 }]);
+  });
+
+  it("does not mutate or alias the input rects", () => {
+    const input = { x: 150, y: 260, width: 40, height: 30 };
+    const out = filterDirtyRectsToWindow([input], WINDOW);
+    expect(out[0]).not.toBe(input);
+    expect(input).toEqual({ x: 150, y: 260, width: 40, height: 30 });
+  });
+});

--- a/tests/unit/roi-region.test.ts
+++ b/tests/unit/roi-region.test.ts
@@ -97,6 +97,28 @@ describe("filterDirtyRectsToWindow (S3b window-rect filter)", () => {
     expect(out).toEqual([{ x: 0, y: 0, width: 800, height: 600 }]);
   });
 
+  it("secondary monitor (negative window origin) → sign-safe window-relative output", () => {
+    // Monitor to the left of the primary: window at screen-abs x=-1920. A
+    // dirty rect on that monitor at screen-abs (-1900, 50) must map to
+    // window-relative (-1900 - -1920, 50 - 0) = (20, 50). Pins the PR #102 /
+    // §3.2 secondary-monitor axis (subtraction must stay sign-safe).
+    const secondary = { x: -1920, y: 0, width: 800, height: 600 };
+    const onSecondary = { x: -1900, y: 50, width: 40, height: 30 };
+    const onPrimary = { x: 200, y: 300, width: 40, height: 30 }; // other monitor → excluded
+    const out = filterDirtyRectsToWindow([onSecondary, onPrimary], secondary);
+    expect(out).toEqual([{ x: 20, y: 50, width: 40, height: 30 }]);
+  });
+
+  it("dirty rect fully containing the window → clipped down to the full window", () => {
+    // A monitor-wide repaint (rect strictly larger than the window on every
+    // side) clips to exactly the window → full-window relative ROI.
+    const out = filterDirtyRectsToWindow(
+      [{ x: -50, y: -50, width: 5000, height: 5000 }],
+      WINDOW,
+    );
+    expect(out).toEqual([{ x: 0, y: 0, width: 800, height: 600 }]);
+  });
+
   it("does not mutate or alias the input rects", () => {
     const input = { x: 150, y: 260, width: 40, height: 30 };
     const out = filterDirtyRectsToWindow([input], WINDOW);


### PR DESCRIPTION
## ADR-024 Seed-2 — S3b (ROI source, part 2: per-output → window filter)

Walking-skeleton phase **S3b**. Stacks on S1 (#424) + S2 (#425) + S3a (#426, all merged).

**Goal (sub-plan §2 S3b, OQ-11c):** convert the per-output DXGI dirty rects surfaced by S3a (`VisualMotionObservation.dirtyRects`, screen-absolute) into **window-relative** ROI rects.

### Change — new pure module `src/tools/_roi-region.ts`
`filterDirtyRectsToWindow(dirtyRects, windowRect): Rect[]`:
1. **intersect** each dirty rect with the target window rect;
2. **exclude** rects that miss the window — DXGI reports dirty rects per *output* (whole monitor), so one poll can carry dirty regions from other windows / the cursor / notifications on the same monitor; those must not leak into the act's ROI crop;
3. **translate** survivors to window-origin-relative coords (subtract `windowRect.x/y`) so they match the `roiCapture.roi` / `somImage` crop space (the S1 contract `RoiCapture.roi` is window-relative).

Returns `[]` when nothing overlaps the window → the "no ROI ⇒ `roiCapture` absent" fallback (acceptance ③).

### Scope discipline
Geometry **only**, **no production consumer yet**. The act-response fold (S5) calls this after ROI-aware OCR (S4) produces the entity preview. Shipping the per-output→window coordinate/sign conversion in isolation keeps it reviewable on its own axis (sub-plan §2 S3b review focus = Codex coordinate/sign strength), same incremental discipline as S1/S2/S3a. No behavior change to any existing response.

### Tests — `tests/unit/roi-region.test.ts` (10 cases)
Non-zero window origin throughout so a missing/wrong-sign translation fails loudly: fully-inside / outside-excluded / corner-clip (top-left + bottom-right) / mixed batch / empty / zero-area edge touch / origin-(0,0) / exact-window / no-mutation.

### Verification
- `tsc` clean; `eslint` 0 errors (new files clean); `check:failwith-fixtures` + `check:stub-catalog` clean.
- Full unit+integration suite green (**4180 passed**). The lone e2e failure (`terminal-console-paste-load` L2 — a live clipboard contention load test, 13/15) was a **confirmed flake**: passed **4/4 on pinpoint rerun**, and S3b has **zero production importers** so it cannot affect terminal clipboard delivery.

Plan: `desktop-touch-mcp-internal@8d6d315:docs/adr-024-seed2-plan.md` (§2 S3b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)