### PR TITLE
ci: skip CodeQL on fork PRs (token downgrade breaks codeql-action/init)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,12 @@ on:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
+    # Skip on fork PRs: GitHub downgrades GITHUB_TOKEN to near-anonymous access
+    # for PRs from forks regardless of the permissions block, so
+    # codeql-action/init fails with "HttpError: Requires authentication"
+    # (observed on PR #449). The push to main after merge still runs the full
+    # analysis, so no commit lands unscanned. Guard suggested by @licat2023.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       actions: read


### PR DESCRIPTION
## Summary

CodeQL fails on every PR from a fork because GitHub downgrades `GITHUB_TOKEN` to near-anonymous access for fork PRs regardless of the workflow `permissions` block, so `codeql-action/init@v3` cannot authenticate ("HttpError: Requires authentication" — observed on #449).

This adds an `if` guard that skips the analyze job for fork PRs only:

- Same-repo PRs and the post-merge push to `main` still run the full analysis, so **every landed commit remains scanned** — only the redundant (and always-failing) fork-PR run is skipped.
- Scheduled weekly scan is unaffected.

Credit: guard suggested by @licat2023 in #449.

🤖 Generated with [Claude Code](https://claude.com/claude-code)