### PR TITLE
test(desktop_act): ADR-024 S5b-3 — carry-forward / flag-parity / @active pins

### DIFF
--- a/benches/fixtures/visual-only-canvas.ps1
+++ b/benches/fixtures/visual-only-canvas.ps1
@@ -20,8 +20,15 @@
 # centre so it lands inside the local-repaint SSIM crop (a localized ROI, never
 # full-window).
 #
-# Usage: powershell -NoProfile -ExecutionPolicy Bypass -File visual-only-canvas.ps1 -Title <name>
-param([string]$Title)
+# Usage: powershell -NoProfile -ExecutionPolicy Bypass -File visual-only-canvas.ps1 -Title <name> [-FontSize 34]
+#
+# -FontSize (default 34): anchor text point size. The default (34pt) is the
+# bench/e2e canvas. A SMALL size (e.g. 11) is the ADR-024 S5b-3 R1 carry-forward
+# regression canvas: small text is the regime where ROI-crop OCR is least
+# reliable (the S5b-2 root-cause), so it stresses that the diff (carry-forward of
+# the full-window discover OCR) stays correct independent of the ROI-OCR. Leaving
+# it unset preserves the existing fixture byte-for-byte.
+param([string]$Title, [int]$FontSize = 34)
 
 # Hide the PowerShell host console so only the form is visible (same trick as
 # tests/e2e/helpers/blank-window.ts — do NOT use -WindowStyle Hidden, that hides
@@ -57,7 +64,7 @@ $form.TopMost = $true
 
 # Backing bitmap (client-sized) — the single source of pixels for the panel.
 $bmp = New-Object System.Drawing.Bitmap($W, $H)
-$bigFont = New-Object System.Drawing.Font('Segoe UI', 34, [System.Drawing.FontStyle]::Bold)
+$bigFont = New-Object System.Drawing.Font('Segoe UI', $FontSize, [System.Drawing.FontStyle]::Bold)
 
 # Two anchors: text (always black-on-white, always OCR-readable) + a toggle bar
 # just below it. Bar toggles crimson<->white on each click of that anchor.

--- a/tests/e2e/desktop-act-roi-carry-forward.test.ts
+++ b/tests/e2e/desktop-act-roi-carry-forward.test.ts
@@ -1,0 +1,101 @@
+/**
+ * desktop-act-roi-carry-forward.test.ts — ADR-024 Seed-2 S5b-3 R1 (headed e2e).
+ *
+ * The LIVE half of the R1 carry-forward pin (the deterministic half is
+ * `tests/unit/guarded-touch.test.ts` "S5b-3 R1 carry-forward"). It spawns the
+ * visual-only canvas with a SMALL anchor font — the regime where ROI-crop OCR is
+ * least reliable (a crop ≈ a text line defeats Windows OCR's line segmentation,
+ * the S5b-2 root-cause that forced the carry-forward pivot) — and proves that a
+ * real `desktop_act` STILL reports no `entity_disappeared`.
+ *
+ * Why this matters end-to-end: the fold's diff baseline carries the FULL-WINDOW
+ * discover OCR entities forward rather than re-OCRing the ROI, so the touched
+ * anchor keeps its identity even when the ROI-OCR would read nothing. The
+ * companion `desktop-act-roi-capture.test.ts` runs the same flow at the default
+ * 34pt; this file stresses the small-text regime that historically broke.
+ *
+ * Gating mirrors the repo convention (`const IS_HEADED = Boolean(process.env.HEADED)`,
+ * `browser-cdp.test.ts:29`): a REAL OS click on a real GUI + the native engine, so
+ * HEADED-only and CI-skipped (also skipped when the fixture cannot be spawned).
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+  getDesktopFacade,
+  desktopActRawHandler,
+  _resetFacadeForTest,
+} from "../../src/tools/desktop-register.js";
+import { spawnVisualOnlyCanvas, type VisualOnlyCanvas } from "./helpers/visual-only-canvas.js";
+
+const IS_HEADED = Boolean(process.env.HEADED);
+
+// Small anchor font (11pt) = the ROI-OCR-hostile regime. Full-window discover OCR
+// still reads it (line context); a tight ROI crop is where it degrades.
+const canvas: VisualOnlyCanvas | null = IS_HEADED ? await spawnVisualOnlyCanvas({ fontSize: 11 }) : null;
+
+function parseHandler(content: ReadonlyArray<{ type: string; text?: string }>): Record<string, unknown> {
+  const block = content[0];
+  if (!block || block.type !== "text" || typeof block.text !== "string") {
+    throw new Error("expected text content");
+  }
+  return JSON.parse(block.text) as Record<string, unknown>;
+}
+
+describe.runIf(IS_HEADED && canvas !== null)("desktop_act R1 carry-forward on small text (S5b-3 headed e2e)", () => {
+  let prevAutoGuard: string | undefined;
+  beforeAll(() => {
+    prevAutoGuard = process.env.DESKTOP_TOUCH_AUTO_GUARD;
+    process.env.DESKTOP_TOUCH_AUTO_GUARD = "0";
+  });
+  afterAll(() => {
+    if (prevAutoGuard === undefined) delete process.env.DESKTOP_TOUCH_AUTO_GUARD;
+    else process.env.DESKTOP_TOUCH_AUTO_GUARD = prevAutoGuard;
+    canvas?.close();
+    _resetFacadeForTest();
+  });
+
+  it("touched small-text anchor keeps its identity (no entity_disappeared) on a real folded act", async () => {
+    const facade = getDesktopFacade();
+
+    // Discover the canvas — visual-only (UIA-blind) + small OCR anchors.
+    const disc = await facade.see({ target: { windowTitle: canvas!.title } });
+    const warnings = (disc as { warnings?: string[] }).warnings ?? [];
+    expect(warnings.some((w) => String(w).startsWith("uia_blind"))).toBe(true);
+
+    // The full-window discover OCR must still find the small anchor (it has line
+    // context); selecting by label avoids the (also-OCR'd) title bar.
+    const ent = disc.entities.find(
+      (e) =>
+        (e.label === "TARGET ALPHA" || e.label === "ZONE BETA") &&
+        e.sources?.includes("ocr") &&
+        e.primaryAction === "click",
+    );
+    expect(
+      ent,
+      "full-window discover OCR should read the small-text anchor (carry-forward source)",
+    ).toBeDefined();
+
+    const result = await desktopActRawHandler({
+      lease: ent!.lease,
+      action: "click",
+      returnCapture: "on-change",
+    });
+    const parsed = parseHandler(result.content);
+    expect(parsed["ok"]).toBe(true);
+
+    // THE R1 INVARIANT: the diff baseline is carry-forward of the discover OCR, so
+    // the touched anchor keeps the entityId the full-window OCR minted — it must
+    // NOT read as disappeared, EVEN THOUGH a ROI-crop OCR on this small text would
+    // be unreliable. A regression that re-coupled the diff to ROI-OCR would surface
+    // here as a spurious entity_disappeared.
+    expect(parsed["diff"] as string[]).not.toContain("entity_disappeared");
+
+    // The roiCapture still rides along (the change region was painted) — its
+    // entity preview may legitimately be empty on this small-text crop; the diff
+    // correctness above does not depend on it.
+    const cap = parsed["roiCapture"] as { entities?: unknown[]; source?: string } | undefined;
+    if (cap) {
+      expect(Array.isArray(cap.entities)).toBe(true);
+      expect(cap.source).toBe("frame_diff");
+    }
+  });
+});

--- a/tests/e2e/helpers/visual-only-canvas.ts
+++ b/tests/e2e/helpers/visual-only-canvas.ts
@@ -31,14 +31,16 @@ export interface VisualOnlyCanvas {
  * Spawn the visual-only canvas and resolve once it is on screen. Returns null if
  * the window does not appear within 12s (callers should skip rather than fall
  * back). Always pair with `close()` in afterAll.
+ *
+ * @param opts.fontSize anchor text point size (default = the fixture's 34pt). A
+ *   small size (e.g. 11) is the ADR-024 S5b-3 R1 carry-forward regression canvas
+ *   (small text = the regime where ROI-crop OCR is least reliable).
  */
-export async function spawnVisualOnlyCanvas(): Promise<VisualOnlyCanvas | null> {
+export async function spawnVisualOnlyCanvas(opts: { fontSize?: number } = {}): Promise<VisualOnlyCanvas | null> {
   const title = `dt-visualonly-e2e-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
-  const child = spawn(
-    "powershell",
-    ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", FIXTURE, "-Title", title],
-    { stdio: "ignore" },
-  );
+  const args = ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", FIXTURE, "-Title", title];
+  if (opts.fontSize !== undefined) args.push("-FontSize", String(opts.fontSize));
+  const child = spawn("powershell", args, { stdio: "ignore" });
   let closed = false;
   const close = () => {
     if (closed) return;

--- a/tests/unit/desktop-act-frame-diff-dispatch.test.ts
+++ b/tests/unit/desktop-act-frame-diff-dispatch.test.ts
@@ -420,3 +420,91 @@ describe("desktop_act frame-diff dispatch — S5b-2 fold (default on)", () => {
     expect(parsed["roiCapture"]).toBeUndefined();
   });
 });
+
+// ── ADR-024 Seed-2 S5b-3 — flag parity: DESKTOP_TOUCH_STAGE5B_FOLD_OCR=0 ⇒ S5 ──
+//
+// The fold is guarded by a single env safety valve. `=0` must fall fully back to
+// the S5 2-OCR path: the loop receives NO postSnapshot closure, the post OCR runs
+// via the legacy handler-direct path (full composeCandidates diff baseline +
+// buildRoiCapture's SECOND OCR), and the roiCapture carries the RAW frame-diff
+// bbox (un-padded — S5c-1b shape) rather than the fold's PADDED OCR region. The
+// PUBLIC envelope `{ok, executor, diff, next}` is identical either way — the flag
+// only swaps the internal post-snapshot mechanism, never the act's contract.
+describe("desktop_act S5b flag parity — STAGE5B_FOLD_OCR=0 falls back to the S5 path", () => {
+  let savedStage5: string | undefined;
+  let savedFold: string | undefined;
+
+  beforeEach(() => {
+    savedStage5 = process.env["DESKTOP_TOUCH_STAGE5_DXGI"];
+    savedFold = process.env["DESKTOP_TOUCH_STAGE5B_FOLD_OCR"];
+  });
+  afterEach(() => {
+    if (savedStage5 === undefined) delete process.env["DESKTOP_TOUCH_STAGE5_DXGI"];
+    else process.env["DESKTOP_TOUCH_STAGE5_DXGI"] = savedStage5;
+    if (savedFold === undefined) delete process.env["DESKTOP_TOUCH_STAGE5B_FOLD_OCR"];
+    else process.env["DESKTOP_TOUCH_STAGE5B_FOLD_OCR"] = savedFold;
+    _resetFacadeForTest();
+    vi.restoreAllMocks();
+  });
+
+  // Drive ONE identical act under a given fold state. Returns the parsed envelope
+  // plus whether the loop received a postSnapshot closure (= fold taken).
+  async function runOnce(foldOff: boolean): Promise<{ parsed: Record<string, unknown>; closurePassed: boolean }> {
+    _resetFacadeForTest();
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    delete process.env["DESKTOP_TOUCH_STAGE5_DXGI"]; // Stage 5 on
+    if (foldOff) process.env["DESKTOP_TOUCH_STAGE5B_FOLD_OCR"] = "0";
+    else delete process.env["DESKTOP_TOUCH_STAGE5B_FOLD_OCR"]; // fold on (default)
+
+    const facade = spyFacadeFold({});
+    mockGetWindowRect.mockReturnValue(WINDOW_RECT);
+    mockRunSomPipeline.mockResolvedValue({ somImage: { base64: "iVBORw0KGgo=" }, elements: [] });
+    mockCaptureFrame.mockResolvedValue({
+      rawPixels: Buffer.alloc(800 * 600 * 4),
+      width: 800,
+      height: 600,
+      channels: 4,
+      source: "printwindow",
+    });
+    mockVerifyLocalRepaint.mockResolvedValue({
+      motion: "local_repaint",
+      source: "ssim_residual",
+      roiBbox: { x: 50, y: 60, width: 100, height: 80 },
+      framesSampled: 2,
+      totalElapsedMs: 80,
+    });
+
+    const result = await desktopActRawHandler({ lease: FAKE_LEASE, action: "click", returnCapture: "on-change" });
+    const calls = (facade.touch as unknown as { mock: { calls: Array<[{ postSnapshot?: unknown }]> } }).mock.calls;
+    return { parsed: parse(result.content), closurePassed: calls[0]![0].postSnapshot !== undefined };
+  }
+
+  it("=0 → no closure + RAW bbox roi (S5 shape); default → closure + PADDED roi; envelope identical", async () => {
+    const off = await runOnce(true);
+    const on = await runOnce(false);
+
+    // The flag selects the mechanism: legacy (no closure) vs fold (closure).
+    expect(off.closurePassed).toBe(false);
+    expect(on.closurePassed).toBe(true);
+
+    // roiCapture.roi differs by the flag ONLY: legacy emits the raw frame-diff
+    // bbox; the fold pads it for the WinRT OCR line context (resolveFoldOcrRoi).
+    const offCap = off.parsed["roiCapture"] as { roi?: unknown; source?: unknown };
+    const onCap = on.parsed["roiCapture"] as { roi?: unknown; source?: unknown };
+    expect(offCap.roi).toEqual({ x: 50, y: 60, width: 100, height: 80 }); // raw (S5c-1b)
+    expect(onCap.roi).toEqual({ x: 10, y: 20, width: 180, height: 160 }); // padded (fold)
+    expect(offCap.source).toBe("frame_diff");
+    expect(onCap.source).toBe("frame_diff");
+
+    // The PUBLIC contract envelope is byte-equal regardless of the flag — the
+    // safety valve never changes ok/executor/diff/next.
+    const envelope = (p: Record<string, unknown>) => ({
+      ok: p["ok"], executor: p["executor"], diff: p["diff"], next: p["next"],
+    });
+    expect(envelope(off.parsed)).toEqual(envelope(on.parsed));
+    // And the internal roiMaterial channel never leaks to the wire on either path.
+    expect("roiMaterial" in off.parsed).toBe(false);
+    expect("roiMaterial" in on.parsed).toBe(false);
+  });
+});

--- a/tests/unit/guarded-touch.test.ts
+++ b/tests/unit/guarded-touch.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
 import { GuardedTouchLoop, type TouchEnvironment, type RoiCaptureMaterial } from "../../src/engine/world-graph/guarded-touch.js";
 import { LeaseStore } from "../../src/engine/world-graph/lease-store.js";
+import { resolveCandidates } from "../../src/engine/world-graph/resolver.js";
+import { somElementsToCandidates } from "../../src/tools/_roi-preview.js";
 import type { UiEntity } from "../../src/engine/world-graph/types.js";
 import type { Rect, UiEntityCandidate } from "../../src/engine/vision-gpu/types.js";
 
@@ -793,5 +795,113 @@ describe("GuardedTouchLoop — ADR-024 S5b postSnapshot seam", () => {
       // proving the diff actually ran (not vacuously empty).
       expect(result.diff).toContain("entity_disappeared");
     }
+  });
+});
+
+// ── ADR-024 Seed-2 S5b-3 — R1 carry-forward decouples the diff from ROI-OCR ──
+//
+// The S5b-2 PIVOT: the fold does NOT re-OCR the ROI to build the diff baseline.
+// ROI-crop OCR is unreliable (a crop ≈ a text line defeats Windows OCR's line
+// segmentation — Opus S5b-2 root-cause), so the diff baseline carries the
+// discover entities FORWARD: the closure rebuilds them as candidates with the
+// SAME target+label+rect, which `resolveCandidates` mints to the SAME entityId
+// → post == pre → the touched entity never reads as a false `entity_disappeared`.
+//
+// This is the DETERMINISTIC half of the R1 pin (the live small-text canvas is the
+// headed e2e half — `desktop-act-roi-carry-forward.test.ts`). It builds the
+// touched entity from a REAL OCR candidate, runs the REAL loop + REAL
+// `somElementsToCandidates` + REAL `resolveCandidates`, and proves the touched
+// entity survives EVEN WHEN the fold's roiCapture preview is EMPTY (the exact
+// signature of a ROI-OCR that found nothing on small text). The diff's
+// correctness does not depend on the ROI-OCR succeeding.
+describe("GuardedTouchLoop — ADR-024 S5b-3 R1 carry-forward (diff ⟂ ROI-OCR)", () => {
+  const TARGET = { kind: "window" as const, id: "win-1" };
+  const ANCHOR = { text: "TARGET ALPHA", region: { x: 100, y: 200, width: 220, height: 40 } };
+
+  /** Mint the touched UiEntity exactly as the discover OCR lane would: an OCR
+   *  candidate → `resolveCandidates(gen)`. Its entityId is the real
+   *  sha1(window:id | label | snapRect) the carry-forward must reproduce. */
+  function discoverTouched(): UiEntity {
+    const [e] = resolveCandidates(
+      somElementsToCandidates([ANCHOR], TARGET, /* observedAtMs */ 0),
+      GEN,
+    );
+    if (!e) throw new Error("resolveCandidates yielded no entity");
+    return e;
+  }
+
+  /** The carry-forward closure result: discover entities rebuilt as candidates
+   *  (same target+label+rect, a DIFFERENT observedAtMs to prove time-invariance),
+   *  plus a roiCapture whose `entities` preview is EMPTY — i.e. the ROI-OCR found
+   *  nothing (the small-text failure mode). `observedAtMs` differs from the
+   *  discover mint to prove entityId is time-invariant (matches roi-preview.test). */
+  function carryForwardSnapshot(): { candidates: UiEntityCandidate[]; roiMaterial: RoiCaptureMaterial } {
+    return {
+      candidates: somElementsToCandidates([ANCHOR], TARGET, /* observedAtMs */ 999_999),
+      roiMaterial: {
+        roiCapture: {
+          roi: { x: 100, y: 240, width: 220, height: 60 },
+          somImage: "iVBORw0KGgo=",
+          entities: [], // ROI-OCR found nothing — diff must NOT depend on this
+          source: "frame_diff",
+        },
+        observation: {
+          motion: "local_repaint",
+          source: "ssim_residual",
+          framesSampled: 2,
+          totalElapsedMs: 80,
+        },
+      },
+    };
+  }
+
+  it("touched survives with NO entity_disappeared even when the ROI-OCR preview is empty", async () => {
+    const touched = discoverTouched();
+    const store = new LeaseStore({ nowFn: () => 0, defaultTtlMs: 60_000 });
+    const lease = store.issue(touched, "v1");
+    // env.resolvePostTouchEntities must NOT be consulted on the fold path — if it
+    // were, the empty default would (wrongly) drop the touched entity. Spy to prove
+    // the closure replaced it.
+    const resolvePost = vi.fn(async () => [] as UiEntity[]);
+    const loop = new GuardedTouchLoop(
+      store,
+      makeEnv({ resolveLiveEntities: () => [touched], resolvePostTouchEntities: resolvePost }),
+    );
+
+    const result = await loop.touch({ lease, postSnapshot: async () => carryForwardSnapshot() });
+
+    expect(resolvePost).not.toHaveBeenCalled();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // The whole point: the touched OCR anchor keeps its identity via carry-forward,
+      // so it is NOT reported as disappeared despite the empty ROI-OCR preview.
+      expect(result.diff).not.toContain("entity_disappeared");
+      // No churn at all — post == pre by construction (carry-forward).
+      expect(result.diff).toHaveLength(0);
+      expect(result.next).toBe("none");
+      // The roiCapture rode through on roiMaterial for the wrapper to lift, and it
+      // is genuinely empty-previewed — decoupled from the (clean) diff above.
+      expect(result.roiMaterial?.roiCapture?.entities).toEqual([]);
+      expect(result.roiMaterial?.roiCapture?.source).toBe("frame_diff");
+    }
+  });
+
+  it("NEGATIVE control — WITHOUT carry-forward (no candidates) the same touched DOES disappear", async () => {
+    // Proves the assertion above is load-bearing: it is the carry-forward, not the
+    // test setup, that keeps the touched entity alive. Drop the candidates (as a
+    // ROI-OCR-only post would when it reads nothing) and the touched vanishes.
+    const touched = discoverTouched();
+    const store = new LeaseStore({ nowFn: () => 0, defaultTtlMs: 60_000 });
+    const lease = store.issue(touched, "v1");
+    const loop = new GuardedTouchLoop(store, makeEnv({ resolveLiveEntities: () => [touched] }));
+
+    const result = await loop.touch({
+      lease,
+      // No carry-forward and no observedRect scoping → unscoped diff, post empty.
+      postSnapshot: async () => ({ candidates: [], roiMaterial: {} }),
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.diff).toContain("entity_disappeared");
   });
 });

--- a/tests/unit/roi-capture-flag-persistence.test.ts
+++ b/tests/unit/roi-capture-flag-persistence.test.ts
@@ -133,7 +133,8 @@ describe("ADR-024 Seed-2 S5c-1a — resolveEntityCenterForViewId (frame-diff foc
 
 // ADR-024 Seed-2 S5b — facade fold accessors (read at act time on the discover
 // session). `resolveOcrTargetIdForViewId` MUST mirror the discover OCR lane's id
-// formula (`ocr-provider.ts`: `target.hwnd ?? target.windowTitle ?? "@active"`)
+// formula (`src/tools/desktop-providers/ocr-provider.ts:38`:
+// `target.hwnd ?? target.windowTitle ?? "@active"`)
 // so the fold's carry-forward candidates key to the SAME entityId (R1). This is
 // the facade half of the @active parity pin (the resolver half is in
 // roi-preview.test.ts). `discoverHasVisualGpuForViewId` is the D6 fold gate.
@@ -156,7 +157,7 @@ describe("ADR-024 Seed-2 S5b — resolveOcrTargetIdForViewId (@active parity)", 
   });
 
   it("returns the '@active' literal when the target pinned neither hwnd nor title", async () => {
-    // The exact fallback ocr-provider.ts keys on — both sides read the same
+    // The exact fallback the discover OCR lane keys on — both sides read the same
     // un-normalized lastTarget, so an @active discover and its fold agree (Codex
     // PR #438 P2 refute, pinned).
     const facade = facadeWith([]);

--- a/tests/unit/roi-capture-flag-persistence.test.ts
+++ b/tests/unit/roi-capture-flag-persistence.test.ts
@@ -130,3 +130,63 @@ describe("ADR-024 Seed-2 S5c-1a — resolveEntityCenterForViewId (frame-diff foc
     expect(facade.resolveEntityCenterForViewId(ent.lease.viewId, "ent-does-not-exist")).toBeNull();
   });
 });
+
+// ADR-024 Seed-2 S5b — facade fold accessors (read at act time on the discover
+// session). `resolveOcrTargetIdForViewId` MUST mirror the discover OCR lane's id
+// formula (`ocr-provider.ts`: `target.hwnd ?? target.windowTitle ?? "@active"`)
+// so the fold's carry-forward candidates key to the SAME entityId (R1). This is
+// the facade half of the @active parity pin (the resolver half is in
+// roi-preview.test.ts). `discoverHasVisualGpuForViewId` is the D6 fold gate.
+describe("ADR-024 Seed-2 S5b — resolveOcrTargetIdForViewId (@active parity)", () => {
+  /** see() with an explicit target → its viewId. Each unique target keys its own
+   *  session; the facade stores `lastTarget = input.target` verbatim. */
+  const seeWith = async (facade: DesktopFacade, target: Record<string, string>): Promise<string> => {
+    const out = await facade.see({ target });
+    return out.entities[0].lease.viewId;
+  };
+
+  it("returns target.hwnd when the discover target pinned an HWND", async () => {
+    const facade = facadeWith([]);
+    expect(facade.resolveOcrTargetIdForViewId(await seeWith(facade, { hwnd: "0xABC" }))).toBe("0xABC");
+  });
+
+  it("returns target.windowTitle when only a title was given", async () => {
+    const facade = facadeWith([]);
+    expect(facade.resolveOcrTargetIdForViewId(await seeWith(facade, { windowTitle: "Canvas" }))).toBe("Canvas");
+  });
+
+  it("returns the '@active' literal when the target pinned neither hwnd nor title", async () => {
+    // The exact fallback ocr-provider.ts keys on — both sides read the same
+    // un-normalized lastTarget, so an @active discover and its fold agree (Codex
+    // PR #438 P2 refute, pinned).
+    const facade = facadeWith([]);
+    expect(facade.resolveOcrTargetIdForViewId(await seeWith(facade, {}))).toBe("@active");
+  });
+
+  it("prefers hwnd over windowTitle when both are present (matches the `??` chain)", async () => {
+    const facade = facadeWith([]);
+    expect(
+      facade.resolveOcrTargetIdForViewId(await seeWith(facade, { hwnd: "0xDEAD", windowTitle: "Canvas" })),
+    ).toBe("0xDEAD");
+  });
+
+  it("returns null for an unknown viewId (no session → handler skips the fold)", () => {
+    expect(new DesktopFacade(() => []).resolveOcrTargetIdForViewId("never-issued-view-id")).toBeNull();
+  });
+});
+
+describe("ADR-024 Seed-2 S5b — discoverHasVisualGpuForViewId (D6 fold gate)", () => {
+  it("is true when the discover snapshot produced a visual_gpu entity (fold disabled → S5 2-OCR)", async () => {
+    const facade = facadeWith(["uia_blind_single_pane"], [cand("Icon", "visual_gpu")]);
+    expect(facade.discoverHasVisualGpuForViewId(await discover(facade))).toBe(true);
+  });
+
+  it("is false for an OCR-only discover (the fold-eligible visual-only target)", async () => {
+    const facade = facadeWith(["uia_blind_single_pane"], [cand("TARGET ALPHA", "ocr")]);
+    expect(facade.discoverHasVisualGpuForViewId(await discover(facade))).toBe(false);
+  });
+
+  it("returns false (safe default) for an unknown viewId", () => {
+    expect(new DesktopFacade(() => []).discoverHasVisualGpuForViewId("never-issued-view-id")).toBe(false);
+  });
+});

--- a/tests/unit/roi-preview.test.ts
+++ b/tests/unit/roi-preview.test.ts
@@ -135,7 +135,8 @@ describe("somElementsToCandidates (S5b diff baseline mapping)", () => {
 
   // ADR-024 Seed-2 S5b-3 — @active parity (Codex PR #438 P2 defensive pin). The
   // fold's carry-forward keys candidates by the SAME `target.id` the discover OCR
-  // lane used: `target.hwnd ?? target.windowTitle ?? "@active"` (ocr-provider.ts).
+  // lane used: `target.hwnd ?? target.windowTitle ?? "@active"`
+  // (src/tools/desktop-providers/ocr-provider.ts:38).
   // Codex flagged a possible `@active`-vs-normalized-HWND divergence; it was
   // refuted in code (both sides read the same un-normalized lastTarget). This pins
   // the structural half across ALL THREE id forms: for each, the ROI-crop

--- a/tests/unit/roi-preview.test.ts
+++ b/tests/unit/roi-preview.test.ts
@@ -132,4 +132,42 @@ describe("somElementsToCandidates (S5b diff baseline mapping)", () => {
   it("returns [] for no elements", () => {
     expect(somElementsToCandidates([], target, 0)).toEqual([]);
   });
+
+  // ADR-024 Seed-2 S5b-3 — @active parity (Codex PR #438 P2 defensive pin). The
+  // fold's carry-forward keys candidates by the SAME `target.id` the discover OCR
+  // lane used: `target.hwnd ?? target.windowTitle ?? "@active"` (ocr-provider.ts).
+  // Codex flagged a possible `@active`-vs-normalized-HWND divergence; it was
+  // refuted in code (both sides read the same un-normalized lastTarget). This pins
+  // the structural half across ALL THREE id forms: for each, the ROI-crop
+  // candidate and the discover candidate for the same label+rect resolve to the
+  // SAME entityId — so a `windowTitle` or `@active`-keyed target is as stable as
+  // an HWND-keyed one (no id form silently breaks carry-forward identity).
+  it.each(["hwnd-42", "Some Window Title", "@active"])(
+    "entityId parity holds for target.id = %s (hwnd / windowTitle / @active)",
+    (id) => {
+      const t = { kind: "window" as const, id };
+      const discoverOcr: UiEntityCandidate = {
+        source: "ocr",
+        target: t,
+        role: "label",
+        label: "TARGET ALPHA",
+        rect: RECT_A,
+        actionability: ["click"],
+        confidence: 0.7,
+        observedAtMs: 5,
+        provisional: false,
+      };
+      const roiOcr = somElementsToCandidates([{ text: "TARGET ALPHA", region: { ...RECT_A } }], t, 777);
+      const [discoverEntity] = resolveCandidates([discoverOcr], "gen-1");
+      const [roiEntity] = resolveCandidates(roiOcr, "gen-1");
+      expect(roiEntity?.entityId).toBe(discoverEntity?.entityId);
+      // And different id forms key to DIFFERENT entityIds (the id is part of the
+      // hash), so this is not vacuously true for some collapsed key.
+      const [other] = resolveCandidates(
+        somElementsToCandidates([{ text: "TARGET ALPHA", region: { ...RECT_A } }], { kind: "window", id: `${id}-x` }, 0),
+        "gen-1",
+      );
+      expect(roiEntity?.entityId).not.toBe(other?.entityId);
+    },
+  );
 });


### PR DESCRIPTION
ADR-024 Seed-2 **S5b-3** — the test-only PR completing the S5b order-trap fold
(carry-forward diff + padded roiCapture, landed in #437 / #438). **No production
code changes** — tests, the shared visual-only fixture (additive `-FontSize`
param), and its helper only.

## What it pins

- **R1 carry-forward decoupling (deterministic, CI-run)** — `guarded-touch.test.ts`:
  a real `GuardedTouchLoop` + real `somElementsToCandidates` + `resolveCandidates`
  proves the touched OCR anchor keeps its `entityId` (no `entity_disappeared`)
  **even when the fold's ROI-OCR preview is empty** — the exact signature of a
  ROI-crop OCR that read nothing on small text (the S5b-2 root cause). The diff
  baseline carries the discover entities forward and never re-OCRs the ROI. A
  **negative control** (drop the carry-forward → the same touched DOES disappear)
  pins the assertion is load-bearing.
- **R1 small-text headed e2e** — new `desktop-act-roi-carry-forward.test.ts` drives
  an **11pt** visual-only canvas (the ROI-OCR-hostile regime) and asserts a real
  folded `desktop_act` still reports no `entity_disappeared`. The fixture gains an
  additive `-FontSize` param (default 34 = existing canvas byte-equal). HEADED-gated.
- **Flag parity** — `desktop-act-frame-diff-dispatch.test.ts`:
  `DESKTOP_TOUCH_STAGE5B_FOLD_OCR=0` falls fully back to the S5 path (no
  `postSnapshot` closure, RAW frame-diff bbox roi) vs the fold's PADDED roi; the
  public `{ok, executor, diff, next}` envelope is **byte-equal** either way, and
  the internal `roiMaterial` never reaches the wire on either path.
- **@active parity (Codex #438 P2 defensive pin)** — `somElementsToCandidates`
  entityId parity over `[hwnd / windowTitle / @active]`; facade
  `resolveOcrTargetIdForViewId` mirrors `ocr-provider`'s
  `target.hwnd ?? target.windowTitle ?? "@active"`; `discoverHasVisualGpuForViewId`
  D6 gate.

## Live validation
- Both headed e2e pass `HEADED=1` (11pt full-window OCR reads the anchor; default
  34pt regression clean).
- **S6 bench re-run** (2 runs): round-trips **3→1** stable, total + payload favor
  folded in both. The S5b one-OCR removal is **within the live-desktop variance
  floor** (+162..+343 ms folded-act gap across runs) — recorded honestly, not
  claimed as a latency win. **Settle budget pinned** (`RING_WALLCLOCK_BUDGET_MS`=700
  et al.) in the plan repo (强制命令10).
- Full unit suite: 4261 passed; the single failure (`benchmark-gates` idle-latency
  perf gate) is a known timing flake under full-suite load — passes on isolated
  re-run, unrelated to these test-only changes.

Plan: `desktop-touch-mcp-internal@e59575a:docs/adr-024-seed2-plan.md` §S5b-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)