### PR TITLE
test(vision): restore cargo test compilation against tokenizers 0.21 drift + CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,19 @@ jobs:
           if (-not $found) { throw "node.lib not found in $cache" }
           Copy-Item -LiteralPath $found.FullName -Destination (Join-Path $PWD "node.lib")
 
+      - name: Check Rust test targets compile (guards dep-API drift in #[cfg(test)] code)
+        # `check:rs-workspace` only compiles non-test code, so test-only code —
+        # e.g. the vision-gpu tokenizer tests under #[cfg(all(test, feature =
+        # "vision-gpu"))] — can silently rot against upstream crate API changes
+        # (tokenizers 0.21 moved `WordLevelBuilder::vocab` to AHashMap and made
+        # `with_post_processor` take Option<_>). This `--no-run` step compiles
+        # every test binary so that drift fails CI. We intentionally do NOT run
+        # the tests here: the runtime unit suite is non-hermetic on the 2-core
+        # windows runners (DXGI screen-capture / focus tests flake without a
+        # live desktop), so a compile guard is the robust CI contract. Placed
+        # after the node.lib fetch because the napi test binary links node.lib.
+        run: npm run check:rs-test-compile
+
       - name: Build native addon (Rust → .node, debug profile for CI speed)
         run: npm run build:rs:debug
 

--- a/.gitignore
+++ b/.gitignore
@@ -78,11 +78,19 @@ target/
 *.node
 *.node.bak
 *.node.old
+# native-rebuild rename trick: in-use .node is moved aside so cargo can relink
+# while the session MCP server keeps its handle (see ADR-024 env notes).
+*.node.inuse-*
 libnode.a
 libnode.dll.a
 node.def
 node.lib
 .pr*.diff
+
+# Local dogfood / diagnostic scratch scripts (ADR-024 visual-only ROI sessions).
+# Kept at repo root, never committed — wire-up lives in tests/benches instead.
+.dogfood-*
+.diag-*
 
 # napi-rs scaffolding tests — never wired into vitest; not run in CI.
 # Kept locally for the upstream sync script (scripts/sync-rust-from-engine-rs.sh)

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "check:native-types": "node scripts/check-native-types.mjs",
     "check:no-koffi": "node scripts/check-no-koffi.mjs",
     "check:rs-workspace": "cargo check --workspace --locked",
+    "check:rs-test-compile": "cargo test --workspace --locked --no-run",
     "check:expansion-disjoint": "node scripts/check-expansion-disjoint.mjs",
     "build:rs": "node scripts/build-rs.mjs --release",
     "build:rs:debug": "node scripts/build-rs.mjs --debug",

--- a/src/vision_backend/florence2.rs
+++ b/src/vision_backend/florence2.rs
@@ -726,6 +726,7 @@ impl PromptTokens {
 /// Loading is from a `tokenizer.json` file produced by HuggingFace tokenizers
 /// (the format Microsoft ships at `microsoft/Florence-2-base/tokenizer.json`).
 /// Network-based `from_pretrained` is intentionally NOT exposed.
+#[derive(Debug)]
 pub struct Florence2Tokenizer {
     inner: tokenizers::Tokenizer,
 }
@@ -794,19 +795,25 @@ mod tokenizer_tests {
         models::wordlevel::WordLevelBuilder,
         Tokenizer,
     };
-    use std::collections::HashMap;
 
     /// Build a synthetic Florence-2-like tokenizer programmatically:
     /// vocab = {"<s>": 0, "<pad>": 1, "</s>": 2, "<unk>": 3, "<REGION_PROPOSAL>": 50267}
     /// uses WordLevel model (simple whole-word lookup, sufficient for special-token tests).
     /// Special tokens BOS=0, EOS=2 are added so encode("<REGION_PROPOSAL>") yields [0, 50267, 2].
     fn build_synthetic_tokenizer() -> Tokenizer {
-        let mut vocab: HashMap<String, u32> = HashMap::new();
-        vocab.insert("<s>".to_string(), 0);
-        vocab.insert("<pad>".to_string(), 1);
-        vocab.insert("</s>".to_string(), 2);
-        vocab.insert("<unk>".to_string(), 3);
-        vocab.insert("<REGION_PROPOSAL>".to_string(), 50267);
+        // tokenizers 0.21 `WordLevelBuilder::vocab` takes `AHashMap<String, u32>`
+        // (an `ahash`-backed map). Build it via a type-inferred `collect()` so the
+        // target map type comes from the `.vocab()` parameter, avoiding a direct
+        // `ahash` dependency in this test.
+        let vocab = [
+            ("<s>".to_string(), 0),
+            ("<pad>".to_string(), 1),
+            ("</s>".to_string(), 2),
+            ("<unk>".to_string(), 3),
+            ("<REGION_PROPOSAL>".to_string(), 50267),
+        ]
+        .into_iter()
+        .collect();
         let model = WordLevelBuilder::default()
             .vocab(vocab)
             .unk_token("<unk>".into())
@@ -815,13 +822,14 @@ mod tokenizer_tests {
         let mut tok = Tokenizer::new(model);
         // BART-style: BOS at start, EOS at end, controlled by post-processor.
         // For test simplicity we use TemplateProcessing.
-        tok.with_post_processor(
+        // tokenizers 0.21 `with_post_processor` takes `Option<PP>`.
+        tok.with_post_processor(Some(
             tokenizers::processors::template::TemplateProcessing::builder()
                 .try_single("<s> $A </s>").unwrap()
-                .special_tokens(vec![("<s>".into(), 0), ("</s>".into(), 2)])
+                .special_tokens(vec![("<s>", 0u32), ("</s>", 2u32)])
                 .build()
                 .unwrap(),
-        );
+        ));
         tok.add_special_tokens(&[
             tokenizers::AddedToken::from("<s>", true),
             tokenizers::AddedToken::from("</s>", true),

--- a/src/vision_backend/paddleocr.rs
+++ b/src/vision_backend/paddleocr.rs
@@ -58,6 +58,7 @@ struct Crop {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// PaddleOCR dictionary wrapper.
+#[derive(Debug)]
 pub struct PaddleOcrDict {
     /// Characters indexed by class id (index 0 is CTC blank, indices 1.. are real chars).
     chars: Vec<String>,


### PR DESCRIPTION
## What
`cargo test` no longer compiles on `main` — the vision-gpu tokenizer tests rotted against the `tokenizers` 0.21 API. Since CI only ran `cargo check` (non-test code), the breakage was invisible. This restores compilation and adds a CI guard so it can't silently recur.

## Why it matters
Rust unit tests (incl. the freshly-added `ssim` native-bbox tests from ADR-024 S5c-1b) have not been runnable in CI. Restoring the compile path puts that layer back under guard.

## Changes
- **florence2.rs (test code)**: `WordLevelBuilder::vocab` now takes `AHashMap` → build via type-inferred `collect()` (no new `ahash` dep); `with_post_processor` now takes `Option<PP>` → wrap in `Some(...)`; `special_tokens` needs `(&str, u32)` literals.
- **florence2.rs / paddleocr.rs**: `#[derive(Debug)]` on `Florence2Tokenizer` / `PaddleOcrDict` (their test-only `unwrap_err()` requires `T: Debug`).
- **CI guard**: new `check:rs-test-compile` = `cargo test --workspace --locked --no-run`, run after the node.lib fetch (the napi test binary links node.lib). Compiles every test target so dep-API drift fails CI.
- **.gitignore**: dogfood/diag scratch scripts + `*.node.inuse-*` rename artifact.

## Why compile-only (not run) in CI
The runtime unit suite is non-hermetic on the 2-core windows runners: DXGI screen-capture / focus tests need a live desktop. Locally `cargo test -p desktop-touch-engine` is **173 passed / 1 failed**, the single failure being `duplication::thread::dxgi_emit_fork_enable_disable_roundtrip` — a real-screen DXGI test that flakes under broker contention with a live session server (same class as the ADR-024 F2 finding), unrelated to this change. A `--no-run` compile guard is the robust CI contract; runtime DXGI test hermeticity is a separate follow-up.

## Verification
- `npm run check:rs-test-compile` → Finished, 0 errors
- `cargo test -p desktop-touch-engine` → vision_backend + ssim tests all pass (11 ssim, all florence2/paddleocr/omniparser green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)