### PR TITLE
[codex] Improve site SEO metadata

### DIFF
--- a/site/articles/beyond-coordinate-roulette.html
+++ b/site/articles/beyond-coordinate-roulette.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Beyond Coordinate Roulette</title>
-    <meta name="description" content="A public-facing name for the idea that UI automation should operate on meaning, not on blind coordinate guesses." />
+    <title>Beyond Coordinate Roulette | desktop-touch-mcp</title>
+    <meta name="description" content="How desktop-touch-mcp frames meaning-first UI automation for LLM agents: act on entities and guarded intent, not blind coordinate guesses." />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Manrope:wght@500;700;800&family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,700&display=swap" rel="stylesheet" />

--- a/site/articles/client-setup.html
+++ b/site/articles/client-setup.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Client Setup</title>
-    <meta name="description" content="Copy-paste setup snippets for connecting desktop-touch-mcp to Claude, GitHub Copilot, VS Code, Codex, ChatGPT Developer mode, and Gemini CLI." />
+    <title>desktop-touch-mcp Client Setup | Windows MCP server</title>
+    <meta name="description" content="Copy-paste setup snippets for connecting the desktop-touch-mcp Windows MCP server to Claude, GitHub Copilot, VS Code, Codex, ChatGPT Developer mode, and Gemini CLI." />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Manrope:wght@500;700;800&family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,700&display=swap" rel="stylesheet" />

--- a/site/articles/planned-evaluation.html
+++ b/site/articles/planned-evaluation.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Planned Evaluation</title>
-    <meta name="description" content="Planned scenarios, metrics, and reporting format for evaluating RPG, leases, and guarded execution." />
+    <title>Planned Evaluation | desktop-touch-mcp</title>
+    <meta name="description" content="Planned scenarios, metrics, and reporting format for evaluating desktop-touch-mcp's Reactive Perception Graph, leases, and guarded Windows desktop execution." />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Manrope:wght@500;700;800&family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,700&display=swap" rel="stylesheet" />

--- a/site/articles/reactive-perception-graph.html
+++ b/site/articles/reactive-perception-graph.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Reactive Perception Graph</title>
-    <meta name="description" content="Why screenshots are not enough, and how Reactive Perception Graph treats external state as provisional." />
+    <title>Reactive Perception Graph | desktop-touch-mcp</title>
+    <meta name="description" content="Why screenshots are not enough for LLM desktop agents, and how desktop-touch-mcp's Reactive Perception Graph treats external state as provisional." />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Manrope:wght@500;700;800&family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,700&display=swap" rel="stylesheet" />

--- a/site/articles/v1.0-milestone.html
+++ b/site/articles/v1.0-milestone.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>v1.0 Milestone: Less Surface, More Meaning</title>
-    <meta name="description" content="The v1.0 release marks the crystallization of the Beyond Coordinate Roulette philosophy through tool surface reduction and World-Graph standardisation." />
+    <title>desktop-touch-mcp v1.0 Milestone: Less Surface, More Meaning</title>
+    <meta name="description" content="The desktop-touch-mcp v1.0 release reduces the MCP tool surface and standardizes World-Graph interaction for meaning-first Windows desktop automation." />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Manrope:wght@500;700;800&family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,700&display=swap" rel="stylesheet" />

--- a/site/articles/v1.10-milestone.html
+++ b/site/articles/v1.10-milestone.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>v1.10 Milestone: Targeting by Meaning, Confirming in One Call</title>
-    <meta name="description" content="How v1.9 and v1.10 extend 'see entities, not coordinates' to the two surfaces that resisted it — the browser DOM and apps with no accessible surface at all — and let a single act both confirm its result and reveal the next target." />
+    <title>desktop-touch-mcp v1.10 Milestone: Meaning-first targeting</title>
+    <meta name="description" content="How desktop-touch-mcp v1.9 and v1.10 bring semantic browser targeting and one-call visual confirmation to Windows apps, canvas surfaces, RDP, and custom UIs." />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Manrope:wght@500;700;800&family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,700&display=swap" rel="stylesheet" />

--- a/site/articles/v1.2-milestone.html
+++ b/site/articles/v1.2-milestone.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>v1.2 Milestone: Putting Meaning Into the Response</title>
-    <meta name="description" content="The v1.2 release adds opt-in envelope and causal context to every tool response, so agents can stop guessing and start observing." />
+    <title>desktop-touch-mcp v1.2 Milestone: Meaning in responses</title>
+    <meta name="description" content="The desktop-touch-mcp v1.2 release adds opt-in envelopes and causal context to MCP tool responses, helping LLM agents stop guessing and start observing." />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Manrope:wght@500;700;800&family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,700&display=swap" rel="stylesheet" />

--- a/site/articles/v1.4-milestone.html
+++ b/site/articles/v1.4-milestone.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>v1.4 Milestone: From Observation to Memory and Trustworthy Delivery</title>
-    <meta name="description" content="The v1.3 and v1.4 series add four cognitive memory layers and close the silent-failure gaps in delivery, so agents can both re-query their past calls and trust the verdict on whether each one worked." />
+    <title>desktop-touch-mcp v1.4 Milestone: Memory and delivery</title>
+    <meta name="description" content="The desktop-touch-mcp v1.3 and v1.4 releases add agent memory and delivery verification for safer Windows desktop actions, terminal input, and browser control." />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Manrope:wght@500;700;800&family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,700&display=swap" rel="stylesheet" />

--- a/site/articles/v1.8-milestone.html
+++ b/site/articles/v1.8-milestone.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>v1.8 Milestone: From Delivery to Completion, and Reaching Deeper Into Apps</title>
-    <meta name="description" content="The v1.5–v1.8 series extend trustworthy delivery into real command completion (terminal exit codes), reach into apps with almost no clickable surface (Excel VBA), and harden how the agent acts and observes." />
+    <title>desktop-touch-mcp v1.8 Milestone: Completion and deeper app control</title>
+    <meta name="description" content="The desktop-touch-mcp v1.5-v1.8 releases add terminal completion checks, Excel VBA app control, race-free visual verification, and safer Windows agent actions." />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Manrope:wght@500;700;800&family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,700&display=swap" rel="stylesheet" />

--- a/site/index.html
+++ b/site/index.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>desktop-touch-mcp</title>
-    <meta name="description" content="An experimental project exploring safer contracts between LLM agents and dynamic desktop interfaces." />
+    <title>desktop-touch-mcp | Computer-use MCP server for Windows agents</title>
+    <meta name="description" content="desktop-touch-mcp is a Windows computer-use MCP server for LLM agents, with screenshots, UI Automation, Chrome CDP, semantic targeting, and guarded actions." />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Manrope:wght@500;700;800&family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,700&display=swap" rel="stylesheet" />
@@ -40,7 +40,7 @@
           <div class="hero-copy">
             <span class="eyebrow">Experimental by design</span>
             <h1>A safer way for LLM agents to touch the outside world</h1>
-            <p class="lead"><code>desktop-touch-mcp</code> is an experimental MCP server for giving LLM agents eyes, hands, and a better safety contract with dynamic interfaces.</p>
+            <p class="lead"><code>desktop-touch-mcp</code> is an experimental Windows computer-use MCP server for giving LLM agents eyes, hands, and a better safety contract with dynamic interfaces.</p>
             <p>For now, treat this project as <strong>Windows 11 only</strong>. It already lets LLMs interact with Windows applications through screenshots, keyboard, mouse, Windows UI Automation, and Chrome DevTools Protocol.</p>
             <p>But the deeper goal is not just “look at a screenshot and click some coordinates.” This project is exploring how LLM agents can interact with changing interfaces in a way that is more semantic, more bounded, and less fragile.</p>
             <div class="hero-actions">

--- a/site/index.md
+++ b/site/index.md
@@ -1,6 +1,6 @@
 # desktop-touch-mcp
 
-An experimental project for giving LLM agents a safer contract with the outside world.
+An experimental Windows computer-use MCP server for giving LLM agents a safer contract with the outside world.
 
 ---
 
@@ -12,7 +12,7 @@ An experimental project for giving LLM agents a safer contract with the outside 
 
 ### Subheadline
 
-`desktop-touch-mcp` is an experimental MCP server for giving LLM agents eyes, hands, and a better safety contract with dynamic interfaces.
+`desktop-touch-mcp` is an experimental Windows computer-use MCP server for giving LLM agents eyes, hands, and a better safety contract with dynamic interfaces.
 
 ### Short lead
 


### PR DESCRIPTION
## Summary

- Update the GitHub Pages top page title, description, and lead to identify desktop-touch-mcp as a Windows computer-use MCP server for LLM agents.
- Add `desktop-touch-mcp`, Windows/MCP, and agent-oriented category terms to article page titles and meta descriptions.
- Keep page body content and sitemap URLs unchanged.

## Why

Bing Webmaster Tools search performance currently shows mostly branded queries. The site body already explains the project well, but several search-result surfaces were too abstract or lacked the project/category terms.

## Validation

- Checked every `site/index.html` and `site/articles/*.html` title and meta description for brand/category coverage.
- Verified title length <= 70 and meta description length <= 165 for all public pages.
- Ran `git diff --check -- site`.