### PR TITLE
fix: restore fail-closed PENDING SHA256 guard + close OCR mock gaps (follow-up to #449/#450)

### DIFF
--- a/bin/launcher.js
+++ b/bin/launcher.js
@@ -48,6 +48,16 @@ function fail(message) {
 }
 
 /**
+ * Opt-in escape hatch for running the launcher from a source tree whose
+ * RELEASE_MANIFEST.sha256 is still the "PENDING" placeholder (i.e. the
+ * release workflow has not finalized the manifest). Published npm packages
+ * always ship a real SHA256, so end users never need this.
+ */
+function allowUnverifiedRelease() {
+  return process.env.DESKTOP_TOUCH_MCP_ALLOW_UNVERIFIED === "1";
+}
+
+/**
  * Reads the GitHub token from the environment.
  * Supports both GITHUB_TOKEN (GitHub Actions standard) and GH_TOKEN (gh CLI).
  */
@@ -158,11 +168,21 @@ function expectedReleaseSpec() {
   if (!RELEASE_MANIFEST.sha256 || RELEASE_MANIFEST.assetName !== ASSET_NAME) {
     throw new Error(`Missing release manifest for ${RELEASE_TAG}`);
   }
-  // "PENDING" is the pre-release placeholder set in source.
-  // It means the npm publish CI did not finalize the manifest (e.g.
-  // update-sha.mjs was not run).  In that case we skip SHA256
-  // verification so the launcher is still usable.
+  // "PENDING" is the pre-release placeholder set in source. The release
+  // workflow (scripts/update-sha.mjs) replaces it with the real zip SHA256
+  // before npm publish, so a PENDING manifest at runtime means this launcher
+  // was not finalized — fail closed by default so an accidentally published
+  // launcher can never silently run an unverified runtime zip. Developers
+  // running straight from source can opt in to skipping verification with
+  // DESKTOP_TOUCH_MCP_ALLOW_UNVERIFIED=1.
   const isPending = RELEASE_MANIFEST.sha256 === "PENDING";
+  if (isPending && !allowUnverifiedRelease()) {
+    throw new Error(
+      `Release SHA256 manifest for ${RELEASE_TAG} is PENDING — this launcher was not finalized by the release workflow. ` +
+      `Published npm packages always ship a real SHA256. If you are intentionally running the launcher from source, ` +
+      `set DESKTOP_TOUCH_MCP_ALLOW_UNVERIFIED=1 to skip integrity verification (development only).`
+    );
+  }
   if (!isPending && !/^[a-f0-9]{64}$/i.test(RELEASE_MANIFEST.sha256)) {
     throw new Error(`Invalid release SHA256 manifest for ${RELEASE_TAG}`);
   }
@@ -349,8 +369,8 @@ async function installRelease(release, expected) {
     if (expected.sha256 !== null) {
       await verifySha256(zipPath, expected.sha256);
     } else {
-      warn("SHA256 is PENDING — skipping integrity verification. " +
-           "Set the GITHUB_TOKEN environment variable and re-run to ensure download integrity.");
+      warn("SHA256 manifest is PENDING and DESKTOP_TOUCH_MCP_ALLOW_UNVERIFIED=1 is set — " +
+           "skipping integrity verification of the downloaded zip. Development use only.");
     }
     await mkdir(extractDir, { recursive: true });
     await expandZip(zipPath, extractDir);

--- a/src/engine/vision-gpu/onnx-backend.ts
+++ b/src/engine/vision-gpu/onnx-backend.ts
@@ -40,6 +40,7 @@ import { spawn } from "node:child_process";
 import sharp from "sharp";
 
 import { nativeVision, type NativeRawCandidate } from "../native-engine.js";
+import { detectOcrLanguage } from "../ocr-bridge.js";
 import type { VisualBackend } from "./backend.js";
 import { ModelRegistry, type ModelVariant } from "./model-registry.js";
 import { runStagePipeline, type StageSessionKeys, type StagePipelineInput } from "./stage-pipeline.js";
@@ -91,9 +92,7 @@ const winOcrTierInfinity: WinOcrFallbackFn = async (
       .toBuffer();
 
     // Spawn win-ocr.exe and feed PNG bytes (mirrors ocr-bridge.ts::runOcrExe pattern).
-    // Use system locale for OCR language instead of hardcoded "ja".
-    // Detects e.g. "zh" for Chinese Windows, "ja" for Japanese, "en" for English.
-    const ocrLang = Intl.DateTimeFormat().resolvedOptions().locale.split("-")[0]?.toLowerCase() || "ja";
+    const ocrLang = detectOcrLanguage();
     const stdout = await new Promise<string>((resolve, reject) => {
       const child = spawn(WIN_OCR_EXE_PATH, [ocrLang], { windowsHide: true });
       const timer = setTimeout(() => {

--- a/tests/unit/issue-207-foreground-refusal-terminal.test.ts
+++ b/tests/unit/issue-207-foreground-refusal-terminal.test.ts
@@ -69,6 +69,7 @@ vi.mock("../../src/engine/uia-bridge.js", () => ({
 vi.mock("../../src/engine/ocr-bridge.js", () => ({
   recognizeWindow: vi.fn(),
   ocrWordsToLines: vi.fn(),
+  detectOcrLanguage: () => "en",
 }));
 
 vi.mock("../../src/engine/identity-tracker.js", () => ({

--- a/tests/unit/terminal-run-validation.test.ts
+++ b/tests/unit/terminal-run-validation.test.ts
@@ -163,7 +163,9 @@ describe("terminal(action='run') — Zod default leak guard (PR #37 Codex P1)", 
     const parsed = TERMINAL_RUN_READ_OPTIONS_SCHEMA.parse(input);
     expect(parsed.stripAnsi).toBe(true);
     expect(parsed.source).toBe("auto");
-    expect(parsed.ocrLanguage).toBe("ja");
+    // ocrLanguage lost its .default("ja") in PR #450 (now optional; the handler
+    // auto-detects from the system locale) — it must NOT materialise here.
+    expect(parsed.ocrLanguage).toBeUndefined();
     expect(parsed.lines).toBe(10);
   });
 

--- a/tests/unit/terminal-send-console-paste.test.ts
+++ b/tests/unit/terminal-send-console-paste.test.ts
@@ -42,6 +42,7 @@ vi.mock("../../src/engine/uia-bridge.js", () => ({
 vi.mock("../../src/engine/ocr-bridge.js", () => ({
   recognizeWindow: vi.fn(),
   ocrWordsToLines: vi.fn(),
+  detectOcrLanguage: () => "en",
 }));
 
 vi.mock("../../src/engine/identity-tracker.js", () => ({

--- a/tests/unit/visual-gpu-ocr-adapter.test.ts
+++ b/tests/unit/visual-gpu-ocr-adapter.test.ts
@@ -18,6 +18,7 @@ import type { UiEntityCandidate } from "../../src/engine/vision-gpu/types.js";
 // ── Static mock for ocr-bridge (intercepted by vitest for dynamic imports too) ──
 vi.mock("../../src/engine/ocr-bridge.js", () => ({
   runSomPipeline: vi.fn(),
+  detectOcrLanguage: () => "en",
 }));
 
 // Import after mock is registered.


### PR DESCRIPTION
## Summary

Follow-up to the two excellent contributions from @licat2023 (#449, #450), closing the gaps identified during review while keeping both features intact.

### Launcher (follow-up to #449)

- **Fail-closed PENDING guard restored**: `RELEASE_MANIFEST.sha256 = "PENDING"` now throws again by default. This placeholder is part of the release procedure — `scripts/update-sha.mjs` finalizes it before npm publish, so a PENDING manifest at runtime means the launcher was not finalized. Failing closed guarantees an accidentally published launcher can never silently run an unverified runtime zip.
- **New opt-in for source-tree development**: `DESKTOP_TOUCH_MCP_ALLOW_UNVERIFIED=1` enables the skip-verification path from #449 (warning retained), preserving the contributor use case of running the launcher straight from source.
- **Warning text corrected**: the previous message suggested setting `GITHUB_TOKEN` "to ensure download integrity" — the token only raises GitHub API rate limits and has no integrity effect.
- The GitHub API authentication from #449 is untouched.

### OCR tests + unification (follow-up to #450)

- **3 wholesale `vi.mock("ocr-bridge.js")` factories** now include the new `detectOcrLanguage` export (`visual-gpu-ocr-adapter.test.ts`, `issue-207-foreground-refusal-terminal.test.ts`, `terminal-send-console-paste.test.ts`). Without it, Vitest returns `undefined` for the missing named export and `visual-gpu-ocr-adapter.test.ts` failed 4 cases at call time (swallowed by the adapter try/catch into empty poll results). CI does not run the TS unit suite on PRs, so this was only visible locally.
- **`onnx-backend.ts` unified** to import the canonical `detectOcrLanguage()` — its inline duplicate had an empty-locale fallback of `"ja"` vs the canonical `"en"`.

## Verification

- `node --check bin/launcher.js` / `npm run build` green
- Pinpoint vitest: the 4 previously failing `visual-gpu-ocr-adapter` cases now pass; 58/58 across the 4 touched test files; 42/42 across the 3 onnx-backend-dependent files

🤖 Generated with [Claude Code](https://claude.com/claude-code)