### PR TITLE
test(adr-024): center the visual-only canvas fixture off the Recycle Bin zone

### DIFF
--- a/benches/fixtures/visual-only-canvas.ps1
+++ b/benches/fixtures/visual-only-canvas.ps1
@@ -46,8 +46,9 @@ $form.MinimizeBox = $false
 # title bar — or the brief spawn/close moment when the desktop is exposed under
 # the TopMost form — selected the Recycle Bin instead. This is the same hazard
 # tests/e2e/helpers/blank-window.ts documents (a (50,50) click "selected the
-# Recycle Bin desktop icon at every full-suite run"). CenterScreen keeps the whole
-# window clear of the edge/corner icons on any resolution. We don't need the old
+# Recycle Bin desktop icon at every full-suite run"). CenterScreen keeps the
+# window clear of the top-left desktop-icon column where the Recycle Bin lives.
+# We don't need the old
 # "no overlapping background" rationale: busy-background correctness is handled
 # structurally by the S5c frame-diff regime (occlusion-immune PrintWindow).
 $form.StartPosition = 'CenterScreen'

--- a/benches/fixtures/visual-only-canvas.ps1
+++ b/benches/fixtures/visual-only-canvas.ps1
@@ -40,12 +40,17 @@ $form.Text = $Title
 $form.FormBorderStyle = 'FixedSingle'
 $form.MaximizeBox = $false
 $form.MinimizeBox = $false
-$form.StartPosition = 'Manual'
-# Place the window near the top-left (no overlapping background activity) so the
-# headed bench/e2e is deterministic. NOTE: this no-overlap placement is for test
-# determinism only — busy-background correctness is handled structurally by the
-# S5c frame-diff regime (occlusion-immune PrintWindow), NOT avoided here.
-$form.Location = New-Object System.Drawing.Point(40, 40)
+# Centre the window — NOT the top-left corner. A previous Point(40, 40) placement
+# put this window's title bar directly over the Recycle Bin / desktop-icon zone
+# (icons live at the screen's top-left edge), so a real OS click that grazed the
+# title bar — or the brief spawn/close moment when the desktop is exposed under
+# the TopMost form — selected the Recycle Bin instead. This is the same hazard
+# tests/e2e/helpers/blank-window.ts documents (a (50,50) click "selected the
+# Recycle Bin desktop icon at every full-suite run"). CenterScreen keeps the whole
+# window clear of the edge/corner icons on any resolution. We don't need the old
+# "no overlapping background" rationale: busy-background correctness is handled
+# structurally by the S5c frame-diff regime (occlusion-immune PrintWindow).
+$form.StartPosition = 'CenterScreen'
 $form.ClientSize = New-Object System.Drawing.Size($W, $H)
 $form.TopMost = $true
 


### PR DESCRIPTION
## Symptom
At the start of a headed E2E run, the **Recycle Bin desktop icon gets clicked/selected**.

## Root cause
The ADR-024 Seed-2 visual-only canvas fixture (`benches/fixtures/visual-only-canvas.ps1`) — shared by the S6 round-trip bench and the headed `desktop-act-roi-capture` e2e — spawned at `Point(40, 40)`, i.e. its title bar sat **directly over the top-left desktop-icon zone where the Recycle Bin lives**. Empirically confirmed: the discovered window title-bar entities land at (48,48)/(57,48), pixels from the Recycle Bin's clickable area, and the icon pokes out above/left of the TopMost form (screenshot taken during investigation). A real OS click grazing the title bar — or the brief spawn/close moment exposing the desktop under the form — selects the Recycle Bin.

This is the **same hazard `tests/e2e/helpers/blank-window.ts:7-9` already documents**: a `(50,50)` top-left click "selected the Recycle Bin desktop icon at every full-suite run." The fixture's old comment had the reasoning backwards — it claimed the top-left placement was chosen for determinism.

## Fix
`StartPosition = 'CenterScreen'` — desktop icons live at the screen's edges/corners, never the center, so the whole window clears them on any resolution. The OCR anchors are still discovered by label and the click still lands on the canvas, so the localized frame-diff `roiCapture` is unaffected.

## Verification
- `HEADED=1 vitest run tests/e2e/desktop-act-roi-capture.test.ts` → **1 passed** with the canvas centered (proves the click still toggles the canvas bar → localized `roiCapture`, `source:frame_diff`).
- `desktop_state` after the run: cursor at (794,331), center region — **never visits the top-left**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)