### PR TITLE
test(desktop_act): S6 — round-trip reduction bench + headed e2e for visual-only roiCapture

### DIFF
--- a/benches/adr-024-seed2-roundtrip.mjs
+++ b/benches/adr-024-seed2-roundtrip.mjs
@@ -181,10 +181,15 @@ const folded = { total: [], act: [], bytes: [], somBytes: [], entityCounts: [], 
 async function leaseFor(label) {
   const d = await discoverCanvas();
   if (!d) return null;
-  const ent =
-    d.entities.find((e) => e.label === label && e.sources?.includes("ocr") && e.primaryAction === "click") ??
-    d.entities.find((e) => e.sources?.includes("ocr") && e.primaryAction === "click");
-  return ent ?? null;
+  // Match the requested anchor by label ONLY. Do NOT fall back to "the first OCR
+  // entity" — the window title bar is also OCR'd, and clicking it produces no
+  // content change (no_change → no roiCapture), which would spuriously fail the
+  // acceptance gate. A transient discover miss → skip the iter instead.
+  return (
+    d.entities.find(
+      (e) => e.label === label && e.sources?.includes("ocr") && e.primaryAction === "click",
+    ) ?? null
+  );
 }
 
 for (let i = 0; i < iterations; i++) {

--- a/benches/adr-024-seed2-roundtrip.mjs
+++ b/benches/adr-024-seed2-roundtrip.mjs
@@ -105,13 +105,22 @@ const closeFixture = () => {
     fixtureChild = null;
   }
 };
+// Definitive leak guard (Codex PR #434 P2): kill the GUI fixture on ANY process
+// exit — including paths that bypass cleanupAndExit, e.g. an uncaught rejection
+// from `client.connect` / a `callTool` (which terminates Node with a non-zero
+// exit → this handler still fires). Without it a failed run could leave a
+// TopMost WinForms window on screen. `child.kill` is synchronous, safe in 'exit'.
+process.on("exit", () => { try { fixtureChild?.kill(); } catch { /* gone */ } });
 
 // ─── MCP stdio client ────────────────────────────────────────────────────────
 const transport = new StdioClientTransport({
   command: process.execPath,
   args: [serverPath],
   env: { ...process.env, DESKTOP_TOUCH_AUTO_GUARD: "0" },
-  stderr: "pipe",
+  // "ignore" (not "pipe"): the bench never reads the server's stderr, and an
+  // unread "pipe" can fill during headed runs (native/UIA/OCR diagnostics) and
+  // block the MCP child mid-call → bench hang (Codex PR #434 P2).
+  stderr: "ignore",
 });
 const client = new Client({ name: "s6-roundtrip-bench", version: "0.0.0" }, { capabilities: {} });
 await client.connect(transport);

--- a/benches/adr-024-seed2-roundtrip.mjs
+++ b/benches/adr-024-seed2-roundtrip.mjs
@@ -1,0 +1,283 @@
+#!/usr/bin/env node
+// ADR-024 Seed-2 S6 — round-trip reduction bench for the visual-only roiCapture.
+//
+// North Star (`adr-024-seed2-plan.md` §0): on a visual-only (UIA-blind) target,
+// fold the post-action "confirm the result + find the next target" round-trips
+// into the act itself. The agent's current flow is
+//   desktop_act -> desktop_state -> screenshot   (3 calls; 2 post-act confirms)
+// and S5c makes it
+//   desktop_act(returnCapture:"on-change")        (1 call; 0 post-act confirms)
+// because the act response carries roiCapture { somImage (≈ the screenshot crop),
+// entities (≈ the discover/state preview) }.
+//
+// This bench QUANTIFIES that reduction live. It is **headed-gated** (needs a real
+// GUI + the full native engine: DXGI / PrintWindow / OCR) and therefore is NOT a
+// CI test — it spawns its own server over stdio MCP, spawns a visual-only canvas
+// fixture, and reports numbers. With no GUI / no canvas it degrades to exit 0.
+//
+// ## What it measures (recorded in adr-024-seed2-dogfood-findings.md §S6)
+//   - post-act round-trips      : baseline 3 (act+state+screenshot) vs folded 1 (act)
+//   - total latency per flow     : wall-clock of [act (+state+screenshot)] (mean/p50/p95)
+//   - per-call act latency       : baseline act-only vs folded act-only (the folded
+//                                  act is heavier — it runs the frame-diff capture +
+//                                  settle + ROI-OCR + SoM render inline — so the win
+//                                  is the *eliminated round-trips*, not a cheaper act;
+//                                  we report both so the trade-off is not hidden)
+//   - payload bytes per flow     : baseline = act+state+screenshot(full-window SoM) JSON;
+//                                  folded = act JSON (bundles a LOCALIZED SoM crop). Both
+//                                  carry a SoM PNG, so the folded crop is typically the
+//                                  SMALLER of the two (it is the changed region, not the
+//                                  whole window). Payload scales with the ROI size; a
+//                                  full-window roiCapture fallback would approach the
+//                                  baseline screenshot's bytes.
+//   - roiCapture content         : somImage bytes, entities count, roi localized
+//                                  (not full-window)
+//
+// ## Usage
+//   npm run build && npm run build:rs   # dist/index.js + native addon present
+//   node benches/adr-024-seed2-roundtrip.mjs               # 10 iters, auto-spawn fixture
+//   node benches/adr-024-seed2-roundtrip.mjs 20            # custom iter count
+//   node benches/adr-024-seed2-roundtrip.mjs --title Foo   # attach to an already-open canvas
+//
+// ## Requirements
+//   - Windows session with a real GUI (no RDP-headless / service session)
+//   - `npm run build` (dist/index.js) + `npm run build:rs` (native addon)
+
+import { performance } from "node:perf_hooks";
+import { setTimeout as sleep } from "node:timers/promises";
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+// ─── Arg parsing ─────────────────────────────────────────────────────────────
+const rawArgs = process.argv.slice(2);
+let iterations = 10;
+let externalTitle = null; // when set, attach to an already-open canvas (no spawn)
+for (let i = 0; i < rawArgs.length; i++) {
+  const a = rawArgs[i];
+  if (a === "--title") {
+    externalTitle = rawArgs[++i];
+  } else if (Number.isFinite(Number(a))) {
+    iterations = Number(a);
+  } else {
+    console.error(`error: unrecognised argument: ${a}`);
+    console.error("usage: node adr-024-seed2-roundtrip.mjs [iterations] [--title <existing-canvas-title>]");
+    process.exit(2);
+  }
+}
+if (!Number.isFinite(iterations) || iterations < 1) {
+  console.error("error: iterations must be >= 1");
+  process.exit(2);
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "..");
+const serverPath = resolve(repoRoot, "dist", "index.js");
+const fixturePath = resolve(__dirname, "fixtures", "visual-only-canvas.ps1");
+if (!existsSync(serverPath)) {
+  console.error(`server entry not found: ${serverPath} — run \`npm run build\``);
+  process.exit(2);
+}
+
+// ─── Fixture spawn (skip when --title attaches to an existing canvas) ─────────
+// Same spawn discipline as tests/e2e/helpers/blank-window.ts: NOT detached (a
+// detached GUI exits immediately), console hidden inside the script, killed on exit.
+const title = externalTitle ?? `dt-s6-roundtrip-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+let fixtureChild = null;
+if (!externalTitle) {
+  if (!existsSync(fixturePath)) {
+    console.error(`fixture not found: ${fixturePath}`);
+    process.exit(2);
+  }
+  fixtureChild = spawn(
+    "powershell",
+    ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", fixturePath, "-Title", title],
+    { stdio: "ignore" },
+  );
+}
+const closeFixture = () => {
+  if (fixtureChild) {
+    try { fixtureChild.kill(); } catch { /* already gone */ }
+    fixtureChild = null;
+  }
+};
+
+// ─── MCP stdio client ────────────────────────────────────────────────────────
+const transport = new StdioClientTransport({
+  command: process.execPath,
+  args: [serverPath],
+  env: { ...process.env, DESKTOP_TOUCH_AUTO_GUARD: "0" },
+  stderr: "pipe",
+});
+const client = new Client({ name: "s6-roundtrip-bench", version: "0.0.0" }, { capabilities: {} });
+await client.connect(transport);
+
+const callTool = async (name, args) => {
+  const t0 = performance.now();
+  const result = await client.callTool({ name, arguments: args });
+  const ms = performance.now() - t0;
+  const text = Array.isArray(result?.content)
+    ? (result.content.find((c) => c?.type === "text")?.text ?? "")
+    : "";
+  const bytes = Buffer.byteLength(text, "utf8");
+  let parsed = null;
+  try { parsed = text ? JSON.parse(text) : null; } catch { /* leave null */ }
+  return { ms, bytes, parsed };
+};
+
+// ─── Discover the visual-only canvas (poll until present) ─────────────────────
+async function discoverCanvas() {
+  const { parsed } = await callTool("desktop_discover", {
+    target: { windowTitle: title },
+    view: "action",
+  });
+  if (!parsed || !Array.isArray(parsed.entities)) return null;
+  const warnings = parsed.warnings ?? [];
+  const visualOnly = warnings.some((w) => String(w).startsWith("uia_blind"));
+  return { ...parsed, visualOnly };
+}
+
+const cleanupAndExit = async (code) => {
+  try { await client.close(); } catch { /* ignore */ }
+  closeFixture();
+  process.exit(code);
+};
+
+let disc = null;
+{
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    const d = await discoverCanvas();
+    if (d && d.visualOnly && d.entities.some((e) => e.sources?.includes("ocr") && e.primaryAction === "click")) {
+      disc = d;
+      break;
+    }
+    await sleep(500);
+  }
+}
+if (!disc) {
+  // Graceful degrade — headed-gated bench, no hard fail on a headless / no-GUI host.
+  console.log("# OPERATOR NOTE: visual-only canvas did not appear within 20s.");
+  console.log("#   This bench needs a real GUI session + the native addon (npm run build:rs).");
+  console.log("#   On a headless / RDP-service / locked session it cannot run — degrading to exit 0.");
+  await cleanupAndExit(0);
+}
+
+// ─── Pick the two OCR anchors to alternate clicks across ──────────────────────
+const ocrEntities = disc.entities.filter((e) => e.sources?.includes("ocr") && e.primaryAction === "click");
+const anchorLabels = ["TARGET ALPHA", "ZONE BETA"].filter((l) => ocrEntities.some((e) => e.label === l));
+const labelsToUse = anchorLabels.length > 0 ? anchorLabels : [ocrEntities[0].label];
+
+// ─── Measurement loop ────────────────────────────────────────────────────────
+// Each iteration re-discovers (a fresh lease per act), then runs ONE flow. We
+// alternate baseline / folded across iters so both see the same fixture wear.
+const baseline = { total: [], act: [], bytes: [] };
+const folded = { total: [], act: [], bytes: [], somBytes: [], entityCounts: [], localized: 0, present: 0 };
+
+async function leaseFor(label) {
+  const d = await discoverCanvas();
+  if (!d) return null;
+  const ent =
+    d.entities.find((e) => e.label === label && e.sources?.includes("ocr") && e.primaryAction === "click") ??
+    d.entities.find((e) => e.sources?.includes("ocr") && e.primaryAction === "click");
+  return ent ?? null;
+}
+
+for (let i = 0; i < iterations; i++) {
+  const label = labelsToUse[i % labelsToUse.length];
+  const ent = await leaseFor(label);
+  if (!ent) continue;
+
+  if (i % 2 === 0) {
+    // ── Baseline: act(never) + desktop_state + screenshot (3 round-trips) ──
+    // The screenshot uses detail:"som" (Set-of-Marks + OCR elements) — the SAME
+    // information roiCapture bundles, but full-window. This is the fair baseline:
+    // folded = localized SoM crop folded into the act; baseline = full-window SoM
+    // fetched as a separate round-trip. (detail:"image" is blocked without
+    // confirmImage and would only return a guidance stub, not real pixels.)
+    const t0 = performance.now();
+    const act = await callTool("desktop_act", { lease: ent.lease, action: "click", returnCapture: "never" });
+    const state = await callTool("desktop_state", {});
+    const shot = await callTool("screenshot", { windowTitle: title, detail: "som", confirmImage: true });
+    const total = performance.now() - t0;
+    baseline.total.push(total);
+    baseline.act.push(act.ms);
+    baseline.bytes.push(act.bytes + state.bytes + shot.bytes);
+  } else {
+    // ── Folded: act(on-change) only (1 round-trip) ──
+    const act = await callTool("desktop_act", { lease: ent.lease, action: "click", returnCapture: "on-change" });
+    folded.total.push(act.ms);
+    folded.act.push(act.ms);
+    folded.bytes.push(act.bytes);
+    const cap = act.parsed?.roiCapture;
+    if (cap) {
+      folded.present++;
+      const somB = cap.somImage ? Buffer.byteLength(String(cap.somImage), "utf8") : 0;
+      folded.somBytes.push(somB);
+      folded.entityCounts.push(Array.isArray(cap.entities) ? cap.entities.length : 0);
+      const roi = cap.roi;
+      // Localized = the ROI covers well under the 800×600 client area (the toggle
+      // bar within the SSIM crop is ≤ ~192², far below a full-window grab).
+      if (roi && roi.width * roi.height < 800 * 600 * 0.6) folded.localized++;
+    }
+  }
+  await sleep(150); // let the form settle between clicks
+}
+
+// ─── Stats ───────────────────────────────────────────────────────────────────
+const stats = (xs) => {
+  if (!xs.length) return null;
+  const s = [...xs].sort((a, b) => a - b);
+  const pct = (p) => s[Math.min(s.length - 1, Math.floor(s.length * p))];
+  return { n: s.length, mean: s.reduce((a, b) => a + b, 0) / s.length, p50: pct(0.5), p95: pct(0.95) };
+};
+const ms = (v) => (v == null ? "—" : `${v.toFixed(1)} ms`);
+const bytes = (v) => (v == null ? "—" : `${Math.round(v)} B`);
+const line = (s) => (s ? `mean ${ms(s.mean)} | p50 ${ms(s.p50)} | p95 ${ms(s.p95)} (n=${s.n})` : "no samples");
+
+const bTotal = stats(baseline.total), bAct = stats(baseline.act), bBytes = stats(baseline.bytes);
+const fTotal = stats(folded.total), fAct = stats(folded.act), fBytes = stats(folded.bytes);
+const somB = stats(folded.somBytes), entC = stats(folded.entityCounts);
+
+console.log(`# adr-024-seed2-roundtrip — visual-only roiCapture round-trip reduction (${iterations} iters)`);
+console.log(`# canvas="${title}" anchors=[${labelsToUse.join(", ")}]`);
+console.log("");
+console.log("## post-act round-trips (the North Star)");
+console.log(`baseline : 3  (desktop_act + desktop_state + screenshot)`);
+console.log(`folded   : 1  (desktop_act, roiCapture bundled)   →  N→1 = 3→1`);
+console.log("");
+console.log("## total latency (act + post-act confirmation, wall-clock)");
+console.log(`baseline : ${line(bTotal)}`);
+console.log(`folded   : ${line(fTotal)}`);
+console.log("");
+console.log("## per-call act latency (decomposition — the folded act is heavier)");
+console.log(`baseline act(never)     : ${line(bAct)}`);
+console.log(`folded   act(on-change) : ${line(fAct)}`);
+console.log("");
+console.log("## payload bytes per flow (folded bundles a LOCALIZED SoM crop)");
+console.log(`baseline (act+state+screenshot[full-window som]) : ${bBytes ? bytes(bBytes.mean) : "—"}`);
+console.log(`folded   (act only, localized som crop)          : ${fBytes ? bytes(fBytes.mean) : "—"}`);
+console.log("");
+console.log("## folded roiCapture content");
+console.log(`present       : ${folded.present}/${folded.total.length}`);
+console.log(`localized roi : ${folded.localized}/${folded.present} (roi < full window)`);
+console.log(`somImage      : ${somB ? bytes(somB.mean) : "—"} (base64)`);
+console.log(`entities      : ${entC ? entC.mean.toFixed(1) : "—"} preview avg`);
+console.log("");
+
+// ─── Acceptance gate ─────────────────────────────────────────────────────────
+// Headed (canvas found): the folded act MUST attach roiCapture, else exit 1.
+let exitCode = 0;
+if (folded.total.length > 0 && folded.present === 0) {
+  console.log("# ACCEPTANCE FAIL: folded act produced NO roiCapture on any iteration.");
+  console.log("#   Expected the visual-only frame-diff to fire and bundle the SoM crop.");
+  exitCode = 1;
+} else {
+  console.log("# ACCEPTANCE: folded act bundles roiCapture (state+screenshot round-trips eliminated).");
+}
+
+await cleanupAndExit(exitCode);

--- a/benches/adr-024-seed2-roundtrip.mjs
+++ b/benches/adr-024-seed2-roundtrip.mjs
@@ -275,14 +275,27 @@ console.log(`entities      : ${entC ? entC.mean.toFixed(1) : "—"} preview avg`
 console.log("");
 
 // ─── Acceptance gate ─────────────────────────────────────────────────────────
-// Headed (canvas found): the folded act MUST attach roiCapture, else exit 1.
+// We only reach here in headed mode (the canvas was found; otherwise we degraded
+// to exit 0 above). The fold MUST be exercised AND every folded act MUST attach
+// roiCapture — a partial pass (some iters missing it) is a flaky regression, and
+// zero folded samples means the fold was never validated (Codex PR #434 P2).
 let exitCode = 0;
-if (folded.total.length > 0 && folded.present === 0) {
-  console.log("# ACCEPTANCE FAIL: folded act produced NO roiCapture on any iteration.");
-  console.log("#   Expected the visual-only frame-diff to fire and bundle the SoM crop.");
+if (folded.total.length === 0) {
+  console.log("# ACCEPTANCE FAIL: no folded samples collected — the fold was never exercised.");
+  console.log("#   Pass >= 2 iterations (folded runs on odd iters) on a real GUI session.");
+  exitCode = 1;
+} else if (folded.present !== folded.total.length) {
+  console.log(
+    `# ACCEPTANCE FAIL: only ${folded.present}/${folded.total.length} folded acts attached roiCapture.`,
+  );
+  console.log("#   On this fixture EVERY folded act must bundle roiCapture (each click toggles a");
+  console.log("#   localized bar → a visible change). A miss means the frame-diff fold is flaky.");
   exitCode = 1;
 } else {
-  console.log("# ACCEPTANCE: folded act bundles roiCapture (state+screenshot round-trips eliminated).");
+  console.log(
+    `# ACCEPTANCE: all ${folded.present}/${folded.total.length} folded acts bundled roiCapture ` +
+    "(state+screenshot round-trips eliminated).",
+  );
 }
 
 await cleanupAndExit(exitCode);

--- a/benches/fixtures/visual-only-canvas.ps1
+++ b/benches/fixtures/visual-only-canvas.ps1
@@ -1,0 +1,105 @@
+# benches/fixtures/visual-only-canvas.ps1
+#
+# ADR-024 Seed-2 S6 — self-contained visual-only (UIA-blind) canvas fixture for
+# the round-trip bench (`benches/adr-024-seed2-roundtrip.mjs`) and the headed-
+# gated e2e (`tests/e2e/desktop-act-roi-capture.test.ts`).
+#
+# WHAT: a Form whose entire client area is one full-bleed, custom-painted Panel
+# (UIA "Pane" + only-child => single-giant-pane / too-few-elements =>
+# uiaBlindForOcr fires => the visual-only regime that roiCapture targets). The
+# only readable content is OCR text ("TARGET ALPHA" / "ZONE BETA"), so
+# desktop_discover surfaces OCR entities (no UIA controls).
+#
+# WHY THE TOGGLE BAR (vs the dogfood canvas's cumulative crimson): the bench
+# clicks the SAME OCR anchors across many iterations. If a click painted over the
+# text, the next discover could no longer find the anchor. Instead each anchor has
+# a thin highlight bar just BELOW its (always-readable, black-on-white) text;
+# clicking an anchor TOGGLES that bar crimson<->white. This yields a *fresh,
+# localized* repaint at the click point on every click while the OCR text always
+# survives — repeatable for N iterations. The bar sits within ~96px of the click
+# centre so it lands inside the local-repaint SSIM crop (a localized ROI, never
+# full-window).
+#
+# Usage: powershell -NoProfile -ExecutionPolicy Bypass -File visual-only-canvas.ps1 -Title <name>
+param([string]$Title)
+
+# Hide the PowerShell host console so only the form is visible (same trick as
+# tests/e2e/helpers/blank-window.ts — do NOT use -WindowStyle Hidden, that hides
+# the form too; do NOT use a detached process, a detached GUI exits immediately).
+$sig = '[DllImport("kernel32.dll")] public static extern System.IntPtr GetConsoleWindow(); [DllImport("user32.dll")] public static extern bool ShowWindow(System.IntPtr h,int n);'
+$native = Add-Type -MemberDefinition $sig -Name CanvasNative -PassThru
+[void]$native::ShowWindow($native::GetConsoleWindow(), 0)
+
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName System.Drawing
+
+$W = 800; $H = 600
+
+$form = New-Object System.Windows.Forms.Form
+$form.Text = $Title
+$form.FormBorderStyle = 'FixedSingle'
+$form.MaximizeBox = $false
+$form.MinimizeBox = $false
+$form.StartPosition = 'Manual'
+# Place the window near the top-left (no overlapping background activity) so the
+# headed bench/e2e is deterministic. NOTE: this no-overlap placement is for test
+# determinism only — busy-background correctness is handled structurally by the
+# S5c frame-diff regime (occlusion-immune PrintWindow), NOT avoided here.
+$form.Location = New-Object System.Drawing.Point(40, 40)
+$form.ClientSize = New-Object System.Drawing.Size($W, $H)
+$form.TopMost = $true
+
+# Backing bitmap (client-sized) — the single source of pixels for the panel.
+$bmp = New-Object System.Drawing.Bitmap($W, $H)
+$bigFont = New-Object System.Drawing.Font('Segoe UI', 34, [System.Drawing.FontStyle]::Bold)
+
+# Two anchors: text (always black-on-white, always OCR-readable) + a toggle bar
+# just below it. Bar toggles crimson<->white on each click of that anchor.
+$script:state = @{ ALPHA = $false; BETA = $false }
+$anchors = @(
+  @{ Key = 'ALPHA'; Text = 'TARGET ALPHA'; TextY = 70;  BarY = 120 },
+  @{ Key = 'BETA';  Text = 'ZONE BETA';    TextY = 380; BarY = 430 }
+)
+$BarX = 60; $BarW = 300; $BarH = 22
+
+function Repaint-Anchor($a) {
+  $g = [System.Drawing.Graphics]::FromImage($bmp)
+  # Clear the anchor band (text + bar) to white, then redraw text on top and the
+  # toggle bar in its current colour.
+  $g.FillRectangle([System.Drawing.Brushes]::White, 40, ($a.TextY - 8), ($W - 80), 110)
+  $g.DrawString($a.Text, $bigFont, [System.Drawing.Brushes]::Black, 60, $a.TextY)
+  $on = $script:state[$a.Key]
+  $barBrush = if ($on) { [System.Drawing.Brushes]::Crimson } else { [System.Drawing.Brushes]::White }
+  $g.FillRectangle($barBrush, $BarX, $a.BarY, $BarW, $BarH)
+  $g.Dispose()
+}
+
+# Initial paint: white background + both anchors (bars off = white).
+$g0 = [System.Drawing.Graphics]::FromImage($bmp)
+$g0.Clear([System.Drawing.Color]::White)
+$g0.Dispose()
+foreach ($a in $anchors) { Repaint-Anchor $a }
+
+$panel = New-Object System.Windows.Forms.Panel
+$panel.Dock = 'Fill'
+# Enable double-buffering on the panel via reflection (DoubleBuffered is protected).
+$panel.GetType().GetProperty('DoubleBuffered', [System.Reflection.BindingFlags]::Instance -bor [System.Reflection.BindingFlags]::NonPublic).SetValue($panel, $true, $null)
+
+$panel.Add_Paint({
+  param($s, $e)
+  $e.Graphics.DrawImageUnscaled($bmp, 0, 0)
+}.GetNewClosure())
+
+$panel.Add_MouseClick({
+  param($s, $e)
+  # Pick the nearer anchor by Y; toggle its bar and repaint just that band so the
+  # change is localized to the click point.
+  $a = if ($e.Y -lt 300) { $anchors[0] } else { $anchors[1] }
+  $script:state[$a.Key] = -not $script:state[$a.Key]
+  Repaint-Anchor $a
+  $s.Invalidate((New-Object System.Drawing.Rectangle(40, ($a.TextY - 8), ($W - 80), 110)))
+}.GetNewClosure())
+
+$form.Controls.Add($panel)
+$form.Add_Shown({ $form.Activate() })
+[System.Windows.Forms.Application]::Run($form)

--- a/tests/e2e/desktop-act-roi-capture.test.ts
+++ b/tests/e2e/desktop-act-roi-capture.test.ts
@@ -1,0 +1,109 @@
+/**
+ * desktop-act-roi-capture.test.ts — ADR-024 Seed-2 S6 headed-gated e2e.
+ *
+ * Live, reproducible regression asset for the visual-only roiCapture fold: spawn
+ * the UIA-blind canvas fixture, discover an OCR anchor, `desktop_act` with
+ * `returnCapture:"on-change"`, and assert the response carries a roiCapture whose
+ * `somImage` is a real PNG crop and whose `roi` is localized (not full-window) —
+ * i.e. the click's repaint, captured via the S5c frame-diff path, in ONE call.
+ *
+ * Gating (matches the repo convention — `const IS_HEADED = Boolean(process.env.HEADED)`,
+ * `browser-cdp.test.ts:29`): this performs a REAL OS click and needs the native
+ * engine (PrintWindow / SSIM / OCR) on a real GUI, so it is **HEADED-only** and
+ * CI-skipped. It also skips when the fixture window cannot be spawned (no GUI).
+ *
+ * The bench (`benches/adr-024-seed2-roundtrip.mjs`) shares this fixture and
+ * measures the round-trip numbers; this file is the assertion/regression half.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+  getDesktopFacade,
+  desktopActRawHandler,
+  _resetFacadeForTest,
+} from "../../src/tools/desktop-register.js";
+import { spawnVisualOnlyCanvas, type VisualOnlyCanvas } from "./helpers/visual-only-canvas.js";
+
+const IS_HEADED = Boolean(process.env.HEADED);
+
+// Spawn the fixture up front (top-level await, as blank-window.ts does) so the
+// describe gate can see whether a real GUI window came up.
+const canvas: VisualOnlyCanvas | null = IS_HEADED ? await spawnVisualOnlyCanvas() : null;
+
+function parseHandler(content: ReadonlyArray<{ type: string; text?: string }>): Record<string, unknown> {
+  const block = content[0];
+  if (!block || block.type !== "text" || typeof block.text !== "string") {
+    throw new Error("expected text content");
+  }
+  return JSON.parse(block.text) as Record<string, unknown>;
+}
+
+// runIf: HEADED env AND the fixture actually appeared. On CI / headless both are
+// false → the whole suite is skipped (no real OS click attempted).
+describe.runIf(IS_HEADED && canvas !== null)("desktop_act roiCapture (S6 headed e2e)", () => {
+  let prevAutoGuard: string | undefined;
+  beforeAll(() => {
+    prevAutoGuard = process.env.DESKTOP_TOUCH_AUTO_GUARD;
+    process.env.DESKTOP_TOUCH_AUTO_GUARD = "0";
+  });
+  afterAll(() => {
+    if (prevAutoGuard === undefined) delete process.env.DESKTOP_TOUCH_AUTO_GUARD;
+    else process.env.DESKTOP_TOUCH_AUTO_GUARD = prevAutoGuard;
+    canvas?.close();
+    _resetFacadeForTest();
+  });
+
+  it("folds a localized PNG roiCapture into a single act on the visual-only canvas", async () => {
+    const facade = getDesktopFacade();
+
+    // Discover the canvas — visual-only (UIA-blind) regime + OCR anchors.
+    const disc = await facade.see({ target: { windowTitle: canvas!.title } });
+    const warnings = (disc as { warnings?: string[] }).warnings ?? [];
+    expect(warnings.some((w) => String(w).startsWith("uia_blind"))).toBe(true);
+
+    // Select an anchor by its label, NOT the first OCR entity — the window's
+    // (long, unique) title bar is also OCR'd, and clicking it would land on the
+    // title bar (no content change → no_change → no roiCapture). The anchors are
+    // the only in-canvas localized-change targets.
+    const ent =
+      disc.entities.find(
+        (e) =>
+          (e.label === "TARGET ALPHA" || e.label === "ZONE BETA") &&
+          e.sources?.includes("ocr") &&
+          e.primaryAction === "click",
+      );
+    expect(ent, "expected the TARGET ALPHA / ZONE BETA OCR anchor on the canvas").toBeDefined();
+
+    // Act with returnCapture:on-change → the click toggles the anchor's bar, a
+    // localized repaint the frame-diff path should detect.
+    const result = await desktopActRawHandler({
+      lease: ent!.lease,
+      action: "click",
+      returnCapture: "on-change",
+    });
+    const parsed = parseHandler(result.content);
+    expect(parsed["ok"]).toBe(true);
+
+    const cap = parsed["roiCapture"] as
+      | { roi?: { width: number; height: number }; somImage?: string; entities?: unknown[]; source?: string }
+      | undefined;
+    expect(cap, "act should bundle roiCapture on a visual-only localized change").toBeDefined();
+
+    // somImage is a real PNG crop (magic bytes 89 50 4E 47), not empty.
+    const b64 = String(cap!.somImage ?? "").replace(/^data:image\/\w+;base64,/, "");
+    expect(b64.length).toBeGreaterThan(0);
+    const magic = Buffer.from(b64, "base64").subarray(0, 4).toString("hex");
+    expect(magic).toBe("89504e47");
+
+    // entities is a (lease-less) preview array.
+    expect(Array.isArray(cap!.entities)).toBe(true);
+
+    // roi is localized — the frame-diff bbox, well under the 800×600 client area
+    // (a full-window fallback would be ~the whole window). Proves the click's own
+    // repaint was captured, not a whole-window grab.
+    expect(cap!.roi).toBeDefined();
+    expect(cap!.roi!.width * cap!.roi!.height).toBeLessThan(800 * 600 * 0.6);
+
+    // Provenance is the frame-diff regime.
+    expect(cap!.source).toBe("frame_diff");
+  });
+});

--- a/tests/e2e/helpers/visual-only-canvas.ts
+++ b/tests/e2e/helpers/visual-only-canvas.ts
@@ -1,0 +1,59 @@
+/**
+ * tests/e2e/helpers/visual-only-canvas.ts
+ *
+ * Spawn the ADR-024 Seed-2 visual-only (UIA-blind) canvas fixture
+ * (`benches/fixtures/visual-only-canvas.ps1`) for the roiCapture e2e. Shares the
+ * SAME fixture script as the round-trip bench so the bench numbers and the e2e
+ * assertions exercise one canvas definition.
+ *
+ * Spawn discipline matches `blank-window.ts`: NOT detached (a detached GUI exits
+ * immediately), the PowerShell host console is hidden inside the script (not via
+ * -WindowStyle Hidden, which would hide the form too), and the process is killed
+ * on close().
+ */
+import { spawn } from "child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { enumWindowsInZOrder } from "../../../src/engine/win32.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// tests/e2e/helpers → repo root → benches/fixtures/visual-only-canvas.ps1
+const FIXTURE = resolve(__dirname, "..", "..", "..", "benches", "fixtures", "visual-only-canvas.ps1");
+
+export interface VisualOnlyCanvas {
+  /** Unique window title — pass as `target.windowTitle` to desktop_discover. */
+  title: string;
+  /** Close the window (kills the backing PowerShell process). Idempotent. */
+  close: () => void;
+}
+
+/**
+ * Spawn the visual-only canvas and resolve once it is on screen. Returns null if
+ * the window does not appear within 12s (callers should skip rather than fall
+ * back). Always pair with `close()` in afterAll.
+ */
+export async function spawnVisualOnlyCanvas(): Promise<VisualOnlyCanvas | null> {
+  const title = `dt-visualonly-e2e-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+  const child = spawn(
+    "powershell",
+    ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", FIXTURE, "-Title", title],
+    { stdio: "ignore" },
+  );
+  let closed = false;
+  const close = () => {
+    if (closed) return;
+    closed = true;
+    try { child.kill(); } catch { /* already gone */ }
+  };
+
+  const deadline = Date.now() + 12_000;
+  while (Date.now() < deadline) {
+    const w = enumWindowsInZOrder().find((x) => x.title === title && !x.isMinimized);
+    if (w && w.region.width > 0 && w.region.height > 0) {
+      return { title, close };
+    }
+    await new Promise((res) => setTimeout(res, 200));
+  }
+  close();
+  return null;
+}


### PR DESCRIPTION
## ADR-024 Seed-2 S6 — North Star measurement (no production change)

Quantifies + pins the walking-skeleton North Star: on a visual-only (UIA-blind)
target, folding the post-action *confirm + find-next* round-trips into the act
itself (`act → desktop_state → screenshot` = 3 → `act` = 1).

### Deliverables
- **`benches/adr-024-seed2-roundtrip.mjs`** — headed-gated, self-spawning round-trip
  bench (stdio MCP server + visual-only fixture, `d2_desktop_state_roundtrip.mjs`
  conventions). Measures **baseline** (`act` + `desktop_state` + `screenshot[detail:som]`
  = 3 round-trips) vs **folded** (`act` w/ `returnCapture:on-change` = 1), reporting
  round-trips, total + per-call act latency, payload bytes, and roiCapture content.
  Graceful-degrades to exit 0 with no GUI (not a CI test).
- **`benches/fixtures/visual-only-canvas.ps1`** — shared UIA-blind canvas. Anchors
  stay OCR-readable; clicking toggles a highlight bar just below the anchor → a fresh
  *localized* repaint at the click on every click (repeatable for N iters).
- **`tests/e2e/desktop-act-roi-capture.test.ts`** + **`helpers/visual-only-canvas.ts`**
  — headed-gated (`HEADED=1`) e2e reusing the fixture: discover an anchor → act
  (`on-change`) → assert `roiCapture.somImage` is a real PNG, `entities` is an array,
  `roi` is localized (< full window), `source=frame_diff`.
  `describe.runIf(IS_HEADED && fixture!==null)` → CI-skipped (real OS click).

### Live results (10 iters, single representative dev-machine run)
| metric | baseline (3 calls) | folded (1 call) |
|---|---|---|
| **post-act round-trips** | **3** | **1** (N→1) |
| total wall-clock (mean) | 1747 ms | **1456 ms** (~17% faster) |
| per-call act latency (mean) | 1226 ms | 1456 ms (+230 ms, inline ROI-OCR) |
| payload bytes (mean) | 1202 B | **879 B** (localized crop < full-window SoM) |
| roiCapture present / localized | — | **5/5 · 5/5** |

**Honest reading**: the round-trip win (3→1) is the North Star — each eliminated
call is a full LLM turn (seconds), far bigger than the MCP wall-clock. Total
wall-clock *also* favors folded; the single folded act is heavier (inline frame-diff
+ ROI-OCR), reported, not hidden. Full numbers + trade-off in the findings doc.

### Notes
- Selecting the OCR anchor **by label** (not the first OCR entity) matters — the
  window title bar is also OCR'd; clicking it yields no content change → no
  roiCapture. Both bench and e2e filter to TARGET ALPHA / ZONE BETA.
- F1/F2 busy-bg correctness was settled structurally in S5c (frame-diff regime); the
  fixture's no-overlap placement is for e2e determinism only.
- Build + lint (0 errors) + e2e load (skips without HEADED) green; headed e2e passes live.

Plan: `desktop-touch-mcp-internal@9f3672a:docs/adr-024-seed2-plan.md` (S6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)