### PR TITLE
feat(desktop_act): S4 — ROI-aware OCR crop (ADR-024 Seed-2)

### DIFF
--- a/src/engine/ocr-bridge.ts
+++ b/src/engine/ocr-bridge.ts
@@ -8,6 +8,8 @@ import sharp from "sharp";
 import { captureWindowBackground } from "./image.js";
 import { enumWindowsInZOrder, getWindowDpi, printWindowToBuffer } from "./win32.js";
 import { nativeEngine } from "./native-engine.js";
+import { cropRgbaToRoi } from "./roi-crop.js";
+import type { Rect } from "./vision-gpu/types.js";
 import type { ActionableElement } from "./uia-bridge.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -672,6 +674,12 @@ export async function runSomPipeline(
   preprocessPolicy: "auto" | "aggressive" | "minimal" = "auto",
   adaptive = false,
   dictionary: OcrDictionaryEntry[] = [],
+  // ADR-024 Seed-2 S4 — optional image-local ROI to OCR a sub-region of the
+  // captured window instead of the whole window (visual-only post-action ROI
+  // crop). MUST be the LAST positional param: existing callers pass `dictionary`
+  // positionally, so inserting `roi` earlier would shift their args and break
+  // byte-equality. Omitted by every existing caller → full-window OCR unchanged.
+  roi?: Rect,
 ): Promise<SomPipelineResult> {
   // ── Locate window & capture raw RGBA ───────────────────────────────────────
   let targetHwnd: unknown = hwnd ?? null;
@@ -701,8 +709,30 @@ export async function runSomPipeline(
     }
   }
 
-  const { data: rawData, width, height } = printWindowToBuffer(targetHwnd);
+  // `let` (not `const`) so the optional ROI crop below can reassign these +
+  // the `origin` offset, after which the ENTIRE downstream pipeline (scale,
+  // preprocess, OCR, image-local→screen conversion, SoM label placement)
+  // operates on the cropped buffer transparently — no other change needed.
+  let { data: rawData, width, height } = printWindowToBuffer(targetHwnd);
   // printWindowToBuffer returns RGBA (4 channels)
+
+  // ── ADR-024 Seed-2 S4 — optional ROI crop ──────────────────────────────────
+  // When a ROI is supplied (image-local, = window-relative from S3b), crop the
+  // captured buffer to it and shift `origin` by the clamped crop offset so the
+  // `origin + bbox` screen-absolute conversion still lands entities at their
+  // true screen coordinates (acceptance ②: a ROI-crop entity has the same
+  // screen-abs rect a full-window OCR would have produced).
+  if (roi) {
+    const cropped = cropRgbaToRoi(rawData, width, height, roi);
+    if (cropped === null) {
+      // ROI does not overlap the captured buffer → nothing to OCR.
+      return { somImage: null, elements: [], preprocessScale: scale, resolvedWindowTitle };
+    }
+    rawData = cropped.data;
+    width = cropped.width;
+    height = cropped.height;
+    origin = { x: origin.x + cropped.x, y: origin.y + cropped.y };
+  }
 
   const _somT0 = performance.now();
 

--- a/src/engine/roi-crop.ts
+++ b/src/engine/roi-crop.ts
@@ -1,0 +1,78 @@
+/**
+ * roi-crop.ts — ADR-024 Seed-2 S4 — RGBA buffer ROI crop helper.
+ *
+ * Pure helper used by `runSomPipeline` (`ocr-bridge.ts`) to crop a captured
+ * window RGBA buffer down to a region of interest before OCR, so the
+ * visual-only post-action path (ADR-024 Seed-2) OCRs only the changed region
+ * instead of the whole window.
+ *
+ * Coordinate space: `roi` is **image-local** — i.e. relative to the captured
+ * window buffer's top-left, the SAME space the OCR pipeline already works in
+ * before it adds `origin` to reach screen-absolute coords. (S3b produces
+ * window-relative rects; since the SoM buffer's (0,0) maps to the window's
+ * top-left, window-relative == image-local here.) The crop is clamped to the
+ * buffer bounds, and the returned `x`/`y` are the **clamped** top-left so the
+ * caller can shift its `origin` by exactly the crop offset and keep every
+ * downstream coordinate (screen-absolute conversion, SoM label placement)
+ * correct without any other change.
+ *
+ * Pure + side-effect-free; returns `null` when the ROI does not overlap the
+ * buffer at all (caller treats that as "nothing to OCR").
+ *
+ * Sub-plan: `desktop-touch-mcp-internal@…:docs/adr-024-seed2-plan.md` §2 S4.
+ */
+
+import type { Rect } from "./vision-gpu/types.js";
+
+export interface CroppedRgba {
+  /** Tightly-packed RGBA bytes of the cropped region (`width * height * 4`). */
+  data: Buffer;
+  /** Crop width in pixels (clamped to the source buffer). */
+  width: number;
+  /** Crop height in pixels (clamped to the source buffer). */
+  height: number;
+  /** Clamped image-local x of the crop's top-left (= origin shift to apply). */
+  x: number;
+  /** Clamped image-local y of the crop's top-left (= origin shift to apply). */
+  y: number;
+}
+
+/**
+ * Crop an RGBA buffer to `roi` (image-local), clamped to the buffer bounds.
+ *
+ * @param data   Source RGBA bytes, row-major, `width * height * 4` length.
+ * @param width  Source buffer width in pixels.
+ * @param height Source buffer height in pixels.
+ * @param roi    Image-local crop rect. Fractional coords are floored (top-left)
+ *               / ceiled (bottom-right) so the crop never loses edge pixels.
+ * @returns The cropped region + its clamped top-left, or `null` when `roi`
+ *          does not overlap the buffer (zero-area intersection).
+ */
+export function cropRgbaToRoi(
+  data: Buffer,
+  width: number,
+  height: number,
+  roi: Rect,
+): CroppedRgba | null {
+  // Clamp the ROI to the buffer. Floor the top-left and ceil the bottom-right
+  // so a sub-pixel ROI still captures the pixels it touches.
+  const x0 = Math.max(0, Math.floor(roi.x));
+  const y0 = Math.max(0, Math.floor(roi.y));
+  const x1 = Math.min(width, Math.ceil(roi.x + roi.width));
+  const y1 = Math.min(height, Math.ceil(roi.y + roi.height));
+
+  const cw = x1 - x0;
+  const ch = y1 - y0;
+  if (cw <= 0 || ch <= 0) return null; // no overlap with the buffer
+
+  const out = Buffer.allocUnsafe(cw * ch * 4);
+  const srcRowStride = width * 4;
+  const dstRowStride = cw * 4;
+  for (let row = 0; row < ch; row++) {
+    const srcStart = (y0 + row) * srcRowStride + x0 * 4;
+    const dstStart = row * dstRowStride;
+    data.copy(out, dstStart, srcStart, srcStart + dstRowStride);
+  }
+
+  return { data: out, width: cw, height: ch, x: x0, y: y0 };
+}

--- a/src/tools/desktop-providers/ocr-provider.ts
+++ b/src/tools/desktop-providers/ocr-provider.ts
@@ -16,7 +16,7 @@
  *   ocr_attempted_empty  — pipeline ran successfully but returned 0 candidates
  */
 
-import type { UiEntityCandidate } from "../../engine/vision-gpu/types.js";
+import type { Rect, UiEntityCandidate } from "../../engine/vision-gpu/types.js";
 import type { TargetSpec } from "../../engine/world-graph/session-registry.js";
 import type { ProviderResult } from "../../engine/world-graph/candidate-ingress.js";
 import type { OcrDictionaryEntry } from "../../engine/ocr-bridge.js";
@@ -25,6 +25,10 @@ import { getOcrVisualAdapter } from "../../engine/vision-gpu/ocr-adapter-registr
 export async function fetchOcrCandidates(
   target: TargetSpec | undefined,
   dictionary: OcrDictionaryEntry[] = [],
+  // ADR-024 Seed-2 S4 — optional image-local ROI forwarded to `runSomPipeline`
+  // so the visual-only post-action path OCRs only the changed region. Omitted
+  // by the existing discover lane caller → full-window OCR unchanged.
+  roi?: Rect,
 ): Promise<ProviderResult> {
   if (!target || (!target.hwnd && !target.windowTitle)) {
     return { candidates: [], warnings: [] };
@@ -36,7 +40,7 @@ export async function fetchOcrCandidates(
 
   try {
     const { runSomPipeline } = await import("../../engine/ocr-bridge.js");
-    const somResult = await runSomPipeline(windowTitle, hwnd, "ja", 2, "auto", false, dictionary);
+    const somResult = await runSomPipeline(windowTitle, hwnd, "ja", 2, "auto", false, dictionary, roi);
 
     if (somResult.elements.length === 0) {
       return { candidates: [], warnings: ["ocr_attempted_empty"] };

--- a/tests/unit/roi-crop.test.ts
+++ b/tests/unit/roi-crop.test.ts
@@ -1,0 +1,118 @@
+/**
+ * ADR-024 Seed-2 S4 — `cropRgbaToRoi` unit tests.
+ *
+ * Pins the RGBA row-copy crop + buffer-bounds clamp + clamped-offset return
+ * that lets `runSomPipeline` OCR only the ROI while keeping screen-absolute
+ * coordinates correct (the caller shifts `origin` by the returned `x`/`y`).
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { cropRgbaToRoi } from "../../src/engine/roi-crop.js";
+
+/**
+ * Build a `w * h` RGBA buffer where each pixel's R channel encodes its index
+ * (`y * w + x`), G = x, B = y, A = 255. Lets a crop assert exact provenance.
+ */
+function makeBuffer(w: number, h: number): Buffer {
+  const buf = Buffer.allocUnsafe(w * h * 4);
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const i = (y * w + x) * 4;
+      buf[i] = (y * w + x) & 0xff;
+      buf[i + 1] = x & 0xff;
+      buf[i + 2] = y & 0xff;
+      buf[i + 3] = 255;
+    }
+  }
+  return buf;
+}
+
+/** Read the (G,B) = (x,y) provenance of pixel `idx` in a cropped buffer. */
+function pixelXY(data: Buffer, idx: number): { x: number; y: number } {
+  return { x: data[idx * 4 + 1], y: data[idx * 4 + 2] };
+}
+
+describe("cropRgbaToRoi (S4 ROI buffer crop)", () => {
+  it("crops a fully-inside ROI with correct dimensions, offset, and pixels", () => {
+    const src = makeBuffer(10, 8); // 10x8
+    const out = cropRgbaToRoi(src, 10, 8, { x: 3, y: 2, width: 4, height: 3 });
+    expect(out).not.toBeNull();
+    expect(out!.width).toBe(4);
+    expect(out!.height).toBe(3);
+    expect(out!.x).toBe(3);
+    expect(out!.y).toBe(2);
+    expect(out!.data.length).toBe(4 * 3 * 4);
+    // top-left pixel of the crop is source (x=3, y=2)
+    expect(pixelXY(out!.data, 0)).toEqual({ x: 3, y: 2 });
+    // last pixel of the first crop row is source (x=6, y=2)
+    expect(pixelXY(out!.data, 3)).toEqual({ x: 6, y: 2 });
+    // first pixel of the second crop row is source (x=3, y=3)
+    expect(pixelXY(out!.data, 4)).toEqual({ x: 3, y: 3 });
+    // bottom-right pixel is source (x=6, y=4)
+    expect(pixelXY(out!.data, 11)).toEqual({ x: 6, y: 4 });
+  });
+
+  it("clamps an ROI that overruns the bottom-right edge and reports clamped size", () => {
+    const src = makeBuffer(10, 8);
+    // ROI starts at (8,6) and asks for 5x5 → clamps to 2x2 (buffer is 10x8).
+    const out = cropRgbaToRoi(src, 10, 8, { x: 8, y: 6, width: 5, height: 5 });
+    expect(out).not.toBeNull();
+    expect(out!.width).toBe(2);
+    expect(out!.height).toBe(2);
+    expect(out!.x).toBe(8);
+    expect(out!.y).toBe(6);
+    expect(pixelXY(out!.data, 0)).toEqual({ x: 8, y: 6 });
+  });
+
+  it("clamps a negative-origin ROI to (0,0) and shrinks the size accordingly", () => {
+    const src = makeBuffer(10, 8);
+    // ROI from (-2,-3) size 5x6 → clamps top-left to (0,0), size to 3x3.
+    const out = cropRgbaToRoi(src, 10, 8, { x: -2, y: -3, width: 5, height: 6 });
+    expect(out).not.toBeNull();
+    expect(out!.x).toBe(0);
+    expect(out!.y).toBe(0);
+    expect(out!.width).toBe(3);
+    expect(out!.height).toBe(3);
+    expect(pixelXY(out!.data, 0)).toEqual({ x: 0, y: 0 });
+  });
+
+  it("returns null when the ROI does not overlap the buffer", () => {
+    const src = makeBuffer(10, 8);
+    expect(cropRgbaToRoi(src, 10, 8, { x: 100, y: 100, width: 4, height: 4 })).toBeNull();
+  });
+
+  it("returns null for a zero-area ROI", () => {
+    const src = makeBuffer(10, 8);
+    expect(cropRgbaToRoi(src, 10, 8, { x: 2, y: 2, width: 0, height: 4 })).toBeNull();
+  });
+
+  it("floors the top-left and ceils the bottom-right for sub-pixel ROIs", () => {
+    const src = makeBuffer(10, 8);
+    // x:[2.4, 5.1) → floor 2 .. ceil 6 = width 4; y:[1.9, 3.2) → floor 1 .. ceil 4 = height 3.
+    const out = cropRgbaToRoi(src, 10, 8, { x: 2.4, y: 1.9, width: 2.7, height: 1.3 });
+    expect(out!.x).toBe(2);
+    expect(out!.y).toBe(1);
+    expect(out!.width).toBe(4);
+    expect(out!.height).toBe(3);
+  });
+
+  it("crops the full buffer when the ROI matches its bounds (identity offset)", () => {
+    const src = makeBuffer(4, 3);
+    const out = cropRgbaToRoi(src, 4, 3, { x: 0, y: 0, width: 4, height: 3 });
+    expect(out!.width).toBe(4);
+    expect(out!.height).toBe(3);
+    expect(out!.x).toBe(0);
+    expect(out!.y).toBe(0);
+    expect(out!.data.equals(src)).toBe(true);
+  });
+
+  it("does not alias the source buffer (crop is a fresh copy)", () => {
+    const src = makeBuffer(4, 3);
+    const out = cropRgbaToRoi(src, 4, 3, { x: 1, y: 1, width: 2, height: 2 });
+    out!.data[0] = 7;
+    // Mutating the crop must not touch the source pixel it came from (x=1,y=1).
+    const srcIdx = (1 * 4 + 1) * 4;
+    expect(src[srcIdx]).toBe((1 * 4 + 1) & 0xff);
+  });
+});


### PR DESCRIPTION
## ADR-024 Seed-2 — S4 (ROI-aware OCR)

Walking-skeleton **S4**. Stacks on S1–S3b (all merged). Lets the SoM/OCR pipeline OCR a **sub-region** of the captured window instead of the whole window, so the visual-only post-action path reads only the changed ROI (OQ-11b).

### Changes
- **`src/engine/roi-crop.ts`** (new pure helper) — `cropRgbaToRoi(data, w, h, roi)`: RGBA row-copy crop clamped to the buffer, returns cropped bytes + the **clamped** top-left offset, or `null` when the ROI misses the buffer.
- **`runSomPipeline`** — new **trailing** optional `roi?: Rect`. When supplied: crop the captured buffer + shift `origin` by the clamped crop offset. After that the **entire downstream pipeline** (scale, preprocess, OCR, image-local→screen conversion, SoM label placement) runs on the cropped buffer **unchanged**, so a ROI-crop entity keeps the exact screen-absolute rect a full-window OCR would produce (acceptance ②). `somImage` becomes the cropped region.
- **`fetchOcrCandidates`** — trailing optional `roi?` forwarded to `runSomPipeline`.

### Why `roi` is the LAST param (plan deviation, please scrutinize)
The sub-plan said "insert after preprocessPolicy/adaptive". That would **break byte-equality**: three call sites pass `dictionary` (the 7th param) **positionally**, so inserting `roi` before it shifts their args. Trailing optional keeps all callers byte-equal — the §3.2 byte-equal sweep wins over the plan's wording.

### byte-equal sweep (acceptance ①)
All existing callers omit `roi` → full-window OCR unchanged:
- `runSomPipeline`: `ocr-adapter.ts:146`, `screenshot.ts:490`, `screenshot.ts:723` (omit), `ocr-provider.ts:43` (forwards `undefined` unless its own caller supplies one).
- `fetchOcrCandidates`: `compose-providers.ts:289` (omits).

### Scope discipline
Pipeline capability **only** — no production caller passes a ROI yet. The act-response fold (S5) supplies the S3b window-relative ROI and assembles `roiCapture`. Same incremental discipline as S1–S3b.

### Tests — `tests/unit/roi-crop.test.ts` (8 cases)
fully-inside (pixel provenance) / clamp-bottom-right / clamp-negative-origin / no-overlap→null / zero-area→null / sub-pixel floor-ceil / full-buffer identity / no-alias.

### Verification
Full suite **4191 passed / 0 failed**; `tsc` clean; `eslint` 0 errors; `check:failwith-fixtures` + `check:stub-catalog` clean.

Plan: `desktop-touch-mcp-internal@a7e8e83:docs/adr-024-seed2-plan.md` (§2 S4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)