### PR TITLE
fix(mouse): preserve screenshot-time window position for homing delta

### DIFF
--- a/src/engine/window-cache.ts
+++ b/src/engine/window-cache.ts
@@ -34,11 +34,50 @@ const cache = new Map<string, CachedWindow>();
 
 /** Cache entries older than this are treated as stale — HWND may have been recycled. */
 const CACHE_TTL_MS = 60_000;
+
+/**
+ * Snapshot cache: persists screenshot-time window positions by title.
+ * Separate from the main cache — NOT mutated by updateWindowCache(),
+ * focus_window(), or window_dock(). Only screenshot tools write to it,
+ * and only applyHoming reads from it.
+ *
+ * This guarantees that mouse_click's homing correction always compares
+ * against the position the LLM saw in the screenshot, even when other
+ * tools have overwritten the main cache between screenshot and click.
+ */
+const snapshotCache = new Map<string, { region: { x: number; y: number; width: number; height: number }; timestamp: number }>();
+const SNAPSHOT_TTL_MS = 90_000;
+
 export const WINDOW_CACHE_TTL_EXPORTED_MS = CACHE_TTL_MS;
 
 /** Get the timestamp this hwnd was last cached, or null if not cached. */
 export function getWindowCacheTimestamp(hwnd: bigint): number | null {
   return cache.get(String(hwnd))?.timestamp ?? null;
+}
+
+/**
+ * Save a screenshot-time window position to the snapshot cache.
+ * Call from screenshot tools after capturing a single-window screenshot.
+ * The snapshot survives mutations to the main cache from focus/dock tools.
+ */
+export function saveSnapshot(title: string, region: { x: number; y: number; width: number; height: number }): void {
+  const key = title.toLowerCase();
+  snapshotCache.set(key, { region: { ...region }, timestamp: Date.now() });
+}
+
+/**
+ * Read a saved screenshot-time position for a given window title.
+ * Returns null if never saved or expired (TTL > 90s).
+ */
+export function getSnapshot(title: string): { x: number; y: number; width: number; height: number } | null {
+  const key = title.toLowerCase();
+  const entry = snapshotCache.get(key);
+  if (!entry) return null;
+  if (Date.now() - entry.timestamp > SNAPSHOT_TTL_MS) {
+    snapshotCache.delete(key);
+    return null;
+  }
+  return entry.region;
 }
 
 // ─── Public API ───────────────────────────────────────────────────────────────

--- a/src/tools/mouse.ts
+++ b/src/tools/mouse.ts
@@ -110,9 +110,21 @@ async function applyHoming(
   const notes: string[] = [];
 
   // ── Tier 2: focus the target window if it went behind another ─────────────
+  //
+  // IMPORTANT: before any cache mutation in Tier 2, capture the screenshot-time
+  // window position. If we call updateWindowCache() before computeWindowDelta(),
+  // the cache is overwritten with the CURRENT position and the delta is always
+  // zero — homing correction is silently disabled.
+  let screenshotRegion: { x: number; y: number; width: number; height: number } | null = null;
+  if (windowTitle) {
+    const cachedBefore = getCachedWindowByTitle(windowTitle);
+    if (cachedBefore) {
+      screenshotRegion = { ...cachedBefore.region };
+    }
+  }
+
   if (windowTitle) {
     const windows = enumWindowsInZOrder();
-    updateWindowCache(windows); // keep cache fresh before delta check below
     const active = windows.find((w) => w.isActive);
     if (!active || !active.title.toLowerCase().includes(windowTitle.toLowerCase())) {
       const target = windows.find((w) =>
@@ -170,16 +182,49 @@ async function applyHoming(
   }
 
   // ── Tier 1: window-delta correction ──────────────────────────────────────
-  const cached = windowTitle
-    ? getCachedWindowByTitle(windowTitle)
-    : findContainingWindow(x, y);
+  //
+  // Compute delta from the SCREENSHOT-TIME position (saved before Tier 2
+  // mutated the cache), not from the post-focus position. Without this,
+  // updateWindowCache in Tier 2 silently nullifies the delta and homing
+  // correction becomes a no-op whenever a focus attempt was made.
+  let delta: { dx: number; dy: number; sizeChanged: boolean } | null = null;
 
-  if (!cached) {
-    // No cache entry — nothing to correct
-    return { x, y, notes };
+  if (screenshotRegion && windowTitle) {
+    // Use saved screenshot-time position for delta computation
+    const cachedAfter = getCachedWindowByTitle(windowTitle);
+    if (cachedAfter) {
+      const live = getWindowRectByHwnd(cachedAfter.hwnd);
+      if (live) {
+        const dx = live.x - screenshotRegion.x;
+        const dy = live.y - screenshotRegion.y;
+        const sizeChanged =
+          live.width !== screenshotRegion.width || live.height !== screenshotRegion.height;
+        delta = { dx, dy, sizeChanged };
+        notes.push(`homing delta computed from saved snapshot: (${dx > 0 ? "+" : ""}${dx},${dy > 0 ? "+" : ""}${dy})`);
+      }
+    }
   }
 
-  const delta = computeWindowDelta(cached.hwnd);
+  if (!delta) {
+    // Fallback: standard path — read from cache (only reliable when Tier 2 didn't mutate it)
+    const cached = windowTitle
+      ? getCachedWindowByTitle(windowTitle)
+      : findContainingWindow(x, y);
+
+    if (!cached) {
+      // If windowTitle was provided but cache missed, do a fresh enumeration
+      // so future calls have the window in cache. We still return unmodified
+      // coords (no delta to apply), but at least populate the cache.
+      if (windowTitle) {
+        const fresh = enumWindowsInZOrder();
+        updateWindowCache(fresh);
+        notes.push(`no cached position for "${windowTitle}", cache refreshed for next call`);
+      }
+      return { x, y, notes };
+    }
+
+    delta = computeWindowDelta(cached.hwnd);
+  }
   if (!delta) {
     // Window no longer exists — leave coords as-is
     return { x, y, notes };

--- a/src/tools/mouse.ts
+++ b/src/tools/mouse.ts
@@ -14,6 +14,8 @@ import {
   findContainingWindow,
   getCachedWindowByTitle,
   computeWindowDelta,
+  saveSnapshot,
+  getSnapshot,
 } from "../engine/window-cache.js";
 import { getElementBounds } from "../engine/uia-bridge.js";
 import { captureWindowRawAndHash } from "../engine/layer-buffer.js";
@@ -115,11 +117,18 @@ async function applyHoming(
   // window position. If we call updateWindowCache() before computeWindowDelta(),
   // the cache is overwritten with the CURRENT position and the delta is always
   // zero — homing correction is silently disabled.
+  //
+  // Prefer the snapshot cache (set by screenshot tools, survives external focus/
+  // dock calls) over the regular cache (mutated by updateWindowCache in Tier 2
+  // and by other tools like focus_window / window_dock).
   let screenshotRegion: { x: number; y: number; width: number; height: number } | null = null;
   if (windowTitle) {
-    const cachedBefore = getCachedWindowByTitle(windowTitle);
-    if (cachedBefore) {
-      screenshotRegion = { ...cachedBefore.region };
+    screenshotRegion = getSnapshot(windowTitle);
+    if (!screenshotRegion) {
+      const cachedBefore = getCachedWindowByTitle(windowTitle);
+      if (cachedBefore) {
+        screenshotRegion = { ...cachedBefore.region };
+      }
     }
   }
 

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -10,7 +10,7 @@ import { getUiElements, extractActionableElements, WINUI3_CLASS_RE, detectUiaBli
 import type { UiElementsResult } from "../engine/uia-bridge.js";
 import { recognizeWindow, ocrWordsToActionable, runOcr, mergeNearbyWords, runSomPipeline, snapToDictionary } from "../engine/ocr-bridge.js";
 import type { OcrDictionaryEntry } from "../engine/ocr-bridge.js";
-import { updateWindowCache } from "../engine/window-cache.js";
+import { updateWindowCache, saveSnapshot } from "../engine/window-cache.js";
 import { CHROMIUM_TITLE_RE } from "./workspace.js";
 import { computeViewportPosition } from "../utils/viewport-position.js";
 import { ok, buildDesc } from "./_types.js";
@@ -600,6 +600,11 @@ export const screenshotHandler = async (args: {
         const wins = enumWindowsInZOrder();
         updateWindowCache(wins);
 
+        // Save screenshot-time snapshot for homing — survives external cache
+        // mutations from focus_window / window_dock between screenshot and click.
+        const snapWin = wins.find((w) => w.title.toLowerCase().includes(effectiveTitle.toLowerCase()));
+        if (snapWin) saveSnapshot(effectiveTitle, snapWin.region);
+
         // Resolve the full window title from the partial match, then test the
         // Chromium regex against the resolved title — not the user-supplied
         // substring (which typically won't contain the "- Google Chrome" suffix).
@@ -1092,6 +1097,10 @@ export const screenshotOcrHandler = async ({
     const ocrWarnings: string[] = [...(resolvedWin?.warnings ?? [])];
     const wins = enumWindowsInZOrder();
     const win = wins.find((w) => w.title.toLowerCase().includes(effectiveTitle.toLowerCase()));
+    if (win) {
+      updateWindowCache(wins);
+      saveSnapshot(effectiveTitle, win.region);
+    }
     if (!win) {
       // Phase 4: surfaced to LLM via screenshot(detail='ocr') dispatcher.
       return failWith(`Window not found: "${effectiveTitle}"`, "screenshot", { windowTitle: effectiveTitle });


### PR DESCRIPTION
## Summary

Two-layer fix for homing delta correction being silently disabled:

### Layer 1: Preserve screenshot-time position within applyHoming

\pplyHoming\ saves the cached window region before Tier 2 (focus) mutates the cache. Delta is then computed from the saved position vs live \GetWindowRect\, not from the freshly-overwritten cache.

### Layer 2: Snapshot cache to survive external cache mutations

Added \saveSnapshot\ / \getSnapshot\ — a separate write-once cache populated by screenshot tools. Unlike the main cache, the snapshot cache is **never mutated** by \ocus_window\, \window_dock\, or Tier 2's \updateWindowCache\. \pplyHoming\ reads from the snapshot cache first.

Together these fix both:
1. Tier 2 self-nullifying the delta within \pplyHoming\ itself
2. External tools (\ocus_window\/docking) nullifying the cache between screenshot and click

## Changes

- \src/engine/window-cache.ts\: add snapshot cache + \saveSnapshot\/\getSnapshot\
- \src/tools/mouse.ts\: \pplyHoming\ uses \getSnapshot\ first, falls back to \getCachedWindowByTitle\; cache miss on known title refreshes cache
- \src/tools/screenshot.ts\: \detail='text'\ and \detail='ocr'\ call \saveSnapshot\ after screenshot

## Testing

Verified on Windows with Doubao desktop app:
1. Screenshot via \screenshot(detail='ocr', windowTitle='豆包')\ at position (1077, 354)
2. Moved window to (8, 8) via \window_dock\
3. \mouse_click(1166, 867, windowTitle='豆包')\ → homing: \window moved -1069,-346\ → correctly clicked target