### PR TITLE
feat(desktop_act): S5c-1a — frame-diff motion for visual-only acts (ADR-024 dogfood F1/F2 fix)

### DIFF
--- a/src/tools/desktop-register.ts
+++ b/src/tools/desktop-register.ts
@@ -622,26 +622,35 @@ export const desktopActRawHandler = async (
   let postVerify: { observation: VisualMotionObservation; dirtyRects: Rect[] } | null = null;
   let frameDiffObservation: VisualMotionObservation | undefined;
   if (result.ok && postVerifyEnabled) {
-    if (visualOnly && preFrame !== null && frameDiffHwnd !== null && frameDiffWindowRect !== null) {
-      // Visual-only — frame-diff motion via the existing Stage 4 orchestrator
-      // (caller pre-frame + capturePostFrameUntilStable settle + native SIMD
-      // computeChangeFraction/SSIM). Its background-animation guard degrades to
-      // `indeterminate`, which the gate excludes (so a noisy desktop yields no
-      // spurious roiCapture = F1). `observation.source` becomes `ssim_residual`
-      // (frame-diff family) on this path only; non-visual stays `dxgi_dirty_rect`.
-      frameDiffObservation = await verifyLocalRepaint({
-        hwnd: frameDiffHwnd,
-        hint: {
-          windowRect: frameDiffWindowRect,
-          ...(frameDiffPoint !== null && { point: frameDiffPoint }),
-        },
-        preFrame,
-      });
-      (result as { observation?: VisualMotionObservation }).observation = frameDiffObservation;
+    if (visualOnly) {
+      // Visual-only — frame-diff ONLY. Never fall back to the DXGI verifier:
+      // DXGI is exactly the occlusion-blind / drain-race path this phase replaces,
+      // so a visual-only frame-diff *miss* (capture/hwnd/rect unavailable) must
+      // degrade to no observation — NOT reintroduce F1/F2 via DXGI (Codex PR #431
+      // round 2 P2). With no observation the gate sees `motion=undefined` and
+      // declines (except `returnCapture:"always"`, whose full-window fallback in
+      // buildRoiCapture still applies — a best-effort capture, never DXGI motion).
+      if (preFrame !== null && frameDiffHwnd !== null && frameDiffWindowRect !== null) {
+        // Stage 4 orchestrator: caller pre-frame + capturePostFrameUntilStable
+        // settle + native SIMD computeChangeFraction/SSIM. Its background-animation
+        // guard degrades to `indeterminate`, which the gate excludes (so a noisy
+        // desktop yields no spurious roiCapture = F1). `observation.source` becomes
+        // `ssim_residual` (frame-diff family) on this path only.
+        frameDiffObservation = await verifyLocalRepaint({
+          hwnd: frameDiffHwnd,
+          hint: {
+            windowRect: frameDiffWindowRect,
+            ...(frameDiffPoint !== null && { point: frameDiffPoint }),
+          },
+          preFrame,
+        });
+        (result as { observation?: VisualMotionObservation }).observation = frameDiffObservation;
+      }
+      // else: frame-diff setup missed → degrade silently (no observation, no DXGI).
     } else {
-      // Non-visual-only — existing DXGI Stage 5 path. `dirtyRects` is an internal
-      // ROI-source channel for buildRoiCapture (S3a), kept off the public
-      // `result.observation` telemetry by the split in tryVerifyAnyChange.
+      // Non-visual-only — existing DXGI Stage 5 path (byte-equal). `dirtyRects` is
+      // an internal ROI-source channel for buildRoiCapture (S3a), kept off the
+      // public `result.observation` telemetry by the split in tryVerifyAnyChange.
       postVerify = await tryVerifyAnyChange(facade, input.lease.viewId);
       if (postVerify !== null) {
         (result as { observation?: VisualMotionObservation }).observation = postVerify.observation;
@@ -663,7 +672,11 @@ export const desktopActRawHandler = async (
       frameDiffObservation ?? postVerify?.observation,
       postVerify?.dirtyRects ?? [],
       input.returnCapture,
-      frameDiffObservation !== undefined ? "frame_diff" : "dxgi",
+      // Source is regime-determined: buildRoiCapture's gate only passes for
+      // visual-only targets (the frame-diff regime), so a visual-only capture
+      // is always `frame_diff` — including the `returnCapture:"always"` full-
+      // window fallback when the frame-diff observation was a miss.
+      visualOnly ? "frame_diff" : "dxgi",
     );
     if (roiCapture !== undefined) {
       (result as { roiCapture?: RoiCapture }).roiCapture = roiCapture;
@@ -787,7 +800,11 @@ async function buildRoiCapture(
   });
   if (!gatePassed) return undefined;
 
-  const hwnd = facade.resolveHwndForViewId(viewId);
+  // buildRoiCapture only runs for visual-only targets (the gate above), so the
+  // SoM crop must come from the SAME window the frame-diff motion used — resolve
+  // the target window by title, not foreground, for consistency with
+  // verifyLocalRepaint (Codex PR #431 round 2 P2, same axis as the motion path).
+  const hwnd = await facade.resolveTargetHwndForFrameDiff(viewId);
   if (hwnd === null) return undefined;
   const windowRect = getWindowRectByHwnd(hwnd);
   if (windowRect === null || windowRect.width <= 0 || windowRect.height <= 0) {

--- a/src/tools/desktop-register.ts
+++ b/src/tools/desktop-register.ts
@@ -592,7 +592,10 @@ export const desktopActRawHandler = async (
   let frameDiffWindowRect: { x: number; y: number; width: number; height: number } | null = null;
   let frameDiffPoint: { x: number; y: number } | null = null;
   if (postVerifyEnabled && visualOnly) {
-    frameDiffHwnd = facade.resolveHwndForViewId(input.lease.viewId);
+    // Resolve the TARGET window (not foreground): the pre-frame is captured
+    // before the click, so a not-yet-foreground windowTitle target must still
+    // diff the right window (Codex PR #431 P2).
+    frameDiffHwnd = await facade.resolveTargetHwndForFrameDiff(input.lease.viewId);
     if (frameDiffHwnd !== null) {
       const wr = getWindowRectByHwnd(frameDiffHwnd);
       if (wr !== null && wr.width > 0 && wr.height > 0) {

--- a/src/tools/desktop-register.ts
+++ b/src/tools/desktop-register.ts
@@ -63,6 +63,8 @@ import {
 } from "../engine/win32.js";
 import { computeViewportPosition } from "../utils/viewport-position.js";
 import { verifyAnyChange } from "../engine/any-change.js";
+import { captureFrame, type RawFrame } from "../engine/layer-buffer.js";
+import { verifyLocalRepaint } from "../engine/local-repaint.js";
 import { disposeSharedDirtyRectBroker } from "../engine/dxgi-broker.js";
 import type { VisualMotionObservation } from "./_input-pipeline.js";
 import { shouldReturnRoiCapture, type ReturnCaptureMode } from "./_roi-capture-gate.js";
@@ -571,6 +573,43 @@ export const desktopActRawHandler = async (
     return failCode("InvalidArgs", validationError, { suggest: getSuggestsForCode("InvalidArgs") });
   }
   const facade = getDesktopFacade();
+
+  // ADR-024 Seed-2 S5c-1a — for visual-only targets, derive the post-action
+  // motion verdict (and, via buildRoiCapture, the ROI) from a true window
+  // frame-diff rather than DXGI dirty rects. A PrintWindow pre/post diff captures
+  // only the target window's own pixels (occlusion-immune) and never touches the
+  // DXGI dirty-rect broker, so it sidesteps both dogfood defects: F1 (occlusion-
+  // blind geometry filter) and F2 (the same-process DirtyRectRouter draining the
+  // frame before the act polls). See adr-024-seed2-dogfood-findings. The pre-
+  // action frame MUST be captured BEFORE the touch, so resolve the visual-only
+  // flag + window geometry up front. Non-visual-only targets are untouched: they
+  // keep the DXGI tryVerifyAnyChange path and their `result.observation` stays
+  // byte-equal (ADR-019 Stage 5 telemetry contract; S5c review R2-P1).
+  const postVerifyEnabled = process.env["DESKTOP_TOUCH_STAGE5_DXGI"] !== "0";
+  const visualOnly = facade.resolveVisualOnlyForViewId(input.lease.viewId);
+  let preFrame: RawFrame | null = null;
+  let frameDiffHwnd: bigint | null = null;
+  let frameDiffWindowRect: { x: number; y: number; width: number; height: number } | null = null;
+  let frameDiffPoint: { x: number; y: number } | null = null;
+  if (postVerifyEnabled && visualOnly) {
+    frameDiffHwnd = facade.resolveHwndForViewId(input.lease.viewId);
+    if (frameDiffHwnd !== null) {
+      const wr = getWindowRectByHwnd(frameDiffHwnd);
+      if (wr !== null && wr.width > 0 && wr.height > 0) {
+        frameDiffWindowRect = wr;
+        // Focal point for the frame-diff = the clicked entity's centre, so the
+        // diff clips to a padded region around the expected change rather than
+        // diluting a small localized repaint across the whole window (→ false
+        // `indeterminate`). Resolved before the touch from the discover snapshot.
+        frameDiffPoint = facade.resolveEntityCenterForViewId(
+          input.lease.viewId,
+          input.lease.entityId,
+        );
+        preFrame = await captureFrame(frameDiffHwnd, wr);
+      }
+    }
+  }
+
   const result = await facade.touch({
     lease: input.lease,
     action: input.action,
@@ -578,30 +617,50 @@ export const desktopActRawHandler = async (
   });
 
   let postVerify: { observation: VisualMotionObservation; dirtyRects: Rect[] } | null = null;
-  if (result.ok && process.env["DESKTOP_TOUCH_STAGE5_DXGI"] !== "0") {
-    postVerify = await tryVerifyAnyChange(facade, input.lease.viewId);
-    if (postVerify !== null) {
-      // Attach the motion verdict to the serialized response. `dirtyRects` is an
-      // internal ROI-source channel for buildRoiCapture (S3a) — it is NOT part
-      // of the public observation telemetry, so the split in tryVerifyAnyChange
-      // keeps it off `result.observation`.
-      (result as { observation?: VisualMotionObservation }).observation = postVerify.observation;
+  let frameDiffObservation: VisualMotionObservation | undefined;
+  if (result.ok && postVerifyEnabled) {
+    if (visualOnly && preFrame !== null && frameDiffHwnd !== null && frameDiffWindowRect !== null) {
+      // Visual-only — frame-diff motion via the existing Stage 4 orchestrator
+      // (caller pre-frame + capturePostFrameUntilStable settle + native SIMD
+      // computeChangeFraction/SSIM). Its background-animation guard degrades to
+      // `indeterminate`, which the gate excludes (so a noisy desktop yields no
+      // spurious roiCapture = F1). `observation.source` becomes `ssim_residual`
+      // (frame-diff family) on this path only; non-visual stays `dxgi_dirty_rect`.
+      frameDiffObservation = await verifyLocalRepaint({
+        hwnd: frameDiffHwnd,
+        hint: {
+          windowRect: frameDiffWindowRect,
+          ...(frameDiffPoint !== null && { point: frameDiffPoint }),
+        },
+        preFrame,
+      });
+      (result as { observation?: VisualMotionObservation }).observation = frameDiffObservation;
+    } else {
+      // Non-visual-only — existing DXGI Stage 5 path. `dirtyRects` is an internal
+      // ROI-source channel for buildRoiCapture (S3a), kept off the public
+      // `result.observation` telemetry by the split in tryVerifyAnyChange.
+      postVerify = await tryVerifyAnyChange(facade, input.lease.viewId);
+      if (postVerify !== null) {
+        (result as { observation?: VisualMotionObservation }).observation = postVerify.observation;
+      }
     }
   }
 
   // ADR-024 Seed-2 S5 — fold the post-action ROI capture into the act response
   // for visual-only targets. `buildRoiCapture` gates on the visual-only regime +
-  // motion verdict, then turns the S3a dirty rects into a window-relative ROI
-  // (S3b), OCRs only that region (S4), and assembles `{roi, somImage, entities}`.
+  // motion verdict, then assembles `{roi, somImage, entities, source}`. S5c-1a:
+  // on the frame-diff path the ROI is provisionally the whole window (empty
+  // dirtyRects → full-window fallback); the localized bbox lands in S5c-1b.
   // Absent (gate declines / no change / no ROI) → response stays bit-equal with
   // the pre-Seed-2 shape (additive — existing destructures unaffected).
   if (result.ok) {
     const roiCapture = await buildRoiCapture(
       facade,
       input.lease.viewId,
-      postVerify?.observation,
+      frameDiffObservation ?? postVerify?.observation,
       postVerify?.dirtyRects ?? [],
       input.returnCapture,
+      frameDiffObservation !== undefined ? "frame_diff" : "dxgi",
     );
     if (roiCapture !== undefined) {
       (result as { roiCapture?: RoiCapture }).roiCapture = roiCapture;
@@ -712,6 +771,10 @@ async function buildRoiCapture(
   observation: VisualMotionObservation | undefined,
   dirtyRects: Rect[],
   returnCapture: ReturnCaptureMode | undefined,
+  // S5c-1a — ROI provenance label for the assembled capture. `frame_diff` on the
+  // visual-only PrintWindow path (dirtyRects empty → full-window ROI until the
+  // S5c-1b bbox lands); `dxgi` on the legacy dirty-rect path.
+  source: RoiCapture["source"],
 ): Promise<RoiCapture | undefined> {
   const gatePassed = shouldReturnRoiCapture({
     ok: true, // only called on the success path
@@ -752,7 +815,7 @@ async function buildRoiCapture(
       facade.getDiscoverEntitiesForViewId(viewId),
     );
 
-    return { roi, somImage: som.somImage.base64, entities, source: "dxgi" };
+    return { roi, somImage: som.somImage.base64, entities, source };
   } catch (err) {
     // OCR is best-effort; never break the act envelope on a pipeline failure.
     console.error(

--- a/src/tools/desktop.ts
+++ b/src/tools/desktop.ts
@@ -645,6 +645,27 @@ export class DesktopFacade {
       .map((e) => ({ rect: e.rect, label: e.label ?? "" }));
   }
 
+  /**
+   * ADR-024 Seed-2 S5c-1a — screen-absolute centre of the entity a lease points
+   * at, used as the focal `hint.point` for the visual-only frame-diff motion
+   * verdict (`verifyLocalRepaint`). Without a focal point the diff runs over the
+   * whole window, so a small localized change (a click that repaints ~few % of
+   * the window) is diluted below the SSIM delivery threshold and degrades to
+   * `indeterminate`. The clicked entity's centre is where the change is expected,
+   * so a padded region around it captures the repaint. Returns `null` when the
+   * session/entity is gone or the entity carries no rect.
+   */
+  resolveEntityCenterForViewId(viewId: string, entityId: string): { x: number; y: number } | null {
+    const session = this.registry.getByViewId(viewId, this.opts.nowFn);
+    if (!session) return null;
+    const entity = session.entities.find((e) => e.entityId === entityId);
+    if (!entity?.rect) return null;
+    return {
+      x: Math.round(entity.rect.x + entity.rect.width / 2),
+      y: Math.round(entity.rect.y + entity.rect.height / 2),
+    };
+  }
+
   validateLeaseOnly(lease: EntityLease): LeaseValidationResult {
     const session = this.registry.getByViewId(lease.viewId, this.opts.nowFn);
     if (!session) {

--- a/src/tools/desktop.ts
+++ b/src/tools/desktop.ts
@@ -14,7 +14,7 @@ import {
 } from "../engine/world-graph/session-registry.js";
 import type { CandidateIngress } from "../engine/world-graph/candidate-ingress.js";
 import { createDesktopExecutor, type ExecutorDeps } from "./desktop-executor.js";
-import { resolveWindowTarget } from "./_resolve-window.js";
+import { resolveWindowTarget, findPlainTopLevelWindowByTitle } from "./_resolve-window.js";
 import type { TouchAction, TouchResult } from "../engine/world-graph/guarded-touch.js";
 import { deriveViewConstraints, type ViewConstraints, type EntityCapabilities } from "./desktop-constraints.js";
 import { UIA_BLIND_WARNINGS } from "./desktop-providers/compose-providers.js";
@@ -648,6 +648,19 @@ export class DesktopFacade {
       }
     }
     if (target?.windowTitle) {
+      // `resolveWindowTarget` deliberately returns null for a plain top-level
+      // window (it only special-cases `@active` + dialogs, _resolve-window.ts
+      // Case 3), so a plain title would otherwise fall through to foreground —
+      // defeating the fix (Codex PR #431 round 2 P2). Resolve plain titles via
+      // the top-level-by-title SSOT first (the same predicate discover's title
+      // flow relies on), then fall back to `resolveWindowTarget` for the
+      // `@active` / dialog cases.
+      try {
+        const win = findPlainTopLevelWindowByTitle(target.windowTitle, { excludeMinimized: true });
+        if (win) return typeof win.hwnd === "bigint" ? win.hwnd : BigInt(win.hwnd);
+      } catch {
+        // enum failure — fall through.
+      }
       try {
         const resolved = await resolveWindowTarget({ windowTitle: target.windowTitle });
         if (resolved) return resolved.hwnd;

--- a/src/tools/desktop.ts
+++ b/src/tools/desktop.ts
@@ -14,6 +14,7 @@ import {
 } from "../engine/world-graph/session-registry.js";
 import type { CandidateIngress } from "../engine/world-graph/candidate-ingress.js";
 import { createDesktopExecutor, type ExecutorDeps } from "./desktop-executor.js";
+import { resolveWindowTarget } from "./_resolve-window.js";
 import type { TouchAction, TouchResult } from "../engine/world-graph/guarded-touch.js";
 import { deriveViewConstraints, type ViewConstraints, type EntityCapabilities } from "./desktop-constraints.js";
 import { UIA_BLIND_WARNINGS } from "./desktop-providers/compose-providers.js";
@@ -609,6 +610,52 @@ export class DesktopFacade {
         // Intentionally fall through to the foreground resolver below.
       }
     }
+    if (!this.opts.getFocusedHwnd) return null;
+    try {
+      return this.opts.getFocusedHwnd();
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * ADR-024 Seed-2 S5c-1a — resolve the HWND of the window the lease's session
+   * actually targets, for the visual-only frame-diff pre/post capture.
+   *
+   * This deliberately does NOT reuse `resolveHwndForViewId` (the ADR-019 Stage 5
+   * resolver, which foreground-falls-back for `windowTitle` targets). That
+   * fallback is sound for Stage 5 because its DXGI poll runs *after* the action,
+   * by which point clicking the target has usually brought it to the foreground.
+   * The frame-diff captures its PRE frame *before* the click, so a `windowTitle`
+   * target that is not yet foreground would otherwise diff the wrong (foreground)
+   * window and report `no_change` (Codex PR #431 P2). Resolve `windowTitle → hwnd`
+   * via the same `resolveWindowTarget` the discover providers use
+   * (`compose-providers.ts`), so we capture the exact window discover enumerated.
+   * A pinned `hwnd` is used directly; a target with neither (the bare
+   * `desktop_discover()` foreground flow) falls back to the foreground HWND, which
+   * is the honest target there. Returns `null` when the session is gone or no
+   * window resolves. Never throws.
+   */
+  async resolveTargetHwndForFrameDiff(viewId: string): Promise<bigint | null> {
+    const session = this.registry.getByViewId(viewId, this.opts.nowFn);
+    if (!session) return null;
+    const target = session.lastTarget;
+    if (target?.hwnd) {
+      try {
+        return BigInt(target.hwnd);
+      } catch {
+        // Malformed pinned hwnd — fall through to title / foreground resolution.
+      }
+    }
+    if (target?.windowTitle) {
+      try {
+        const resolved = await resolveWindowTarget({ windowTitle: target.windowTitle });
+        if (resolved) return resolved.hwnd;
+      } catch {
+        // Resolution failure — fall through to foreground.
+      }
+    }
+    // Bare `desktop_discover()` (no hwnd / no title) → foreground is the target.
     if (!this.opts.getFocusedHwnd) return null;
     try {
       return this.opts.getFocusedHwnd();

--- a/tests/unit/roi-capture-flag-persistence.test.ts
+++ b/tests/unit/roi-capture-flag-persistence.test.ts
@@ -97,3 +97,36 @@ describe("ADR-024 Seed-2 — visual-only flag persistence (discover → act)", (
     expect(facade.resolveVisualOnlyForViewId(v2)).toBe(false);
   });
 });
+
+// ADR-024 Seed-2 S5c-1a — the visual-only frame-diff motion verdict
+// (verifyLocalRepaint) needs a focal `hint.point` so a small localized repaint
+// is not diluted across the whole window (→ false `indeterminate`). The act
+// wrapper uses the clicked entity's screen-absolute centre, resolved from the
+// discover snapshot by lease (viewId + entityId).
+describe("ADR-024 Seed-2 S5c-1a — resolveEntityCenterForViewId (frame-diff focal point)", () => {
+  const discoverEntity = async (facade: DesktopFacade) => {
+    const out = await facade.see({ target: { windowTitle: "Canvas" } });
+    return out.entities[0];
+  };
+
+  it("returns the screen-absolute centre of the clicked entity's rect", async () => {
+    // cand("Foo") rect = { x: 10, y: 20, width: 80, height: 30 } → centre (50, 35).
+    const facade = facadeWith(["uia_blind_single_pane"]);
+    const ent = await discoverEntity(facade);
+    expect(facade.resolveEntityCenterForViewId(ent.lease.viewId, ent.entityId)).toEqual({
+      x: 50,
+      y: 35,
+    });
+  });
+
+  it("returns null for an unknown viewId (no session)", () => {
+    const facade = new DesktopFacade(() => []);
+    expect(facade.resolveEntityCenterForViewId("never-issued-view-id", "ent-x")).toBeNull();
+  });
+
+  it("returns null for an unknown entityId within a known view", async () => {
+    const facade = facadeWith(["uia_blind_single_pane"]);
+    const ent = await discoverEntity(facade);
+    expect(facade.resolveEntityCenterForViewId(ent.lease.viewId, "ent-does-not-exist")).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

ADR-024 Seed-2 **S5c-1a**. A manual live dogfood of the shipped S5 `roiCapture` surfaced two correctness defects on a real (busy) desktop. This routes the visual-only post-action motion verdict through a **true window frame-diff** instead of DXGI dirty rects, fixing both.

## Why (dogfood findings, Opus-reviewed)

- **F1 — occlusion-blind geometry filter**: `filterDirtyRectsToWindow` is pure geometry / z-order-blind, and DXGI dirty rects are per-output, so background activity (e.g. a video) that overlaps the opaque, top-most target window's rect was passed through → spurious `motion=any_change` on a static window + a ROI locked onto a noise sliver.
- **F2 — action change missed**: the same-process vision-gpu `DirtyRectRouter` fan-out drains the DXGI frame (drain-once) before the act's `sub.next()` cursor is placed → the action's real change read as `no_change`.

Root-caused + reviewed across 3 Opus rounds; see `adr-024-seed2-dogfood-findings.md` and the S5c design in the plan (private repo).

## How

- Capture a pre-action frame (`captureFrame` / PrintWindow) **before** the touch, gated on the visual-only flag → structured targets pay nothing and keep their DXGI observation **byte-equal** (ADR-019 Stage 5 telemetry contract).
- After the touch, reuse `verifyLocalRepaint` (caller pre-frame + settle + native-SIMD `computeChangeFraction`/SSIM). PrintWindow captures only the target window's pixels (**occlusion-immune → F1**); no DXGI broker dependency (**→ F2 drain race gone**). Its background-animation guard degrades to `indeterminate`, which the gate excludes.
- Focal `hint.point` = the clicked entity's screen-absolute centre (new `DesktopFacade.resolveEntityCenterForViewId`) so a small localized repaint isn't diluted across the whole window into a false `indeterminate`.
- `roiCapture.source` is `"frame_diff"`; ROI is provisionally the whole window (empty dirtyRects → full-window fallback) until the **S5c-1b** bbox.

Non-visual-only acts are unchanged (DXGI `tryVerifyAnyChange`, byte-equal).

## Verification

Re-dogfooded on a self-contained visual-only canvas (single full-bleed Panel = `uia_blind_single_pane`, click paints a localized rectangle):

| scenario | before (S5/DXGI) | after (S5c-1a/frame-diff) |
|---|---|---|
| clean bg + change | `no_change` (missed, F2) | **`local_repaint`** + roiCapture(frame_diff) |
| busy bg + change | noise ROI (F1) | **`local_repaint`** (change caught despite overlap) |
| busy bg + no change | `any_change` (spurious, F1) | **`no_change`** + roiCapture absent |

Build clean; unit suite green (new `resolveEntityCenterForViewId` tests + existing roiCapture gate/flag tests).

## Scope / follow-ups (this is S5c-1a of a 3-part fix)

- **S5c-1b**: native bbox aggregation (SIMD scan) → localized ROI instead of full-window; `source` branch for the BitBlt-fallback (occlusion-inclusive) case → full-window degrade.
- **S5c-2**: occlusion/race regression tests (live desktop).

Known 1a limitation: `verifyLocalRepaint`'s `MAX_RECT_AREA_PX` cap means very large visual-only windows degrade to `indeterminate` → roiCapture absent (relaxed in 1b).

Plan: `desktop-touch-mcp-internal@ce5d565:docs/adr-024-seed2-plan.md` (S5c-1a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)