### PR TITLE
fix(mouse/screenshot): close homing snapshot gaps (follow-up to #444 / issue #443)

### DIFF
--- a/src/engine/window-cache.ts
+++ b/src/engine/window-cache.ts
@@ -68,6 +68,13 @@ export function saveSnapshot(title: string, region: { x: number; y: number; widt
 /**
  * Read a saved screenshot-time position for a given window title.
  * Returns null if never saved or expired (TTL > 90s).
+ *
+ * Matching is an exact (case-insensitive) key lookup, NOT the substring match
+ * used by getCachedWindowByTitle. A snapshot is keyed by the screenshot's
+ * effectiveTitle and read back by the mouse_click windowTitle; these coincide
+ * for the normal workflow (same title string passed to both), so a caller that
+ * uses different title strings for the screenshot and the click simply misses
+ * here and degrades to the main-cache path — no incorrect correction results.
  */
 export function getSnapshot(title: string): { x: number; y: number; width: number; height: number } | null {
   const key = title.toLowerCase();

--- a/src/tools/mouse.ts
+++ b/src/tools/mouse.ts
@@ -204,9 +204,14 @@ async function applyHoming(
   let delta: { dx: number; dy: number; sizeChanged: boolean } | null = null;
 
   if (screenshotRegion && windowTitle) {
-    // Use saved screenshot-time position for delta computation
+    // Use saved screenshot-time position for delta computation. The live rect
+    // is read from the cached HWND, so honour the same 60s stale guard
+    // computeWindowDelta() applies: a cache entry older than CACHE_TTL_MS may
+    // point at a recycled HWND (the snapshot region can be up to its own 90s
+    // TTL old), and reading GetWindowRect on a recycled handle would yield a
+    // bogus delta. When stale, skip and let the fallback path decide.
     const cachedAfter = getCachedWindowByTitle(windowTitle);
-    if (cachedAfter) {
+    if (cachedAfter && Date.now() - cachedAfter.timestamp <= WINDOW_CACHE_TTL_EXPORTED_MS) {
       const live = getWindowRectByHwnd(cachedAfter.hwnd);
       if (live) {
         const dx = live.x - screenshotRegion.x;

--- a/src/tools/mouse.ts
+++ b/src/tools/mouse.ts
@@ -14,8 +14,8 @@ import {
   findContainingWindow,
   getCachedWindowByTitle,
   computeWindowDelta,
-  saveSnapshot,
   getSnapshot,
+  WINDOW_CACHE_TTL_EXPORTED_MS,
 } from "../engine/window-cache.js";
 import { getElementBounds } from "../engine/uia-bridge.js";
 import { captureWindowRawAndHash } from "../engine/layer-buffer.js";
@@ -126,7 +126,12 @@ async function applyHoming(
     screenshotRegion = getSnapshot(windowTitle);
     if (!screenshotRegion) {
       const cachedBefore = getCachedWindowByTitle(windowTitle);
-      if (cachedBefore) {
+      // Honour the main cache's 60s stale guard (same window the snapshot path
+      // omits): a cache entry older than CACHE_TTL_MS may point at a recycled
+      // HWND / pre-move layout, so falling back to it for the manual delta below
+      // — which bypasses computeWindowDelta()'s own staleness check — could apply
+      // a bogus offset. Skip stale entries and let the standard path handle it.
+      if (cachedBefore && Date.now() - cachedBefore.timestamp <= WINDOW_CACHE_TTL_EXPORTED_MS) {
         screenshotRegion = { ...cachedBefore.region };
       }
     }

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -852,6 +852,17 @@ export const screenshotHandler = async (args: {
         return failWith(`Window not found: "${effectiveTitle}"`, "screenshot", { windowTitle: effectiveTitle });
       }
 
+      // Populate caches for homing. This is the primary coordinate-copy path
+      // (dotByDot=true / detail='image' single-window capture), so it must seed
+      // homing just like detail='text'/'ocr' do:
+      //   - updateWindowCache gives applyHoming a live HWND to resolve at click
+      //     time (getCachedWindowByTitle), and
+      //   - saveSnapshot preserves this screenshot-time window position so the
+      //     delta survives focus_window / window_dock mutating the main cache
+      //     between this capture and the follow-up mouse_click.
+      updateWindowCache(enumWindowsInZOrder());
+      saveSnapshot(effectiveTitle, windowRegion);
+
       let originX = windowRegion.x;
       let originY = windowRegion.y;
 

--- a/tests/fixtures/failwith-callsite-shapes.json
+++ b/tests/fixtures/failwith-callsite-shapes.json
@@ -338,56 +338,56 @@
     },
     {
       "file": "src/tools/mouse.ts",
-      "line": 411,
+      "line": 470,
       "tool": "mouse_move",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/mouse.ts",
-      "line": 529,
+      "line": 588,
       "tool": "mouse_click",
       "errKind": "new-error",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/mouse.ts",
-      "line": 703,
+      "line": 762,
       "tool": "mouse_click",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/mouse.ts",
-      "line": 752,
+      "line": 811,
       "tool": "mouse_drag",
       "errKind": "new-error",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/mouse.ts",
-      "line": 917,
+      "line": 976,
       "tool": "mouse_drag",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/mouse.ts",
-      "line": 1421,
+      "line": 1480,
       "tool": "scroll",
       "errKind": "new-error",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/mouse.ts",
-      "line": 1563,
+      "line": 1622,
       "tool": "scroll",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/mouse.ts",
-      "line": 1572,
+      "line": 1631,
       "tool": "get_cursor_position",
       "errKind": "identifier",
       "contextShape": "none"
@@ -436,21 +436,21 @@
     },
     {
       "file": "src/tools/screenshot.ts",
-      "line": 847,
+      "line": 852,
       "tool": "screenshot",
       "errKind": "string-literal",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/screenshot.ts",
-      "line": 1074,
+      "line": 1090,
       "tool": "screenshot",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/screenshot.ts",
-      "line": 1193,
+      "line": 1213,
       "tool": "get_screen_info",
       "errKind": "identifier",
       "contextShape": "none"

--- a/tests/fixtures/failwith-callsite-shapes.json
+++ b/tests/fixtures/failwith-callsite-shapes.json
@@ -338,56 +338,56 @@
     },
     {
       "file": "src/tools/mouse.ts",
-      "line": 470,
+      "line": 475,
       "tool": "mouse_move",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/mouse.ts",
-      "line": 588,
+      "line": 593,
       "tool": "mouse_click",
       "errKind": "new-error",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/mouse.ts",
-      "line": 762,
+      "line": 767,
       "tool": "mouse_click",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/mouse.ts",
-      "line": 811,
+      "line": 816,
       "tool": "mouse_drag",
       "errKind": "new-error",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/mouse.ts",
-      "line": 976,
+      "line": 981,
       "tool": "mouse_drag",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/mouse.ts",
-      "line": 1480,
+      "line": 1485,
       "tool": "scroll",
       "errKind": "new-error",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/mouse.ts",
-      "line": 1622,
+      "line": 1627,
       "tool": "scroll",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/mouse.ts",
-      "line": 1631,
+      "line": 1636,
       "tool": "get_cursor_position",
       "errKind": "identifier",
       "contextShape": "none"

--- a/tests/unit/homing-snapshot-delta.test.ts
+++ b/tests/unit/homing-snapshot-delta.test.ts
@@ -1,0 +1,188 @@
+/**
+ * tests/unit/homing-snapshot-delta.test.ts
+ *
+ * Regression pin for issue #443 / PR #444: mouse_click homing delta was
+ * silently nullified because applyHoming's Tier 2 (focus) ran
+ * updateWindowCache() before Tier 1 computed the delta, overwriting the
+ * screenshot-time position so computeWindowDelta() always returned (0,0).
+ *
+ * The fix computes the delta from the screenshot-time position — taken from the
+ * snapshot cache (set by screenshot tools, immune to focus/dock mutations) or,
+ * failing that, from a *fresh* main-cache entry — against the live GetWindowRect.
+ *
+ * These tests drive the real mouseClickHandler with the window-cache / win32
+ * surface mocked, and assert the FINAL cursor position (moveTo → setPosition)
+ * reflects the screenshot-time → live delta.
+ *
+ * Assertion point: with speed:0, moveTo() teleports via mouse.setPosition(Point),
+ * so the Point passed there is the post-homing click coordinate.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock(import("../../src/engine/win32.js"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    enumWindowsInZOrder: vi.fn(),
+    restoreAndFocusWindow: vi.fn(),
+    getWindowIdentity: vi.fn(() => null),
+    readScrollInfo: vi.fn(() => null),
+    getForegroundHwnd: vi.fn(() => null),
+    getWindowRectByHwnd: vi.fn(() => null),
+  };
+});
+
+vi.mock("../../src/engine/window-cache.js", () => ({
+  updateWindowCache: vi.fn(),
+  findContainingWindow: vi.fn(() => null),
+  getCachedWindowByTitle: vi.fn(() => null),
+  computeWindowDelta: vi.fn(() => null),
+  getSnapshot: vi.fn(() => null),
+  // mouse.ts reads this constant for the stale-cache TTL guard; provide the
+  // real value so the guard arithmetic behaves as in production.
+  WINDOW_CACHE_TTL_EXPORTED_MS: 60_000,
+}));
+
+vi.mock("../../src/tools/_action-guard.js", () => ({
+  runActionGuard: vi.fn(),
+  isAutoGuardEnabled: vi.fn(() => false),
+}));
+
+vi.mock("../../src/engine/perception/registry.js", () => ({
+  evaluatePreToolGuards: vi.fn(),
+  buildEnvelopeFor: vi.fn(() => null),
+}));
+
+vi.mock("../../src/engine/perception/tab-drag-heuristic.js", () => ({
+  detectTabDragRisk: vi.fn(() => ({ shouldBlock: false })),
+}));
+
+vi.mock("../../src/engine/uia-bridge.js", () => ({
+  getElementBounds: vi.fn(() => null),
+}));
+
+vi.mock("../../src/engine/nutjs.js", () => ({
+  mouse: {
+    click: vi.fn(),
+    doubleClick: vi.fn(),
+    setPosition: vi.fn(),
+    move: vi.fn(),
+    config: { mouseSpeed: 1000 },
+  },
+  Button: { LEFT: "left", RIGHT: "right", MIDDLE: "middle" },
+  // Real constructor: applyHoming → moveTo does `new Point(x, y)`, which an
+  // arrow-function mock cannot satisfy.
+  Point: class { constructor(public x: number, public y: number) {} },
+  straightTo: vi.fn((p) => p),
+  DEFAULT_MOUSE_SPEED: 1000,
+}));
+
+vi.mock("../../src/tools/_focus.js", () => ({
+  detectFocusLoss: vi.fn(() => Promise.resolve(undefined)),
+}));
+
+vi.mock("../../src/tools/_mouse-verify.js", () => ({
+  snapshotForVerify: vi.fn(() => Promise.resolve(null)),
+  classifyDelivery: vi.fn(() => "unverifiable"),
+}));
+
+vi.mock("../../src/tools/_resolve-window.js", () => ({
+  resolveWindowTarget: vi.fn(async ({ windowTitle }: { windowTitle?: string }) => ({
+    title: windowTitle,
+    warnings: [],
+  })),
+}));
+
+import { mouseClickHandler } from "../../src/tools/mouse.js";
+import * as win32 from "../../src/engine/win32.js";
+import * as cache from "../../src/engine/window-cache.js";
+import * as nutjs from "../../src/engine/nutjs.js";
+
+const mockEnum = vi.mocked(win32.enumWindowsInZOrder);
+const mockGetRect = vi.mocked(win32.getWindowRectByHwnd);
+const mockGetSnapshot = vi.mocked(cache.getSnapshot);
+const mockGetCachedByTitle = vi.mocked(cache.getCachedWindowByTitle);
+const mockComputeDelta = vi.mocked(cache.computeWindowDelta);
+const mockSetPosition = vi.mocked(nutjs.mouse.setPosition);
+
+const TITLE = "Doubao";
+const HWND = 4242n;
+
+/** Target window present and already active → Tier 2 focus path is a no-op. */
+function activeTargetWindow() {
+  return [{
+    hwnd: HWND,
+    title: TITLE,
+    isActive: true,
+    zOrder: 0,
+    isMinimized: false,
+    isMaximized: false,
+    region: { x: 0, y: 0, width: 800, height: 600 },
+    processName: "doubao.exe",
+  }];
+}
+
+function cachedEntry(region: { x: number; y: number; width: number; height: number }, timestamp: number) {
+  return { hwnd: HWND, title: TITLE, region, zOrder: 0, timestamp };
+}
+
+const BASE_ARGS = {
+  button: "left" as const,
+  doubleClick: false,
+  tripleClick: false,
+  homing: true,
+  windowTitle: TITLE,
+  speed: 0,
+  trackFocus: false,
+  settleMs: 0,
+  verifyDelivery: false,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockEnum.mockReturnValue(activeTargetWindow());
+});
+
+describe("issue #443: homing delta uses screenshot-time position", () => {
+  it("applies the snapshot→live delta from the snapshot cache", async () => {
+    // Screenshot-time window was at (100,100); it has since moved to (50,80).
+    mockGetSnapshot.mockReturnValue({ x: 100, y: 100, width: 800, height: 600 });
+    mockGetCachedByTitle.mockReturnValue(cachedEntry({ x: 50, y: 80, width: 800, height: 600 }, Date.now()));
+    mockGetRect.mockReturnValue({ x: 50, y: 80, width: 800, height: 600 });
+
+    await mouseClickHandler({ ...BASE_ARGS, x: 300, y: 400 });
+
+    // delta = live(50,80) - snapshot(100,100) = (-50,-20)
+    // corrected = (300-50, 400-20) = (250, 380)
+    expect(mockSetPosition).toHaveBeenCalledWith({ x: 250, y: 380 });
+  });
+
+  it("falls back to a fresh main-cache entry when no snapshot exists", async () => {
+    mockGetSnapshot.mockReturnValue(null);
+    // Fresh cache entry (timestamp now) holds the screenshot-time position.
+    mockGetCachedByTitle.mockReturnValue(cachedEntry({ x: 100, y: 100, width: 800, height: 600 }, Date.now()));
+    mockGetRect.mockReturnValue({ x: 130, y: 160, width: 800, height: 600 });
+
+    await mouseClickHandler({ ...BASE_ARGS, x: 300, y: 400 });
+
+    // delta = live(130,160) - cached(100,100) = (+30,+60) → (330, 460)
+    expect(mockSetPosition).toHaveBeenCalledWith({ x: 330, y: 460 });
+  });
+
+  it("ignores a stale main-cache entry (TTL guard) instead of applying a bogus offset", async () => {
+    mockGetSnapshot.mockReturnValue(null);
+    // Stale entry (older than the 60s cache TTL) — must NOT seed screenshotRegion.
+    mockGetCachedByTitle.mockReturnValue(cachedEntry({ x: 100, y: 100, width: 800, height: 600 }, Date.now() - 120_000));
+    // If the TTL guard were broken, the snapshot path would compute
+    // live(130,160) - stale(100,100) = (+30,+60). The guard skips it, so the
+    // fallback computeWindowDelta() (mocked → no movement) governs instead.
+    mockGetRect.mockReturnValue({ x: 130, y: 160, width: 800, height: 600 });
+    mockComputeDelta.mockReturnValue({ dx: 0, dy: 0, sizeChanged: false });
+
+    await mouseClickHandler({ ...BASE_ARGS, x: 300, y: 400 });
+
+    // No correction from the stale region → original coords.
+    expect(mockSetPosition).toHaveBeenCalledWith({ x: 300, y: 400 });
+  });
+});

--- a/tests/unit/homing-snapshot-delta.test.ts
+++ b/tests/unit/homing-snapshot-delta.test.ts
@@ -170,6 +170,23 @@ describe("issue #443: homing delta uses screenshot-time position", () => {
     expect(mockSetPosition).toHaveBeenCalledWith({ x: 330, y: 460 });
   });
 
+  it("skips the snapshot delta when the cached HWND entry is stale (recycle guard)", async () => {
+    // Snapshot region is fresh, but the main-cache HWND entry used to read the
+    // live rect is older than the 60s cache TTL → the HWND may have been
+    // recycled, so the snapshot delta path must NOT trust GetWindowRect on it.
+    mockGetSnapshot.mockReturnValue({ x: 100, y: 100, width: 800, height: 600 });
+    mockGetCachedByTitle.mockReturnValue(cachedEntry({ x: 100, y: 100, width: 800, height: 600 }, Date.now() - 120_000));
+    // If the recycle guard were missing, the snapshot path would apply
+    // live(130,160) - snapshot(100,100) = (+30,+60). The guard skips it; the
+    // fallback computeWindowDelta() (mocked → no movement) governs instead.
+    mockGetRect.mockReturnValue({ x: 130, y: 160, width: 800, height: 600 });
+    mockComputeDelta.mockReturnValue({ dx: 0, dy: 0, sizeChanged: false });
+
+    await mouseClickHandler({ ...BASE_ARGS, x: 300, y: 400 });
+
+    expect(mockSetPosition).toHaveBeenCalledWith({ x: 300, y: 400 });
+  });
+
   it("ignores a stale main-cache entry (TTL guard) instead of applying a bogus offset", async () => {
     mockGetSnapshot.mockReturnValue(null);
     // Stale entry (older than the 60s cache TTL) — must NOT seed screenshotRegion.

--- a/tests/unit/issue-207-foreground-refusal-mouse-drag.test.ts
+++ b/tests/unit/issue-207-foreground-refusal-mouse-drag.test.ts
@@ -44,6 +44,7 @@ vi.mock("../../src/engine/window-cache.js", () => ({
   findContainingWindow: vi.fn(() => null),
   getCachedWindowByTitle: vi.fn(() => null),
   computeWindowDelta: vi.fn(() => null),
+  getSnapshot: vi.fn(() => null),
 }));
 
 vi.mock("../../src/tools/_action-guard.js", () => ({

--- a/tests/unit/issue-207-foreground-refusal-mouse-drag.test.ts
+++ b/tests/unit/issue-207-foreground-refusal-mouse-drag.test.ts
@@ -45,6 +45,7 @@ vi.mock("../../src/engine/window-cache.js", () => ({
   getCachedWindowByTitle: vi.fn(() => null),
   computeWindowDelta: vi.fn(() => null),
   getSnapshot: vi.fn(() => null),
+  WINDOW_CACHE_TTL_EXPORTED_MS: 60_000,
 }));
 
 vi.mock("../../src/tools/_action-guard.js", () => ({

--- a/tests/unit/issue-207-foreground-refusal-mouse.test.ts
+++ b/tests/unit/issue-207-foreground-refusal-mouse.test.ts
@@ -48,6 +48,7 @@ vi.mock("../../src/engine/window-cache.js", () => ({
   getCachedWindowByTitle: vi.fn(() => null),
   computeWindowDelta: vi.fn(() => null),
   getSnapshot: vi.fn(() => null),
+  WINDOW_CACHE_TTL_EXPORTED_MS: 60_000,
 }));
 
 vi.mock("../../src/tools/_action-guard.js", () => ({

--- a/tests/unit/issue-207-foreground-refusal-mouse.test.ts
+++ b/tests/unit/issue-207-foreground-refusal-mouse.test.ts
@@ -47,6 +47,7 @@ vi.mock("../../src/engine/window-cache.js", () => ({
   findContainingWindow: vi.fn(() => null),
   getCachedWindowByTitle: vi.fn(() => null),
   computeWindowDelta: vi.fn(() => null),
+  getSnapshot: vi.fn(() => null),
 }));
 
 vi.mock("../../src/tools/_action-guard.js", () => ({

--- a/tests/unit/mouse-click-coord-order.test.ts
+++ b/tests/unit/mouse-click-coord-order.test.ts
@@ -52,6 +52,7 @@ vi.mock("../../src/engine/window-cache.js", () => ({
   findContainingWindow: vi.fn(() => null),
   getCachedWindowByTitle: vi.fn(() => null),
   computeWindowDelta: vi.fn(() => null),
+  getSnapshot: vi.fn(() => null),
 }));
 
 vi.mock("../../src/engine/uia-bridge.js", () => ({

--- a/tests/unit/mouse-click-coord-order.test.ts
+++ b/tests/unit/mouse-click-coord-order.test.ts
@@ -53,6 +53,7 @@ vi.mock("../../src/engine/window-cache.js", () => ({
   getCachedWindowByTitle: vi.fn(() => null),
   computeWindowDelta: vi.fn(() => null),
   getSnapshot: vi.fn(() => null),
+  WINDOW_CACHE_TTL_EXPORTED_MS: 60_000,
 }));
 
 vi.mock("../../src/engine/uia-bridge.js", () => ({

--- a/tests/unit/window-cache-snapshot.test.ts
+++ b/tests/unit/window-cache-snapshot.test.ts
@@ -1,0 +1,53 @@
+/**
+ * tests/unit/window-cache-snapshot.test.ts
+ *
+ * Unit pin for the homing snapshot cache (saveSnapshot / getSnapshot) added in
+ * PR #444 (issue #443). The snapshot cache preserves the screenshot-time window
+ * position so mouse_click's homing delta survives focus_window / window_dock
+ * mutating the main window cache between screenshot and click.
+ *
+ * Contract pinned here:
+ *   - round-trips a saved region by case-insensitive title
+ *   - decouples the stored region from the caller's input object (copy on save)
+ *   - returns null for an unknown title
+ *   - expires entries older than the 90s snapshot TTL
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { saveSnapshot, getSnapshot } from "../../src/engine/window-cache.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("window-cache snapshot (homing screenshot-time position)", () => {
+  it("round-trips a saved region by case-insensitive title", () => {
+    saveSnapshot("MyApp", { x: 10, y: 20, width: 800, height: 600 });
+    expect(getSnapshot("myapp")).toEqual({ x: 10, y: 20, width: 800, height: 600 });
+  });
+
+  it("stores a copy — later mutation of the caller's object does not leak in", () => {
+    const region = { x: 1, y: 2, width: 3, height: 4 };
+    saveSnapshot("CopyApp", region);
+    region.x = 999;
+    expect(getSnapshot("CopyApp")).toEqual({ x: 1, y: 2, width: 3, height: 4 });
+  });
+
+  it("returns null for a title that was never saved", () => {
+    expect(getSnapshot("never-saved-window-xyz")).toBeNull();
+  });
+
+  it("expires entries older than the 90s snapshot TTL", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    saveSnapshot("TtlApp", { x: 5, y: 5, width: 100, height: 100 });
+
+    // 89s later — still fresh
+    vi.setSystemTime(89_000);
+    expect(getSnapshot("TtlApp")).not.toBeNull();
+
+    // 91s later — expired
+    vi.setSystemTime(91_000);
+    expect(getSnapshot("TtlApp")).toBeNull();
+  });
+});


### PR DESCRIPTION
Follow-up to #444 (issue #443). #444 correctly fixed the homing root cause
(Tier 2's `updateWindowCache()` ran before Tier 1's delta computation, so the
screenshot-time position was overwritten and the delta collapsed to `(0,0)`).
This PR closes the gaps found while reviewing #444 together with Codex + Opus.

## What this fixes

- **Broken existing tests (CI red after #444).** The new `getSnapshot` export
  was not added to the wholesale `window-cache` mocks in the mouse unit tests,
  so `applyHoming` threw and the foreground-refusal contract tests regressed to
  `ToolError`. Added `getSnapshot` to the three mouse-test mocks.
- **Primary coordinate-copy path was uncovered.** `screenshot(dotByDot=true)` /
  `detail='image'` single-window capture never seeded the snapshot or the main
  cache, so homing could not resolve a live HWND there — i.e. the fix was
  absent for the scenario it most needs to protect. Now seeds both, matching
  the `detail='text'` / `detail='ocr'` paths.
- **Stale-cache guards.** The `cachedBefore` fallback copied a region without
  honouring the 60s cache TTL, and the snapshot delta path read `GetWindowRect`
  on a title-resolved HWND without any TTL/recycle guard. Both now apply the
  `WINDOW_CACHE_TTL_EXPORTED_MS` guard so a recycled HWND / minute-old layout
  can't produce a bogus offset.

## Also

- Drop the unused `saveSnapshot` import in `mouse.ts`.
- Regenerate the failWith callsite fixtures for the shifted line numbers.
- Document `getSnapshot`'s exact (vs substring) title-match semantics.

## Tests

- New `tests/unit/window-cache-snapshot.test.ts` — snapshot save / get / 90s TTL.
- New `tests/unit/homing-snapshot-delta.test.ts` — pins the issue #443 delta
  path: snapshot delta, fresh-cache fallback, stale-cache skip, and the
  HWND-recycle guard.
- All related unit suites green; `build` / `check:stub-catalog` /
  `check:failwith-fixtures` clean.

## Review

Reviewed with Codex (no regressions) and Opus (P1 zero; the snapshot-path
recycle guard was added in response to Opus round 1). Residual lower-priority
follow-ups (integration-level ordering pin, snapshot/main TTL coherence,
cross-call title-key match) are recorded in the internal docs repo.