### PR TITLE
feat(desktop_act): ADR-024 S5b-1 — postSnapshot seam + single-OCR assembly extract

### DIFF
--- a/src/engine/world-graph/guarded-touch.ts
+++ b/src/engine/world-graph/guarded-touch.ts
@@ -1,8 +1,9 @@
 import type { UiEntity, EntityLease, ExecutorKind, ExecutorOutcome, UiAffordance } from "./types.js";
 import type { LeaseStore } from "./lease-store.js";
 import type { VisualMotionObservation } from "../../tools/_input-pipeline.js";
-import type { Rect } from "../vision-gpu/types.js";
+import type { Rect, UiEntityCandidate } from "../vision-gpu/types.js";
 import { classifyModal } from "./session-registry.js";
+import { resolveCandidates } from "./resolver.js";
 
 export type TouchAction = "auto" | "invoke" | "click" | "type" | "setValue" | "select";
 
@@ -10,6 +11,24 @@ export interface TouchInput {
   lease: EntityLease;
   action?: TouchAction;
   text?: string;
+  /**
+   * ADR-024 Seed-2 S5b — optional per-call post-action snapshot closure. When
+   * present, `touch()` invokes it (AFTER execute) IN PLACE OF
+   * `env.resolvePostTouchEntities()` to obtain the post-touch candidates for the
+   * semantic diff, and surfaces its `roiMaterial` on the result. Built by the
+   * registration wrapper (`desktop-register.ts`) for visual-only acts so the ONE
+   * ROI-OCR it runs feeds both the diff baseline and the folded `roiCapture`
+   * (order-trap elimination). The loop stays capture-agnostic: this is an opaque
+   * callback — it does not know the closure does a frame-diff / OCR. Absent on
+   * every non-visual / flag-off path → `env.resolvePostTouchEntities()` is used
+   * exactly as before (byte-equal). Returns lease-LESS `UiEntityCandidate[]`;
+   * `touch()` runs `resolveCandidates(generation)` to mint `UiEntity[]` (same
+   * conversion as `resolvePostTouchEntities`), so the closure must NOT pre-resolve.
+   */
+  postSnapshot?: () => Promise<{
+    candidates: UiEntityCandidate[];
+    roiMaterial?: RoiCaptureMaterial;
+  }>;
 }
 
 export type SemanticDiff = Array<
@@ -91,6 +110,28 @@ export interface RoiCapture {
   source: "dxgi" | "frame_diff";
 }
 
+/**
+ * ADR-024 Seed-2 S5b — internal channel carried from a `postSnapshot` closure
+ * through `touch()` back to the registration wrapper. NEVER serialized: the
+ * wrapper strips it off the result (same split pattern as the Stage 5
+ * `observation` / `roiBbox` plumbing) and attaches its parts to the public
+ * fields. Lets the single ROI-OCR the closure runs feed the diff (via the
+ * returned `candidates`) AND the folded outputs here, without a second OCR.
+ */
+export interface RoiCaptureMaterial {
+  /**
+   * Screen-absolute region the post snapshot actually re-observed (the
+   * frame-diff change bbox ∪ touched rect). Threaded into the diff as
+   * `DiffContext.observedRect` so entities OUTSIDE it are treated as
+   * non-observed (not removed). Absent → the diff is unscoped (full-window).
+   */
+  observedRect?: Rect;
+  /** The assembled fold capture; the wrapper sets `result.roiCapture` to it. */
+  roiCapture?: RoiCapture;
+  /** The frame-diff motion observation; the wrapper sets `result.observation`. */
+  observation?: VisualMotionObservation;
+}
+
 export type TouchResult =
   | {
       ok: true;
@@ -127,6 +168,14 @@ export type TouchResult =
        * Live since S5 (the fold).
        */
       roiCapture?: RoiCapture;
+      /**
+       * ADR-024 Seed-2 S5b — INTERNAL channel from a `postSnapshot` closure;
+       * the registration wrapper strips this before serialization and copies
+       * its `roiCapture` / `observation` onto the public fields. Never present
+       * on the bare loop return when no `postSnapshot` was supplied (additive —
+       * existing destructures unaffected). See {@link RoiCaptureMaterial}.
+       */
+      roiMaterial?: RoiCaptureMaterial;
     }
   | {
       ok: false;
@@ -231,6 +280,19 @@ function hasEntityMoved(pre: UiEntity, post: UiEntity): boolean {
   );
 }
 
+/**
+ * Axis-aligned rect overlap test (ADR-024 S5b observed-scope diff). Touching
+ * edges count as non-overlapping (strict `<`). Both rects screen-absolute.
+ */
+function rectsIntersect(a: Rect, b: Rect): boolean {
+  return (
+    a.x < b.x + b.width &&
+    b.x < a.x + a.width &&
+    a.y < b.y + b.height &&
+    b.y < a.y + a.height
+  );
+}
+
 
 /**
  * Value fingerprint for an entity — what counts as "the value" varies by source:
@@ -257,38 +319,65 @@ interface DiffContext {
   postEntities: UiEntity[];
   preFocusId: string | undefined;
   postFocusId: string | undefined;
+  /**
+   * ADR-024 Seed-2 S5b (D2) — screen-absolute region the POST snapshot actually
+   * re-observed. When set (visual-only fold path), the diff is scoped to it:
+   * pre-entities OUTSIDE it were not re-observed, so they must NOT be counted as
+   * removed/dismissed, and the touched-entity fate is only asserted when the
+   * touched entity lies inside it. Absent (the default / non-fold path) → the
+   * diff is unscoped, identical to pre-S5b behaviour (byte-equal).
+   */
+  observedRect?: Rect;
 }
 
 function computeDiff(ctx: DiffContext): SemanticDiff {
-  const { touched, preEntities, postEntities, preFocusId, postFocusId } = ctx;
+  const { touched, preEntities, postEntities, preFocusId, postFocusId, observedRect } = ctx;
   const diff: SemanticDiff = [];
 
   const preIds  = new Set(preEntities.map((e) => e.entityId));
   const postIds = new Set(postEntities.map((e) => e.entityId));
 
+  // ADR-024 Seed-2 S5b (D2) — observed-scope predicate. When `observedRect` is
+  // set, the post snapshot only re-observed that region; an entity outside it
+  // was NOT looked at, so it must not be judged removed/dismissed and the
+  // touched fate is only asserted for an in-region touched entity. When unset
+  // (default / non-fold), every entity is in scope → identical to pre-S5b
+  // behaviour (byte-equal). An entity with no rect is in scope only when
+  // unscoped (we cannot prove overlap), so the unscoped path stays unchanged.
+  const inScope = (e: UiEntity): boolean =>
+    observedRect === undefined ||
+    (e.rect !== undefined && rectsIntersect(e.rect, observedRect));
+
   // ── Touched entity fate ───────────────────────────────────────────────────
 
   // entityId stability is the identity contract.
   // id-preserving move → entity_moved; id-changing replace → entity_disappeared.
-  const postTouched = postEntities.find((e) => e.entityId === touched.entityId);
-  if (!postTouched) {
-    diff.push("entity_disappeared");
-  } else {
-    if (hasEntityMoved(touched, postTouched)) diff.push("entity_moved");
+  // Scoped: only assert fate when the touched entity was in the re-observed
+  // region (always true on the unscoped path).
+  if (inScope(touched)) {
+    const postTouched = postEntities.find((e) => e.entityId === touched.entityId);
+    if (!postTouched) {
+      diff.push("entity_disappeared");
+    } else {
+      if (hasEntityMoved(touched, postTouched)) diff.push("entity_moved");
 
-    // value_changed: compare entity.value (or label for terminal) pre vs post.
-    // Only emitted when both sides expose a value — absence of value means not comparable.
-    const preVal  = extractValueFingerprint(touched);
-    const postVal = extractValueFingerprint(postTouched);
-    if (preVal !== undefined && postVal !== undefined && preVal !== postVal) {
-      diff.push("value_changed");
+      // value_changed: compare entity.value (or label for terminal) pre vs post.
+      // Only emitted when both sides expose a value — absence of value means not comparable.
+      const preVal  = extractValueFingerprint(touched);
+      const postVal = extractValueFingerprint(postTouched);
+      if (preVal !== undefined && postVal !== undefined && preVal !== postVal) {
+        diff.push("value_changed");
+      }
     }
   }
 
   // ── Appeared / disappeared entities ───────────────────────────────────────
 
+  // `appeared` is drawn from the post snapshot (already region-bound on the
+  // fold path); `removed` is scoped so out-of-region pre-entities (never
+  // re-observed) are not falsely counted as gone.
   const appeared = postEntities.filter((e) => !preIds.has(e.entityId));
-  const removed  = preEntities.filter((e) => !postIds.has(e.entityId));
+  const removed  = preEntities.filter((e) => !postIds.has(e.entityId) && inScope(e));
 
   // modal_appeared / modal_dismissed take priority for modal entities.
   // ADR-020 PR-P2-1: unified classifier (post-touch-diff context, no self-exclusion;
@@ -401,10 +490,33 @@ export class GuardedTouchLoop {
       typeof outcome === "string" ? undefined : outcome.downgrade;
 
     // 6. Compute semantic diff against the pre-touch snapshot.
-    const post        = await this.env.resolvePostTouchEntities();
+    //
+    // ADR-024 Seed-2 S5b — when the caller supplied a `postSnapshot` closure
+    // (visual-only fold path), use it for the post-touch candidates INSTEAD of
+    // `env.resolvePostTouchEntities()`, and carry its `roiMaterial` back out.
+    // The closure returns lease-less candidates; convert with the SAME
+    // `resolveCandidates(gen)` (gen captured at step 1) the env path uses, so
+    // entityIds match the pre snapshot. Absent (every non-fold path) → the
+    // existing env path runs and `roiMaterial` stays undefined (byte-equal).
+    let post: UiEntity[];
+    let roiMaterial: RoiCaptureMaterial | undefined;
+    if (input.postSnapshot) {
+      const snapshot = await input.postSnapshot();
+      post = resolveCandidates(snapshot.candidates, gen);
+      roiMaterial = snapshot.roiMaterial;
+    } else {
+      post = await this.env.resolvePostTouchEntities();
+    }
     const postFocusId = this.env.getFocusedEntityId?.();
 
-    const diff = computeDiff({ touched: entity, preEntities: live, postEntities: post, preFocusId, postFocusId });
+    const diff = computeDiff({
+      touched: entity,
+      preEntities: live,
+      postEntities: post,
+      preFocusId,
+      postFocusId,
+      observedRect: roiMaterial?.observedRect,
+    });
 
     return {
       ok: true,
@@ -412,6 +524,7 @@ export class GuardedTouchLoop {
       diff,
       next: diff.length > 0 ? "refresh_view" : "none",
       ...(downgrade ? { downgrade } : {}),
+      ...(roiMaterial ? { roiMaterial } : {}),
     };
   }
 }

--- a/src/tools/_roi-preview.ts
+++ b/src/tools/_roi-preview.ts
@@ -14,7 +14,7 @@
  * Side-effect-free; native OCR + facade access stay in `desktop-register.ts`.
  */
 
-import type { Rect } from "../engine/vision-gpu/types.js";
+import type { Rect, UiEntityCandidate } from "../engine/vision-gpu/types.js";
 import type { RoiPreviewEntity } from "../engine/world-graph/guarded-touch.js";
 import { rectIoU } from "./_roi-region.js";
 
@@ -69,4 +69,39 @@ export function buildRoiPreviewEntities(
       rect: el.region,
       actionability: ["click"],
     }));
+}
+
+/**
+ * ADR-024 Seed-2 S5b — map ROI-aware SoM/OCR elements to lease-less
+ * `UiEntityCandidate[]` for the post-touch DIFF baseline (distinct from
+ * `buildRoiPreviewEntities`, which builds the lease-less *preview*).
+ *
+ * MUST mirror the discover OCR lane (`ocr-provider.ts` `fetchOcrCandidates`)
+ * field-for-field — same `source:"ocr"`, `target`, `role:"label"`, `label`,
+ * `rect`, `actionability:["click"]` — so that an UNCHANGED on-screen element
+ * yields the SAME `entityId` whether it was first seen via the full-window
+ * discover OCR or this ROI-crop OCR. `computeDiff`'s touched-entity fate (and
+ * removed/appeared) depend on that identity; a mismatch would read the touched
+ * entity as `entity_disappeared` (R1). `target` is the SAME `{kind,id}` the
+ * discover lane used for the window; `observedAtMs` is injected (not
+ * `Date.now()`) to keep the mapper pure / deterministic for tests.
+ */
+export function somElementsToCandidates(
+  elements: readonly { text: string; region: Rect; confidence?: number }[],
+  target: { kind: "window" | "browserTab"; id: string },
+  observedAtMs: number,
+): UiEntityCandidate[] {
+  return elements.map((el): UiEntityCandidate => ({
+    source: "ocr",
+    target,
+    // locator omitted — EntityLocator has no .ocr slot; executor routes to mouse
+    // click (identical to fetchOcrCandidates).
+    role: "label",
+    label: el.text,
+    rect: el.region,
+    actionability: ["click"],
+    confidence: el.confidence ?? 0.7,
+    observedAtMs,
+    provisional: false,
+  }));
 }

--- a/src/tools/desktop-register.ts
+++ b/src/tools/desktop-register.ts
@@ -857,17 +857,7 @@ async function buildRoiCapture(
     // S4 — OCR only the ROI crop. hwnd is provided so the empty windowTitle is
     // unused; no UIA dictionary (visual-only target has no UIA candidates).
     const som = await runSomPipeline("", hwnd, "ja", 2, "auto", false, [], roi);
-    if (som.somImage === null) return undefined; // SoM render unavailable
-
-    // OQ-10 — map ROI-OCR elements to the lease-less preview, deduped against
-    // the discover snapshot by geometry AND label (so an in-place text change is
-    // preserved). Pure logic in `_roi-preview.ts` (`buildRoiPreviewEntities`).
-    const entities = buildRoiPreviewEntities(
-      som.elements,
-      facade.getDiscoverEntitiesForViewId(viewId),
-    );
-
-    return { roi, somImage: som.somImage.base64, entities, source };
+    return assembleRoiCaptureFromSom(som, roi, source, facade, viewId);
   } catch (err) {
     // OCR is best-effort; never break the act envelope on a pipeline failure.
     console.error(
@@ -875,6 +865,34 @@ async function buildRoiCapture(
     );
     return undefined;
   }
+}
+
+/**
+ * ADR-024 Seed-2 S5b — OCR-free assembly of a {@link RoiCapture} from an
+ * already-computed SoM pipeline result. Extracted from {@link buildRoiCapture}
+ * so the S5b fold can reuse the SAME assembly on the single ROI-OCR it already
+ * ran (instead of a second `runSomPipeline`), keeping the `roiCapture` output
+ * byte-equal between the legacy 2-OCR path and the folded 1-OCR path (S5b
+ * acceptance ③). Gate-less: the caller is responsible for the visual-only gate.
+ */
+function assembleRoiCaptureFromSom(
+  som: Awaited<ReturnType<typeof runSomPipeline>>,
+  roi: Rect,
+  source: RoiCapture["source"],
+  facade: DesktopFacade,
+  viewId: string,
+): RoiCapture | undefined {
+  if (som.somImage === null) return undefined; // SoM render unavailable
+
+  // OQ-10 — map ROI-OCR elements to the lease-less preview, deduped against
+  // the discover snapshot by geometry AND label (so an in-place text change is
+  // preserved). Pure logic in `_roi-preview.ts` (`buildRoiPreviewEntities`).
+  const entities = buildRoiPreviewEntities(
+    som.elements,
+    facade.getDiscoverEntitiesForViewId(viewId),
+  );
+
+  return { roi, somImage: som.somImage.base64, entities, source };
 }
 
 /** Pre-flight lease validation closure used by the commit wrapper

--- a/src/tools/desktop.ts
+++ b/src/tools/desktop.ts
@@ -15,7 +15,7 @@ import {
 import type { CandidateIngress } from "../engine/world-graph/candidate-ingress.js";
 import { createDesktopExecutor, type ExecutorDeps } from "./desktop-executor.js";
 import { resolveWindowTarget, findPlainTopLevelWindowByTitle } from "./_resolve-window.js";
-import type { TouchAction, TouchResult } from "../engine/world-graph/guarded-touch.js";
+import type { TouchAction, TouchInput, TouchResult } from "../engine/world-graph/guarded-touch.js";
 import { deriveViewConstraints, type ViewConstraints, type EntityCapabilities } from "./desktop-constraints.js";
 import { UIA_BLIND_WARNINGS } from "./desktop-providers/compose-providers.js";
 import { deriveEntityCapabilities } from "./desktop-capabilities.js";
@@ -127,6 +127,13 @@ export interface DesktopTouchInput {
   lease: EntityLease;
   action?: TouchAction;
   text?: string;
+  /**
+   * ADR-024 Seed-2 S5b — per-call post-action snapshot closure, forwarded
+   * verbatim to `GuardedTouchLoop.touch`. See {@link TouchInput.postSnapshot}.
+   * Built by `desktop-register.ts` for the visual-only fold; undefined on every
+   * other path (passthrough — `facade.touch` hands `input` straight to the loop).
+   */
+  postSnapshot?: TouchInput["postSnapshot"];
 }
 
 export type DesktopTouchOutput = TouchResult;

--- a/tests/unit/guarded-touch.test.ts
+++ b/tests/unit/guarded-touch.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from "vitest";
-import { GuardedTouchLoop, type TouchEnvironment } from "../../src/engine/world-graph/guarded-touch.js";
+import { describe, it, expect, vi } from "vitest";
+import { GuardedTouchLoop, type TouchEnvironment, type RoiCaptureMaterial } from "../../src/engine/world-graph/guarded-touch.js";
 import { LeaseStore } from "../../src/engine/world-graph/lease-store.js";
 import type { UiEntity } from "../../src/engine/world-graph/types.js";
+import type { Rect, UiEntityCandidate } from "../../src/engine/vision-gpu/types.js";
 
 function entity(id: string, gen: string, opts: Partial<UiEntity> = {}): UiEntity {
   return {
@@ -659,5 +660,138 @@ describe("GuardedTouchLoop — H3 dialog-own session modal guard", () => {
     }));
     const result = await loop.touch({ lease });
     expect(result.ok).toBe(true);
+  });
+});
+
+// ── ADR-024 Seed-2 S5b — postSnapshot seam (未配線 in prod; wired in the loop) ──
+//
+// The loop consumes an optional per-call `postSnapshot` closure (W2): when
+// present it supplies the post-touch candidates IN PLACE OF
+// `env.resolvePostTouchEntities()`, surfaces `roiMaterial`, and scopes the diff
+// to `roiMaterial.observedRect`. Absent → the env path runs and no `roiMaterial`
+// is attached (byte-equal). Production does not pass a closure yet (S5b-2), so
+// these tests exercise the seam with a fake closure.
+describe("GuardedTouchLoop — ADR-024 S5b postSnapshot seam", () => {
+  function ocrCandidate(label: string, rect: Rect): UiEntityCandidate {
+    return {
+      source: "ocr",
+      target: { kind: "window", id: "w1" },
+      role: "label",
+      label,
+      rect,
+      actionability: ["click"],
+      confidence: 0.7,
+      observedAtMs: 0,
+      provisional: false,
+    };
+  }
+
+  it("postSnapshot present → used instead of resolvePostTouchEntities; candidates feed the diff; roiMaterial surfaces", async () => {
+    const e = entity("e1", GEN); // touched, rect 100,200,80,30
+    const store = new LeaseStore({ nowFn: () => 0, defaultTtlMs: 60_000 });
+    const lease = store.issue(e, "v1");
+    const resolvePost = vi.fn(async () => [] as UiEntity[]);
+    const loop = new GuardedTouchLoop(store, makeEnv({
+      resolveLiveEntities: () => [e],
+      resolvePostTouchEntities: resolvePost,
+    }));
+    const roiMaterial: RoiCaptureMaterial = { observedRect: { x: 0, y: 0, width: 50, height: 50 } };
+    const postSnapshot = vi.fn(async () => ({
+      // A fresh OCR candidate inside the observed region; e (touched) sits OUTSIDE
+      // it (100,200) so its fate is not asserted — isolating "candidate → diff".
+      candidates: [ocrCandidate("Hello", { x: 10, y: 10, width: 20, height: 10 })],
+      roiMaterial,
+    }));
+
+    const result = await loop.touch({ lease, postSnapshot });
+
+    expect(postSnapshot).toHaveBeenCalledOnce();
+    expect(resolvePost).not.toHaveBeenCalled(); // env path bypassed
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // The closure's candidate was resolved into the post snapshot → appeared.
+      expect(result.diff).toContain("entity_appeared");
+      // The touched entity (outside observedRect) was not re-observed → not disappeared.
+      expect(result.diff).not.toContain("entity_disappeared");
+      // roiMaterial threaded straight through for the wrapper to strip.
+      expect(result.roiMaterial).toBe(roiMaterial);
+    }
+  });
+
+  it("postSnapshot absent → resolvePostTouchEntities used and no roiMaterial key (byte-equal)", async () => {
+    const e = entity("e1", GEN);
+    const store = new LeaseStore({ nowFn: () => 0, defaultTtlMs: 60_000 });
+    const lease = store.issue(e, "v1");
+    const resolvePost = vi.fn(async () => [e]);
+    const loop = new GuardedTouchLoop(store, makeEnv({
+      resolveLiveEntities: () => [e],
+      resolvePostTouchEntities: resolvePost,
+    }));
+
+    const result = await loop.touch({ lease });
+
+    expect(resolvePost).toHaveBeenCalledOnce();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.diff).toHaveLength(0);
+      // Field omitted entirely (not `roiMaterial: undefined`) so JSON.stringify
+      // matches the pre-S5b shape.
+      expect("roiMaterial" in result).toBe(false);
+    }
+  });
+
+  it("observedRect scopes the touched fate — out-of-region touched is NOT entity_disappeared", async () => {
+    const e = entity("e1", GEN); // rect 100,200,80,30
+    const store = new LeaseStore({ nowFn: () => 0, defaultTtlMs: 60_000 });
+    const lease = store.issue(e, "v1");
+    const loop = new GuardedTouchLoop(store, makeEnv({ resolveLiveEntities: () => [e] }));
+
+    // post empty (e absent), observedRect far from e → e was not re-observed.
+    const result = await loop.touch({
+      lease,
+      postSnapshot: async () => ({ candidates: [], roiMaterial: { observedRect: { x: 0, y: 0, width: 10, height: 10 } } }),
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.diff).not.toContain("entity_disappeared");
+  });
+
+  it("observedRect covering the touched entity DOES report entity_disappeared when it vanishes", async () => {
+    const e = entity("e1", GEN); // rect 100,200,80,30
+    const store = new LeaseStore({ nowFn: () => 0, defaultTtlMs: 60_000 });
+    const lease = store.issue(e, "v1");
+    const loop = new GuardedTouchLoop(store, makeEnv({ resolveLiveEntities: () => [e] }));
+
+    const result = await loop.touch({
+      lease,
+      postSnapshot: async () => ({ candidates: [], roiMaterial: { observedRect: { x: 100, y: 200, width: 80, height: 30 } } }),
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.diff).toContain("entity_disappeared");
+  });
+
+  it("observedRect scopes the removed set — an out-of-region dismissed modal is NOT modal_dismissed", async () => {
+    const touched = entity("t1", GEN, { rect: { x: 500, y: 500, width: 10, height: 10 } });
+    const modal   = entity("m1", GEN, { role: "unknown", sources: ["uia"], rect: { x: 0, y: 0, width: 10, height: 10 } });
+    const store = new LeaseStore({ nowFn: () => 0, defaultTtlMs: 60_000 });
+    const lease = store.issue(touched, "v1");
+    const loop = new GuardedTouchLoop(store, makeEnv({ resolveLiveEntities: () => [touched, modal] }));
+
+    // observedRect covers the touched (500,500) only; the modal (0,0) is outside.
+    // post=[] → unscoped this would emit modal_dismissed (modal in removed); scoped
+    // the out-of-region modal is excluded from removed.
+    const result = await loop.touch({
+      lease,
+      postSnapshot: async () => ({ candidates: [], roiMaterial: { observedRect: { x: 495, y: 495, width: 20, height: 20 } } }),
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.diff).not.toContain("modal_dismissed");
+      // The touched IS in the observed region and vanished → entity_disappeared,
+      // proving the diff actually ran (not vacuously empty).
+      expect(result.diff).toContain("entity_disappeared");
+    }
   });
 });

--- a/tests/unit/roi-preview.test.ts
+++ b/tests/unit/roi-preview.test.ts
@@ -10,9 +10,12 @@ import { describe, it, expect } from "vitest";
 
 import {
   buildRoiPreviewEntities,
+  somElementsToCandidates,
   type RoiOcrElement,
   type DiscoverEntityRef,
 } from "../../src/tools/_roi-preview.js";
+import { resolveCandidates } from "../../src/engine/world-graph/resolver.js";
+import type { UiEntityCandidate } from "../../src/engine/vision-gpu/types.js";
 
 const RECT_A = { x: 100, y: 100, width: 40, height: 20 };
 
@@ -67,5 +70,66 @@ describe("buildRoiPreviewEntities (S5 OQ-10 dedup + mapping)", () => {
 
   it("returns [] for no OCR elements", () => {
     expect(buildRoiPreviewEntities([], [{ rect: RECT_A, label: "x" }])).toEqual([]);
+  });
+});
+
+describe("somElementsToCandidates (S5b diff baseline mapping)", () => {
+  const target = { kind: "window" as const, id: "hwnd-42" };
+
+  it("mirrors the discover OCR candidate shape field-for-field", () => {
+    const out = somElementsToCandidates(
+      [{ text: "Save", region: RECT_A, confidence: 0.9 }],
+      target,
+      123,
+    );
+    expect(out).toEqual([
+      {
+        source: "ocr",
+        target,
+        role: "label",
+        label: "Save",
+        rect: RECT_A,
+        actionability: ["click"],
+        confidence: 0.9,
+        observedAtMs: 123,
+        provisional: false,
+      },
+    ]);
+  });
+
+  it("defaults confidence to 0.7 when the element omits it (matches fetchOcrCandidates)", () => {
+    const out = somElementsToCandidates([{ text: "X", region: RECT_A }], target, 0);
+    expect(out[0]?.confidence).toBe(0.7);
+  });
+
+  it("produces the SAME entityId as the discover OCR lane for the same label+rect+target (R1 structural half)", () => {
+    // The discover OCR lane builds candidates exactly like ocr-provider's
+    // fetchOcrCandidates. entityId = sha1(window:id | label | snapRect) — NOT
+    // observedAtMs — so the ROI-crop candidate and the full-window discover
+    // candidate for the same on-screen text must resolve to the same entityId.
+    // (The real-OCR end-to-end half is the S5b-2 headed test.)
+    const discoverOcr: UiEntityCandidate = {
+      source: "ocr",
+      target,
+      role: "label",
+      label: "TARGET ALPHA",
+      rect: RECT_A,
+      actionability: ["click"],
+      confidence: 0.7,
+      observedAtMs: 999, // different time — must NOT affect entityId
+      provisional: false,
+    };
+    const roiOcr = somElementsToCandidates(
+      [{ text: "TARGET ALPHA", region: { ...RECT_A } }],
+      target,
+      1,
+    );
+    const [discoverEntity] = resolveCandidates([discoverOcr], "gen-1");
+    const [roiEntity] = resolveCandidates(roiOcr, "gen-1");
+    expect(roiEntity?.entityId).toBe(discoverEntity?.entityId);
+  });
+
+  it("returns [] for no elements", () => {
+    expect(somElementsToCandidates([], target, 0)).toEqual([]);
   });
 });


### PR DESCRIPTION
## What
First of three S5b sub-PRs (order-trap fold). Introduces the **seam** for folding the visual-only post-touch OCR into a single ROI-OCR that feeds both the diff and the `roiCapture`. **Unwired in production** — the handler does not build/pass a `postSnapshot` closure yet (S5b-2), so every prod path is **byte-equal with S5** (flag off, no closure).

Plan: `desktop-touch-mcp-internal@0d72257:docs/adr-024-seed2-plan.md` (Plan PR #14, Opus R1+R2 / Codex R1+R2, P1=0).

## Changes
- **`guarded-touch.ts`**: `TouchInput.postSnapshot?` (per-call closure → `{candidates, roiMaterial?}`); `TouchResult.roiMaterial?` (internal, wrapper-stripped); `RoiCaptureMaterial` type. `touch()` uses the closure **in place of** `env.resolvePostTouchEntities()` when present, converting its lease-less candidates with the **same `resolveCandidates(gen)`** so entityIds match the pre snapshot. `DiffContext.observedRect` + `computeDiff` **observed-scope (D2)**: touched-fate and the removed set are restricted to entities intersecting the re-observed region; out-of-region entities are *non-observed* (not removed). `observedRect` undefined → **identical to pre-S5b** (byte-equal).
- **`desktop.ts`**: `DesktopTouchInput.postSnapshot?` passthrough.
- **`_roi-preview.ts`**: `somElementsToCandidates()` mirrors `ocr-provider.fetchOcrCandidates` field-for-field so the same on-screen text yields the same entityId (R1 structural half).
- **`desktop-register.ts`**: extract OCR-free `assembleRoiCaptureFromSom()` from `buildRoiCapture` (which now delegates — byte-equal output) so the fold reuses the SAME assembly on its single OCR.

## Acceptance (S5b-1)
- Non-visual / flag-off paths byte-equal (no closure built in prod).
- Loop seam unit-tested with a fake closure; public envelope unchanged (`roiMaterial` absent when no closure).

## Verification
- Full unit suite **4239 passed / 0 failed** (30 skipped); `tsc` clean; lint 0 new (14 pre-existing warnings in an untouched file).
- 5 loop seam tests + 4 `somElementsToCandidates` tests (incl. entityId parity with the discover OCR lane via `resolveCandidates`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)