### PR TITLE
feat(scroll,workspace): ADR-026 Phase 2b — scroll-capture + workspace by-ref

### DIFF
--- a/src/tools/scroll-capture.ts
+++ b/src/tools/scroll-capture.ts
@@ -9,6 +9,7 @@ import {
   findPlainTopLevelWindowByTitle,
 } from "./_resolve-window.js";
 import type { ToolResult } from "./_types.js";
+import { buildImageBlocks } from "./screenshot-response.js";
 
 // Horizontal mouse scroll units per step (matches nut-js scroll granularity)
 const H_SCROLL_STEPS = 25;
@@ -613,12 +614,27 @@ export const scrollCaptureHandler = async ({
       ...(sizeReduced ? { sizeReduced, tip: "Reduce maxScrolls or add grayscale=true for smaller output." } : {}),
     };
 
-    return {
-      content: [
-        { type: "image" as const, data: imageBuffer!.toString("base64"), mimeType: mimeType as "image/png" | "image/webp" },
-        { type: "text" as const, text: JSON.stringify(summary, null, 2) },
-      ],
-    };
+    // ADR-026 §3: deliver the stitched image by-ref (ref-only — scroll-capture
+    // has no confirmImage param). The structured `summary` (incl. sizeReduced /
+    // overlap stats) stays bit-equal; the existing encode/guard pipeline above is
+    // unchanged (full-res-on-disk is OQ-1, deferred). R6 degrades to inline.
+    const { blocks, warning } = buildImageBlocks({
+      base64: imageBuffer!.toString("base64"),
+      mimeType,
+      width: outW,
+      height: outH,
+      wantInline: false,
+      meta: { tag: windowTitle },
+      describe: (i) =>
+        `Stitched scroll capture ${i.width}×${i.height} (${i.mimeType}, ${i.bytes} bytes). ` +
+        `Open only if you need the stitched pixels — the summary above carries frame count and overlap stats.`,
+    });
+    const content: ToolResult["content"] = [
+      ...blocks,
+      { type: "text" as const, text: JSON.stringify(summary, null, 2) },
+    ];
+    if (warning) content.push({ type: "text" as const, text: JSON.stringify({ hints: { warnings: [warning] } }) });
+    return { content };
   } catch (err) {
     return {
       content: [{ type: "text" as const, text: `scroll(action='capture') failed: ${String(err)}` }],

--- a/src/tools/workspace.ts
+++ b/src/tools/workspace.ts
@@ -171,13 +171,14 @@ export const workspaceSnapshotHandler = async ({
     const content: ToolResult["content"] = [];
     content.push({ type: "text", text: JSON.stringify(result, null, 2) });
     for (const snap of snapshots) {
-      if (snap.thumbnail) {
-        const dims = snap.thumbnailSize ?? { width: 0, height: 0 };
+      // thumbnail and thumbnailSize are set/cleared together in buildWindowSnapshot
+      // (same try block), so a truthy thumbnail always has a non-null size.
+      if (snap.thumbnail && snap.thumbnailSize) {
         const { blocks, warning } = buildImageBlocks({
           base64: snap.thumbnail,
           mimeType: "image/png",
-          width: dims.width,
-          height: dims.height,
+          width: snap.thumbnailSize.width,
+          height: snap.thumbnailSize.height,
           wantInline: false,
           meta: { tag: snap.title },
           describe: (i) =>

--- a/src/tools/workspace.ts
+++ b/src/tools/workspace.ts
@@ -4,6 +4,7 @@ import { mouse } from "../engine/nutjs.js";
 import { validateLaunchCommand, resolveLaunchExecutable, spawnDetached } from "../utils/launch.js";
 import { enumMonitors, getVirtualScreen, enumWindowsInZOrder, type WindowZInfo } from "../engine/win32.js";
 import { captureScreen } from "../engine/image.js";
+import { buildImageBlocks } from "./screenshot-response.js";
 import { clearLayers } from "../engine/layer-buffer.js";
 import { noteInvalidation } from "../engine/identity-tracker.js";
 import { getUiElements, extractActionableElements, WINUI3_CLASS_RE } from "../engine/uia-bridge.js";
@@ -163,12 +164,29 @@ export const workspaceSnapshotHandler = async ({
       windowCount: snapshots.length,
     };
 
+    // ADR-026 §3: persist each thumbnail + return a by-ref link (ref-only —
+    // workspace_snapshot is an orientation call; N inline thumbnails are the
+    // heaviest token accumulator). windows[].thumbnailSize + the per-thumb label
+    // stay bit-equal. R6 degrades to inline per thumbnail independently.
     const content: ToolResult["content"] = [];
     content.push({ type: "text", text: JSON.stringify(result, null, 2) });
     for (const snap of snapshots) {
       if (snap.thumbnail) {
-        content.push({ type: "image", data: snap.thumbnail, mimeType: "image/png" });
+        const dims = snap.thumbnailSize ?? { width: 0, height: 0 };
+        const { blocks, warning } = buildImageBlocks({
+          base64: snap.thumbnail,
+          mimeType: "image/png",
+          width: dims.width,
+          height: dims.height,
+          wantInline: false,
+          meta: { tag: snap.title },
+          describe: (i) =>
+            `Thumbnail of "${snap.title}" ${i.width}×${i.height} (${i.bytes} bytes). ` +
+            `Open only if you need the pixels — the window's title/region/thumbnailSize are in the JSON above.`,
+        });
+        content.push(...blocks);
         content.push({ type: "text", text: `↑ "${snap.title}" ${snap.region.width}x${snap.region.height} at (${snap.region.x},${snap.region.y})` });
+        if (warning) content.push({ type: "text", text: JSON.stringify({ hints: { warnings: [warning] } }) });
       }
     }
 

--- a/tests/fixtures/failwith-callsite-shapes.json
+++ b/tests/fixtures/failwith-callsite-shapes.json
@@ -597,14 +597,14 @@
     },
     {
       "file": "src/tools/workspace.ts",
-      "line": 177,
+      "line": 195,
       "tool": "workspace_snapshot",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/workspace.ts",
-      "line": 262,
+      "line": 280,
       "tool": "workspace_launch",
       "errKind": "identifier",
       "contextShape": "none"

--- a/tests/fixtures/failwith-callsite-shapes.json
+++ b/tests/fixtures/failwith-callsite-shapes.json
@@ -597,14 +597,14 @@
     },
     {
       "file": "src/tools/workspace.ts",
-      "line": 195,
+      "line": 196,
       "tool": "workspace_snapshot",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/workspace.ts",
-      "line": 280,
+      "line": 281,
       "tool": "workspace_launch",
       "errKind": "identifier",
       "contextShape": "none"

--- a/tests/unit/scroll-capture-ref.test.ts
+++ b/tests/unit/scroll-capture-ref.test.ts
@@ -1,0 +1,85 @@
+/**
+ * scroll-capture-ref.test.ts — ADR-026 Phase 2b.
+ *
+ * Pins the by-ref delivery of scroll(action='capture'): the stitched scroll image
+ * is persisted to the disk-cache and returned as a resource_link (ref-only — no
+ * confirmImage param). The structured `summary` (frame count / overlap stats /
+ * sizeReduced) stays bit-equal.
+ *
+ * nut-js (libXtst) is the only native aborter on a Linux unit runner, so it is a
+ * complete fake (screen.grabRegion returns uniform frames → page-end after two
+ * identical reads → a single stitched frame goes through real sharp). win32 /
+ * _resolve-window are importOriginal overrides.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+
+const { mockGrabRegion, mockRestoreAndFocus, mockResolveWindowTarget, mockFindPlain } = vi.hoisted(() => ({
+  mockGrabRegion: vi.fn(),
+  mockRestoreAndFocus: vi.fn(),
+  mockResolveWindowTarget: vi.fn(),
+  mockFindPlain: vi.fn(),
+}));
+
+// Complete fake for nut-js (the only Linux aborter). scroll-capture imports
+// screen / keyboard / mouse / Region from it.
+vi.mock("../../src/engine/nutjs.js", () => ({
+  screen: { grabRegion: mockGrabRegion },
+  keyboard: { pressKey: vi.fn(async () => {}), releaseKey: vi.fn(async () => {}) },
+  mouse: { scrollRight: vi.fn(async () => {}) },
+  Region: class { constructor(public x: number, public y: number, public width: number, public height: number) {} },
+}));
+vi.mock("../../src/engine/win32.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/engine/win32.js")>();
+  return { ...actual, restoreAndFocusWindow: mockRestoreAndFocus };
+});
+vi.mock("../../src/tools/_resolve-window.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/tools/_resolve-window.js")>();
+  return { ...actual, resolveWindowTarget: mockResolveWindowTarget, findPlainTopLevelWindowByTitle: mockFindPlain };
+});
+
+const { scrollCaptureHandler } = await import("../../src/tools/scroll-capture.js");
+
+/** A uniform-gray RGBA frame; identical reads trigger the page-end break. */
+function uniformFrame(w: number, h: number) {
+  const data = Buffer.alloc(w * h * 4, 128);
+  return { toRGB: async () => ({ data, width: w, height: h, hasAlphaChannel: true }) };
+}
+
+let cacheDir: string;
+beforeEach(() => {
+  vi.clearAllMocks();
+  cacheDir = path.join(os.tmpdir(), `dt-scroll-test-${crypto.randomBytes(6).toString("hex")}`);
+  process.env.DESKTOP_TOUCH_SCREENSHOTS_DIR = cacheDir;
+  mockResolveWindowTarget.mockResolvedValue(null);
+  mockFindPlain.mockReturnValue({ hwnd: 1n });
+  mockRestoreAndFocus.mockReturnValue({ x: 0, y: 0, width: 200, height: 200 });
+  mockGrabRegion.mockResolvedValue(uniformFrame(200, 200));
+});
+afterEach(() => {
+  delete process.env.DESKTOP_TOUCH_SCREENSHOTS_DIR;
+  try { fs.rmSync(cacheDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+describe("scroll(action='capture') — ADR-026 §3 ref-only delivery", () => {
+  it("stitched image is a resource_link (no inline) and the summary survives", async () => {
+    const result = await scrollCaptureHandler({
+      windowTitle: "Doc", direction: "down", maxScrolls: 5, scrollDelayMs: 100, maxWidth: 1280,
+    });
+
+    const links = result.content.filter((c) => c.type === "resource_link");
+    const images = result.content.filter((c) => c.type === "image");
+    expect(links).toHaveLength(1);
+    expect(images).toHaveLength(0);
+
+    // The structured summary (frames / overlapMode / direction) is preserved.
+    const summaryText = (result.content.find((c) => c.type === "text") as { text: string }).text;
+    const summary = JSON.parse(summaryText);
+    expect(summary.ok).toBe(true);
+    expect(summary.direction).toBe("down");
+    expect(typeof summary.frames).toBe("number");
+  }, 15000);
+});

--- a/tests/unit/scroll-capture-ref.test.ts
+++ b/tests/unit/scroll-capture-ref.test.ts
@@ -6,10 +6,14 @@
  * confirmImage param). The structured `summary` (frame count / overlap stats /
  * sizeReduced) stays bit-equal.
  *
- * nut-js (libXtst) is the only native aborter on a Linux unit runner, so it is a
- * complete fake (screen.grabRegion returns uniform frames → page-end after two
- * identical reads → a single stitched frame goes through real sharp). win32 /
- * _resolve-window are importOriginal overrides.
+ * nut-js (libXtst) is the hard native aborter on a Linux unit runner. It reaches
+ * this graph two ways, so BOTH are cut off: `engine/nutjs.js` (used directly by
+ * scroll-capture) is a complete fake, and `utils/key-map.js` is mocked so its
+ * direct raw `@nut-tree-fork/nut-js` import never loads (Codex review). With those
+ * faked, screen.grabRegion returns uniform frames → page-end after two identical
+ * reads → a single stitched frame goes through REAL sharp. win32 / _resolve-window
+ * stay importOriginal: their windows-rs napi addon loads in the unit lane (run
+ * Windows-local; CI does not run the TS unit suite on Linux).
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
@@ -24,7 +28,7 @@ const { mockGrabRegion, mockRestoreAndFocus, mockResolveWindowTarget, mockFindPl
   mockFindPlain: vi.fn(),
 }));
 
-// Complete fake for nut-js (the only Linux aborter). scroll-capture imports
+// Complete fake for nut-js (the Linux aborter). scroll-capture imports
 // screen / keyboard / mouse / Region from it.
 vi.mock("../../src/engine/nutjs.js", () => ({
   screen: { grabRegion: mockGrabRegion },
@@ -32,6 +36,12 @@ vi.mock("../../src/engine/nutjs.js", () => ({
   mouse: { scrollRight: vi.fn(async () => {}) },
   Region: class { constructor(public x: number, public y: number, public width: number, public height: number) {} },
 }));
+// scroll-capture's `parseKeys` comes from key-map.ts, which imports the RAW
+// @nut-tree-fork/nut-js (`Key` enum) directly — NOT via engine/nutjs.js — so the
+// real package's libXtst aborts at load on a Linux lane (Codex P1). Mock key-map
+// itself so the raw package never loads; parseKeys' result is fed to the mocked
+// keyboard (no-op), so an empty key list suffices.
+vi.mock("../../src/utils/key-map.js", () => ({ parseKeys: () => [] }));
 vi.mock("../../src/engine/win32.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../src/engine/win32.js")>();
   return { ...actual, restoreAndFocusWindow: mockRestoreAndFocus };

--- a/tests/unit/workspace-snapshot-ref.test.ts
+++ b/tests/unit/workspace-snapshot-ref.test.ts
@@ -7,10 +7,13 @@
  * the heaviest token accumulator). windows[].thumbnailSize + the per-thumb label
  * stay bit-equal; a persist failure degrades to inline per thumbnail (R6).
  *
- * nut-js (libXtst) is the only native dep that aborts on a Linux unit runner, so
- * nutjs + image (which imports nutjs) are complete fakes; the rest are
- * importOriginal overrides (Rust .node loads cross-platform). includeUiSummary
- * is false so the UIA lane is never exercised.
+ * nut-js (libXtst) is the hard native aborter on a Linux unit runner, so nutjs +
+ * image (which imports nutjs) are complete fakes. workspace.ts does not reach the
+ * raw @nut-tree-fork/nut-js package (no key-map import), so that path is safe
+ * here. The remaining engine mocks stay importOriginal overrides — their
+ * windows-rs napi addon loads in the unit lane (run Windows-local; CI does not
+ * run the TS unit suite on Linux). includeUiSummary is false so the UIA lane is
+ * never exercised.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";

--- a/tests/unit/workspace-snapshot-ref.test.ts
+++ b/tests/unit/workspace-snapshot-ref.test.ts
@@ -1,0 +1,108 @@
+/**
+ * workspace-snapshot-ref.test.ts — ADR-026 Phase 2b.
+ *
+ * Pins the by-ref delivery of workspace_snapshot thumbnails: each window
+ * thumbnail is persisted to the disk-cache and surfaced as a resource_link
+ * (ref-only — workspace_snapshot is an orientation call, N inline thumbnails are
+ * the heaviest token accumulator). windows[].thumbnailSize + the per-thumb label
+ * stay bit-equal; a persist failure degrades to inline per thumbnail (R6).
+ *
+ * nut-js (libXtst) is the only native dep that aborts on a Linux unit runner, so
+ * nutjs + image (which imports nutjs) are complete fakes; the rest are
+ * importOriginal overrides (Rust .node loads cross-platform). includeUiSummary
+ * is false so the UIA lane is never exercised.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+
+const { mockCaptureScreen, mockEnumMonitors, mockEnumWindowsInZOrder, mockGetVirtualScreen } = vi.hoisted(() => ({
+  mockCaptureScreen: vi.fn(),
+  mockEnumMonitors: vi.fn(),
+  mockEnumWindowsInZOrder: vi.fn(),
+  mockGetVirtualScreen: vi.fn(),
+}));
+
+// Complete fakes for the only native aborter (nut-js / libXtst) and image.js
+// (imports nutjs). workspace.ts uses mouse.getPosition + captureScreen from them.
+vi.mock("../../src/engine/nutjs.js", () => ({ mouse: { getPosition: async () => ({ x: 7, y: 9 }) } }));
+vi.mock("../../src/engine/image.js", () => ({ captureScreen: mockCaptureScreen }));
+
+vi.mock("../../src/engine/win32.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/engine/win32.js")>();
+  return { ...actual, enumMonitors: mockEnumMonitors, enumWindowsInZOrder: mockEnumWindowsInZOrder, getVirtualScreen: mockGetVirtualScreen };
+});
+vi.mock("../../src/engine/layer-buffer.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/engine/layer-buffer.js")>();
+  return { ...actual, clearLayers: vi.fn() };
+});
+vi.mock("../../src/engine/identity-tracker.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/engine/identity-tracker.js")>();
+  return { ...actual, noteInvalidation: vi.fn() };
+});
+vi.mock("../../src/engine/window-cache.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/engine/window-cache.js")>();
+  return { ...actual, updateWindowCache: vi.fn() };
+});
+
+const { workspaceSnapshotHandler } = await import("../../src/tools/workspace.js");
+
+const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 3, 1, 4, 1]);
+const B64 = PNG.toString("base64");
+
+let cacheDir: string;
+beforeEach(() => {
+  vi.clearAllMocks();
+  cacheDir = path.join(os.tmpdir(), `dt-ws-test-${crypto.randomBytes(6).toString("hex")}`);
+  process.env.DESKTOP_TOUCH_SCREENSHOTS_DIR = cacheDir;
+  mockEnumMonitors.mockReturnValue([{ id: 0, primary: true, bounds: { x: 0, y: 0, width: 1920, height: 1080 }, dpi: 96, scale: 100 }]);
+  mockGetVirtualScreen.mockReturnValue({ x: 0, y: 0, width: 1920, height: 1080 });
+  mockCaptureScreen.mockResolvedValue({ base64: B64, width: 400, height: 300 });
+});
+afterEach(() => {
+  delete process.env.DESKTOP_TOUCH_SCREENSHOTS_DIR;
+  try { fs.rmSync(cacheDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+function win(title: string) {
+  return { title, region: { x: 0, y: 0, width: 800, height: 600 }, zOrder: 0, isActive: true, isMinimized: false };
+}
+
+describe("workspace_snapshot — ADR-026 §3 ref-only thumbnails", () => {
+  it("each window thumbnail is a resource_link, NO inline image; thumbnailSize preserved", async () => {
+    mockEnumWindowsInZOrder.mockReturnValue([win("Window A"), win("Window B")]);
+    const result = await workspaceSnapshotHandler({ thumbnailMaxDimension: 400, includeUiSummary: false });
+
+    const links = result.content.filter((c) => c.type === "resource_link");
+    const images = result.content.filter((c) => c.type === "image");
+    expect(links).toHaveLength(2);   // one ref per window
+    expect(images).toHaveLength(0);  // no inline thumbnails
+
+    // The structured JSON still carries thumbnailSize for each window.
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed.windowCount).toBe(2);
+    expect(parsed.windows[0].thumbnailSize).toEqual({ width: 400, height: 300 });
+    // The per-thumb label survives.
+    expect(result.content.some((c) => c.type === "text" && /↑ "Window A"/.test((c as { text: string }).text))).toBe(true);
+  });
+
+  it("R6: a persist failure degrades that thumbnail to an inline image + warning", async () => {
+    mockEnumWindowsInZOrder.mockReturnValue([win("Window A")]);
+    // Point the cache under an existing file so the per-user dir create throws.
+    const blockerDir = fs.mkdtempSync(path.join(os.tmpdir(), "dt-ws-blocker-"));
+    const blocker = path.join(blockerDir, "file");
+    fs.writeFileSync(blocker, "x");
+    process.env.DESKTOP_TOUCH_SCREENSHOTS_DIR = path.join(blocker, "sub");
+    try {
+      const result = await workspaceSnapshotHandler({ thumbnailMaxDimension: 400, includeUiSummary: false });
+      expect(result.content.some((c) => c.type === "image")).toBe(true);            // degrade keeps the pixels
+      expect(result.content.some((c) => c.type === "resource_link")).toBe(false);   // no ref when persist failed
+      expect(result.content.some((c) => c.type === "text" && /disk-cache write failed/i.test((c as { text: string }).text))).toBe(true);
+      expect(result.isError).toBeUndefined();
+    } finally {
+      fs.rmSync(blockerDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## What

ADR-026 **Phase 2b** — route the two cross-tool image emitters through `buildImageBlocks` (landed in 2a, #475) so their pixels go by-ref instead of inline.

- **`scroll(action='capture')`** → the stitched image is now a `resource_link` (ref-only; no `confirmImage` param). The existing encode/downscale pipeline is unchanged so `summary.sizeReduced` + overlap stats stay **bit-equal** (full-res-on-disk is OQ-1, deferred to ADR §8 R10). R6 degrades to inline.
- **`workspace_snapshot`** → each window thumbnail is a `resource_link` (ref-only — N inline thumbnails are the heaviest token accumulator, ADR §1 path #6). `windows[].thumbnailSize` + the per-thumb label stay bit-equal; R6 degrades per thumbnail independently.

## Tests

Hermetic handler tests (nut-js/libXtst complete-faked — the Linux-abort lesson from 2a's Codex round):
- `workspace-snapshot-ref`: N refs / no inline / `thumbnailSize` preserved / R6 per-thumb degrade.
- `scroll-capture-ref`: ref-only stitched image (real sharp stitch) / `summary` preserved.
- 39 passed across the scroll/workspace/screenshot/macro regression set; build + lint clean.

## Review

Opus + Codex (production change). Branched from main after 2a merged (plan §4 order). 2c (roiCapture) is the remaining emitter.

Plan: `desktop-touch-mcp-internal@6b9b096:docs/adr-026-phase2-emitter-fanout-plan.md` §3.4/§3.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)