### PR TITLE
feat(desktop_act): S5c-1b — native bbox localizes visual-only ROI to the changed region

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -248,11 +248,25 @@ export interface NativeSsimCentroid {
   y: number
 }
 
+/** ADR-024 Seed-2 S5c-1b — bbox of above-threshold windows (same basis as
+ *  centroid; crop-local when called with region=null). Omitted (NOT null)
+ *  when no window crossed the threshold. */
+export interface NativeSsimBbox {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
 export interface NativeSsimResidualResult {
   fractionChanged: number
   /** Omitted (NOT null) when `fractionChanged === 0`. Use `result.centroid != null`
    *  to handle both napi-rs omission and a hypothetical future explicit null. */
   centroid?: NativeSsimCentroid
+  /** ADR-024 Seed-2 S5c-1b — bbox of above-threshold windows. Omitted (NOT
+   *  null) when no window crossed the threshold / graceful-degrade paths.
+   *  Use `result.bbox != null`. */
+  bbox?: NativeSsimBbox
   /** Mean SSIM across all windows; exposed via
    *  `VisualMotionObservation.residual.meanSsim` (Stage 4 sub-plan §4 P15). */
   meanSsim: number

--- a/src/engine/layer-buffer.ts
+++ b/src/engine/layer-buffer.ts
@@ -6,7 +6,12 @@
  * Only changed layers are re-sent on subsequent captures (MPEG P-frame style).
  */
 
-import { encodeToWebPFromRaw, dHashFromRaw, captureWindowRawWithFallback } from "./image.js";
+import {
+  encodeToWebPFromRaw,
+  dHashFromRaw,
+  captureWindowRawWithFallback,
+  type CaptureSource,
+} from "./image.js";
 import { nativeEngine } from "./native-engine.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -132,7 +137,7 @@ async function captureWindowRaw(
   hwnd: bigint,
   region: { x: number; y: number; width: number; height: number },
 ): Promise<{
-  rawPixels: Buffer; channels: 3 | 4; width: number; height: number;
+  rawPixels: Buffer; channels: 3 | 4; width: number; height: number; source: CaptureSource;
 } | null> {
   try {
     // PrintWindow primary + BitBlt fallback. Each captured layer is now sourced
@@ -144,6 +149,11 @@ async function captureWindowRaw(
       channels: raw.channels,
       width: raw.width,
       height: raw.height,
+      // ADR-024 Seed-2 S5c-1b — surface the capture provenance so the frame-diff
+      // ROI path can tell a true-PrintWindow (occlusion-immune) frame from a
+      // BitBlt fallback (occlusion-inclusive screen grab) and demote the ROI to
+      // full-window when immunity is unavailable (P1-1).
+      source: raw.source,
     };
   } catch {
     return null;
@@ -477,6 +487,17 @@ export type RawFrame = {
   width: number;
   height: number;
   channels: 3 | 4;
+  /**
+   * ADR-024 Seed-2 S5c-1b — which capture backend produced this frame.
+   * `"printwindow"` = the window's own pixels (occlusion-immune); a
+   * `"bitblt-fallback"` is a screen-rect grab (occlusion-inclusive) that
+   * PrintWindow degraded to on an all-black frame. Optional + additive:
+   * existing Stage 2a/4 consumers (`_mouse-verify.ts`, `keyboard.ts`,
+   * `capturePostFrameUntilStable`, the scroll smart-diff path) ignore it and
+   * stay byte-equal. Only the visual-only frame-diff ROI path reads it, to
+   * demote the ROI to full-window when immunity is unavailable (P1-1).
+   */
+  source?: CaptureSource;
 };
 
 /**

--- a/src/engine/local-repaint.ts
+++ b/src/engine/local-repaint.ts
@@ -24,6 +24,7 @@
  */
 
 import type { VisualMotionObservation } from "../tools/_input-pipeline.js";
+import type { Rect } from "./vision-gpu/types.js";
 import { nativeEngine } from "./native-engine.js";
 import {
   capturePostFrameUntilStable,
@@ -248,6 +249,20 @@ export async function verifyLocalRepaint(opts: {
    *  / `unverifiable` and `keyboard.ts` BG verify reaching its terminal
    *  `unverifiable + read_back_unsupported` sink). */
   preFrame: RawFrame | null;
+  /**
+   * ADR-024 Seed-2 S5c-1b — opt-in: when `true`, attach the **window-relative**
+   * changed-region bounding box to the returned observation as `roiBbox` on the
+   * positive `local_repaint` path. Default `false` — every existing caller
+   * (`_mouse-verify.ts`, `keyboard.ts`, bench, tests) leaves it off and their
+   * observation stays byte-equal (additive optional field). Only the
+   * visual-only `desktop_act` ROI path passes `true`; the act handler then
+   * splits `roiBbox` off before serializing `result.observation` so it never
+   * reaches the public Stage 5 telemetry envelope. The bbox is emitted ONLY
+   * when the capture was occlusion-immune (pre AND post both PrintWindow, not
+   * the BitBlt fallback) — otherwise the consumer falls back to full-window
+   * (P1-1).
+   */
+  includeRoiBbox?: boolean;
 }): Promise<VisualMotionObservation> {
   const startMs = performance.now();
 
@@ -416,6 +431,44 @@ export async function verifyLocalRepaint(opts: {
   if (fractionChanged >= RESIDUAL_DELIVERED_FRACTION) {
     // Positive delivery — local_repaint observed.
     // P15 decision lock default (a): expose meanSsim on the envelope.
+    //
+    // ADR-024 Seed-2 S5c-1b — when the caller opted in (`includeRoiBbox`),
+    // attach the window-relative changed-region bbox so the visual-only ROI
+    // path can crop to the change instead of the whole window. Two guards:
+    //
+    //  1. **Occlusion immunity (P1-1)**: emit the bbox ONLY when BOTH the pre
+    //     and the final post frame came from PrintWindow (the window's own
+    //     pixels). A BitBlt fallback grabs the screen rect (occlusion-
+    //     inclusive), so its bbox could lock onto background motion — demote to
+    //     full-window by leaving `roiBbox` absent. `source === undefined`
+    //     (capture provenance unavailable) is treated conservatively as
+    //     non-immune. NB: a BitBlt frame also changes the buffer dimensions
+    //     (device vs logical px), so a pre/post source mismatch is already
+    //     caught by the parity guards above (→ `indeterminate`, never reaching
+    //     here) — this check is the explicit, defence-in-depth statement of the
+    //     same invariant, so "occlusion-immune yet roiBbox absent" via the
+    //     parity path is expected, not a bug.
+    //  2. **bbox present**: `ssim.bbox` is omitted when no window crossed the
+    //     residual threshold (cannot happen on this `>= 0.05` branch) or on the
+    //     graceful-degrade single-window path.
+    //
+    // Coordinate basis: `compute_ssim_residual` ran with `region = null` over
+    // the **already-cropped** `localRect` buffer, so `ssim.bbox` is crop-local
+    // (origin = localRect top-left). `localRect` is itself window-relative
+    // (rect minus windowRect origin, see Step 2.5), so adding `localRect.{x,y}`
+    // lifts the bbox to window-relative coordinates — exactly the basis
+    // `RoiCapture.roi` expects.
+    const occlusionImmune =
+      opts.preFrame.source === "printwindow" && finalStable.source === "printwindow";
+    const roiBbox: Rect | undefined =
+      opts.includeRoiBbox === true && occlusionImmune && ssim.bbox != null
+        ? {
+            x: localRect.x + ssim.bbox.x,
+            y: localRect.y + ssim.bbox.y,
+            width: ssim.bbox.width,
+            height: ssim.bbox.height,
+          }
+        : undefined;
     return {
       motion: "local_repaint",
       source: "ssim_residual",
@@ -426,6 +479,7 @@ export async function verifyLocalRepaint(opts: {
         }),
         meanSsim,
       },
+      ...(roiBbox !== undefined && { roiBbox }),
       framesSampled,
       totalElapsedMs,
     };

--- a/src/engine/native-types.ts
+++ b/src/engine/native-types.ts
@@ -221,6 +221,19 @@ export interface NativeSsimCentroid {
   y: number
 }
 
+/** ADR-024 Seed-2 S5c-1b — bounding box of the above-threshold sliding
+ *  windows, same coordinate basis as `NativeSsimCentroid` (region-absolute
+ *  frame pixels; **crop-local** when the caller passes `region = null` over an
+ *  already-cropped buffer, as the visual-only ROI path does). **Omitted**
+ *  (NOT `null`) by napi-rs when no window crossed the threshold — same
+ *  `Option::None` omission semantic as `centroid`. */
+export interface NativeSsimBbox {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
 /** Aggregated SSIM residual over the requested region. `fractionChanged`
  *  is the fraction of 8×8 sliding windows (stride 4) whose `1 - SSIM`
  *  exceeded the per-window residual threshold (0.05 default in
@@ -235,6 +248,10 @@ export interface NativeSsimResidualResult {
    *  to handle both `undefined` (napi-rs omission) and a hypothetical
    *  future explicit `null`. */
   centroid?: NativeSsimCentroid
+  /** ADR-024 Seed-2 S5c-1b — bounding box of above-threshold windows. Omitted
+   *  (NOT `null`) when no window crossed the threshold and on the graceful-
+   *  degrade single-window / zero-grid paths. Use `result.bbox != null`. */
+  bbox?: NativeSsimBbox
   meanSsim: number
 }
 

--- a/src/ssim.rs
+++ b/src/ssim.rs
@@ -57,6 +57,23 @@ pub struct SsimCentroid {
     pub y: f64,
 }
 
+/// ADR-024 Seed-2 S5c-1b — bounding box of the above-threshold sliding
+/// windows, in the same coordinate basis as the centroid (region coordinates
+/// when a `region` is supplied, else absolute frame coordinates). The
+/// visual-only ROI-capture path calls `compute_ssim_residual` with
+/// `region = None` over an already-cropped pre/post buffer, so the bbox is
+/// **crop-local** there (the caller adds the crop origin to lift it to
+/// window-relative coordinates). Omitted (napi-rs `Option::None` → field
+/// absent, NOT `null`) when no window crossed the residual threshold, mirroring
+/// the `centroid` omission semantic.
+#[napi(object)]
+pub struct SsimBbox {
+    pub x: u32,
+    pub y: u32,
+    pub width: u32,
+    pub height: u32,
+}
+
 #[napi(object)]
 pub struct SsimResidualResult {
     /// Fraction of 8×8 sliding windows whose `1 - SSIM` exceeded
@@ -68,6 +85,13 @@ pub struct SsimResidualResult {
     /// coordinates). Omitted when `fraction_changed === 0` (no changed
     /// windows to mean).
     pub centroid: Option<SsimCentroid>,
+    /// ADR-024 Seed-2 S5c-1b — outer bounding box (min/max corners) of the
+    /// above-threshold windows, same coordinate basis as `centroid`. Omitted
+    /// when no window crossed the threshold (and on the graceful-degrade
+    /// single-window / zero-grid paths, which have no sliding-window grid to
+    /// aggregate). Used to localize the post-action ROI crop to the changed
+    /// region (P1-2) instead of falling back to the whole window.
+    pub bbox: Option<SsimBbox>,
     /// Mean SSIM across all windows in the region. Useful for the Wang
     /// "perceptually identical" cutoff (≥ 0.99) as a `no_change` disambiguator.
     pub mean_ssim: f64,
@@ -121,6 +145,7 @@ pub fn compute_ssim_residual(
         return Ok(SsimResidualResult {
             fraction_changed: 0.0,
             centroid: None,
+            bbox: None,
             mean_ssim: 1.0,
         });
     }
@@ -139,10 +164,12 @@ pub fn compute_ssim_residual(
             pre, post, width, channels, rx, ry, rw, rh,
         );
         // No sliding window grid — caller sees mean_ssim only, with no
-        // residual fraction (region too small for the 8×8 analysis).
+        // residual fraction (region too small for the 8×8 analysis). No grid
+        // means no above-threshold windows to aggregate → bbox omitted.
         return Ok(SsimResidualResult {
             fraction_changed: 0.0,
             centroid: None,
+            bbox: None,
             mean_ssim: ssim_full.clamp(-1.0, 1.0),
         });
     }
@@ -175,6 +202,7 @@ fn compute_ssim_scalar(
         return Ok(SsimResidualResult {
             fraction_changed: 0.0,
             centroid: None,
+            bbox: None,
             mean_ssim: 1.0,
         });
     }
@@ -183,6 +211,15 @@ fn compute_ssim_scalar(
     let mut sum_ssim: f64 = 0.0;
     let mut centroid_sum_x: f64 = 0.0;
     let mut centroid_sum_y: f64 = 0.0;
+    // ADR-024 Seed-2 S5c-1b — outer corners of above-threshold windows. Each
+    // window spans `[x0, x0 + WINDOW_SIZE) × [y0, y0 + WINDOW_SIZE)`, so the
+    // bbox tracks `min(x0) / min(y0)` and `max(x0 + WINDOW_SIZE) /
+    // max(y0 + WINDOW_SIZE)`. Aggregated in the SAME scan as the centroid (no
+    // extra pass) per the sub-plan "min/max in the existing SIMD scan" mandate.
+    let mut min_x0: u32 = u32::MAX;
+    let mut min_y0: u32 = u32::MAX;
+    let mut max_x1: u32 = 0;
+    let mut max_y1: u32 = 0;
 
     for wy in 0..y_steps {
         let y0 = ry + wy * WINDOW_STRIDE;
@@ -209,24 +246,51 @@ fn compute_ssim_scalar(
                 let cy = y0 as f64 + (WINDOW_SIZE as f64) / 2.0;
                 centroid_sum_x += cx;
                 centroid_sum_y += cy;
+                // Bbox corners (same coordinate basis as the centroid).
+                let x1 = x0 + WINDOW_SIZE;
+                let y1 = y0 + WINDOW_SIZE;
+                if x0 < min_x0 {
+                    min_x0 = x0;
+                }
+                if y0 < min_y0 {
+                    min_y0 = y0;
+                }
+                if x1 > max_x1 {
+                    max_x1 = x1;
+                }
+                if y1 > max_y1 {
+                    max_y1 = y1;
+                }
             }
         }
     }
 
     let fraction_changed = above_count as f64 / total_windows as f64;
     let mean_ssim = sum_ssim / total_windows as f64;
-    let centroid = if above_count > 0 {
-        Some(SsimCentroid {
-            x: centroid_sum_x / above_count as f64,
-            y: centroid_sum_y / above_count as f64,
-        })
+    let (centroid, bbox) = if above_count > 0 {
+        (
+            Some(SsimCentroid {
+                x: centroid_sum_x / above_count as f64,
+                y: centroid_sum_y / above_count as f64,
+            }),
+            // `max_x1 >= min_x0` and `max_y1 >= min_y0` hold whenever
+            // `above_count > 0` (every above-threshold window contributes both a
+            // min and a max corner), so the subtractions never underflow.
+            Some(SsimBbox {
+                x: min_x0,
+                y: min_y0,
+                width: max_x1 - min_x0,
+                height: max_y1 - min_y0,
+            }),
+        )
     } else {
-        None
+        (None, None)
     };
 
     Ok(SsimResidualResult {
         fraction_changed,
         centroid,
+        bbox,
         mean_ssim,
     })
 }
@@ -316,6 +380,7 @@ mod tests {
         let r = compute_ssim_residual(&buf, &buf, 64, 64, 4, None).unwrap();
         assert!(r.fraction_changed.abs() < 1e-9, "fraction_changed should be 0");
         assert!(r.centroid.is_none(), "no centroid for identical frames");
+        assert!(r.bbox.is_none(), "no bbox for identical frames");
         assert!(
             r.mean_ssim >= 0.999,
             "mean_ssim should be ≥ 0.999 for identical frames, got {}",
@@ -376,6 +441,23 @@ mod tests {
             "centroid ({}, {}) should be within 16 px of (100, 100)",
             c.x,
             c.y
+        );
+        // ADR-024 Seed-2 S5c-1b — bbox must enclose the 20×20 black rect
+        // ([90,110) × [90,110)) and be far smaller than the full 200×200 frame.
+        let b = r.bbox.expect("bbox present when fraction > 0");
+        assert!(
+            b.x <= 90 && b.y <= 90 && b.x + b.width >= 110 && b.y + b.height >= 110,
+            "bbox ({}, {}, {}, {}) should enclose the [90,110)×[90,110) rect",
+            b.x,
+            b.y,
+            b.width,
+            b.height
+        );
+        assert!(
+            b.width < 200 && b.height < 200,
+            "bbox ({}×{}) should be smaller than the full 200×200 frame",
+            b.width,
+            b.height
         );
         // mean_ssim should be high (most windows untouched) but < 1.0.
         assert!(
@@ -440,7 +522,97 @@ mod tests {
         let r = compute_ssim_residual(&buf, &buf, 16, 16, 4, Some(region)).unwrap();
         // Identical → mean_ssim ≈ 1.0, no above-threshold windows.
         assert!(r.fraction_changed.abs() < 1e-9);
+        // Graceful-degrade single-window path has no sliding-window grid → no bbox.
+        assert!(r.bbox.is_none(), "single-window degrade must omit bbox");
         assert!(r.mean_ssim >= 0.999);
+    }
+
+    #[test]
+    fn bbox_unions_two_disjoint_patches() {
+        // ADR-024 Seed-2 S5c-1b — two separated changed patches must yield a
+        // single bbox that is the OUTER bounding box of both (min/max corners).
+        let w = 200u32;
+        let h = 200u32;
+        let ch = 4u32;
+        let pre = buf_filled(w, h, ch, 255);
+        let mut post = pre.clone();
+        let stride = (w * ch) as usize;
+        let chan = ch as usize;
+        // Patch A near top-left: [20,40) × [20,40). Patch B near bottom-right:
+        // [150,170) × [150,170).
+        for (rx0, ry0) in [(20usize, 20usize), (150usize, 150usize)] {
+            for y in ry0..ry0 + 20 {
+                for x in rx0..rx0 + 20 {
+                    let i = y * stride + x * chan;
+                    post[i] = 0;
+                    post[i + 1] = 0;
+                    post[i + 2] = 0;
+                }
+            }
+        }
+        let r = compute_ssim_residual(&pre, &post, w, h, ch, None).unwrap();
+        let b = r.bbox.expect("bbox present for two changed patches");
+        // Outer bbox must contain both patches: top-left corner ≤ (20,20),
+        // bottom-right corner ≥ (170,170).
+        assert!(
+            b.x <= 20 && b.y <= 20,
+            "bbox origin ({}, {}) should be ≤ (20, 20)",
+            b.x,
+            b.y
+        );
+        assert!(
+            b.x + b.width >= 170 && b.y + b.height >= 170,
+            "bbox far corner ({}, {}) should be ≥ (170, 170)",
+            b.x + b.width,
+            b.y + b.height
+        );
+    }
+
+    #[test]
+    fn bbox_with_region_is_region_absolute() {
+        // ADR-024 Seed-2 S5c-1b P1-2 — when a `region` IS supplied, the bbox is
+        // in region-absolute (frame) coordinates (x0 = rx + window offset). The
+        // visual-only ROI path relies on the COMPLEMENT of this: it passes
+        // `region = None` over an already-cropped buffer, so the bbox it sees is
+        // crop-local (rx = 0). This test pins the basis so the TS-side origin
+        // translation (`localRect + bbox`) stays correct.
+        let w = 200u32;
+        let h = 200u32;
+        let ch = 4u32;
+        let pre = buf_filled(w, h, ch, 255);
+        let mut post = pre.clone();
+        let stride = (w * ch) as usize;
+        let chan = ch as usize;
+        // Change a patch at [110,130) × [110,130) (frame coords).
+        for y in 110..130usize {
+            for x in 110..130usize {
+                let i = y * stride + x * chan;
+                post[i] = 0;
+                post[i + 1] = 0;
+                post[i + 2] = 0;
+            }
+        }
+        // Region starts at (100, 100): the patch is at region-local (10..30).
+        let region = SsimRegion {
+            x: 100,
+            y: 100,
+            width: 64,
+            height: 64,
+        };
+        let r = compute_ssim_residual(&pre, &post, w, h, ch, Some(region)).unwrap();
+        let b = r.bbox.expect("bbox present");
+        // bbox is region-ABSOLUTE (includes rx=100), NOT region-local — so it
+        // encloses the patch at frame coords [110,130).
+        assert!(
+            b.x >= 100 && b.x <= 110,
+            "bbox.x ({}) should be region-absolute (≈110, ≥ rx=100)",
+            b.x
+        );
+        assert!(
+            b.x + b.width >= 130,
+            "bbox far x ({}) should reach the patch end at 130",
+            b.x + b.width
+        );
     }
 
     #[test]

--- a/src/tools/_input-pipeline.ts
+++ b/src/tools/_input-pipeline.ts
@@ -470,6 +470,24 @@ export interface VisualMotionObservation {
    */
   dirtyRects?: Rect[];
   /**
+   * ADR-024 Seed-2 S5c-1b — the **window-relative** bounding box of the
+   * changed region, derived from the pre/post true-PrintWindow frame-diff
+   * (native SSIM above-threshold-window aggregation). A sibling internal
+   * ROI-source channel to `dirtyRects`: it is **opt-in** (only populated when
+   * `verifyLocalRepaint` is called with `includeRoiBbox === true`, i.e. the
+   * visual-only `desktop_act` ROI path) and the act handler **splits it off
+   * before assigning `result.observation`**, so it never reaches the public
+   * Stage 5 telemetry envelope (ADR-019 contract; byte-equal for every other
+   * caller — additive optional field, CLAUDE.md §3.2 carry-over).
+   *
+   * Only emitted on the positive `motion: "local_repaint"` path AND only when
+   * the capture was occlusion-immune (both pre and post frames came from
+   * PrintWindow, not the BitBlt fallback). Absent on `no_change` /
+   * `indeterminate` / non-occlusion-immune captures → the consumer
+   * (`buildRoiCapture`) falls back to the full-window ROI (P1-1).
+   */
+  roiBbox?: Rect;
+  /**
    * Algorithm that produced this observation. Stage 1 emits
    * `"uia_scroll_percent"` (success) or `"chain_trust_unverified"`
    * (UIA pattern not exposed, chain-trust fall-through). Stages 2-5+

--- a/src/tools/_roi-region.ts
+++ b/src/tools/_roi-region.ts
@@ -101,6 +101,34 @@ export function boundingBox(rects: readonly Rect[]): Rect | null {
 }
 
 /**
+ * ADR-024 Seed-2 S5c-1b — clamp a window-relative rect to the window bounds.
+ *
+ * The frame-diff ROI bbox (`VisualMotionObservation.roiBbox`) is already
+ * window-relative and, by construction, lies inside the captured window (it is
+ * derived from a crop that was itself clipped to the window rect). This is a
+ * defence-in-depth clamp for the rare case where the window resized between the
+ * pre-frame capture and the post-action `getWindowRectByHwnd` read, so the crop
+ * never reads outside the buffer downstream.
+ *
+ * @param roi        Window-relative candidate ROI (origin = window top-left).
+ * @param windowRect Screen-absolute window rect — only its `width`/`height`
+ *                   bound the clamp (the ROI is already window-relative).
+ * @returns The clamped window-relative rect, or `null` when the clamp leaves no
+ *          positive area (ROI fully outside the current window) — the caller
+ *          then falls back to the DXGI bbox / full window.
+ */
+export function clampRectToWindow(roi: Rect, windowRect: Rect): Rect | null {
+  const left = Math.max(0, roi.x);
+  const top = Math.max(0, roi.y);
+  const right = Math.min(roi.x + roi.width, windowRect.width);
+  const bottom = Math.min(roi.y + roi.height, windowRect.height);
+  const width = right - left;
+  const height = bottom - top;
+  if (width <= 0 || height <= 0) return null;
+  return { x: left, y: top, width, height };
+}
+
+/**
  * ADR-024 Seed-2 S5 — intersection-over-union of two rects.
  *
  * Used to dedup the post-action ROI-OCR preview against the entities the most

--- a/src/tools/desktop-register.ts
+++ b/src/tools/desktop-register.ts
@@ -68,7 +68,7 @@ import { verifyLocalRepaint } from "../engine/local-repaint.js";
 import { disposeSharedDirtyRectBroker } from "../engine/dxgi-broker.js";
 import type { VisualMotionObservation } from "./_input-pipeline.js";
 import { shouldReturnRoiCapture, type ReturnCaptureMode } from "./_roi-capture-gate.js";
-import { filterDirtyRectsToWindow, boundingBox } from "./_roi-region.js";
+import { filterDirtyRectsToWindow, boundingBox, clampRectToWindow } from "./_roi-region.js";
 import { buildRoiPreviewEntities } from "./_roi-preview.js";
 import { runSomPipeline } from "../engine/ocr-bridge.js";
 import type { Rect } from "../engine/vision-gpu/types.js";
@@ -621,6 +621,11 @@ export const desktopActRawHandler = async (
 
   let postVerify: { observation: VisualMotionObservation; dirtyRects: Rect[] } | null = null;
   let frameDiffObservation: VisualMotionObservation | undefined;
+  // ADR-024 Seed-2 S5c-1b — the window-relative changed-region bbox from the
+  // frame-diff, split off the observation here so it never reaches the public
+  // `result.observation` telemetry (R2-P1) and is instead threaded into
+  // buildRoiCapture as the localized ROI.
+  let frameDiffRoi: Rect | undefined;
   if (result.ok && postVerifyEnabled) {
     if (visualOnly) {
       // Visual-only — frame-diff ONLY. Never fall back to the DXGI verifier:
@@ -636,15 +641,26 @@ export const desktopActRawHandler = async (
         // guard degrades to `indeterminate`, which the gate excludes (so a noisy
         // desktop yields no spurious roiCapture = F1). `observation.source` becomes
         // `ssim_residual` (frame-diff family) on this path only.
-        frameDiffObservation = await verifyLocalRepaint({
+        // S5c-1b — opt into the ROI bbox surface so the SAME frame-diff that
+        // produces `motion` also yields the localized changed-region rect.
+        const frameDiffObs = await verifyLocalRepaint({
           hwnd: frameDiffHwnd,
           hint: {
             windowRect: frameDiffWindowRect,
             ...(frameDiffPoint !== null && { point: frameDiffPoint }),
           },
           preFrame,
+          includeRoiBbox: true,
         });
-        (result as { observation?: VisualMotionObservation }).observation = frameDiffObservation;
+        // Split `roiBbox` off BEFORE assigning `result.observation` (P2-2):
+        // `roiBbox` is an internal ROI-source channel, not public Stage 5
+        // telemetry — the same split pattern as `tryVerifyAnyChange`'s
+        // `dirtyRects`. The destructured `observation` has no `roiBbox` key, so
+        // the serialized envelope stays byte-equal with the pre-S5c-1b shape.
+        const { roiBbox, ...observation } = frameDiffObs;
+        frameDiffObservation = observation;
+        frameDiffRoi = roiBbox;
+        (result as { observation?: VisualMotionObservation }).observation = observation;
       }
       // else: frame-diff setup missed → degrade silently (no observation, no DXGI).
     } else {
@@ -677,6 +693,10 @@ export const desktopActRawHandler = async (
       // is always `frame_diff` — including the `returnCapture:"always"` full-
       // window fallback when the frame-diff observation was a miss.
       visualOnly ? "frame_diff" : "dxgi",
+      // S5c-1b — the localized changed-region ROI from the frame-diff (when the
+      // capture was occlusion-immune). `undefined` → buildRoiCapture falls back
+      // to the DXGI dirty-rect bbox (legacy path) or the full window.
+      frameDiffRoi,
     );
     if (roiCapture !== undefined) {
       (result as { roiCapture?: RoiCapture }).roiCapture = roiCapture;
@@ -788,9 +808,13 @@ async function buildRoiCapture(
   dirtyRects: Rect[],
   returnCapture: ReturnCaptureMode | undefined,
   // S5c-1a — ROI provenance label for the assembled capture. `frame_diff` on the
-  // visual-only PrintWindow path (dirtyRects empty → full-window ROI until the
-  // S5c-1b bbox lands); `dxgi` on the legacy dirty-rect path.
+  // visual-only PrintWindow path; `dxgi` on the legacy dirty-rect path.
   source: RoiCapture["source"],
+  // S5c-1b — the localized changed-region ROI from the frame-diff (window-
+  // relative), present only when the visual-only capture was occlusion-immune.
+  // When present it takes precedence over the DXGI dirty-rect bbox and the
+  // full-window fallback (P1-2). `undefined` → legacy dirty-rect / full-window.
+  frameDiffRoi?: Rect,
 ): Promise<RoiCapture | undefined> {
   const gatePassed = shouldReturnRoiCapture({
     ok: true, // only called on the success path
@@ -811,15 +835,23 @@ async function buildRoiCapture(
     return undefined;
   }
 
-  // S3b — per-output dirty rects → window-relative; S5 — reduce to one ROI.
+  // ROI resolution priority (S5c-1b P1-2):
+  //   1. `frameDiffRoi` — the localized changed-region bbox from an occlusion-
+  //      immune frame-diff (visual-only PrintWindow path). Already window-
+  //      relative; clamped to the window rect below to stay in bounds.
+  //   2. DXGI dirty-rect bbox — `filterDirtyRectsToWindow` → bounding box
+  //      (legacy dxgi-source path; `dirtyRects` is empty on the frame-diff
+  //      path, so this only fires for the dxgi regime).
+  //   3. Full window — the gate already passed, so we owe a capture even when
+  //      no localized region is available: `returnCapture: "always"` on a
+  //      no-change act, or a frame-diff that was not occlusion-immune
+  //      (BitBlt-fallback demotion, P1-1), or a no-change/indeterminate motion.
   const windowRel = filterDirtyRectsToWindow(dirtyRects, windowRect);
-  // Fall back to the whole window (window-relative full rect) when no dirty
-  // region intersects it. The gate already passed, so we owe a capture — this
-  // happens for `returnCapture: "always"` on a no-change act, or when motion
-  // was reported by a non-DXGI source (SSIM translation/local_repaint) that
-  // leaves `dirtyRects` empty (Codex PR #429 P2: honor `always`).
+  const fullWindow = { x: 0, y: 0, width: windowRect.width, height: windowRect.height };
   const roi =
-    boundingBox(windowRel) ?? { x: 0, y: 0, width: windowRect.width, height: windowRect.height };
+    (frameDiffRoi !== undefined ? clampRectToWindow(frameDiffRoi, windowRect) : undefined) ??
+    boundingBox(windowRel) ??
+    fullWindow;
 
   try {
     // S4 — OCR only the ROI crop. hwnd is provided so the empty windowTitle is

--- a/tests/unit/local-repaint-orchestrator.test.ts
+++ b/tests/unit/local-repaint-orchestrator.test.ts
@@ -368,3 +368,120 @@ describe("verifyLocalRepaint (§2.3 orchestrator)", () => {
     expect(r.motion).toBe("indeterminate");
   });
 });
+
+// ─── ADR-024 Seed-2 S5c-1b — roiBbox surface (opt-in, occlusion-gated) ───────
+describe("verifyLocalRepaint roiBbox (S5c-1b)", () => {
+  beforeEach(() => {
+    mockComputeSsim.mockReset();
+    mockCapturePostFrame.mockReset();
+  });
+
+  // Tag a frame with its capture provenance (P1-1 occlusion-immunity gate).
+  const withSource = (
+    f: RawFrame,
+    source: "printwindow" | "bitblt-fallback",
+  ): RawFrame => ({ ...f, source });
+
+  // window 300×300, click at centre (150,150) → resolveLocalRepaintRect yields a
+  // 192×192 padded square at (54,54) clipped inside the window → localRect
+  // origin (54,54). A native bbox at crop-local (10,20) therefore lifts to
+  // window-relative (64,74).
+  const WINDOW = { x: 0, y: 0, width: 300, height: 300 };
+  const POINT = { x: 150, y: 150 };
+
+  function driveLocalRepaint(opts: {
+    preSource?: "printwindow" | "bitblt-fallback";
+    postSource?: "printwindow" | "bitblt-fallback";
+    bbox?: { x: number; y: number; width: number; height: number };
+    includeRoiBbox?: boolean;
+  }) {
+    const preBase = makeFrame(300, 300, 4, 0);
+    const postBase = makeFrame(300, 300, 4, 200); // differs → SSIM runs
+    const pre = opts.preSource ? withSource(preBase, opts.preSource) : preBase;
+    const post = opts.postSource ? withSource(postBase, opts.postSource) : postBase;
+    mockCapturePostFrame.mockResolvedValueOnce({
+      frames: [post],
+      deltas: [0],
+      stableReached: true,
+      framesToStability: 1,
+      totalElapsedMs: 80,
+    });
+    mockComputeSsim.mockReturnValueOnce({
+      fractionChanged: 0.12,
+      centroid: { x: 30, y: 40 },
+      meanSsim: 0.85,
+      ...(opts.bbox !== undefined && { bbox: opts.bbox }),
+    });
+    return verifyLocalRepaint({
+      hwnd: HWND,
+      hint: { point: POINT, windowRect: WINDOW },
+      preFrame: pre,
+      ...(opts.includeRoiBbox !== undefined && { includeRoiBbox: opts.includeRoiBbox }),
+    });
+  }
+
+  it("occlusion-immune (pre+post PrintWindow) + bbox present → roiBbox lifted to window-relative", async () => {
+    const r = await driveLocalRepaint({
+      preSource: "printwindow",
+      postSource: "printwindow",
+      bbox: { x: 10, y: 20, width: 30, height: 40 },
+      includeRoiBbox: true,
+    });
+    expect(r.motion).toBe("local_repaint");
+    // localRect origin (54,54) + crop-local bbox (10,20) → window-relative (64,74).
+    expect(r.roiBbox).toEqual({ x: 64, y: 74, width: 30, height: 40 });
+  });
+
+  it("pre frame is BitBlt-fallback → roiBbox absent (occlusion not immune, P1-1)", async () => {
+    const r = await driveLocalRepaint({
+      preSource: "bitblt-fallback",
+      postSource: "printwindow",
+      bbox: { x: 10, y: 20, width: 30, height: 40 },
+      includeRoiBbox: true,
+    });
+    expect(r.motion).toBe("local_repaint");
+    expect(r.roiBbox).toBeUndefined();
+  });
+
+  it("post frame is BitBlt-fallback → roiBbox absent (occlusion not immune, P1-1)", async () => {
+    const r = await driveLocalRepaint({
+      preSource: "printwindow",
+      postSource: "bitblt-fallback",
+      bbox: { x: 10, y: 20, width: 30, height: 40 },
+      includeRoiBbox: true,
+    });
+    expect(r.roiBbox).toBeUndefined();
+  });
+
+  it("capture source undefined → roiBbox absent (conservative demote)", async () => {
+    const r = await driveLocalRepaint({
+      // no preSource / postSource → frames carry no `source` field
+      bbox: { x: 10, y: 20, width: 30, height: 40 },
+      includeRoiBbox: true,
+    });
+    expect(r.roiBbox).toBeUndefined();
+  });
+
+  it("native bbox absent (omitted) → roiBbox absent (full-window fallback downstream)", async () => {
+    const r = await driveLocalRepaint({
+      preSource: "printwindow",
+      postSource: "printwindow",
+      // bbox omitted from the SSIM result
+      includeRoiBbox: true,
+    });
+    expect(r.motion).toBe("local_repaint");
+    expect(r.roiBbox).toBeUndefined();
+  });
+
+  it("includeRoiBbox not set (default) → roiBbox absent even when immune + bbox present (byte-equal for Stage 4 callers)", async () => {
+    const r = await driveLocalRepaint({
+      preSource: "printwindow",
+      postSource: "printwindow",
+      bbox: { x: 10, y: 20, width: 30, height: 40 },
+      // includeRoiBbox omitted → default false
+    });
+    expect(r.motion).toBe("local_repaint");
+    expect(r.roiBbox).toBeUndefined();
+    expect("roiBbox" in r).toBe(false);
+  });
+});

--- a/tests/unit/roi-region.test.ts
+++ b/tests/unit/roi-region.test.ts
@@ -15,6 +15,7 @@ import {
   filterDirtyRectsToWindow,
   boundingBox,
   rectIoU,
+  clampRectToWindow,
 } from "../../src/tools/_roi-region.js";
 
 // Window at a non-zero screen origin so the relative translation is observable.
@@ -218,5 +219,44 @@ describe("rectIoU (S5 OQ-10 dedup metric)", () => {
     );
     expect(iou).toBeCloseTo(25 / 175, 6);
     expect(iou).toBeLessThan(0.5);
+  });
+});
+
+describe("clampRectToWindow (S5c-1b frame-diff ROI bounds guard)", () => {
+  // Window dimensions only (the ROI is already window-relative, so the
+  // window origin is irrelevant to the clamp).
+  const WIN = { x: 0, y: 0, width: 200, height: 150 };
+
+  it("returns an in-bounds rect unchanged", () => {
+    const roi = { x: 10, y: 20, width: 50, height: 40 };
+    expect(clampRectToWindow(roi, WIN)).toEqual(roi);
+  });
+
+  it("clamps a rect overflowing the right/bottom edges", () => {
+    // Extends past the 200×150 window → clamped to the window's far edges.
+    const out = clampRectToWindow({ x: 180, y: 130, width: 100, height: 100 }, WIN);
+    expect(out).toEqual({ x: 180, y: 130, width: 20, height: 20 });
+  });
+
+  it("clamps negative origin to 0 and shrinks the size accordingly", () => {
+    // x:-10 → left=0, far edge stays at 40 → width 40.
+    const out = clampRectToWindow({ x: -10, y: -5, width: 50, height: 30 }, WIN);
+    expect(out).toEqual({ x: 0, y: 0, width: 40, height: 25 });
+  });
+
+  it("returns null when the rect is fully outside the window", () => {
+    // Origin at/after the far edge → no positive area remains.
+    expect(clampRectToWindow({ x: 200, y: 0, width: 50, height: 50 }, WIN)).toBeNull();
+    expect(clampRectToWindow({ x: 0, y: 150, width: 50, height: 50 }, WIN)).toBeNull();
+  });
+
+  it("returns null for a zero-area rect", () => {
+    expect(clampRectToWindow({ x: 10, y: 10, width: 0, height: 20 }, WIN)).toBeNull();
+  });
+
+  it("does not mutate the input rect", () => {
+    const roi = { x: 180, y: 130, width: 100, height: 100 };
+    clampRectToWindow(roi, WIN);
+    expect(roi).toEqual({ x: 180, y: 130, width: 100, height: 100 });
   });
 });


### PR DESCRIPTION
## ADR-024 Seed-2 S5c-1b — native bbox ROI localization

S5c-1a made the visual-only post-action **motion verdict** come from a
true-PrintWindow frame-diff (occlusion-immune, DXGI-broker-free), fixing dogfood
defects F1 (occlusion-blind geometry filter) + F2 (DirtyRectRouter drain race) —
but left the **ROI provisionally full-window**. S5c-1b localizes the ROI to the
actual changed region.

### What changed
- **`src/ssim.rs`** — `compute_ssim_residual` additionally aggregates the bounding
  box of the above-threshold sliding windows (min/max corners) in the **same scan**
  as the centroid → new `SsimBbox`, omitted (`Option::None`) when no window crosses
  the threshold / on the graceful-degrade single-window path. No extra pass, no TS
  pixel loop. Mirrored into both hand-maintained napi type files (`index.d.ts` +
  `src/engine/native-types.ts`, SoT = `native-types.ts`).
- **`src/engine/layer-buffer.ts`** — surface the capture provenance
  (`RawFrame.source`) through `captureFrame` / `capturePostFrameUntilStable`
  (additive optional; every existing Stage 2a/4 consumer stays byte-equal).
- **`src/engine/local-repaint.ts`** — `verifyLocalRepaint({includeRoiBbox})` opt-in
  attaches a **window-relative** `roiBbox` on the positive `local_repaint` path,
  **only when the capture was occlusion-immune** (pre AND post both PrintWindow;
  `source === undefined` → conservative demote). Crop-local native bbox + localRect
  origin → window-relative.
- **`src/tools/_input-pipeline.ts`** — additive internal
  `VisualMotionObservation.roiBbox` (sibling to `dirtyRects`), opt-in, split off in
  the handler so it never reaches public telemetry.
- **`src/tools/desktop-register.ts`** — pass `includeRoiBbox` in the visual-only
  path, split `{roiBbox, ...observation}` before assigning `result.observation`
  (telemetry byte-equal), thread the bbox into `buildRoiCapture` as `frameDiffRoi`.
  ROI priority: frame-diff bbox (clamped) → DXGI dirty-rect bbox → full window.
- **`src/tools/_roi-region.ts`** — `clampRectToWindow` defence-in-depth bounds guard.

### Correctness guards
- **P1-1**: BitBlt-fallback / PrintWindow-black targets keep the full-window ROI
  (a wrong localized ROI is never emitted). A pre/post source mismatch also changes
  buffer dimensions, so the existing parity guard already demotes it to
  `indeterminate` — the source check is the explicit defence-in-depth statement of
  the same invariant.
- **R2-P1**: non-visual-only acts are untouched and their `result.observation` is
  byte-equal (ADR-019 Stage 5 telemetry contract).

### Dogfood (live, rebuilt native addon)
```
click "TARGET ALPHA" (top): motion=local_repaint source=frame_diff
   roi = {x:150, y:71,  width:184, height:128}
click "ZONE BETA"   (btm): motion=local_repaint source=frame_diff
   roi = {x:107, y:381, width:184, height:128}
```
ROI localizes to the changed region (184×128 ≈ the 170×120 paint) and **tracks the
click location** (y:71 vs y:381), not full-window, not a noise sliver.

### Tests
- Rust unit: bbox enclose / two-disjoint union / single-window-none / region-absolute
  basis (11 ssim tests green).
- TS unit: roiBbox translation + occlusion demote (BitBlt pre/post, undefined source)
  + bbox-absent + opt-in-off byte-equal; `clampRectToWindow` (49 tests green).

### Review
- Opus sub-plan review R1 (NO-GO, 3 P1) → R2 (GO).
- Awaiting Opus impl review + Codex.

Plan: `desktop-touch-mcp-internal@e7b839f:docs/adr-024-seed2-plan.md` (S5c-1b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)