### PR TITLE
feat(desktop_act): S5 — fold post-action roiCapture into the act response (ADR-024 Seed-2)

### DIFF
--- a/src/engine/world-graph/guarded-touch.ts
+++ b/src/engine/world-graph/guarded-touch.ts
@@ -75,9 +75,10 @@ export interface RoiPreviewEntity {
  * `GuardedTouchLoop` — same layering as `observation?` (the loop stays
  * capture-agnostic). Absent on every non-visual-only / no-change path, so
  * existing `{ok, executor, diff, next}` destructures are unaffected (additive,
- * CLAUDE.md §3.2 carry-over). S1 locks the shape; the value stays `undefined`
- * until the ROI source (S3) and ROI-aware OCR (S4) phases are built and S5
- * folds the result into the act response.
+ * CLAUDE.md §3.2 carry-over). Live since S5: a successful act on a visual-only
+ * target with a visible change (and the gate's `returnCapture` mode) carries
+ * this; the registration wrapper builds it from the post-action dirty-rect ROI
+ * (S3a/S3b) + ROI-aware OCR (S4).
  */
 export interface RoiCapture {
   /** Window-relative crop rect the `somImage` covers (the diff region, not the full window). */
@@ -123,7 +124,7 @@ export type TouchResult =
        * entity preview) attached by the registration wrapper when the target is
        * visual-only and the act produced a visible change. Absent otherwise
        * (additive — existing destructures unaffected). See {@link RoiCapture}.
-       * S1 locks the shape; population is built in S3/S4 and folded in S5.
+       * Live since S5 (the fold).
        */
       roiCapture?: RoiCapture;
     }

--- a/src/tools/_roi-preview.ts
+++ b/src/tools/_roi-preview.ts
@@ -1,0 +1,72 @@
+/**
+ * _roi-preview.ts — ADR-024 Seed-2 S5 — ROI-OCR → lease-less preview mapping + dedup.
+ *
+ * Pure helper that turns the ROI-aware OCR elements (S4 `runSomPipeline`) into
+ * the `roiCapture.entities` preview, deduped against the entities the most
+ * recent `desktop_discover` already returned (OQ-10).
+ *
+ * Dedup rule (Codex PR #429 P2): an ROI element is a duplicate ONLY when it
+ * both overlaps a discover entity (IoU ≥ {@link ROI_DEDUP_IOU}) AND carries the
+ * same (normalized) label. An in-place text change — a status/toggle label that
+ * flips "Off"→"On" at the same bounds — has matching geometry but different
+ * text, and IS the change the capture exists to surface, so it is preserved.
+ *
+ * Side-effect-free; native OCR + facade access stay in `desktop-register.ts`.
+ */
+
+import type { Rect } from "../engine/vision-gpu/types.js";
+import type { RoiPreviewEntity } from "../engine/world-graph/guarded-touch.js";
+import { rectIoU } from "./_roi-region.js";
+
+/** Minimum IoU at which an ROI element + a discover entity are considered the
+ *  same geometry for dedup. 0.5 = the two rects share more than half their union. */
+export const ROI_DEDUP_IOU = 0.5;
+
+/** Minimal structural shape of an OCR element (subset of `SomElement`). */
+export interface RoiOcrElement {
+  /** Merged OCR text. */
+  text: string;
+  /** Screen-absolute bounding rect. */
+  region: Rect;
+}
+
+/** Minimal structural shape of a discover entity for dedup. */
+export interface DiscoverEntityRef {
+  rect: Rect;
+  label: string;
+}
+
+function normalizeLabel(s: string): string {
+  return s.trim().toLowerCase();
+}
+
+/**
+ * Map ROI-OCR elements to lease-less `RoiPreviewEntity[]`, dropping the ones
+ * that duplicate a discover entity (same geometry AND same label).
+ *
+ * `role: "label"` + `actionability: ["click"]` mirror how the SAME OCR source
+ * is represented in the discover lane (`ocr-provider.ts`), so the preview and
+ * `desktop_discover` describe the same on-screen text identically. The preview
+ * is lease-less regardless — the caller re-runs `desktop_discover` for an
+ * actionable lease.
+ */
+export function buildRoiPreviewEntities(
+  elements: readonly RoiOcrElement[],
+  discoverEntities: readonly DiscoverEntityRef[],
+): RoiPreviewEntity[] {
+  return elements
+    .filter(
+      (el) =>
+        !discoverEntities.some(
+          (d) =>
+            rectIoU(el.region, d.rect) >= ROI_DEDUP_IOU &&
+            normalizeLabel(d.label) === normalizeLabel(el.text),
+        ),
+    )
+    .map((el) => ({
+      label: el.text,
+      role: "label",
+      rect: el.region,
+      actionability: ["click"],
+    }));
+}

--- a/src/tools/_roi-region.ts
+++ b/src/tools/_roi-region.ts
@@ -73,3 +73,52 @@ export function filterDirtyRectsToWindow(
 
   return out;
 }
+
+/**
+ * ADR-024 Seed-2 S5 — union bounding box of a set of rects.
+ *
+ * The S1 contract `RoiCapture.roi` is a **single** crop rect, but S3b yields a
+ * list of window-relative dirty regions. S5 reduces them to the one rect that
+ * encloses all of them (the crop the `somImage` covers + the region the
+ * ROI-aware OCR runs on).
+ *
+ * @returns The enclosing rect, or `null` for an empty input (no ROI).
+ */
+export function boundingBox(rects: readonly Rect[]): Rect | null {
+  if (rects.length === 0) return null;
+
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const r of rects) {
+    if (r.x < minX) minX = r.x;
+    if (r.y < minY) minY = r.y;
+    if (r.x + r.width > maxX) maxX = r.x + r.width;
+    if (r.y + r.height > maxY) maxY = r.y + r.height;
+  }
+  return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
+}
+
+/**
+ * ADR-024 Seed-2 S5 — intersection-over-union of two rects.
+ *
+ * Used to dedup the post-action ROI-OCR preview against the entities the most
+ * recent `desktop_discover` already returned (OQ-10): an ROI entity whose rect
+ * substantially overlaps a discover entity is "the same entity" and is dropped
+ * from the preview so the act response highlights only what changed.
+ *
+ * @returns IoU in `[0, 1]`; `0` when the rects do not overlap.
+ */
+export function rectIoU(a: Rect, b: Rect): number {
+  const x0 = Math.max(a.x, b.x);
+  const y0 = Math.max(a.y, b.y);
+  const x1 = Math.min(a.x + a.width, b.x + b.width);
+  const y1 = Math.min(a.y + a.height, b.y + b.height);
+  const iw = x1 - x0;
+  const ih = y1 - y0;
+  if (iw <= 0 || ih <= 0) return 0;
+  const inter = iw * ih;
+  const union = a.width * a.height + b.width * b.height - inter;
+  return union > 0 ? inter / union : 0;
+}

--- a/src/tools/desktop-register.ts
+++ b/src/tools/desktop-register.ts
@@ -485,15 +485,14 @@ export const desktopTouchSchema = {
   ),
   text:   z.string().optional().describe("Text to type or set (required when action='type' or action='setValue')."),
   returnCapture: z.enum(["on-change", "always", "never"]).optional().describe(
-    "[EXPERIMENTAL — RESERVED, NOT YET ACTIVE] ADR-024 Seed-2 — will control post-action ROI capture on " +
-    "visual-only targets (UIA-blind / RDP / canvas). Accepted now so clients can adopt the option, but " +
-    "the capture is still being rolled out: this version NEVER attaches 'roiCapture', for any value. Do " +
-    "not depend on a capture yet. When active, a successful act on a visual-only target will carry a " +
-    "'roiCapture' { roi, somImage, entities } (diff-region crop + lease-less entity preview) so you can " +
-    "confirm the result and find the next target without a separate desktop_state / screenshot. Planned " +
-    "semantics: 'on-change' (default) attaches only on a visible change; 'always' on any successful " +
-    "visual-only act; 'never' suppresses it. No effect on structured targets (browser/CDP, UIA-rich " +
-    "native) — use desktop_state there."
+    "[EXPERIMENTAL] ADR-024 Seed-2 — controls the post-action ROI capture on visual-only targets " +
+    "(UIA-blind / RDP / canvas). When it attaches, a successful act carries a 'roiCapture' " +
+    "{ roi, somImage, entities }: a base64 PNG crop of the changed region plus a lease-less entity " +
+    "preview, so you can confirm the result and find the next target without a separate desktop_state / " +
+    "screenshot. The entities are previews only (no lease) — re-run desktop_discover to act on them. " +
+    "Semantics: 'on-change' (default for visual-only targets) attaches only on a visible change; 'always' " +
+    "on any successful visual-only act; 'never' suppresses it. No effect on structured targets " +
+    "(browser/CDP, UIA-rich native) — 'roiCapture' is never attached there; use desktop_state."
   ),
 };
 
@@ -747,6 +746,14 @@ async function buildRoiCapture(
 
     // OQ-10 — dedup the preview against the discover snapshot (screen-abs rects).
     const discoverRects = facade.getDiscoverEntityRectsForViewId(viewId);
+    // `role: "label"` + `actionability: ["click"]` mirror how the SAME OCR
+    // source is represented in the discover lane (`ocr-provider.ts` maps every
+    // SomElement to role "label" / actionability ["click"], since the executor
+    // routes source:"ocr" entities to a mouse click). Keeping the preview's
+    // representation identical to discover's avoids a confusing role/affordance
+    // mismatch between what desktop_discover and roiCapture report for the same
+    // on-screen text. The preview is lease-less regardless, so this is a hint —
+    // the caller must re-run desktop_discover to obtain an actionable lease.
     const entities: RoiPreviewEntity[] = som.elements
       .filter((el) => !discoverRects.some((d) => rectIoU(el.region, d) >= ROI_DEDUP_IOU))
       .map((el) => ({
@@ -941,9 +948,11 @@ export function registerDesktopTools(server: McpServer): void {
       "  executor_failed → fall back to V1 tools (click_element / mouse_click / browser_click);",
       "  executor_failed on terminal textbox (action=type) → use V1 terminal(action='send') instead.",
       "Check desktop_discover response.constraints for pre-emptive fallback hints before calling desktop_act.",
-      "[EXPERIMENTAL — RESERVED] returnCapture is accepted but NOT YET ACTIVE: this version never attaches a",
-      "'roiCapture' for any value. When rolled out it will fold a post-action diff-region crop + lease-less",
-      "entity preview into the response on visual-only targets (UIA-blind / RDP / canvas). Do not depend on it yet.",
+      "[EXPERIMENTAL] On visual-only targets (UIA-blind / RDP / canvas), a successful act may attach a",
+      "'roiCapture' { roi, somImage, entities }: a base64 PNG crop of the changed region + a lease-less entity",
+      "preview, so you can confirm the result + find the next target in one call (no separate desktop_state /",
+      "screenshot). entities are previews (no lease) — re-run desktop_discover to act. Control via returnCapture",
+      "('on-change' default / 'always' / 'never'). Never attached on structured targets (browser/CDP, UIA-rich).",
     ].join(" "),
     desktopActRegistrationSchema,
     desktopActRegistrationHandler as (input: unknown) => Promise<ToolResult>,

--- a/src/tools/desktop-register.ts
+++ b/src/tools/desktop-register.ts
@@ -38,7 +38,7 @@ import type { NativeLeaseTokenSummary } from "../engine/native-types.js";
 import type { ToolResult } from "./_types.js";
 import { Err } from "../types/result.js";
 import { ExecutorFailedError } from "../errors/typed-errors.js";
-import type { TouchAction, RoiCapture, RoiPreviewEntity } from "../engine/world-graph/guarded-touch.js";
+import type { TouchAction, RoiCapture } from "../engine/world-graph/guarded-touch.js";
 import {
   SnapshotIngress,
   combineEventSources,
@@ -66,7 +66,8 @@ import { verifyAnyChange } from "../engine/any-change.js";
 import { disposeSharedDirtyRectBroker } from "../engine/dxgi-broker.js";
 import type { VisualMotionObservation } from "./_input-pipeline.js";
 import { shouldReturnRoiCapture, type ReturnCaptureMode } from "./_roi-capture-gate.js";
-import { filterDirtyRectsToWindow, boundingBox, rectIoU } from "./_roi-region.js";
+import { filterDirtyRectsToWindow, boundingBox } from "./_roi-region.js";
+import { buildRoiPreviewEntities } from "./_roi-preview.js";
 import { runSomPipeline } from "../engine/ocr-bridge.js";
 import type { Rect } from "../engine/vision-gpu/types.js";
 import { createDefaultCapabilityRegistry } from "../capabilities/registry.js";
@@ -684,11 +685,6 @@ async function tryVerifyAnyChange(
   }
 }
 
-/** ADR-024 Seed-2 S5 — minimum IoU at which an ROI-OCR preview entity is
- *  considered "the same" as a discover entity and dropped from the preview
- *  (OQ-10 dedup). 0.5 = the two rects share more than half their union. */
-const ROI_DEDUP_IOU = 0.5;
-
 /**
  * ADR-024 Seed-2 S5 — gate + fold for the post-action `roiCapture`.
  *
@@ -724,7 +720,6 @@ async function buildRoiCapture(
     returnCapture,
   });
   if (!gatePassed) return undefined;
-  if (dirtyRects.length === 0) return undefined;
 
   const hwnd = facade.resolveHwndForViewId(viewId);
   if (hwnd === null) return undefined;
@@ -735,8 +730,13 @@ async function buildRoiCapture(
 
   // S3b — per-output dirty rects → window-relative; S5 — reduce to one ROI.
   const windowRel = filterDirtyRectsToWindow(dirtyRects, windowRect);
-  const roi = boundingBox(windowRel);
-  if (roi === null) return undefined; // no dirty region overlaps the window
+  // Fall back to the whole window (window-relative full rect) when no dirty
+  // region intersects it. The gate already passed, so we owe a capture — this
+  // happens for `returnCapture: "always"` on a no-change act, or when motion
+  // was reported by a non-DXGI source (SSIM translation/local_repaint) that
+  // leaves `dirtyRects` empty (Codex PR #429 P2: honor `always`).
+  const roi =
+    boundingBox(windowRel) ?? { x: 0, y: 0, width: windowRect.width, height: windowRect.height };
 
   try {
     // S4 — OCR only the ROI crop. hwnd is provided so the empty windowTitle is
@@ -744,24 +744,13 @@ async function buildRoiCapture(
     const som = await runSomPipeline("", hwnd, "ja", 2, "auto", false, [], roi);
     if (som.somImage === null) return undefined; // SoM render unavailable
 
-    // OQ-10 — dedup the preview against the discover snapshot (screen-abs rects).
-    const discoverRects = facade.getDiscoverEntityRectsForViewId(viewId);
-    // `role: "label"` + `actionability: ["click"]` mirror how the SAME OCR
-    // source is represented in the discover lane (`ocr-provider.ts` maps every
-    // SomElement to role "label" / actionability ["click"], since the executor
-    // routes source:"ocr" entities to a mouse click). Keeping the preview's
-    // representation identical to discover's avoids a confusing role/affordance
-    // mismatch between what desktop_discover and roiCapture report for the same
-    // on-screen text. The preview is lease-less regardless, so this is a hint —
-    // the caller must re-run desktop_discover to obtain an actionable lease.
-    const entities: RoiPreviewEntity[] = som.elements
-      .filter((el) => !discoverRects.some((d) => rectIoU(el.region, d) >= ROI_DEDUP_IOU))
-      .map((el) => ({
-        label: el.text,
-        role: "label",
-        rect: el.region, // screen-absolute (SomElement.region)
-        actionability: ["click"],
-      }));
+    // OQ-10 — map ROI-OCR elements to the lease-less preview, deduped against
+    // the discover snapshot by geometry AND label (so an in-place text change is
+    // preserved). Pure logic in `_roi-preview.ts` (`buildRoiPreviewEntities`).
+    const entities = buildRoiPreviewEntities(
+      som.elements,
+      facade.getDiscoverEntitiesForViewId(viewId),
+    );
 
     return { roi, somImage: som.somImage.base64, entities, source: "dxgi" };
   } catch (err) {

--- a/src/tools/desktop-register.ts
+++ b/src/tools/desktop-register.ts
@@ -38,7 +38,7 @@ import type { NativeLeaseTokenSummary } from "../engine/native-types.js";
 import type { ToolResult } from "./_types.js";
 import { Err } from "../types/result.js";
 import { ExecutorFailedError } from "../errors/typed-errors.js";
-import type { TouchAction, RoiCapture } from "../engine/world-graph/guarded-touch.js";
+import type { TouchAction, RoiCapture, RoiPreviewEntity } from "../engine/world-graph/guarded-touch.js";
 import {
   SnapshotIngress,
   combineEventSources,
@@ -66,6 +66,9 @@ import { verifyAnyChange } from "../engine/any-change.js";
 import { disposeSharedDirtyRectBroker } from "../engine/dxgi-broker.js";
 import type { VisualMotionObservation } from "./_input-pipeline.js";
 import { shouldReturnRoiCapture, type ReturnCaptureMode } from "./_roi-capture-gate.js";
+import { filterDirtyRectsToWindow, boundingBox, rectIoU } from "./_roi-region.js";
+import { runSomPipeline } from "../engine/ocr-bridge.js";
+import type { Rect } from "../engine/vision-gpu/types.js";
 import { createDefaultCapabilityRegistry } from "../capabilities/registry.js";
 
 // ── Advisory registry singleton (PR-SR1-3) ────────────────────────────────────
@@ -574,20 +577,32 @@ export const desktopActRawHandler = async (
     text: input.text,
   });
 
+  let postVerify: { observation: VisualMotionObservation; dirtyRects: Rect[] } | null = null;
   if (result.ok && process.env["DESKTOP_TOUCH_STAGE5_DXGI"] !== "0") {
-    const observation = await tryVerifyAnyChange(facade, input.lease.viewId);
-    if (observation !== null) {
-      (result as { observation?: VisualMotionObservation }).observation = observation;
+    postVerify = await tryVerifyAnyChange(facade, input.lease.viewId);
+    if (postVerify !== null) {
+      // Attach the motion verdict to the serialized response. `dirtyRects` is an
+      // internal ROI-source channel for buildRoiCapture (S3a) — it is NOT part
+      // of the public observation telemetry, so the split in tryVerifyAnyChange
+      // keeps it off `result.observation`.
+      (result as { observation?: VisualMotionObservation }).observation = postVerify.observation;
     }
   }
 
-  // ADR-024 Seed-2 S2 — gate post-action ROI capture on the visual-only regime.
-  // Reuses the motion verdict from the observation poll above (no extra DXGI
-  // poll). `buildRoiCapture` is the S3/S4/S5 seam: in S2 it returns undefined
-  // whenever the gate passes (ROI source not yet wired), so responses stay
-  // bit-equal with the pre-Seed-2 shape.
+  // ADR-024 Seed-2 S5 — fold the post-action ROI capture into the act response
+  // for visual-only targets. `buildRoiCapture` gates on the visual-only regime +
+  // motion verdict, then turns the S3a dirty rects into a window-relative ROI
+  // (S3b), OCRs only that region (S4), and assembles `{roi, somImage, entities}`.
+  // Absent (gate declines / no change / no ROI) → response stays bit-equal with
+  // the pre-Seed-2 shape (additive — existing destructures unaffected).
   if (result.ok) {
-    const roiCapture = buildRoiCapture(facade, input.lease.viewId, result.observation, input.returnCapture);
+    const roiCapture = await buildRoiCapture(
+      facade,
+      input.lease.viewId,
+      postVerify?.observation,
+      postVerify?.dirtyRects ?? [],
+      input.returnCapture,
+    );
     if (roiCapture !== undefined) {
       (result as { roiCapture?: RoiCapture }).roiCapture = roiCapture;
     }
@@ -647,7 +662,7 @@ export const desktopActRawHandler = async (
 async function tryVerifyAnyChange(
   facade: DesktopFacade,
   viewId: string,
-): Promise<VisualMotionObservation | null> {
+): Promise<{ observation: VisualMotionObservation; dirtyRects: Rect[] } | null> {
   const hwnd = facade.resolveHwndForViewId(viewId);
   if (hwnd === null) return null;
   const windowRect = getWindowRectByHwnd(hwnd);
@@ -655,7 +670,14 @@ async function tryVerifyAnyChange(
     return null;
   }
   try {
-    return await verifyAnyChange({ hwnd, windowRect });
+    // ADR-024 Seed-2 S3a/S5 — opt into the dirty-rect surface so the SAME poll
+    // that produces `motion` also yields the ROI rects (no second DXGI acquire).
+    // Split `dirtyRects` off the observation here: it is an internal ROI-source
+    // channel for buildRoiCapture, not public observation telemetry, so it never
+    // reaches the serialized `result.observation`.
+    const obs = await verifyAnyChange({ hwnd, windowRect, includeDirtyRects: true });
+    const { dirtyRects, ...observation } = obs;
+    return { observation, dirtyRects: dirtyRects ?? [] };
   } catch {
     // Defensive: orchestrator promises never to throw, but a bug there must
     // not break the envelope.
@@ -663,27 +685,39 @@ async function tryVerifyAnyChange(
   }
 }
 
+/** ADR-024 Seed-2 S5 — minimum IoU at which an ROI-OCR preview entity is
+ *  considered "the same" as a discover entity and dropped from the preview
+ *  (OQ-10 dedup). 0.5 = the two rects share more than half their union. */
+const ROI_DEDUP_IOU = 0.5;
+
 /**
- * ADR-024 Seed-2 — gate + population seam for the post-action `roiCapture`.
+ * ADR-024 Seed-2 S5 — gate + fold for the post-action `roiCapture`.
  *
  * Returns the capture to attach to a successful `desktop_act`, or `undefined`
- * when either (a) the gate declines (non-visual-only target / no change / opt-out)
- * or (b) the ROI pipeline is not yet wired.
+ * when the gate declines (non-visual-only target / no change / opt-out) or no
+ * ROI is available.
  *
- * S2 (this commit): the gate is live — it reads the session's visual-only flag
- * (persisted at discover) and reuses the `observation` motion verdict already
- * computed above, so it adds **no** extra DXGI poll. Population is a stub: even
- * when the gate passes there is no ROI source yet (lands in S3), so this returns
- * `undefined` and the act response stays bit-equal with the pre-Seed-2 shape.
- * S3 (ROI source) → S4 (ROI-aware OCR) → S5 (fold) replace the stub tail with the
- * real `{ roi, somImage, entities, source }`.
+ * Fold (S5, walking-skeleton Option A — additive; the order-trap compute
+ * optimization that avoids the post-touch full-window OCR is deferred to S5b):
+ *   1. gate on visual-only regime + motion verdict (`shouldReturnRoiCapture`);
+ *   2. turn the S3a per-output dirty rects into window-relative rects
+ *      (S3b `filterDirtyRectsToWindow`) and reduce them to one ROI (bounding box);
+ *   3. OCR only that ROI (S4 `runSomPipeline(..., roi)`) → `somImage` crop +
+ *      `SomElement[]`;
+ *   4. map the elements to lease-less `RoiPreviewEntity[]` (OQ-8 (b) MVP),
+ *      deduped against the most recent discover snapshot (OQ-10) so the preview
+ *      highlights only what changed.
+ *
+ * Degrades to `undefined` on every miss (no hwnd / no window rect / ROI misses
+ * the window / OCR threw or rendered no image) so the act envelope is unaffected.
  */
-function buildRoiCapture(
+async function buildRoiCapture(
   facade: DesktopFacade,
   viewId: string,
   observation: VisualMotionObservation | undefined,
+  dirtyRects: Rect[],
   returnCapture: ReturnCaptureMode | undefined,
-): RoiCapture | undefined {
+): Promise<RoiCapture | undefined> {
   const gatePassed = shouldReturnRoiCapture({
     ok: true, // only called on the success path
     visualOnly: facade.resolveVisualOnlyForViewId(viewId),
@@ -691,10 +725,45 @@ function buildRoiCapture(
     returnCapture,
   });
   if (!gatePassed) return undefined;
-  // S3 (ROI source via single-poll dirty-rect surface) → S4 (ROI-aware OCR) →
-  // S5 (fold) populate `{ roi, somImage, entities, source }` here. Until S3
-  // lands there is no ROI source, so nothing is attached.
-  return undefined;
+  if (dirtyRects.length === 0) return undefined;
+
+  const hwnd = facade.resolveHwndForViewId(viewId);
+  if (hwnd === null) return undefined;
+  const windowRect = getWindowRectByHwnd(hwnd);
+  if (windowRect === null || windowRect.width <= 0 || windowRect.height <= 0) {
+    return undefined;
+  }
+
+  // S3b — per-output dirty rects → window-relative; S5 — reduce to one ROI.
+  const windowRel = filterDirtyRectsToWindow(dirtyRects, windowRect);
+  const roi = boundingBox(windowRel);
+  if (roi === null) return undefined; // no dirty region overlaps the window
+
+  try {
+    // S4 — OCR only the ROI crop. hwnd is provided so the empty windowTitle is
+    // unused; no UIA dictionary (visual-only target has no UIA candidates).
+    const som = await runSomPipeline("", hwnd, "ja", 2, "auto", false, [], roi);
+    if (som.somImage === null) return undefined; // SoM render unavailable
+
+    // OQ-10 — dedup the preview against the discover snapshot (screen-abs rects).
+    const discoverRects = facade.getDiscoverEntityRectsForViewId(viewId);
+    const entities: RoiPreviewEntity[] = som.elements
+      .filter((el) => !discoverRects.some((d) => rectIoU(el.region, d) >= ROI_DEDUP_IOU))
+      .map((el) => ({
+        label: el.text,
+        role: "label",
+        rect: el.region, // screen-absolute (SomElement.region)
+        actionability: ["click"],
+      }));
+
+    return { roi, somImage: som.somImage.base64, entities, source: "dxgi" };
+  } catch (err) {
+    // OCR is best-effort; never break the act envelope on a pipeline failure.
+    console.error(
+      `[desktop_act] ROI capture OCR failed for viewId=${viewId}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return undefined;
+  }
 }
 
 /** Pre-flight lease validation closure used by the commit wrapper

--- a/src/tools/desktop.ts
+++ b/src/tools/desktop.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import type { UiEntityCandidate } from "../engine/vision-gpu/types.js";
+import type { Rect, UiEntityCandidate } from "../engine/vision-gpu/types.js";
 import type {
   UiEntity,
   EntityLease,
@@ -626,6 +626,21 @@ export class DesktopFacade {
   resolveVisualOnlyForViewId(viewId: string): boolean {
     const session = this.registry.getByViewId(viewId, this.opts.nowFn);
     return session?.lastDiscoverVisualOnly ?? false;
+  }
+
+  /**
+   * ADR-024 Seed-2 S5 — screen-absolute rects of the entities the most recent
+   * `desktop_discover` returned for this session's view. The post-action ROI
+   * capture dedups its OCR preview against these (OQ-10) so the act response
+   * surfaces only entities that changed, not ones the caller already saw.
+   * Returns `[]` when the session is gone or no discover has run.
+   */
+  getDiscoverEntityRectsForViewId(viewId: string): Rect[] {
+    const session = this.registry.getByViewId(viewId, this.opts.nowFn);
+    if (!session) return [];
+    return session.entities
+      .map((e) => e.rect)
+      .filter((r): r is Rect => r !== undefined);
   }
 
   validateLeaseOnly(lease: EntityLease): LeaseValidationResult {

--- a/src/tools/desktop.ts
+++ b/src/tools/desktop.ts
@@ -629,18 +629,20 @@ export class DesktopFacade {
   }
 
   /**
-   * ADR-024 Seed-2 S5 — screen-absolute rects of the entities the most recent
-   * `desktop_discover` returned for this session's view. The post-action ROI
-   * capture dedups its OCR preview against these (OQ-10) so the act response
-   * surfaces only entities that changed, not ones the caller already saw.
-   * Returns `[]` when the session is gone or no discover has run.
+   * ADR-024 Seed-2 S5 — screen-absolute rect + label of the entities the most
+   * recent `desktop_discover` returned for this session's view. The post-action
+   * ROI capture dedups its OCR preview against these (OQ-10): an ROI entity is a
+   * duplicate only when it overlaps a discover entity **and** carries the same
+   * label, so an in-place text change (toggle "Off"→"On" at the same rect) is
+   * preserved rather than dropped (Codex PR #429 P2). Returns `[]` when the
+   * session is gone or no discover has run.
    */
-  getDiscoverEntityRectsForViewId(viewId: string): Rect[] {
+  getDiscoverEntitiesForViewId(viewId: string): Array<{ rect: Rect; label: string }> {
     const session = this.registry.getByViewId(viewId, this.opts.nowFn);
     if (!session) return [];
     return session.entities
-      .map((e) => e.rect)
-      .filter((r): r is Rect => r !== undefined);
+      .filter((e): e is typeof e & { rect: Rect } => e.rect !== undefined)
+      .map((e) => ({ rect: e.rect, label: e.label ?? "" }));
   }
 
   validateLeaseOnly(lease: EntityLease): LeaseValidationResult {

--- a/tests/unit/roi-preview.test.ts
+++ b/tests/unit/roi-preview.test.ts
@@ -1,0 +1,71 @@
+/**
+ * ADR-024 Seed-2 S5 — `buildRoiPreviewEntities` unit tests.
+ *
+ * Pins the OQ-10 dedup contract: an ROI-OCR element is dropped only when it
+ * BOTH overlaps a discover entity AND carries the same label — so an in-place
+ * text change (same bounds, different text) is preserved (Codex PR #429 P2).
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  buildRoiPreviewEntities,
+  type RoiOcrElement,
+  type DiscoverEntityRef,
+} from "../../src/tools/_roi-preview.js";
+
+const RECT_A = { x: 100, y: 100, width: 40, height: 20 };
+
+describe("buildRoiPreviewEntities (S5 OQ-10 dedup + mapping)", () => {
+  it("maps an OCR element to a lease-less preview entity", () => {
+    const els: RoiOcrElement[] = [{ text: "Save", region: RECT_A }];
+    const out = buildRoiPreviewEntities(els, []);
+    expect(out).toEqual([
+      { label: "Save", role: "label", rect: RECT_A, actionability: ["click"] },
+    ]);
+  });
+
+  it("drops an element that overlaps a discover entity with the SAME label", () => {
+    const els: RoiOcrElement[] = [{ text: "Save", region: RECT_A }];
+    const discover: DiscoverEntityRef[] = [{ rect: { ...RECT_A }, label: "Save" }];
+    expect(buildRoiPreviewEntities(els, discover)).toEqual([]);
+  });
+
+  it("KEEPS an in-place text change (same rect, different label)", () => {
+    // The act flipped a status label "Off" → "On" at the same bounds. This is
+    // exactly the change roiCapture exists to surface — it must NOT be deduped.
+    const els: RoiOcrElement[] = [{ text: "On", region: RECT_A }];
+    const discover: DiscoverEntityRef[] = [{ rect: { ...RECT_A }, label: "Off" }];
+    const out = buildRoiPreviewEntities(els, discover);
+    expect(out).toEqual([
+      { label: "On", role: "label", rect: RECT_A, actionability: ["click"] },
+    ]);
+  });
+
+  it("normalizes labels (trim + case) when matching for dedup", () => {
+    const els: RoiOcrElement[] = [{ text: "  SAVE ", region: RECT_A }];
+    const discover: DiscoverEntityRef[] = [{ rect: { ...RECT_A }, label: "save" }];
+    expect(buildRoiPreviewEntities(els, discover)).toEqual([]);
+  });
+
+  it("keeps an element with the same label but non-overlapping geometry", () => {
+    const els: RoiOcrElement[] = [{ text: "Save", region: RECT_A }];
+    const discover: DiscoverEntityRef[] = [
+      { rect: { x: 500, y: 500, width: 40, height: 20 }, label: "Save" },
+    ];
+    expect(buildRoiPreviewEntities(els, discover)).toHaveLength(1);
+  });
+
+  it("keeps a partial overlap below the 0.5 IoU threshold even with same label", () => {
+    // 25% area overlap → IoU ≈ 0.143 < 0.5 → not the same entity → kept.
+    const els: RoiOcrElement[] = [{ text: "Save", region: { x: 0, y: 0, width: 10, height: 10 } }];
+    const discover: DiscoverEntityRef[] = [
+      { rect: { x: 5, y: 5, width: 10, height: 10 }, label: "Save" },
+    ];
+    expect(buildRoiPreviewEntities(els, discover)).toHaveLength(1);
+  });
+
+  it("returns [] for no OCR elements", () => {
+    expect(buildRoiPreviewEntities([], [{ rect: RECT_A, label: "x" }])).toEqual([]);
+  });
+});

--- a/tests/unit/roi-region.test.ts
+++ b/tests/unit/roi-region.test.ts
@@ -11,7 +11,11 @@
 
 import { describe, it, expect } from "vitest";
 
-import { filterDirtyRectsToWindow } from "../../src/tools/_roi-region.js";
+import {
+  filterDirtyRectsToWindow,
+  boundingBox,
+  rectIoU,
+} from "../../src/tools/_roi-region.js";
 
 // Window at a non-zero screen origin so the relative translation is observable.
 const WINDOW = { x: 100, y: 200, width: 800, height: 600 };
@@ -124,5 +128,82 @@ describe("filterDirtyRectsToWindow (S3b window-rect filter)", () => {
     const out = filterDirtyRectsToWindow([input], WINDOW);
     expect(out[0]).not.toBe(input);
     expect(input).toEqual({ x: 150, y: 260, width: 40, height: 30 });
+  });
+});
+
+describe("boundingBox (S5 ROI union)", () => {
+  it("returns null for an empty input", () => {
+    expect(boundingBox([])).toBeNull();
+  });
+
+  it("returns the same rect for a single input", () => {
+    expect(boundingBox([{ x: 10, y: 20, width: 30, height: 40 }])).toEqual({
+      x: 10,
+      y: 20,
+      width: 30,
+      height: 40,
+    });
+  });
+
+  it("encloses several disjoint rects", () => {
+    // (10,10)-(20,20) and (50,40)-(80,100) → enclosing (10,10)-(80,100).
+    const out = boundingBox([
+      { x: 10, y: 10, width: 10, height: 10 },
+      { x: 50, y: 40, width: 30, height: 60 },
+    ]);
+    expect(out).toEqual({ x: 10, y: 10, width: 70, height: 90 });
+  });
+
+  it("encloses overlapping rects (union, not intersection)", () => {
+    const out = boundingBox([
+      { x: 0, y: 0, width: 50, height: 50 },
+      { x: 30, y: 30, width: 50, height: 50 },
+    ]);
+    expect(out).toEqual({ x: 0, y: 0, width: 80, height: 80 });
+  });
+
+  it("handles negative coordinates (secondary monitor space)", () => {
+    const out = boundingBox([
+      { x: -100, y: -50, width: 20, height: 20 },
+      { x: -40, y: 10, width: 30, height: 30 },
+    ]);
+    expect(out).toEqual({ x: -100, y: -50, width: 90, height: 90 });
+  });
+});
+
+describe("rectIoU (S5 OQ-10 dedup metric)", () => {
+  it("is 1 for identical rects", () => {
+    const r = { x: 5, y: 5, width: 10, height: 10 };
+    expect(rectIoU(r, { ...r })).toBe(1);
+  });
+
+  it("is 0 for non-overlapping rects", () => {
+    expect(
+      rectIoU({ x: 0, y: 0, width: 10, height: 10 }, { x: 100, y: 100, width: 10, height: 10 }),
+    ).toBe(0);
+  });
+
+  it("is 0 for a zero-area edge touch", () => {
+    // Share only the right edge (x=10) → no area overlap.
+    expect(
+      rectIoU({ x: 0, y: 0, width: 10, height: 10 }, { x: 10, y: 0, width: 10, height: 10 }),
+    ).toBe(0);
+  });
+
+  it("computes a partial overlap ratio", () => {
+    // Two 10x10 rects offset by (5,0): intersection 5x10=50, union 200-50=150 → 1/3.
+    expect(
+      rectIoU({ x: 0, y: 0, width: 10, height: 10 }, { x: 5, y: 0, width: 10, height: 10 }),
+    ).toBeCloseTo(50 / 150, 6);
+  });
+
+  it("a half-contained quarter-overlap clears/misses the 0.5 dedup gate as expected", () => {
+    // 25% area overlap → IoU = 25/(100+100-25) = 25/175 ≈ 0.143 < 0.5 (kept).
+    const iou = rectIoU(
+      { x: 0, y: 0, width: 10, height: 10 },
+      { x: 5, y: 5, width: 10, height: 10 },
+    );
+    expect(iou).toBeCloseTo(25 / 175, 6);
+    expect(iou).toBeLessThan(0.5);
   });
 });

--- a/tests/unit/roi-region.test.ts
+++ b/tests/unit/roi-region.test.ts
@@ -197,6 +197,19 @@ describe("rectIoU (S5 OQ-10 dedup metric)", () => {
     ).toBeCloseTo(50 / 150, 6);
   });
 
+  it("hits exactly 0.5 at the dedup threshold boundary (>= drops)", () => {
+    // Construct IoU == 0.5 exactly: inter / (A + B - inter) = 0.5 ⟺ inter = A+B-inter
+    // ⟺ 2*inter = A+B. Two 10x10 rects (A=B=100) need inter=100 → identical... so
+    // use different sizes: A=10x10=100, B fully inside A but 100 too → use a 10x10
+    // and a rect that overlaps with inter=100/... Instead: A=20x10=200, B=10x10=100
+    // fully inside A → inter=100, union=200+100-100=200 → IoU=0.5 exactly.
+    const a = { x: 0, y: 0, width: 20, height: 10 }; // area 200
+    const b = { x: 0, y: 0, width: 10, height: 10 }; // area 100, fully inside a
+    expect(rectIoU(a, b)).toBe(0.5);
+    // ROI_DEDUP_IOU uses `>= 0.5`, so this pair would dedup (drop the preview).
+    expect(rectIoU(a, b)).toBeGreaterThanOrEqual(0.5);
+  });
+
   it("a half-contained quarter-overlap clears/misses the 0.5 dedup gate as expected", () => {
     // 25% area overlap → IoU = 25/(100+100-25) = 25/175 ≈ 0.143 < 0.5 (kept).
     const iou = rectIoU(


### PR DESCRIPTION
## ADR-024 Seed-2 — S5 (fold) — the walking skeleton's payoff

Stacks on S1–S4 (all merged). **First phase where the act response shape changes** (additive, gated). A successful `desktop_act` on a **visual-only** target now carries a `roiCapture` (diff-region crop + lease-less entity preview), folding `act → desktop_state → screenshot` (2-3 round-trips) into a single `act` — the North Star.

### Design choice (confirmed with maintainer): Option A — additive
The post-touch full-window OCR runs inside `touch()` (for the diff) **before** the handler's `buildRoiCapture`. Rather than restructure the touch lifecycle now, S5 **adds** the ROI-OCR alongside (visual-only act does a second, ROI-scoped OCR pass). The order-trap compute optimization (replace the post-touch full-window OCR with the ROI-OCR — parent ADR §5 option II) is **deferred to S5b**. The round-trip North Star is achieved either way.

### Changes
- **`tryVerifyAnyChange`** — opts into the S3a dirty-rect surface (`includeDirtyRects:true`) and splits `{ observation, dirtyRects }`. The rects feed `buildRoiCapture`; the clean observation goes on `result.observation` (dirtyRects never reach serialized telemetry).
- **`buildRoiCapture`** (now async) folds: gate (visual-only + motion) → `filterDirtyRectsToWindow` (S3b) → `boundingBox` → single window-relative ROI → `runSomPipeline(roi)` (S4) → `somImage` crop + `SomElement[]` → lease-less `RoiPreviewEntity[]` (OQ-8 (b) MVP), **deduped against the discover snapshot** via IoU ≥ 0.5 (OQ-10) so the preview highlights only what changed.
- **`boundingBox` / `rectIoU`** — new pure helpers in `_roi-region.ts`.
- **`getDiscoverEntityRectsForViewId`** — new facade accessor (screen-abs discover rects for the dedup).

### Coordinate alignment (please scrutinize)
`filterDirtyRectsToWindow`'s basis (`getWindowRectByHwnd`) and `runSomPipeline`'s origin (`enumWindowsInZOrder` region) **both come from the same native `win32GetWindowRect`**, so the window-relative ROI maps 1:1 into the OCR buffer. (Minimized windows use a different region, but a visual-only act targets the foreground → degrades to roiCapture-absent.)

### Graceful degrade
roiCapture is absent on every miss (gate declines / no dirty rects / no hwnd / ROI misses window / OCR threw or rendered nothing). Non-visual-only / no-change paths stay bit-equal.

### Tests
`boundingBox` (5) + `rectIoU` (5) pure cases; existing roi-region/gate/flag-persistence/desktop-register/desktop-facade suites green (146 passed). `buildRoiCapture`'s native-OCR orchestration is covered by S6 e2e. Full suite **4199 passed**; the 2 failures (ui-pattern-store PERSIST-10 debounce-timer, terminal-console-paste-load L2 clipboard-contention) are pre-existing parallel-load flakes — both pass on isolated rerun, zero link to this change.

Plan: `desktop-touch-mcp-internal@6f77d7d:docs/adr-024-seed2-plan.md` (§2 S5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)