### PR TITLE
feat(desktop_act): ADR-024 S5b-2 — order-trap fold (carry-forward diff + padded roiCapture)

### DIFF
--- a/src/tools/_roi-region.ts
+++ b/src/tools/_roi-region.ts
@@ -129,6 +129,42 @@ export function clampRectToWindow(roi: Rect, windowRect: Rect): Rect | null {
 }
 
 /**
+ * ADR-024 Seed-2 S5b — symmetric inflate of a rect by `margin` on every side.
+ * Used to pad the fold's roiCapture OCR crop (see {@link resolveFoldOcrRoi}).
+ */
+export function inflateRect(rect: Rect, margin: number): Rect {
+  return {
+    x: rect.x - margin,
+    y: rect.y - margin,
+    width: rect.width + margin * 2,
+    height: rect.height + margin * 2,
+  };
+}
+
+/**
+ * ADR-024 Seed-2 S5b — the window-relative crop the fold's roiCapture OCR runs
+ * on. The crop is **padded** around the frame-diff change bbox: Windows OCR's
+ * line segmentation fails on a crop ≈ the text-line height (no vertical
+ * context), returning 0 elements where a full-window OCR finds the same text
+ * (verified end-to-end — Opus S5b-2 root-cause). The margin gives that context:
+ * `max(24px, ceil(height * 0.5))` per side, then clamp to the window.
+ *
+ * Note: this ROI feeds ONLY the visual roiCapture crop, NOT the semantic diff.
+ * The diff baseline carries the discover full-window entities forward (so the
+ * touched entity keeps its entityId — R1), because ROI-crop OCR is not a
+ * reliable substitute for full-window OCR.
+ *
+ * `roiBbox` is window-relative (from `verifyLocalRepaint`); `undefined` (miss /
+ * BitBlt demotion / no_change) → the whole window.
+ */
+export function resolveFoldOcrRoi(roiBbox: Rect | undefined, windowRect: Rect): Rect {
+  const fullWindow: Rect = { x: 0, y: 0, width: windowRect.width, height: windowRect.height };
+  if (roiBbox === undefined) return fullWindow;
+  const margin = Math.max(24, Math.ceil(roiBbox.height * 0.5));
+  return clampRectToWindow(inflateRect(roiBbox, margin), windowRect) ?? fullWindow;
+}
+
+/**
  * ADR-024 Seed-2 S5 — intersection-over-union of two rects.
  *
  * Used to dedup the post-action ROI-OCR preview against the entities the most

--- a/src/tools/desktop-register.ts
+++ b/src/tools/desktop-register.ts
@@ -38,7 +38,7 @@ import type { NativeLeaseTokenSummary } from "../engine/native-types.js";
 import type { ToolResult } from "./_types.js";
 import { Err } from "../types/result.js";
 import { ExecutorFailedError } from "../errors/typed-errors.js";
-import type { TouchAction, RoiCapture } from "../engine/world-graph/guarded-touch.js";
+import type { TouchAction, RoiCapture, RoiCaptureMaterial } from "../engine/world-graph/guarded-touch.js";
 import {
   SnapshotIngress,
   combineEventSources,
@@ -68,10 +68,10 @@ import { verifyLocalRepaint } from "../engine/local-repaint.js";
 import { disposeSharedDirtyRectBroker } from "../engine/dxgi-broker.js";
 import type { VisualMotionObservation } from "./_input-pipeline.js";
 import { shouldReturnRoiCapture, type ReturnCaptureMode } from "./_roi-capture-gate.js";
-import { filterDirtyRectsToWindow, boundingBox, clampRectToWindow } from "./_roi-region.js";
-import { buildRoiPreviewEntities } from "./_roi-preview.js";
+import { filterDirtyRectsToWindow, boundingBox, clampRectToWindow, resolveFoldOcrRoi } from "./_roi-region.js";
+import { buildRoiPreviewEntities, somElementsToCandidates } from "./_roi-preview.js";
 import { runSomPipeline } from "../engine/ocr-bridge.js";
-import type { Rect } from "../engine/vision-gpu/types.js";
+import type { Rect, UiEntityCandidate } from "../engine/vision-gpu/types.js";
 import { createDefaultCapabilityRegistry } from "../capabilities/registry.js";
 
 // ── Advisory registry singleton (PR-SR1-3) ────────────────────────────────────
@@ -586,6 +586,11 @@ export const desktopActRawHandler = async (
   // keep the DXGI tryVerifyAnyChange path and their `result.observation` stays
   // byte-equal (ADR-019 Stage 5 telemetry contract; S5c review R2-P1).
   const postVerifyEnabled = process.env["DESKTOP_TOUCH_STAGE5_DXGI"] !== "0";
+  // ADR-024 Seed-2 S5b — the order-trap fold. When ON (default) a visual-only
+  // act folds its post-touch confirmation into a SINGLE ROI-OCR feeding BOTH the
+  // diff and the roiCapture (one OCR vs S5's two). `=0` falls back to the S5
+  // 2-OCR path (every composeCandidates lane preserved).
+  const foldEnabled = process.env["DESKTOP_TOUCH_STAGE5B_FOLD_OCR"] !== "0";
   const visualOnly = facade.resolveVisualOnlyForViewId(input.lease.viewId);
   let preFrame: RawFrame | null = null;
   let frameDiffHwnd: bigint | null = null;
@@ -613,93 +618,139 @@ export const desktopActRawHandler = async (
     }
   }
 
+  // ADR-024 Seed-2 S5b — fold gate. Fold only when: enabled; visual-only;
+  // pre-frame + window geometry in hand; AND the discover snapshot is OCR-only
+  // (D6 — no visual_gpu lane the OCR-only post could silently drop). Otherwise
+  // keep the S5 path (legacy 2-OCR) below, which preserves every lane.
+  const fold =
+    foldEnabled &&
+    postVerifyEnabled &&
+    visualOnly &&
+    preFrame !== null &&
+    frameDiffHwnd !== null &&
+    frameDiffWindowRect !== null &&
+    !facade.discoverHasVisualGpuForViewId(input.lease.viewId);
+
   const result = await facade.touch({
     lease: input.lease,
     action: input.action,
     text: input.text,
+    // Fold path: the loop invokes this closure (post-execute) in place of
+    // env.resolvePostTouchEntities — its single ROI-OCR feeds the diff and the
+    // roiCapture. Non-fold: no closure → loop uses the env path (S5, byte-equal).
+    ...(fold
+      ? {
+          postSnapshot: buildFoldPostSnapshot(
+            facade,
+            input.lease,
+            preFrame as RawFrame,
+            frameDiffHwnd as bigint,
+            frameDiffWindowRect as { x: number; y: number; width: number; height: number },
+            frameDiffPoint,
+            input.returnCapture,
+          ),
+        }
+      : {}),
   });
 
-  let postVerify: { observation: VisualMotionObservation; dirtyRects: Rect[] } | null = null;
-  let frameDiffObservation: VisualMotionObservation | undefined;
-  // ADR-024 Seed-2 S5c-1b — the window-relative changed-region bbox from the
-  // frame-diff, split off the observation here so it never reaches the public
-  // `result.observation` telemetry (R2-P1) and is instead threaded into
-  // buildRoiCapture as the localized ROI.
-  let frameDiffRoi: Rect | undefined;
-  if (result.ok && postVerifyEnabled) {
-    if (visualOnly) {
-      // Visual-only — frame-diff ONLY. Never fall back to the DXGI verifier:
-      // DXGI is exactly the occlusion-blind / drain-race path this phase replaces,
-      // so a visual-only frame-diff *miss* (capture/hwnd/rect unavailable) must
-      // degrade to no observation — NOT reintroduce F1/F2 via DXGI (Codex PR #431
-      // round 2 P2). With no observation the gate sees `motion=undefined` and
-      // declines (except `returnCapture:"always"`, whose full-window fallback in
-      // buildRoiCapture still applies — a best-effort capture, never DXGI motion).
-      if (preFrame !== null && frameDiffHwnd !== null && frameDiffWindowRect !== null) {
-        // Stage 4 orchestrator: caller pre-frame + capturePostFrameUntilStable
-        // settle + native SIMD computeChangeFraction/SSIM. Its background-animation
-        // guard degrades to `indeterminate`, which the gate excludes (so a noisy
-        // desktop yields no spurious roiCapture = F1). `observation.source` becomes
-        // `ssim_residual` (frame-diff family) on this path only.
-        // S5c-1b — opt into the ROI bbox surface so the SAME frame-diff that
-        // produces `motion` also yields the localized changed-region rect.
-        const frameDiffObs = await verifyLocalRepaint({
-          hwnd: frameDiffHwnd,
-          hint: {
-            windowRect: frameDiffWindowRect,
-            ...(frameDiffPoint !== null && { point: frameDiffPoint }),
-          },
-          preFrame,
-          includeRoiBbox: true,
-        });
-        // Split `roiBbox` off BEFORE assigning `result.observation` (P2-2):
-        // `roiBbox` is an internal ROI-source channel, not public Stage 5
-        // telemetry — the same split pattern as `tryVerifyAnyChange`'s
-        // `dirtyRects`. The destructured `observation` has no `roiBbox` key, so
-        // the serialized envelope stays byte-equal with the pre-S5c-1b shape.
-        const { roiBbox, ...observation } = frameDiffObs;
-        frameDiffObservation = observation;
-        frameDiffRoi = roiBbox;
-        (result as { observation?: VisualMotionObservation }).observation = observation;
+  if (fold) {
+    // Fold path — the closure already ran the single ROI-OCR and assembled the
+    // roiCapture. Lift its internal `roiMaterial` onto the public fields and
+    // strip it before serialization (same split discipline as the Stage 5
+    // observation/roiBbox plumbing). No second OCR (buildRoiCapture) here.
+    if (result.ok) {
+      const rm = (result as { roiMaterial?: RoiCaptureMaterial }).roiMaterial;
+      delete (result as { roiMaterial?: RoiCaptureMaterial }).roiMaterial;
+      if (rm?.observation) {
+        (result as { observation?: VisualMotionObservation }).observation = rm.observation;
       }
-      // else: frame-diff setup missed → degrade silently (no observation, no DXGI).
-    } else {
-      // Non-visual-only — existing DXGI Stage 5 path (byte-equal). `dirtyRects` is
-      // an internal ROI-source channel for buildRoiCapture (S3a), kept off the
-      // public `result.observation` telemetry by the split in tryVerifyAnyChange.
-      postVerify = await tryVerifyAnyChange(facade, input.lease.viewId);
-      if (postVerify !== null) {
-        (result as { observation?: VisualMotionObservation }).observation = postVerify.observation;
+      if (rm?.roiCapture) {
+        (result as { roiCapture?: RoiCapture }).roiCapture = rm.roiCapture;
       }
     }
-  }
+  } else {
+    // ── Legacy S5 path (non-visual / fold-off / visual_gpu present / frame-diff
+    // setup missed) — post-verify, then build the roiCapture in a SECOND OCR. ──
+    let postVerify: { observation: VisualMotionObservation; dirtyRects: Rect[] } | null = null;
+    let frameDiffObservation: VisualMotionObservation | undefined;
+    // ADR-024 Seed-2 S5c-1b — the window-relative changed-region bbox from the
+    // frame-diff, split off the observation here so it never reaches the public
+    // `result.observation` telemetry (R2-P1) and is instead threaded into
+    // buildRoiCapture as the localized ROI.
+    let frameDiffRoi: Rect | undefined;
+    if (result.ok && postVerifyEnabled) {
+      if (visualOnly) {
+        // Visual-only — frame-diff ONLY. Never fall back to the DXGI verifier:
+        // DXGI is exactly the occlusion-blind / drain-race path this phase replaces,
+        // so a visual-only frame-diff *miss* (capture/hwnd/rect unavailable) must
+        // degrade to no observation — NOT reintroduce F1/F2 via DXGI (Codex PR #431
+        // round 2 P2). With no observation the gate sees `motion=undefined` and
+        // declines (except `returnCapture:"always"`, whose full-window fallback in
+        // buildRoiCapture still applies — a best-effort capture, never DXGI motion).
+        if (preFrame !== null && frameDiffHwnd !== null && frameDiffWindowRect !== null) {
+          // Stage 4 orchestrator: caller pre-frame + capturePostFrameUntilStable
+          // settle + native SIMD computeChangeFraction/SSIM. Its background-animation
+          // guard degrades to `indeterminate`, which the gate excludes (so a noisy
+          // desktop yields no spurious roiCapture = F1). `observation.source` becomes
+          // `ssim_residual` (frame-diff family) on this path only.
+          // S5c-1b — opt into the ROI bbox surface so the SAME frame-diff that
+          // produces `motion` also yields the localized changed-region rect.
+          const frameDiffObs = await verifyLocalRepaint({
+            hwnd: frameDiffHwnd,
+            hint: {
+              windowRect: frameDiffWindowRect,
+              ...(frameDiffPoint !== null && { point: frameDiffPoint }),
+            },
+            preFrame,
+            includeRoiBbox: true,
+          });
+          // Split `roiBbox` off BEFORE assigning `result.observation` (P2-2):
+          // `roiBbox` is an internal ROI-source channel, not public Stage 5
+          // telemetry — the same split pattern as `tryVerifyAnyChange`'s
+          // `dirtyRects`. The destructured `observation` has no `roiBbox` key, so
+          // the serialized envelope stays byte-equal with the pre-S5c-1b shape.
+          const { roiBbox, ...observation } = frameDiffObs;
+          frameDiffObservation = observation;
+          frameDiffRoi = roiBbox;
+          (result as { observation?: VisualMotionObservation }).observation = observation;
+        }
+        // else: frame-diff setup missed → degrade silently (no observation, no DXGI).
+      } else {
+        // Non-visual-only — existing DXGI Stage 5 path (byte-equal). `dirtyRects` is
+        // an internal ROI-source channel for buildRoiCapture (S3a), kept off the
+        // public `result.observation` telemetry by the split in tryVerifyAnyChange.
+        postVerify = await tryVerifyAnyChange(facade, input.lease.viewId);
+        if (postVerify !== null) {
+          (result as { observation?: VisualMotionObservation }).observation = postVerify.observation;
+        }
+      }
+    }
 
-  // ADR-024 Seed-2 S5 — fold the post-action ROI capture into the act response
-  // for visual-only targets. `buildRoiCapture` gates on the visual-only regime +
-  // motion verdict, then assembles `{roi, somImage, entities, source}`. S5c-1a:
-  // on the frame-diff path the ROI is provisionally the whole window (empty
-  // dirtyRects → full-window fallback); the localized bbox lands in S5c-1b.
-  // Absent (gate declines / no change / no ROI) → response stays bit-equal with
-  // the pre-Seed-2 shape (additive — existing destructures unaffected).
-  if (result.ok) {
-    const roiCapture = await buildRoiCapture(
-      facade,
-      input.lease.viewId,
-      frameDiffObservation ?? postVerify?.observation,
-      postVerify?.dirtyRects ?? [],
-      input.returnCapture,
-      // Source is regime-determined: buildRoiCapture's gate only passes for
-      // visual-only targets (the frame-diff regime), so a visual-only capture
-      // is always `frame_diff` — including the `returnCapture:"always"` full-
-      // window fallback when the frame-diff observation was a miss.
-      visualOnly ? "frame_diff" : "dxgi",
-      // S5c-1b — the localized changed-region ROI from the frame-diff (when the
-      // capture was occlusion-immune). `undefined` → buildRoiCapture falls back
-      // to the DXGI dirty-rect bbox (legacy path) or the full window.
-      frameDiffRoi,
-    );
-    if (roiCapture !== undefined) {
-      (result as { roiCapture?: RoiCapture }).roiCapture = roiCapture;
+    // ADR-024 Seed-2 S5 — fold the post-action ROI capture into the act response
+    // for visual-only targets. `buildRoiCapture` gates on the visual-only regime +
+    // motion verdict, then assembles `{roi, somImage, entities, source}`. Absent
+    // (gate declines / no change / no ROI) → response stays bit-equal with the
+    // pre-Seed-2 shape (additive — existing destructures unaffected).
+    if (result.ok) {
+      const roiCapture = await buildRoiCapture(
+        facade,
+        input.lease.viewId,
+        frameDiffObservation ?? postVerify?.observation,
+        postVerify?.dirtyRects ?? [],
+        input.returnCapture,
+        // Source is regime-determined: buildRoiCapture's gate only passes for
+        // visual-only targets (the frame-diff regime), so a visual-only capture
+        // is always `frame_diff` — including the `returnCapture:"always"` full-
+        // window fallback when the frame-diff observation was a miss.
+        visualOnly ? "frame_diff" : "dxgi",
+        // S5c-1b — the localized changed-region ROI from the frame-diff (when the
+        // capture was occlusion-immune). `undefined` → buildRoiCapture falls back
+        // to the DXGI dirty-rect bbox (legacy path) or the full window.
+        frameDiffRoi,
+      );
+      if (roiCapture !== undefined) {
+        (result as { roiCapture?: RoiCapture }).roiCapture = roiCapture;
+      }
     }
   }
 
@@ -893,6 +944,94 @@ function assembleRoiCaptureFromSom(
   );
 
   return { roi, somImage: som.somImage.base64, entities, source };
+}
+
+/**
+ * ADR-024 Seed-2 S5b — build the visual-only fold's post-snapshot closure.
+ * Captured BEFORE the touch (holds the pre-frame + target identity); invoked by
+ * `GuardedTouchLoop.touch()` AFTER execute.
+ *
+ * **Diff baseline = carry-forward (b).** The post snapshot rebuilds the discover
+ * full-window entities as candidates with the SAME `target.id`, so they resolve
+ * to the SAME entityIds → post == pre → the touched entity keeps its identity and
+ * never reads as a false `entity_disappeared`. This is deliberate: ROI-crop OCR
+ * is NOT a reliable substitute for full-window OCR — a crop ≈ the text-line
+ * height defeats Windows OCR's line segmentation (Opus S5b-2 root-cause), so the
+ * diff must not depend on re-OCRing the ROI. The visual change is surfaced via
+ * `roiCapture`, not the structural diff.
+ *
+ * **roiCapture = padded single OCR (a).** The fold's ONE OCR runs on the PADDED
+ * change region (`resolveFoldOcrRoi` gives WinRT OCR the line context a tight
+ * crop lacks), and only when the gate passes (`returnCapture:"always"` keeps a
+ * full-window capture on no_change/miss — Codex P2-1; other modes omit it).
+ * `observation` is always surfaced for telemetry.
+ */
+function buildFoldPostSnapshot(
+  facade: DesktopFacade,
+  lease: { viewId: string; entityId: string },
+  preFrame: RawFrame,
+  hwnd: bigint,
+  windowRect: { x: number; y: number; width: number; height: number },
+  point: { x: number; y: number } | null,
+  returnCapture: ReturnCaptureMode | undefined,
+): () => Promise<{ candidates: UiEntityCandidate[]; roiMaterial?: RoiCaptureMaterial }> {
+  const viewId = lease.viewId;
+  // The SAME target.id the discover OCR lane used → carry-forward entityId parity (R1).
+  const targetId = facade.resolveOcrTargetIdForViewId(viewId);
+
+  return async () => {
+    // verifyLocalRepaint never throws — it degrades to `indeterminate` (no
+    // roiBbox) on any capture/SSIM failure; the gate then declines roiCapture.
+    const obs = await verifyLocalRepaint({
+      hwnd,
+      hint: { windowRect, ...(point !== null && { point }) },
+      preFrame,
+      includeRoiBbox: true,
+    });
+    const { roiBbox, ...observation } = obs;
+
+    // Diff baseline (b): carry forward the discover entities, rebuilt as
+    // candidates (same target+label+rect → same entityId on resolve → post==pre).
+    const discover = facade.getDiscoverEntitiesForViewId(viewId);
+    const candidates =
+      targetId !== null
+        ? somElementsToCandidates(
+            discover.map((e) => ({ text: e.label, region: e.rect })),
+            { kind: "window", id: targetId },
+            Date.now(),
+          )
+        : [];
+
+    // roiCapture (a): the fold's SINGLE OCR, on the PADDED change region, only
+    // when the gate passes. The diff above never depends on this OCR.
+    let roiCapture: RoiCapture | undefined;
+    const gatePassed = shouldReturnRoiCapture({
+      ok: true,
+      visualOnly: true, // fold only runs for visual-only targets (handler gate)
+      motion: observation.motion,
+      returnCapture,
+    });
+    if (gatePassed) {
+      const ocrRoi = resolveFoldOcrRoi(roiBbox, windowRect);
+      try {
+        const som = await runSomPipeline("", hwnd, "ja", 2, "auto", false, [], ocrRoi);
+        roiCapture = assembleRoiCaptureFromSom(som, ocrRoi, "frame_diff", facade, viewId);
+      } catch (err) {
+        // roiCapture OCR is best-effort; never break the act on a pipeline failure.
+        console.error(
+          `[desktop_act] S5b fold roiCapture OCR failed for viewId=${viewId}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    return {
+      candidates,
+      roiMaterial: {
+        ...(roiCapture !== undefined && { roiCapture }),
+        observation,
+      },
+    };
+  };
 }
 
 /** Pre-flight lease validation closure used by the commit wrapper

--- a/src/tools/desktop.ts
+++ b/src/tools/desktop.ts
@@ -733,6 +733,36 @@ export class DesktopFacade {
     };
   }
 
+  /**
+   * ADR-024 Seed-2 S5b (D6) — true when the most recent discover for this view
+   * produced any `visual_gpu`-sourced entity. The fold replaces the post
+   * snapshot with an OCR-only re-observation; a `visual_gpu` candidate the OCR
+   * lane cannot reproduce (e.g. an icon with no text) would then read as removed
+   * in the diff. So when this is true the handler does NOT fold — it keeps the
+   * S5 2-OCR path (full `composeCandidates` post preserves every lane). The
+   * fold is limited to the OCR-only visual-only targets it can serve faithfully.
+   */
+  discoverHasVisualGpuForViewId(viewId: string): boolean {
+    const session = this.registry.getByViewId(viewId, this.opts.nowFn);
+    if (!session) return false;
+    return session.entities.some((e) => e.sources.includes("visual_gpu"));
+  }
+
+  /**
+   * ADR-024 Seed-2 S5b — the EXACT `target.id` the discover OCR lane used for
+   * this view (`ocr-provider.ts`: `target.hwnd ?? target.windowTitle ?? "@active"`).
+   * The fold's post-OCR candidates must carry the SAME `target.id` so their
+   * entityId (`sha1(window:targetId | label | snapRect)`) matches the
+   * pre-snapshot — otherwise the touched entity reads as `entity_disappeared`
+   * (R1). Returns `null` when the session is gone (handler then skips the fold).
+   */
+  resolveOcrTargetIdForViewId(viewId: string): string | null {
+    const session = this.registry.getByViewId(viewId, this.opts.nowFn);
+    const target = session?.lastTarget;
+    if (!target) return null;
+    return target.hwnd ?? target.windowTitle ?? "@active";
+  }
+
   validateLeaseOnly(lease: EntityLease): LeaseValidationResult {
     const session = this.registry.getByViewId(lease.viewId, this.opts.nowFn);
     if (!session) {

--- a/src/tools/desktop.ts
+++ b/src/tools/desktop.ts
@@ -751,10 +751,19 @@ export class DesktopFacade {
   /**
    * ADR-024 Seed-2 S5b — the EXACT `target.id` the discover OCR lane used for
    * this view (`ocr-provider.ts`: `target.hwnd ?? target.windowTitle ?? "@active"`).
-   * The fold's post-OCR candidates must carry the SAME `target.id` so their
+   * The fold's carry-forward candidates must carry the SAME `target.id` so their
    * entityId (`sha1(window:targetId | label | snapRect)`) matches the
    * pre-snapshot — otherwise the touched entity reads as `entity_disappeared`
    * (R1). Returns `null` when the session is gone (handler then skips the fold).
+   *
+   * Parity is structural (Codex PR #438 P2 / Opus refute): the discover OCR lane
+   * receives the SAME raw `target` object (`see()` stores `lastTarget = input.target`
+   * at `desktop.ts:351` and `composeCandidates(target)` → `fetchOcrCandidates(target)`
+   * gets it UN-normalized at `compose-providers.ts:289`), so `@active` /
+   * `windowTitle` / `hwnd` all key identically here and there — there is no
+   * normalized-HWND-vs-`@active` divergence. (A `lastTarget` change between
+   * discover and act bumps the generation → the stale lease fails validation
+   * before the fold, so the read here always matches the lease's discover.)
    */
   resolveOcrTargetIdForViewId(viewId: string): string | null {
     const session = this.registry.getByViewId(viewId, this.opts.nowFn);

--- a/tests/e2e/desktop-act-roi-capture.test.ts
+++ b/tests/e2e/desktop-act-roi-capture.test.ts
@@ -83,6 +83,14 @@ describe.runIf(IS_HEADED && canvas !== null)("desktop_act roiCapture (S6 headed 
     const parsed = parseHandler(result.content);
     expect(parsed["ok"]).toBe(true);
 
+    // ADR-024 S5b R1 (entityId stability, end-to-end) — the fold re-OCRs the ROI
+    // and feeds those candidates to the diff. The clicked OCR anchor's text is
+    // stable (only the bar below it toggles), so the touched entity must survive
+    // with the SAME entityId the full-window discover OCR minted — i.e. it must
+    // NOT read as `entity_disappeared`. A target-id / snap mismatch in
+    // somElementsToCandidates would surface here as a spurious disappearance.
+    expect(parsed["diff"] as string[]).not.toContain("entity_disappeared");
+
     const cap = parsed["roiCapture"] as
       | { roi?: { width: number; height: number }; somImage?: string; entities?: unknown[]; source?: string }
       | undefined;

--- a/tests/unit/desktop-act-frame-diff-dispatch.test.ts
+++ b/tests/unit/desktop-act-frame-diff-dispatch.test.ts
@@ -105,8 +105,44 @@ function spyFacadeVisualOnly(opts: {
   return facade;
 }
 
-describe("desktop_act frame-diff dispatch (S5c-2 handler-level)", () => {
+/**
+ * Configure the facade for the S5b-2 FOLD path. The `touch` spy SIMULATES the
+ * loop: when a `postSnapshot` closure is supplied it invokes it (so the fold's
+ * single ROI-OCR actually runs through the mocked `runSomPipeline` /
+ * `verifyLocalRepaint`) and surfaces the returned `roiMaterial`, exactly as
+ * `GuardedTouchLoop.touch` does. Returns the facade so callers can read the
+ * `touch` spy's call args (to assert whether a closure was passed = fold on/off).
+ */
+function spyFacadeFold(opts: { hasVisualGpu?: boolean }) {
+  const facade = getDesktopFacade();
+  vi.spyOn(facade, "touch").mockImplementation(
+    async (input: { postSnapshot?: () => Promise<{ candidates: unknown[]; roiMaterial?: unknown }> }) => {
+      const base = { ok: true as const, executor: "mouse" as const, diff: [], next: "none" as const };
+      if (input.postSnapshot) {
+        const snap = await input.postSnapshot();
+        return { ...base, ...(snap.roiMaterial ? { roiMaterial: snap.roiMaterial } : {}) } as Awaited<ReturnType<typeof facade.touch>>;
+      }
+      return base as Awaited<ReturnType<typeof facade.touch>>;
+    },
+  );
+  vi.spyOn(facade, "resolveVisualOnlyForViewId").mockReturnValue(true);
+  vi.spyOn(facade, "resolveTargetHwndForFrameDiff").mockResolvedValue(123n);
+  vi.spyOn(facade, "resolveEntityCenterForViewId").mockReturnValue({ x: 100, y: 100 });
+  vi.spyOn(facade, "getDiscoverEntitiesForViewId").mockReturnValue([]);
+  vi.spyOn(facade, "resolveHwndForViewId").mockReturnValue(123n);
+  vi.spyOn(facade, "discoverHasVisualGpuForViewId").mockReturnValue(opts.hasVisualGpu ?? false);
+  vi.spyOn(facade, "resolveOcrTargetIdForViewId").mockReturnValue("123");
+  return facade;
+}
+
+// These pin the LEGACY S5 dispatch (handler-direct verifyLocalRepaint +
+// buildRoiCapture). With the S5b-2 fold ON (default) that work moves into the
+// postSnapshot closure invoked by the loop, so these run with the fold OFF —
+// the legacy path is still reachable (flag off / D6 gate fail / fold miss) and
+// must stay byte-equal. The fold dispatch is pinned in the separate describe below.
+describe("desktop_act frame-diff dispatch — legacy S5 path (S5b fold off)", () => {
   let savedStage5: string | undefined;
+  let savedFold: string | undefined;
 
   beforeEach(() => {
     _resetFacadeForTest();
@@ -114,6 +150,9 @@ describe("desktop_act frame-diff dispatch (S5c-2 handler-level)", () => {
     // Post-action verification (frame-diff + DXGI) is gated ON by default.
     savedStage5 = process.env["DESKTOP_TOUCH_STAGE5_DXGI"];
     delete process.env["DESKTOP_TOUCH_STAGE5_DXGI"];
+    // Force the legacy (fold-off) path so the handler-direct dispatch is exercised.
+    savedFold = process.env["DESKTOP_TOUCH_STAGE5B_FOLD_OCR"];
+    process.env["DESKTOP_TOUCH_STAGE5B_FOLD_OCR"] = "0";
     mockGetWindowRect.mockReturnValue(WINDOW_RECT);
     mockRunSomPipeline.mockResolvedValue({ somImage: { base64: "iVBORw0KGgo=" }, elements: [] });
   });
@@ -121,6 +160,8 @@ describe("desktop_act frame-diff dispatch (S5c-2 handler-level)", () => {
   afterEach(() => {
     if (savedStage5 === undefined) delete process.env["DESKTOP_TOUCH_STAGE5_DXGI"];
     else process.env["DESKTOP_TOUCH_STAGE5_DXGI"] = savedStage5;
+    if (savedFold === undefined) delete process.env["DESKTOP_TOUCH_STAGE5B_FOLD_OCR"];
+    else process.env["DESKTOP_TOUCH_STAGE5B_FOLD_OCR"] = savedFold;
     _resetFacadeForTest();
     vi.restoreAllMocks();
   });
@@ -260,4 +301,122 @@ describe("S5c-2 acceptance ③ — no TS per-pixel loop in the ROI path", () => 
       expect(src).not.toMatch(channelIndex);
     });
   }
+});
+
+// ── ADR-024 Seed-2 S5b-2 — the order-trap fold dispatch (default on) ──
+describe("desktop_act frame-diff dispatch — S5b-2 fold (default on)", () => {
+  let savedStage5: string | undefined;
+  let savedFold: string | undefined;
+
+  beforeEach(() => {
+    _resetFacadeForTest();
+    vi.clearAllMocks();
+    savedStage5 = process.env["DESKTOP_TOUCH_STAGE5_DXGI"];
+    delete process.env["DESKTOP_TOUCH_STAGE5_DXGI"];
+    savedFold = process.env["DESKTOP_TOUCH_STAGE5B_FOLD_OCR"];
+    delete process.env["DESKTOP_TOUCH_STAGE5B_FOLD_OCR"]; // fold ON (default)
+    mockGetWindowRect.mockReturnValue(WINDOW_RECT);
+    mockRunSomPipeline.mockResolvedValue({ somImage: { base64: "iVBORw0KGgo=" }, elements: [] });
+    mockCaptureFrame.mockResolvedValue({
+      rawPixels: Buffer.alloc(800 * 600 * 4),
+      width: 800,
+      height: 600,
+      channels: 4,
+      source: "printwindow",
+    });
+  });
+
+  afterEach(() => {
+    if (savedStage5 === undefined) delete process.env["DESKTOP_TOUCH_STAGE5_DXGI"];
+    else process.env["DESKTOP_TOUCH_STAGE5_DXGI"] = savedStage5;
+    if (savedFold === undefined) delete process.env["DESKTOP_TOUCH_STAGE5B_FOLD_OCR"];
+    else process.env["DESKTOP_TOUCH_STAGE5B_FOLD_OCR"] = savedFold;
+    _resetFacadeForTest();
+    vi.restoreAllMocks();
+  });
+
+  it("order-trap eliminated → ONE OCR (for roiCapture, on the PADDED change region); no DXGI, no second OCR", async () => {
+    spyFacadeFold({});
+    mockVerifyLocalRepaint.mockResolvedValue({
+      motion: "local_repaint",
+      source: "ssim_residual",
+      roiBbox: { x: 50, y: 60, width: 100, height: 80 },
+      framesSampled: 2,
+      totalElapsedMs: 80,
+    });
+
+    const result = await desktopActRawHandler({ lease: FAKE_LEASE, action: "click", returnCapture: "on-change" });
+    const parsed = parse(result.content);
+
+    // Exactly ONE OCR — the roiCapture's. The diff baseline carries the discover
+    // entities forward (no OCR), so there is no second / full-window post OCR.
+    expect(mockRunSomPipeline).toHaveBeenCalledTimes(1);
+    // roiBbox {50,60,100,80} padded by max(24, ceil(80*0.5)=40)=40 → {10,20,180,160}.
+    expect(mockRunSomPipeline.mock.calls[0]![7]).toEqual({ x: 10, y: 20, width: 180, height: 160 });
+    expect(mockVerifyLocalRepaint).toHaveBeenCalledTimes(1);
+    expect(mockVerifyAnyChange).not.toHaveBeenCalled();
+
+    // roiCapture is on the padded ROI; observation lifted, roiBbox stripped.
+    const cap = parsed["roiCapture"] as { roi?: unknown; source?: unknown };
+    expect(cap.roi).toEqual({ x: 10, y: 20, width: 180, height: 160 });
+    expect(cap.source).toBe("frame_diff");
+    const obs = parsed["observation"] as Record<string, unknown>;
+    expect(obs["motion"]).toBe("local_repaint");
+    expect("roiBbox" in obs).toBe(false);
+  });
+
+  it("D6 gate — discover has visual_gpu → fold disabled, touch called WITHOUT a postSnapshot closure (S5 legacy path)", async () => {
+    const facade = spyFacadeFold({ hasVisualGpu: true });
+    mockVerifyLocalRepaint.mockResolvedValue({
+      motion: "local_repaint",
+      source: "ssim_residual",
+      roiBbox: { x: 50, y: 60, width: 100, height: 80 },
+      framesSampled: 2,
+      totalElapsedMs: 80,
+    });
+
+    await desktopActRawHandler({ lease: FAKE_LEASE, action: "click", returnCapture: "on-change" });
+
+    // Fold NOT taken: the loop received no closure → the post OCR runs via the
+    // legacy handler path (every composeCandidates lane preserved).
+    const calls = (facade.touch as unknown as { mock: { calls: Array<[{ postSnapshot?: unknown }]> } }).mock.calls;
+    expect(calls[0]![0].postSnapshot).toBeUndefined();
+  });
+
+  it("returnCapture:'always' on no_change → still folds a FULL-WINDOW roiCapture (single OCR; Codex P2-1)", async () => {
+    spyFacadeFold({});
+    mockVerifyLocalRepaint.mockResolvedValue({
+      motion: "no_change",
+      source: "ssim_residual",
+      framesSampled: 2,
+      totalElapsedMs: 40,
+    }); // no roiBbox
+
+    const result = await desktopActRawHandler({ lease: FAKE_LEASE, action: "click", returnCapture: "always" });
+    const parsed = parse(result.content);
+
+    expect(mockRunSomPipeline).toHaveBeenCalledTimes(1);
+    expect(mockRunSomPipeline.mock.calls[0]![7]).toEqual({ x: 0, y: 0, width: 800, height: 600 }); // full window
+    const cap = parsed["roiCapture"] as { roi?: unknown; source?: unknown };
+    expect(cap.roi).toEqual({ x: 0, y: 0, width: 800, height: 600 });
+    expect(cap.source).toBe("frame_diff");
+  });
+
+  it("returnCapture:'on-change' on no_change → NO OCR at all (diff is carry-forward; gate declines roiCapture)", async () => {
+    spyFacadeFold({});
+    mockVerifyLocalRepaint.mockResolvedValue({
+      motion: "no_change",
+      source: "ssim_residual",
+      framesSampled: 2,
+      totalElapsedMs: 40,
+    });
+
+    const result = await desktopActRawHandler({ lease: FAKE_LEASE, action: "click", returnCapture: "on-change" });
+    const parsed = parse(result.content);
+
+    // The diff baseline is carry-forward (no OCR), and the gate declines the
+    // roiCapture (no change, not "always") → the fold runs ZERO OCRs here.
+    expect(mockRunSomPipeline).not.toHaveBeenCalled();
+    expect(parsed["roiCapture"]).toBeUndefined();
+  });
 });

--- a/tests/unit/roi-region.test.ts
+++ b/tests/unit/roi-region.test.ts
@@ -16,6 +16,8 @@ import {
   boundingBox,
   rectIoU,
   clampRectToWindow,
+  resolveFoldOcrRoi,
+  inflateRect,
 } from "../../src/tools/_roi-region.js";
 
 // Window at a non-zero screen origin so the relative translation is observable.
@@ -258,5 +260,44 @@ describe("clampRectToWindow (S5c-1b frame-diff ROI bounds guard)", () => {
     const roi = { x: 180, y: 130, width: 100, height: 100 };
     clampRectToWindow(roi, WIN);
     expect(roi).toEqual({ x: 180, y: 130, width: 100, height: 100 });
+  });
+});
+
+describe("inflateRect (S5b — symmetric pad)", () => {
+  it("grows the rect by `margin` on every side", () => {
+    expect(inflateRect({ x: 50, y: 60, width: 100, height: 80 }, 40)).toEqual({
+      x: 10, y: 20, width: 180, height: 160,
+    });
+  });
+});
+
+describe("resolveFoldOcrRoi (S5b — padded roiCapture OCR crop)", () => {
+  const WIN = { x: 100, y: 200, width: 800, height: 600 };
+
+  it("no bbox (miss / no_change / demote) → the whole window", () => {
+    expect(resolveFoldOcrRoi(undefined, WIN)).toEqual({ x: 0, y: 0, width: 800, height: 600 });
+  });
+
+  it("pads the change bbox by max(24, ceil(height*0.5)) so WinRT OCR has line context", () => {
+    // height 80 → margin = max(24, 40) = 40. {50,60,100,80} inflate 40 → {10,20,180,160}.
+    expect(resolveFoldOcrRoi({ x: 50, y: 60, width: 100, height: 80 }, WIN)).toEqual({
+      x: 10, y: 20, width: 180, height: 160,
+    });
+  });
+
+  it("uses the 24px floor for short text (height*0.5 < 24)", () => {
+    // height 20 → margin = max(24, 10) = 24. {50,60,100,20} inflate 24 → {26,36,148,68}.
+    expect(resolveFoldOcrRoi({ x: 50, y: 60, width: 100, height: 20 }, WIN)).toEqual({
+      x: 26, y: 36, width: 148, height: 68,
+    });
+  });
+
+  it("clamps the padded crop to the window bounds", () => {
+    // bbox flush against the right/bottom edge → padding spills → clamp.
+    const roi = resolveFoldOcrRoi({ x: 760, y: 560, width: 40, height: 40 }, WIN);
+    expect(roi.x).toBeGreaterThanOrEqual(0);
+    expect(roi.y).toBeGreaterThanOrEqual(0);
+    expect(roi.x + roi.width).toBeLessThanOrEqual(800);
+    expect(roi.y + roi.height).toBeLessThanOrEqual(600);
   });
 });


### PR DESCRIPTION
## What
Second S5b sub-PR: wires the visual-only **fold** (default on, env `DESKTOP_TOUCH_STAGE5B_FOLD_OCR`). A visual-only `desktop_act` now folds its post-touch confirmation so it runs **at most one OCR** (for the `roiCapture`), down from S5's two. The handler builds a `postSnapshot` closure (captured pre-touch, invoked by the loop post-execute) and lifts its `roiMaterial` onto `result.{observation,roiCapture}`. The legacy S5 2-OCR path is kept for non-visual / flag-off / D6-gate-fail / frame-diff-miss.

Plan: `desktop-touch-mcp-internal@55e0b8f:docs/adr-024-seed2-plan.md` (Plan PR #14).

## Design pivot (Opus root-cause)
The S5b-2 R1 **headed test caught a real break**: the fold's ROI-crop OCR returns 0 elements where a same-moment full-window OCR finds the text. Opus root-cause: `Windows.Media.Ocr` fails line segmentation on a crop ≈ the text-line height (no vertical context); `cropRgbaToRoi` / coordinate basis are correct. Resolution (user-approved):
- **(b) diff baseline = carry-forward** the discover full-window entities (rebuilt with the same `target+label+rect` → same entityId → **post == pre**). The touched entity keeps its identity → never a false `entity_disappeared` (**R1, structural — OCR-independent**). The diff no longer re-OCRs the ROI; the visual change is surfaced via `roiCapture`.
- **(a) roiCapture = a single OCR of the PADDED change region** (`resolveFoldOcrRoi`, margin `max(24, ceil(height*0.5))`) so WinRT OCR has line context; gated, `returnCapture:"always"` full-window fallback preserved.
- **D6**: fold only when discover is `visual_gpu`-free (else S5 2-OCR preserves every `composeCandidates` lane).

## Verification
- **Headed e2e** `desktop-act-roi-capture` passes: no `entity_disappeared`, `roiCapture` localized + `frame_diff` (validates R1 + padded OCR end-to-end on the live canvas).
- Full unit suite **4248 passed / 0 failed**; `tsc` clean; lint 0 new.
- Dispatch tests pin: order-trap (1 OCR for roiCapture, padded ROI), D6 gate fallback (touch without closure), `always`/`on-change`×`no_change` OCR counts. `resolveFoldOcrRoi`/`inflateRect` unit-tested.

## Carry-over (S5b-3)
Small-text R1 OCR-independence test; `DESKTOP_TOUCH_STAGE5B_FOLD_OCR=0` flag-parity; S6 bench re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)