### PR TITLE
feat(desktop_act): ADR-026 Phase 2c — roiCapture crop by-ref (additive)

### DIFF
--- a/benches/adr-024-seed2-roundtrip.mjs
+++ b/benches/adr-024-seed2-roundtrip.mjs
@@ -7,8 +7,8 @@
 //   desktop_act -> desktop_state -> screenshot   (3 calls; 2 post-act confirms)
 // and S5c makes it
 //   desktop_act(returnCapture:"on-change")        (1 call; 0 post-act confirms)
-// because the act response carries roiCapture { somImage (≈ the screenshot crop),
-// entities (≈ the discover/state preview) }.
+// because the act response carries roiCapture { somImageRef (≈ a by-ref link to
+// the screenshot crop, ADR-026), entities (≈ the discover/state preview) }.
 //
 // This bench QUANTIFIES that reduction live. It is **headed-gated** (needs a real
 // GUI + the full native engine: DXGI / PrintWindow / OCR) and therefore is NOT a
@@ -30,8 +30,8 @@
 //                                  whole window). Payload scales with the ROI size; a
 //                                  full-window roiCapture fallback would approach the
 //                                  baseline screenshot's bytes.
-//   - roiCapture content         : somImage bytes, entities count, roi localized
-//                                  (not full-window)
+//   - roiCapture content         : somImageRef (by-ref URI) bytes, entities count,
+//                                  roi localized (not full-window)
 //
 // ## Usage
 //   npm run build && npm run build:rs   # dist/index.js + native addon present
@@ -230,7 +230,9 @@ for (let i = 0; i < iterations; i++) {
     const cap = act.parsed?.roiCapture;
     if (cap) {
       folded.present++;
-      const somB = cap.somImage ? Buffer.byteLength(String(cap.somImage), "utf8") : 0;
+      // ADR-026: the crop is delivered by-ref now (somImage is null); the inline
+      // cost is just the short somImageRef URI, not the base64 bytes.
+      const somB = cap.somImageRef ? Buffer.byteLength(String(cap.somImageRef), "utf8") : 0;
       folded.somBytes.push(somB);
       folded.entityCounts.push(Array.isArray(cap.entities) ? cap.entities.length : 0);
       const roi = cap.roi;

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -209,8 +209,11 @@ screenshot. On `ok:false` read `reason` and follow the recovery path:
 
 > **`roiCapture` (visual-only targets).** On a UIA-blind target (Electron / PWA /
 > game / custom canvas / RDP), a successful act can additionally bundle a
-> `roiCapture: { roi, somImage, entities, source }` — a base64 PNG crop of *just
-> the region that changed* plus a lease-less preview of the entities now visible
+> `roiCapture: { roi, somImageRef, entities, source }` — the PNG crop of *just the
+> region that changed* delivered **by-ref** (`somImageRef` is a `screenshot://by-ref/`
+> resource the act also attaches as a `resource_link`; the inline `somImage` is
+> `null` by default — open the ref only when you need the pixels) plus a lease-less
+> preview of the entities now visible
 > there — so the caller confirms the result and finds the next target in one call
 > instead of a follow-up `desktop_state` + `screenshot`. The preview `entities`
 > carry no lease (re-run `desktop_discover` to act on one). Controlled by the

--- a/src/engine/world-graph/guarded-touch.ts
+++ b/src/engine/world-graph/guarded-touch.ts
@@ -100,10 +100,33 @@ export interface RoiPreviewEntity {
  * (S3a/S3b) + ROI-aware OCR (S4).
  */
 export interface RoiCapture {
-  /** Window-relative crop rect the `somImage` covers (the diff region, not the full window). */
+  /** Window-relative crop rect the crop covers (the diff region, not the full window). */
   roi: Rect;
-  /** Base64 PNG of the cropped diff region. */
-  somImage: string;
+  /**
+   * ADR-026 §3.6: the cropped diff region's PNG is delivered **by-ref** via
+   * `somImageRef` (a `screenshot://by-ref/{id}` resource the act response also
+   * attaches as a `resource_link` content block). This inline base64 is `null` by
+   * default — the pixels are deferred so the act envelope stays cheap. Open the
+   * ref only when you actually need to look at the crop.
+   *
+   * (Widened `string → string | null` in ADR-026: nullability only — the meaning
+   * "base64 PNG of the crop" is unchanged, additive-safe for existing readers.)
+   */
+  somImage: string | null;
+  /**
+   * ADR-026 §3.6: `screenshot://by-ref/{id}` URI for the cropped diff region's
+   * PNG. Present whenever a crop was rendered AND persisted; absent only on a
+   * disk-cache write failure (see `somImageWarning`).
+   */
+  somImageRef?: string;
+  /**
+   * ADR-026 §3.6 R6: set only when persisting the crop failed (disk full /
+   * EACCES). The crop pixels are unavailable this turn (no `somImageRef`), but the
+   * act still succeeded and the structural `roi` / `entities` / `source` are
+   * intact. Never falls back to inline base64 (that would resurrect the token cost
+   * with no ref).
+   */
+  somImageWarning?: string;
   /** Lease-less observation preview (re-run `desktop_discover` for actionable leases). */
   entities: RoiPreviewEntity[];
   /** ROI source: DXGI dirty-rect (local UIA-blind) or software frame-diff (RDP). */

--- a/src/tools/_roi-region.ts
+++ b/src/tools/_roi-region.ts
@@ -12,7 +12,7 @@
  *      sharing the same monitor. Those must not leak into the act's ROI crop.
  *   3. Translate the survivors into window-origin-relative coordinates
  *      (subtract `windowRect.x` / `windowRect.y`) so they line up with the
- *      `roiCapture.roi` / `somImage` crop space (a window-relative rect, per
+ *      `roiCapture.roi` crop space (a window-relative rect, per
  *      the S1 contract `RoiCapture.roi`).
  *
  * Pure + side-effect-free. **No production consumer yet**: the act-response
@@ -79,7 +79,7 @@ export function filterDirtyRectsToWindow(
  *
  * The S1 contract `RoiCapture.roi` is a **single** crop rect, but S3b yields a
  * list of window-relative dirty regions. S5 reduces them to the one rect that
- * encloses all of them (the crop the `somImage` covers + the region the
+ * encloses all of them (the crop the `somImageRef` covers + the region the
  * ROI-aware OCR runs on).
  *
  * @returns The enclosing rect, or `null` for an empty input (no ROI).

--- a/src/tools/desktop-register.ts
+++ b/src/tools/desktop-register.ts
@@ -36,6 +36,8 @@ import {
 import { nativeViewFocus } from "../engine/native-engine.js";
 import type { NativeLeaseTokenSummary } from "../engine/native-types.js";
 import type { ToolResult } from "./_types.js";
+import { persistCapture, REF_URI_PREFIX } from "../engine/screenshot-cache.js";
+import { pngDimensions } from "./screenshot-response.js";
 import { Err } from "../types/result.js";
 import { ExecutorFailedError } from "../errors/typed-errors.js";
 import type { TouchAction, RoiCapture, RoiCaptureMaterial } from "../engine/world-graph/guarded-touch.js";
@@ -490,7 +492,9 @@ export const desktopTouchSchema = {
   returnCapture: z.enum(["on-change", "always", "never"]).optional().describe(
     "[EXPERIMENTAL] ADR-024 Seed-2 — controls the post-action ROI capture on visual-only targets " +
     "(UIA-blind / RDP / canvas). When it attaches, a successful act carries a 'roiCapture' " +
-    "{ roi, somImage, entities }: a base64 PNG crop of the changed region plus a lease-less entity " +
+    "{ roi, somImageRef, entities }: the changed region's PNG crop delivered by-ref (somImageRef is a " +
+    "screenshot://by-ref/ resource, also attached as a resource_link; somImage is null by default — open " +
+    "the ref only when you need the pixels) plus a lease-less entity " +
     "preview, so you can confirm the result and find the next target without a separate desktop_state / " +
     "screenshot. The entities are previews only (no lease) — re-run desktop_discover to act on them. " +
     "Semantics: 'on-change' (default for visual-only targets) attaches only on a visible change; 'always' " +
@@ -728,7 +732,8 @@ export const desktopActRawHandler = async (
 
     // ADR-024 Seed-2 S5 — fold the post-action ROI capture into the act response
     // for visual-only targets. `buildRoiCapture` gates on the visual-only regime +
-    // motion verdict, then assembles `{roi, somImage, entities, source}`. Absent
+    // motion verdict, then assembles `{roi, somImageRef, entities, source}`
+    // (ADR-026: crop pixels by-ref, somImage null by default). Absent
     // (gate declines / no change / no ROI) → response stays bit-equal with the
     // pre-Seed-2 shape (additive — existing destructures unaffected).
     if (result.ok) {
@@ -783,7 +788,28 @@ export const desktopActRawHandler = async (
     };
   }
 
-  return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+  // ADR-026 §3.6: when the act carried a roiCapture crop, attach its by-ref link
+  // as a resource_link content block alongside the JSON result. The crop pixels
+  // are NOT inlined in the envelope (roiCapture.somImage is null); the agent
+  // opens the ref only when it needs to see the crop. The L5 commit wrapper
+  // preserves content[1+] (`...result.content.slice(1)`), so the link survives.
+  const content: ToolResult["content"] = [
+    { type: "text" as const, text: JSON.stringify(result, null, 2) },
+  ];
+  const roiRef = (result as { roiCapture?: RoiCapture }).roiCapture?.somImageRef;
+  if (roiRef) {
+    content.push({
+      type: "resource_link" as const,
+      uri: roiRef,
+      name: `roi-${roiRef.slice(REF_URI_PREFIX.length)}`,
+      mimeType: "image/png",
+      description:
+        "ROI crop of the region that changed after this action. Open only if you " +
+        "need to inspect the pixels — roiCapture.roi / entities above already " +
+        "describe the change.",
+    });
+  }
+  return { content };
 };
 
 /**
@@ -943,7 +969,28 @@ function assembleRoiCaptureFromSom(
     facade.getDiscoverEntitiesForViewId(viewId),
   );
 
-  return { roi, somImage: som.somImage.base64, entities, source };
+  // ADR-026 §3.6: persist the ROI crop + deliver it by-ref. `somImage` stays null
+  // (pixels deferred to the `resource_link` the act handler attaches from
+  // `somImageRef`) so the act envelope stays cheap. R6: on a disk-cache write
+  // failure keep `somImage:null` with a warning — never inline base64 (that
+  // resurrects the token cost) and never throw (the act already succeeded).
+  const base64 = som.somImage.base64;
+  const dims = pngDimensions(base64) ?? { width: roi.width, height: roi.height };
+  try {
+    const persisted = persistCapture(
+      Buffer.from(base64, "base64"),
+      { mimeType: "image/png", width: dims.width, height: dims.height, tag: `roi-${viewId}` },
+    );
+    return { roi, somImage: null, somImageRef: persisted.uri, entities, source };
+  } catch {
+    return {
+      roi,
+      somImage: null,
+      somImageWarning: "ROI crop disk-cache write failed; crop pixels unavailable this turn.",
+      entities,
+      source,
+    };
+  }
 }
 
 /**
@@ -1210,7 +1257,8 @@ export function registerDesktopTools(server: McpServer): void {
       "  executor_failed on terminal textbox (action=type) → use V1 terminal(action='send') instead.",
       "Check desktop_discover response.constraints for pre-emptive fallback hints before calling desktop_act.",
       "[EXPERIMENTAL] On visual-only targets (UIA-blind / RDP / canvas), a successful act may attach a",
-      "'roiCapture' { roi, somImage, entities }: a base64 PNG crop of the changed region + a lease-less entity",
+      "'roiCapture' { roi, somImageRef, entities }: the changed region's PNG crop by-ref (somImageRef +",
+      "a resource_link; somImage null by default) + a lease-less entity",
       "preview, so you can confirm the result + find the next target in one call (no separate desktop_state /",
       "screenshot). entities are previews (no lease) — re-run desktop_discover to act. Control via returnCapture",
       "('on-change' default / 'always' / 'never'). Never attached on structured targets (browser/CDP, UIA-rich).",

--- a/tests/e2e/desktop-act-roi-capture.test.ts
+++ b/tests/e2e/desktop-act-roi-capture.test.ts
@@ -22,6 +22,7 @@ import {
   _resetFacadeForTest,
 } from "../../src/tools/desktop-register.js";
 import { spawnVisualOnlyCanvas, type VisualOnlyCanvas } from "./helpers/visual-only-canvas.js";
+import { readCaptureBytes, REF_URI_PREFIX } from "../../src/engine/screenshot-cache.js";
 
 const IS_HEADED = Boolean(process.env.HEADED);
 
@@ -92,15 +93,22 @@ describe.runIf(IS_HEADED && canvas !== null)("desktop_act roiCapture (S6 headed 
     expect(parsed["diff"] as string[]).not.toContain("entity_disappeared");
 
     const cap = parsed["roiCapture"] as
-      | { roi?: { width: number; height: number }; somImage?: string; entities?: unknown[]; source?: string }
+      | { roi?: { width: number; height: number }; somImage?: string | null; somImageRef?: string; entities?: unknown[]; source?: string }
       | undefined;
     expect(cap, "act should bundle roiCapture on a visual-only localized change").toBeDefined();
 
-    // somImage is a real PNG crop (magic bytes 89 50 4E 47), not empty.
-    const b64 = String(cap!.somImage ?? "").replace(/^data:image\/\w+;base64,/, "");
-    expect(b64.length).toBeGreaterThan(0);
-    const magic = Buffer.from(b64, "base64").subarray(0, 4).toString("hex");
-    expect(magic).toBe("89504e47");
+    // ADR-026: the crop is delivered by-ref (somImage null by default). Resolve
+    // the ref and verify it reads back a real PNG crop (magic bytes 89 50 4E 47).
+    expect(cap!.somImage).toBeNull();
+    expect(typeof cap!.somImageRef).toBe("string");
+    expect(cap!.somImageRef!.startsWith(REF_URI_PREFIX)).toBe(true);
+    const captureId = cap!.somImageRef!.slice(REF_URI_PREFIX.length);
+    const { data } = readCaptureBytes(captureId);
+    expect(data.subarray(0, 4).toString("hex")).toBe("89504e47");
+
+    // The same ref is attached as a resource_link content block.
+    const link = result.content.find((c) => c.type === "resource_link") as { uri?: string } | undefined;
+    expect(link?.uri).toBe(cap!.somImageRef);
 
     // entities is a (lease-less) preview array.
     expect(Array.isArray(cap!.entities)).toBe(true);

--- a/tests/unit/desktop-act-frame-diff-dispatch.test.ts
+++ b/tests/unit/desktop-act-frame-diff-dispatch.test.ts
@@ -32,6 +32,10 @@
 
 import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
 import { readFileSync } from "node:fs";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
 import type { EntityLease } from "../../src/engine/world-graph/types.js";
 
 // ── Module-dep mocks (partial — preserve everything else via importOriginal) ──
@@ -76,6 +80,20 @@ const FAKE_LEASE: EntityLease = {
 };
 
 const WINDOW_RECT = { x: 0, y: 0, width: 800, height: 600 };
+
+// ADR-026 §3.6: roiCapture now persists its crop to the disk-cache. Point that at
+// a throwaway temp dir for every test so the handler does not write the real
+// per-user runtime dir. (Top-level hooks run outer→inner around each describe's
+// own beforeEach/afterEach.)
+let roiCacheDir: string;
+beforeEach(() => {
+  roiCacheDir = path.join(os.tmpdir(), `dt-act-roi-${crypto.randomBytes(6).toString("hex")}`);
+  process.env.DESKTOP_TOUCH_SCREENSHOTS_DIR = roiCacheDir;
+});
+afterEach(() => {
+  delete process.env.DESKTOP_TOUCH_SCREENSHOTS_DIR;
+  try { fs.rmSync(roiCacheDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
 
 function parse(content: ReadonlyArray<{ type: string; text?: string }>): Record<string, unknown> {
   const block = content[0];
@@ -206,6 +224,50 @@ describe("desktop_act frame-diff dispatch — legacy S5 path (S5b fold off)", ()
     expect(cap).toBeDefined();
     expect(cap.roi).toEqual({ x: 50, y: 60, width: 100, height: 80 });
     expect(cap.source).toBe("frame_diff");
+  });
+
+  it("ADR-026: roiCapture crop is delivered by-ref — somImage null, somImageRef set, resource_link attached", async () => {
+    spyFacadeVisualOnly({ visualOnly: true });
+    mockCaptureFrame.mockResolvedValue({ rawPixels: Buffer.alloc(800 * 600 * 4), width: 800, height: 600, channels: 4, source: "printwindow" });
+    mockVerifyLocalRepaint.mockResolvedValue({ motion: "local_repaint", source: "ssim_residual", roiBbox: { x: 50, y: 60, width: 100, height: 80 }, framesSampled: 2, totalElapsedMs: 80 });
+
+    const result = await desktopActRawHandler({ lease: FAKE_LEASE, action: "click" });
+    const parsed = parse(result.content);
+    const cap = parsed["roiCapture"] as { somImage?: unknown; somImageRef?: string; roi?: unknown };
+
+    // The base64 crop is NOT inlined in the JSON envelope…
+    expect(cap.somImage).toBeNull();
+    // …it is delivered by-ref instead.
+    expect(typeof cap.somImageRef).toBe("string");
+    expect((cap.somImageRef as string).startsWith("screenshot://by-ref/")).toBe(true);
+    // …and the SAME ref is attached as a resource_link content block (which the
+    // L5 commit wrapper preserves via content.slice(1)).
+    const link = result.content.find((c) => c.type === "resource_link") as { uri?: string } | undefined;
+    expect(link).toBeDefined();
+    expect(link!.uri).toBe(cap.somImageRef);
+  });
+
+  it("ADR-026 R6: a disk-cache write failure → somImage null + warning, no ref/link, act still ok", async () => {
+    spyFacadeVisualOnly({ visualOnly: true });
+    mockCaptureFrame.mockResolvedValue({ rawPixels: Buffer.alloc(800 * 600 * 4), width: 800, height: 600, channels: 4, source: "printwindow" });
+    mockVerifyLocalRepaint.mockResolvedValue({ motion: "local_repaint", source: "ssim_residual", roiBbox: { x: 50, y: 60, width: 100, height: 80 }, framesSampled: 2, totalElapsedMs: 80 });
+    // Point the cache under an existing file so the per-user dir create throws.
+    const blockerDir = fs.mkdtempSync(path.join(os.tmpdir(), "dt-act-blocker-"));
+    const blocker = path.join(blockerDir, "file");
+    fs.writeFileSync(blocker, "x");
+    process.env.DESKTOP_TOUCH_SCREENSHOTS_DIR = path.join(blocker, "sub");
+    try {
+      const result = await desktopActRawHandler({ lease: FAKE_LEASE, action: "click" });
+      const parsed = parse(result.content);
+      const cap = parsed["roiCapture"] as { somImage?: unknown; somImageRef?: unknown; somImageWarning?: unknown };
+      expect(cap.somImage).toBeNull();                                   // never inline base64 on R6
+      expect(cap.somImageRef).toBeUndefined();                          // no ref when persist failed
+      expect(typeof cap.somImageWarning).toBe("string");                // a warning instead
+      expect(result.content.some((c) => c.type === "resource_link")).toBe(false);
+      expect(parsed["ok"]).toBe(true);                                   // the act still succeeded
+    } finally {
+      fs.rmSync(blockerDir, { recursive: true, force: true });
+    }
   });
 
   it("visual-only frame-diff miss (pre-frame capture fails) → degrade, NO DXGI fallback, no roiCapture", async () => {


### PR DESCRIPTION
## What

ADR-026 **Phase 2c** — the **last** image emitter. `desktop_act`'s `roiCapture` embedded the SoM crop as **base64 inside the JSON envelope** (the worst inline-base64 offender, on the highest-frequency tool). Move it by-ref, **additively**, with no v2 envelope break.

### Changes
- **`RoiCapture`** (`guarded-touch.ts`): `somImage` widens `string → string | null` (**null by default** — meaning unchanged, nullability only, additive-safe) + new `somImageRef?` (the `screenshot://by-ref/` URI) + `somImageWarning?` (R6 only). No internal reader of `roiCapture.somImage` exists (grep 0), so null-by-default is internally safe.
- **`assembleRoiCaptureFromSom`** (the single fold + legacy assembly point) persists the crop and returns `somImage:null` + `somImageRef`. **R6**: a disk-cache write failure keeps `somImage:null` + a warning — never inline base64, never throws (the act already succeeded; `roi`/`entities`/`source` stay intact).
- **`desktopActRawHandler`** attaches the crop as a `resource_link` content block when a `somImageRef` exists; the L5 commit wrapper preserves `content[1+]` (verified `_envelope.ts:3122` `...result.content.slice(1)`).
- Default **never** inlines base64 in the act envelope (OQ-2 default).
- Synced the two public descriptions (`returnCapture` param + recovery-path blob) + internal comments. No stub-catalog mirror (desktop_act is dynamic v2).

### Tests
- `desktop-act-frame-diff-dispatch`: by-ref case (`somImage` null / `somImageRef` set / `resource_link` block) + R6 case (`somImage` null / warning / no ref / act still ok), cache pointed at a temp dir.
- e2e `desktop-act-roi-capture`: resolves the ref via `readCaptureBytes` (PNG magic bytes).
- bench measures `somImageRef` bytes. 103 passed across the desktop-act/roi/macro regression set; build + lint clean.

## Review

Opus + Codex (production change; **most contract-sensitive** — v2 public envelope). This is the final emitter; Phase 2 closes after this. Branched from main after 2b merged (plan §4).

Plan: `desktop-touch-mcp-internal@6b9b096:docs/adr-026-phase2-emitter-fanout-plan.md` §3.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)