### PR TITLE
feat(screenshot-cache): ADR-026 Phase 3a — query / gc / retention engine core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,8 @@ tools/win-ocr/obj/
 .vitest-out*.txt
 .vitest-out*.json
 .vitest-verbose.txt
+# vitest run sentinel (machine-local PID, e2e:stop mechanism)
+.vitest-running
 
 # cargo check / build output (captured for diagnostics)
 .cargo-check-out.txt

--- a/src/engine/screenshot-cache.ts
+++ b/src/engine/screenshot-cache.ts
@@ -656,7 +656,14 @@ function removeIndexEntries(root: string, ids: Set<string>, _env: NodeJS.Process
   withIndexLock(root, () => {
     const all = [...readIndex(root).values()];
     if (!all.some((e) => ids.has(e.captureId))) return;
-    writeIndexAtomic(root, all.filter((e) => !ids.has(e.captureId)));
+    try {
+      writeIndexAtomic(root, all.filter((e) => !ids.has(e.captureId)));
+    } catch {
+      // Best-effort (plan §3.3): a failed rewrite leaves stale entries → read
+      // surfaces not_found (AC3) and the next gc self-heals. Never propagate —
+      // deleteCapture must not throw after a successful unlink, and gcCache must
+      // still return its reclaimed-bytes summary.
+    }
   });
 }
 

--- a/src/engine/screenshot-cache.ts
+++ b/src/engine/screenshot-cache.ts
@@ -141,15 +141,20 @@ function withIndexLock<T>(root: string, fn: () => T): T {
       break;
     } catch (e) {
       if ((e as NodeJS.ErrnoException).code !== "EEXIST") break; // unlockable → best-effort
+      // Lock is held — steal it ONLY if it is stale AND we actually removed it.
+      let cleared = false;
       try {
         const st = fs.statSync(lockPath);
         if (Date.now() - st.mtimeMs > LOCK_STALE_MS) {
-          try { fs.unlinkSync(lockPath); } catch { /* raced another stealer */ }
-          continue;
+          try { fs.unlinkSync(lockPath); cleared = true; } catch { /* can't remove → fall through */ }
         }
       } catch {
-        continue; // lock vanished between open and stat → retry immediately
+        cleared = true; // lock vanished between open and stat → retry acquire immediately
       }
+      if (cleared) continue; // lock removed/gone → retry openSync now
+      // Held-and-fresh OR stale-but-unremovable (e.g. a directory named _index.lock):
+      // wait, then hit the backstop — never `continue` past it, or a wedged lock
+      // would spin forever instead of proceeding best-effort (Codex P2).
       if (Date.now() - start > LOCK_MAX_WAIT_MS) break; // give up → proceed best-effort
       sleepSync(LOCK_RETRY_MS);
     }

--- a/src/engine/screenshot-cache.ts
+++ b/src/engine/screenshot-cache.ts
@@ -110,6 +110,16 @@ export function persistCapture(
   };
   fs.appendFileSync(indexPath(root), JSON.stringify(entry) + "\n");
 
+  // Bound cache growth (R2) without the agent ever calling screenshot_gc. Throttled
+  // + best-effort + protects this very captureId — a prune failure must NEVER fail a
+  // capture, and auto-prune must never delete the ref this call is about to return
+  // (ADR-026 Phase 3 §3.4, keep-newest invariant).
+  try {
+    maybeAutoPrune(captureId, env);
+  } catch {
+    /* never fail a capture because a background prune errored */
+  }
+
   return {
     captureId,
     uri: REF_URI_PREFIX + captureId,
@@ -165,7 +175,11 @@ export type CaptureRefCode =
   | "outside_cache"
   | "symlink"
   | "identity_mismatch"
-  | "not_regular_file";
+  | "not_regular_file"
+  // Any non-ENOENT filesystem error (EACCES/EPERM/EBUSY/…) coerced to an opaque
+  // ref error so the raw fs message — which can contain the absolute cache path
+  // — never reaches the resource handler (ADR-026 §8 R9, Phase 3 hardening).
+  | "unreadable";
 
 export class CaptureRefError extends Error {
   constructor(public readonly code: CaptureRefCode, message: string) {
@@ -180,15 +194,23 @@ export class CaptureRefError extends Error {
  * yields a handle to a file outside the canonical cache root.
  */
 /**
- * Map a filesystem ENOENT to the documented opaque `not_found` ref error.
- * Used wherever a capture file can vanish (GC'd / deleted, R7) between index
- * lookup and the actual syscall — so a dangling ref surfaces
- * `CaptureRefError("not_found")` instead of a raw ENOENT that would leak the
- * absolute cache path through the resource handler (Codex P2).
+ * Coerce a filesystem error into an opaque {@link CaptureRefError}.
+ *
+ * - ENOENT → `not_found`: a capture file can vanish (GC'd / deleted, R7) between
+ *   index lookup and the actual syscall, so a dangling ref surfaces a documented
+ *   `not_found` rather than a raw ENOENT.
+ * - any other fs error with a `.code` (EACCES/EPERM/EBUSY/…) → `unreadable`:
+ *   coerced WITHOUT echoing `e.message`, which can carry the absolute cache path,
+ *   so the resource handler never leaks it (ADR-026 §8 R9, Phase 3 hardening).
+ * - a non-fs error (no `.code`, e.g. a programming bug) is rethrown as-is.
  */
-function asNotFound(e: unknown, captureId: string): never {
-  if ((e as NodeJS.ErrnoException)?.code === "ENOENT") {
+function asRefError(e: unknown, captureId: string): never {
+  const code = (e as NodeJS.ErrnoException)?.code;
+  if (code === "ENOENT") {
     throw new CaptureRefError("not_found", `capture file missing: ${captureId}`);
+  }
+  if (typeof code === "string") {
+    throw new CaptureRefError("unreadable", `capture unreadable (${code}): ${captureId}`);
   }
   throw e;
 }
@@ -215,7 +237,7 @@ function openValidatedCapture(
   try {
     lst = fs.lstatSync(candidate);
   } catch (e) {
-    asNotFound(e, captureId);
+    asRefError(e, captureId);
   }
   if (lst.isSymbolicLink()) throw new CaptureRefError("symlink", `symlink rejected: ${file}`);
   if (!lst.isFile()) throw new CaptureRefError("not_regular_file", `not a regular file: ${file}`);
@@ -228,7 +250,7 @@ function openValidatedCapture(
   try {
     real = fs.realpathSync(candidate);
   } catch (e) {
-    asNotFound(e, captureId);
+    asRefError(e, captureId);
   }
   if (!isWithinRoot(root, real)) {
     throw new CaptureRefError("outside_cache", `resolved path escapes cache: ${real}`);
@@ -247,7 +269,7 @@ function openValidatedCapture(
   try {
     fd = fs.openSync(real, fs.constants.O_RDONLY | noFollow);
   } catch (e) {
-    asNotFound(e, captureId);
+    asRefError(e, captureId);
   }
   try {
     const st = fs.fstatSync(fd);
@@ -288,4 +310,446 @@ export function readCaptureBytes(
   } finally {
     fs.closeSync(fd);
   }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ADR-026 Phase 3 — query / gc / index walk / retention (GC policy)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Case/space-fold a tag or processName so `screenshot_query` and `screenshot_gc`
+ * filters agree on what "the same tag" means regardless of the casing it was
+ * stored with (seed defect #9). The index keeps values verbatim (for display);
+ * this is applied ONLY at compare time — the single source of truth for tag
+ * equality across both tools.
+ */
+export function normalizeCacheTag(tag: string): string {
+  return tag.trim().toLowerCase();
+}
+
+export interface QueryFilter {
+  tag?: string;
+  windowUuid?: string;
+  /** epoch ms, inclusive lower bound. */
+  since?: number;
+  /** epoch ms, inclusive upper bound. */
+  until?: number;
+  /** clamped to [1, 500], default 50. */
+  limit?: number;
+  /** clamped to >= 0, default 0. */
+  offset?: number;
+}
+
+/**
+ * A pixels-free listing row. Carries ONLY the opaque captureId + its ref uri and
+ * metadata — never the on-disk `file` basename or an absolute path, so navigating
+ * the cache cannot widen the path-traversal surface (opaque-ref model, R9).
+ */
+export interface QuerySummaryEntry {
+  captureId: string;
+  uri: string;
+  ts: number;
+  mimeType: string;
+  width: number;
+  height: number;
+  bytes: number;
+  tag?: string;
+  windowUuid?: string;
+  processName?: string;
+}
+
+export interface QueryResult {
+  /** matching count BEFORE limit/offset. */
+  total: number;
+  /** returned count. */
+  count: number;
+  /** newest-first. */
+  captures: QuerySummaryEntry[];
+  /** whole-cache stats so a caller can decide whether to gc (no path leaked). */
+  cache: { totalCaptures: number; totalBytes: number };
+}
+
+/**
+ * Read-only listing of cached captures (ADR-026 §5 / AC4). Always walks the full
+ * index — a `tag` filter does NOT bypass the walk (seed defect #8). Returns
+ * pixels-free metadata only; resolve a `uri` (resources/read) to get the bytes.
+ */
+export function queryCaptures(
+  filter: QueryFilter = {},
+  env: NodeJS.ProcessEnv = process.env
+): QueryResult {
+  const root = getScreenshotCacheRoot(env);
+  const all = [...readIndex(root).values()];
+  const totalCaptures = all.length;
+  const totalBytes = all.reduce((s, e) => s + (e.bytes || 0), 0);
+
+  const nTag = filter.tag !== undefined ? normalizeCacheTag(filter.tag) : undefined;
+  const matched = all
+    .filter((e) => {
+      if (nTag !== undefined && normalizeCacheTag(e.tag ?? "") !== nTag) return false;
+      if (filter.windowUuid !== undefined && e.windowUuid !== filter.windowUuid) return false;
+      if (filter.since !== undefined && e.ts < filter.since) return false;
+      if (filter.until !== undefined && e.ts > filter.until) return false;
+      return true;
+    })
+    .sort((a, b) => b.ts - a.ts);
+
+  const total = matched.length;
+  const offset = Math.max(0, Math.floor(filter.offset ?? 0));
+  const limit = Math.min(500, Math.max(1, Math.floor(filter.limit ?? 50)));
+  const page = matched.slice(offset, offset + limit);
+
+  return {
+    total,
+    count: page.length,
+    captures: page.map((e) => ({
+      captureId: e.captureId,
+      uri: REF_URI_PREFIX + e.captureId,
+      ts: e.ts,
+      mimeType: e.mimeType,
+      width: e.width,
+      height: e.height,
+      bytes: e.bytes,
+      ...(e.tag !== undefined ? { tag: e.tag } : {}),
+      ...(e.windowUuid !== undefined ? { windowUuid: e.windowUuid } : {}),
+      ...(e.processName !== undefined ? { processName: e.processName } : {}),
+    })),
+    cache: { totalCaptures, totalBytes },
+  };
+}
+
+/**
+ * Validate that `file` (a basename, never a path) names a contained, non-symlink
+ * regular file inside `root`, and return its canonical absolute path + lstat.
+ * Shared by index-backed delete and the orphan sweep so the containment / symlink
+ * rules are byte-identical on every delete path (ADR-026 §4). Mirrors
+ * {@link openValidatedCapture}'s ordering: basename assert → lstat-before-realpath
+ * symlink reject → realpath → exported {@link isWithinRoot} (never `startsWith`).
+ * A missing file surfaces as ENOENT for the caller to treat as already-gone.
+ */
+function validateCacheFileForDelete(root: string, file: string): { real: string; st: fs.Stats } {
+  if (file !== path.basename(file) || file.includes("..") || path.isAbsolute(file)) {
+    throw new CaptureRefError("outside_cache", `index file name is not a basename: ${file}`);
+  }
+  const candidate = path.join(root, file);
+  const st = fs.lstatSync(candidate); // ENOENT bubbles up → caller treats as already-gone
+  if (st.isSymbolicLink()) throw new CaptureRefError("symlink", `symlink rejected: ${file}`);
+  if (!st.isFile()) throw new CaptureRefError("not_regular_file", `not a regular file: ${file}`);
+  const real = fs.realpathSync(candidate);
+  if (!isWithinRoot(root, real)) {
+    throw new CaptureRefError("outside_cache", `resolved path escapes cache: ${file}`);
+  }
+  return { real, st };
+}
+
+/**
+ * Securely delete one cached capture by opaque captureId (ADR-026 §4 delete note).
+ *
+ * Runs the full {@link openValidatedCapture} gauntlet to pin the file's dev/ino
+ * identity, releases the handle, then — immediately before unlink — re-validates
+ * (re-lstat symlink reject + re-containment + identity re-check) to minimize the
+ * realpath→unlink TOCTOU window Windows cannot close via fd. Never unlinks
+ * anything outside the canonical cache root. Returns `{deleted:false}` when the
+ * file is already gone (dangling ref).
+ */
+export function deleteCapture(
+  captureId: string,
+  env: NodeJS.ProcessEnv = process.env
+): { bytes: number; deleted: boolean } {
+  const root = getScreenshotCacheRoot(env);
+
+  // 1) Read-grade validation → pin dev/ino, then release the handle.
+  let entry: IndexEntry;
+  let pinnedDev: number;
+  let pinnedIno: number;
+  try {
+    const opened = openValidatedCapture(captureId, env);
+    try {
+      const st = fs.fstatSync(opened.fd);
+      pinnedDev = st.dev;
+      pinnedIno = st.ino;
+    } finally {
+      fs.closeSync(opened.fd);
+    }
+    entry = opened.entry;
+  } catch (e) {
+    if (e instanceof CaptureRefError && e.code === "not_found") return { bytes: 0, deleted: false };
+    throw e;
+  }
+
+  // 2) Re-validate the basename immediately before unlink (symlink/containment).
+  let real: string;
+  let st: fs.Stats;
+  try {
+    ({ real, st } = validateCacheFileForDelete(root, entry.file));
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException)?.code === "ENOENT") return { bytes: 0, deleted: false };
+    throw e;
+  }
+
+  // 3) Identity must still match the pinned regular file (defeats a lstat→unlink swap).
+  if (st.dev !== pinnedDev || st.ino !== pinnedIno) {
+    throw new CaptureRefError("identity_mismatch", `file identity changed before unlink: ${captureId}`);
+  }
+
+  const bytes = st.size;
+  try {
+    fs.unlinkSync(real);
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException)?.code === "ENOENT") return { bytes: 0, deleted: false };
+    throw e;
+  }
+  return { bytes, deleted: true };
+}
+
+export interface GcPolicy {
+  /** delete entries older than this (ms). */
+  maxAgeMs?: number;
+  /** keep the newest N, delete the rest. */
+  maxCount?: number;
+  /** keep the newest captures under this byte cap. */
+  maxTotalBytes?: number;
+  /** scope deletion to this tag only (normalized compare). */
+  tag?: string;
+}
+
+export interface GcCandidate {
+  /** index-backed only — same id `screenshot_query` surfaces, so exposing it leaks nothing. */
+  captureId: string;
+  bytes: number;
+  ageMs: number;
+  reason: "max_age" | "max_count" | "max_total_bytes";
+}
+
+export interface GcResult {
+  dryRun: boolean;
+  policy: { maxAgeMs: number | null; maxCount: number | null; maxTotalBytes: number | null; tag: string | null };
+  /** index-backed candidates (captureId). */
+  candidates: GcCandidate[];
+  /** orphan on-disk files (no index entry) — aggregate ONLY; basenames are
+   *  `{captureId}.ext`, i.e. ids `screenshot_query` deliberately hides, so they
+   *  are never returned individually (ADR-026 Phase 3 P2-2). */
+  orphans: { count: number; bytes: number };
+  deleted: number;
+  reclaimedBytes: number;
+  remaining: { count: number; bytes: number };
+}
+
+/** Image extensions the orphan sweep considers (mirrors MIME_EXT). The index
+ *  rewrite temp file (`_index.ndjson.<rand>.tmp`) is NOT an image ext, so it is
+ *  never mistaken for an orphan (P3-3). */
+const ORPHAN_IMAGE_EXTS = new Set(["png", "webp", "jpg", "bin"]);
+const ORPHAN_GRACE_MS_DEFAULT = 5 * 60 * 1000;
+
+/** Atomically replace the index with `entries` (temp→rename). Temp name is
+ *  `_index.ndjson.<rand>.tmp` — excluded from the orphan sweep's ext filter. */
+function writeIndexAtomic(root: string, entries: IndexEntry[]): void {
+  const tmp = path.join(root, `${INDEX_FILE}.${crypto.randomBytes(6).toString("hex")}.tmp`);
+  const body = entries.map((e) => JSON.stringify(e)).join("\n") + (entries.length ? "\n" : "");
+  fs.writeFileSync(tmp, body, { mode: 0o600 });
+  fs.renameSync(tmp, indexPath(root));
+}
+
+/**
+ * Reclaim cached captures by retention policy (ADR-026 §5 / R2 / R11).
+ *
+ * Caps are a **union** — an entry is a candidate if it violates ANY active cap.
+ * The newest entry (rank 0) is structurally kept by the byte cap, and
+ * `protectCaptureId` (auto-prune passes the just-written id) excludes a specific
+ * id from ALL caps — together guaranteeing a fresh `persistCapture` ref is never
+ * pruned out from under its caller (keep-newest invariant).
+ *
+ * `includeOrphans` also reclaims on-disk image files that have no index entry
+ * (crash residue, or the Phase-2c fold-path orphan, R11) once older than a grace
+ * window. Orphans are reported as an aggregate count/bytes only — never by
+ * basename (which would leak ids `screenshot_query` hides, P2-2).
+ *
+ * `dryRun:true` computes candidates without deleting or rewriting the index.
+ */
+export function gcCache(
+  opts: { dryRun: boolean; policy: GcPolicy; includeOrphans: boolean; now: number; protectCaptureId?: string },
+  env: NodeJS.ProcessEnv = process.env
+): GcResult {
+  const { dryRun, policy, includeOrphans, now, protectCaptureId } = opts;
+  const root = getScreenshotCacheRoot(env);
+  const indexMap = readIndex(root);
+  const all = [...indexMap.values()];
+
+  const maxAgeMs = policy.maxAgeMs ?? null;
+  const maxCount = policy.maxCount ?? null;
+  const maxBytes = policy.maxTotalBytes ?? null;
+  const nTag = policy.tag !== undefined ? normalizeCacheTag(policy.tag) : undefined;
+
+  // universe = tag subset (if scoped) else everything, newest → oldest.
+  const universe = all
+    .filter((e) => (nTag === undefined ? true : normalizeCacheTag(e.tag ?? "") === nTag))
+    .sort((a, b) => b.ts - a.ts);
+
+  const candidates: GcCandidate[] = [];
+  let running = 0;
+  for (let i = 0; i < universe.length; i++) {
+    const e = universe[i];
+    running += e.bytes || 0; // count the byte even when protected — it occupies space
+    if (protectCaptureId !== undefined && e.captureId === protectCaptureId) continue;
+
+    let reason: GcCandidate["reason"] | null = null;
+    if (maxAgeMs !== null && now - e.ts > maxAgeMs) {
+      reason = "max_age"; // age cap can hit any rank (explicit "clear stale cache")
+    } else if (maxCount !== null && i >= Math.max(1, maxCount)) {
+      reason = "max_count"; // keep newest max(1,maxCount) → rank 0 survives
+    } else if (maxBytes !== null && i >= 1 && running > maxBytes) {
+      reason = "max_total_bytes"; // rank 0 always kept; cap reduces older entries
+    }
+    if (reason) {
+      candidates.push({ captureId: e.captureId, bytes: e.bytes || 0, ageMs: now - e.ts, reason });
+    }
+  }
+
+  // Orphan sweep — aggregate only (P2-2).
+  const orphanFiles: { file: string; bytes: number }[] = [];
+  if (includeOrphans) {
+    const referenced = new Set(all.map((e) => e.file));
+    const orphanGraceMs = Math.max(maxAgeMs ?? 0, ORPHAN_GRACE_MS_DEFAULT);
+    let names: string[];
+    try {
+      names = fs.readdirSync(root);
+    } catch {
+      names = [];
+    }
+    for (const name of names) {
+      if (name === INDEX_FILE) continue;
+      const dot = name.lastIndexOf(".");
+      const ext = dot >= 0 ? name.slice(dot + 1).toLowerCase() : "";
+      if (!ORPHAN_IMAGE_EXTS.has(ext)) continue; // skips _index.ndjson.<rand>.tmp + non-image
+      if (referenced.has(name)) continue; // has an index entry → handled above
+      let st: fs.Stats;
+      try {
+        st = fs.lstatSync(path.join(root, name));
+      } catch {
+        continue;
+      }
+      if (st.isSymbolicLink() || !st.isFile()) continue;
+      if (now - st.mtimeMs < orphanGraceMs) continue; // too fresh — index-append may be imminent
+      orphanFiles.push({ file: name, bytes: st.size });
+    }
+  }
+  const orphanBytes = orphanFiles.reduce((s, o) => s + o.bytes, 0);
+
+  let deleted = 0;
+  let reclaimedBytes = 0;
+  const removedIds = new Set<string>();
+
+  if (!dryRun) {
+    for (const c of candidates) {
+      try {
+        const r = deleteCapture(c.captureId, env);
+        if (r.deleted) reclaimedBytes += r.bytes;
+        // whether deleted now or already gone, drop the index entry.
+        removedIds.add(c.captureId);
+        if (r.deleted) deleted++;
+      } catch {
+        // a single failed delete must not abort the whole gc; leave its entry.
+      }
+    }
+    if (removedIds.size > 0) {
+      const survivors = all.filter((e) => !removedIds.has(e.captureId));
+      try {
+        writeIndexAtomic(root, survivors);
+      } catch {
+        // best-effort; a failed rewrite leaves stale entries → read surfaces not_found (AC3)
+      }
+    }
+    for (const o of orphanFiles) {
+      try {
+        const { real } = validateCacheFileForDelete(root, o.file);
+        fs.unlinkSync(real);
+        deleted++;
+        reclaimedBytes += o.bytes;
+      } catch {
+        // skip — already gone / validation failed
+      }
+    }
+  } else {
+    for (const c of candidates) removedIds.add(c.captureId);
+    reclaimedBytes = candidates.reduce((s, c) => s + c.bytes, 0) + orphanBytes;
+  }
+
+  const survivors = all.filter((e) => !removedIds.has(e.captureId));
+  return {
+    dryRun,
+    policy: { maxAgeMs, maxCount, maxTotalBytes: maxBytes, tag: nTag ?? null },
+    candidates,
+    orphans: { count: orphanFiles.length, bytes: orphanBytes },
+    deleted,
+    reclaimedBytes,
+    remaining: {
+      count: survivors.length,
+      bytes: survivors.reduce((s, e) => s + (e.bytes || 0), 0),
+    },
+  };
+}
+
+// ── Retention defaults + auto-prune (ADR-026 §3.4 / §3.6, R2) ────────────────
+
+const MAX_COUNT_DEFAULT = 200;
+const MAX_BYTES_DEFAULT = 256 * 1024 * 1024;
+const AUTO_PRUNE_EVERY = 32;
+
+/** Parse a non-negative integer env value; undefined/blank/invalid → undefined. */
+function parseNonNegIntEnv(v: string | undefined): number | undefined {
+  if (v === undefined || v.trim() === "") return undefined;
+  const n = Number(v);
+  return Number.isFinite(n) && n >= 0 ? Math.floor(n) : undefined;
+}
+
+/**
+ * Retention caps from env (pure parser; ADR-026 §3.6 / OQ2). Count + bytes caps
+ * are active by default so the cache stays bounded regardless of time; the age
+ * cap is opt-in (env only) to avoid silently expiring recent captures.
+ */
+export function envDefaultPolicy(env: NodeJS.ProcessEnv = process.env): GcPolicy {
+  const maxCount = parseNonNegIntEnv(env["DESKTOP_TOUCH_SCREENSHOT_MAX_COUNT"]) ?? MAX_COUNT_DEFAULT;
+  const maxTotalBytes = parseNonNegIntEnv(env["DESKTOP_TOUCH_SCREENSHOT_MAX_BYTES"]) ?? MAX_BYTES_DEFAULT;
+  const maxAgeMs = parseNonNegIntEnv(env["DESKTOP_TOUCH_SCREENSHOT_MAX_AGE_MS"]);
+  return {
+    maxCount,
+    maxTotalBytes,
+    ...(maxAgeMs !== undefined ? { maxAgeMs } : {}),
+  };
+}
+
+function autoPruneEnabled(env: NodeJS.ProcessEnv): boolean {
+  return env["DESKTOP_TOUCH_SCREENSHOT_AUTOPRUNE"] !== "0";
+}
+
+let persistsSincePrune = 0;
+
+/** Reset the auto-prune throttle counter (tests only). */
+export function _resetAutoPruneCounterForTest(): void {
+  persistsSincePrune = 0;
+}
+
+/**
+ * Best-effort, throttled cache prune invoked from {@link persistCapture}. Bounds
+ * cache growth (R2) without the agent ever calling `screenshot_gc`. Fires on the
+ * first persist of each process (0-origin counter) so short-lived sessions still
+ * sweep prior-session cruft, then every `AUTO_PRUNE_EVERY` persists. Index-based
+ * only (orphan sweep is the explicit gc's job) and protects the just-written
+ * captureId so it can never delete the ref the caller is about to return.
+ */
+function maybeAutoPrune(justWrittenId: string, env: NodeJS.ProcessEnv): void {
+  if (!autoPruneEnabled(env)) return;
+  const due = persistsSincePrune % AUTO_PRUNE_EVERY === 0;
+  persistsSincePrune++;
+  if (!due) return;
+  gcCache(
+    {
+      dryRun: false,
+      policy: envDefaultPolicy(env),
+      includeOrphans: false,
+      now: Date.now(),
+      protectCaptureId: justWrittenId,
+    },
+    env
+  );
 }

--- a/src/engine/screenshot-cache.ts
+++ b/src/engine/screenshot-cache.ts
@@ -317,11 +317,10 @@ export function readCaptureBytes(
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * Case/space-fold a tag or processName so `screenshot_query` and `screenshot_gc`
- * filters agree on what "the same tag" means regardless of the casing it was
- * stored with (seed defect #9). The index keeps values verbatim (for display);
- * this is applied ONLY at compare time — the single source of truth for tag
- * equality across both tools.
+ * Case/space-fold a `tag` so `screenshot_query` and `screenshot_gc` filters agree
+ * on what "the same tag" means regardless of the casing it was stored with (seed
+ * defect #9). The index keeps values verbatim (for display); this is applied ONLY
+ * at compare time — the single source of truth for tag equality across both tools.
  */
 export function normalizeCacheTag(tag: string): string {
   return tag.trim().toLowerCase();
@@ -420,9 +419,10 @@ export function queryCaptures(
 
 /**
  * Validate that `file` (a basename, never a path) names a contained, non-symlink
- * regular file inside `root`, and return its canonical absolute path + lstat.
- * Shared by index-backed delete and the orphan sweep so the containment / symlink
- * rules are byte-identical on every delete path (ADR-026 §4). Mirrors
+ * regular file inside `root`, and return its canonical absolute path + the lstat
+ * of THAT canonical path (the unlink target's own identity, not the pre-realpath
+ * leaf). Shared by index-backed delete and the orphan sweep so the containment /
+ * symlink rules are byte-identical on every delete path (ADR-026 §4). Mirrors
  * {@link openValidatedCapture}'s ordering: basename assert → lstat-before-realpath
  * symlink reject → realpath → exported {@link isWithinRoot} (never `startsWith`).
  * A missing file surfaces as ENOENT for the caller to treat as already-gone.
@@ -432,12 +432,21 @@ function validateCacheFileForDelete(root: string, file: string): { real: string;
     throw new CaptureRefError("outside_cache", `index file name is not a basename: ${file}`);
   }
   const candidate = path.join(root, file);
-  const st = fs.lstatSync(candidate); // ENOENT bubbles up → caller treats as already-gone
-  if (st.isSymbolicLink()) throw new CaptureRefError("symlink", `symlink rejected: ${file}`);
-  if (!st.isFile()) throw new CaptureRefError("not_regular_file", `not a regular file: ${file}`);
+  const lst = fs.lstatSync(candidate); // ENOENT bubbles up → caller treats as already-gone
+  if (lst.isSymbolicLink()) throw new CaptureRefError("symlink", `symlink rejected: ${file}`);
+  if (!lst.isFile()) throw new CaptureRefError("not_regular_file", `not a regular file: ${file}`);
   const real = fs.realpathSync(candidate);
   if (!isWithinRoot(root, real)) {
     throw new CaptureRefError("outside_cache", `resolved path escapes cache: ${file}`);
+  }
+  // Re-lstat the RESOLVED target and return ITS identity, not the pre-realpath
+  // leaf's: a candidate→symlink swap between the lstat above and realpath would
+  // make `real` resolve to a *different* in-cache file. The caller compares THIS
+  // identity to its pinned dev/ino, so a mismatch (resolved elsewhere) is caught;
+  // `real` is what gets unlinked, so identity and unlink target now agree (Codex).
+  const st = fs.lstatSync(real);
+  if (st.isSymbolicLink() || !st.isFile()) {
+    throw new CaptureRefError("not_regular_file", `resolved target is not a regular file: ${file}`);
   }
   return { real, st };
 }
@@ -497,7 +506,9 @@ export function deleteCapture(
     fs.unlinkSync(real);
   } catch (e) {
     if ((e as NodeJS.ErrnoException)?.code === "ENOENT") return { bytes: 0, deleted: false };
-    throw e;
+    // Non-ENOENT (EPERM/EBUSY/EACCES): coerce to an opaque ref error so the raw fs
+    // message — which contains the absolute `real` cache path — never leaks (R9).
+    asRefError(e, captureId);
   }
   return { bytes, deleted: true };
 }
@@ -652,9 +663,15 @@ export function gcCache(
       }
     }
     if (removedIds.size > 0) {
-      const survivors = all.filter((e) => !removedIds.has(e.captureId));
+      // Re-read the index immediately before the atomic rewrite and merge: a
+      // capture another process persisted AFTER our initial `all` snapshot is in
+      // the fresh read, so the rename preserves it instead of dropping its line —
+      // which would orphan a just-returned ref (and a later orphan sweep could
+      // then delete it past the protectCaptureId invariant, Codex P1). The
+      // residual fresh-read→rename gap is a single-process synchronous window.
+      const rewriteSurvivors = [...readIndex(root).values()].filter((e) => !removedIds.has(e.captureId));
       try {
-        writeIndexAtomic(root, survivors);
+        writeIndexAtomic(root, rewriteSurvivors);
       } catch {
         // best-effort; a failed rewrite leaves stale entries → read surfaces not_found (AC3)
       }

--- a/src/engine/screenshot-cache.ts
+++ b/src/engine/screenshot-cache.ts
@@ -678,21 +678,25 @@ function writeIndexAtomic(root: string, entries: IndexEntry[]): void {
  * Drop the given captureIds from the index, under the index lock so the fresh
  * read + rewrite cannot lose a concurrent cross-process append (Codex P1). A
  * no-op when none of the ids are currently present (avoids a pointless rewrite).
+ *
+ * NEVER throws (plan §3.3 best-effort): the entire lock+read+rewrite is wrapped, so
+ * a failed rewrite (or any fs error) leaves stale entries that read as `not_found`
+ * (AC3) and self-heal on the next gc. This is what lets the unguarded call sites
+ * (`deleteCapture`, `gcCache`) stay correct — `deleteCapture` must not throw after a
+ * successful unlink, and `gcCache` must still return its reclaimed-bytes summary
+ * (Opus R3 P2-1).
  */
 function removeIndexEntries(root: string, ids: Set<string>, _env: NodeJS.ProcessEnv): void {
   if (ids.size === 0) return;
-  withIndexLock(root, () => {
-    const all = [...readIndex(root).values()];
-    if (!all.some((e) => ids.has(e.captureId))) return;
-    try {
+  try {
+    withIndexLock(root, () => {
+      const all = [...readIndex(root).values()];
+      if (!all.some((e) => ids.has(e.captureId))) return;
       writeIndexAtomic(root, all.filter((e) => !ids.has(e.captureId)));
-    } catch {
-      // Best-effort (plan §3.3): a failed rewrite leaves stale entries → read
-      // surfaces not_found (AC3) and the next gc self-heals. Never propagate —
-      // deleteCapture must not throw after a successful unlink, and gcCache must
-      // still return its reclaimed-bytes summary.
-    }
-  });
+    });
+  } catch {
+    // Best-effort — see the doc comment above. Index cleanup never propagates.
+  }
 }
 
 /**

--- a/src/engine/screenshot-cache.ts
+++ b/src/engine/screenshot-cache.ts
@@ -91,6 +91,18 @@ function indexPath(root: string): string {
 // lockfile serializes ALL index mutations cross-process so every rewrite reads a
 // stable index and no append is lost. Single-process (the common case) takes the
 // lock with zero contention — one create+unlink syscall pair, no sleep.
+//
+// KNOWN RESIDUAL (Codex R3 P2, accepted — ADR-026 OQ8): an mtime-based lockfile
+// cannot distinguish a crashed holder from one merely slow inside `fn`, so the
+// stale-steal could in theory unlink a still-live holder's lock after LOCK_STALE_MS
+// and let a concurrent mutation race the holder's rename. This is a non-issue here:
+// every locked `fn` is a SYNCHRONOUS sub-millisecond op (one append, or a
+// readIndex+write+rename over a count-bounded index), so reaching the 10 s window
+// implies a frozen/dead process whose lock SHOULD be stolen; and any resulting loss
+// is self-healing (the orphaned file is reclaimed by a later orphan sweep, never a
+// wrong-file delete). Closing it fully would need OS advisory locks or an async
+// heartbeat (impossible mid-sync-fn) — disproportionate for a local single-user
+// cache. Deferred as a documented limitation, not a Phase-3 blocker.
 const INDEX_LOCK_FILE = "_index.lock";
 const LOCK_STALE_MS = 10_000;
 const LOCK_RETRY_MS = 20;
@@ -730,8 +742,9 @@ export function gcCache(
     }
   }
 
-  // Orphan sweep — aggregate only (P2-2).
-  const orphanFiles: { file: string; bytes: number }[] = [];
+  // Orphan sweep — aggregate only (P2-2). Carries the scanned dev/ino so the
+  // unlink can verify it is still the same inode (identity gate, Codex P2-788).
+  const orphanFiles: { file: string; bytes: number; dev: number; ino: number }[] = [];
   if (includeOrphans) {
     const referenced = new Set(all.map((e) => e.file));
     const orphanGraceMs = Math.max(maxAgeMs ?? 0, ORPHAN_GRACE_MS_DEFAULT);
@@ -755,7 +768,7 @@ export function gcCache(
       }
       if (st.isSymbolicLink() || !st.isFile()) continue;
       if (now - st.mtimeMs < orphanGraceMs) continue; // too fresh — index-append may be imminent
-      orphanFiles.push({ file: name, bytes: st.size });
+      orphanFiles.push({ file: name, bytes: st.size, dev: st.dev, ino: st.ino });
     }
   }
   const orphanBytes = orphanFiles.reduce((s, o) => s + o.bytes, 0);
@@ -784,7 +797,13 @@ export function gcCache(
     removeIndexEntries(root, removedIds, env);
     for (const o of orphanFiles) {
       try {
-        const { real } = validateCacheFileForDelete(root, o.file);
+        const { real, st } = validateCacheFileForDelete(root, o.file);
+        // Identity gate (mirrors the index-backed delete): the orphan basename could
+        // have been swapped for a symlink to another in-cache capture between the
+        // sweep's lstat and now — validateCacheFileForDelete would then resolve
+        // `real` to that OTHER (index-tracked) file. Require the resolved target to
+        // be the SAME inode the sweep saw before unlinking it (Codex P2-788).
+        if (st.dev !== o.dev || st.ino !== o.ino) continue;
         fs.unlinkSync(real);
         deleted++;
         reclaimedBytes += o.bytes;

--- a/src/engine/screenshot-cache.ts
+++ b/src/engine/screenshot-cache.ts
@@ -662,7 +662,10 @@ const ORPHAN_GRACE_MS_DEFAULT = 5 * 60 * 1000;
 function writeIndexAtomic(root: string, entries: IndexEntry[]): void {
   const tmp = path.join(root, `${INDEX_FILE}.${crypto.randomBytes(6).toString("hex")}.tmp`);
   const body = entries.map((e) => JSON.stringify(e)).join("\n") + (entries.length ? "\n" : "");
-  fs.writeFileSync(tmp, body, { mode: 0o600 });
+  // Exclusive create ("wx"): refuse to follow a pre-planted file/symlink at the
+  // temp path (CodeQL js/insecure-temporary-file). The 6 random bytes make a real
+  // collision astronomically unlikely; mirrors persistCapture's write-side flag.
+  fs.writeFileSync(tmp, body, { mode: 0o600, flag: "wx" });
   fs.renameSync(tmp, indexPath(root));
 }
 

--- a/src/engine/screenshot-cache.ts
+++ b/src/engine/screenshot-cache.ts
@@ -703,6 +703,13 @@ export function gcCache(
   const maxCount = policy.maxCount ?? null;
   const maxBytes = policy.maxTotalBytes ?? null;
   const nTag = policy.tag !== undefined ? normalizeCacheTag(policy.tag) : undefined;
+  // Eviction floor (multi-LLM safety): NEVER evict a capture younger than this, so a
+  // ref another process just handed its caller survives long enough to be read even
+  // if a DIFFERENT desktop-touch process floods the shared cache. The retention budget
+  // is per-cache-dir global, so without this floor LLM-B's persists could auto-prune a
+  // ref LLM-A was just given (graceful not_found, but avoidable). Env-tunable; 0 disables.
+  const minEvictAgeMs =
+    parseNonNegIntEnv(env["DESKTOP_TOUCH_SCREENSHOT_MIN_EVICT_AGE_MS"]) ?? MIN_EVICT_AGE_MS_DEFAULT;
 
   // universe = tag subset (if scoped) else everything, newest → oldest.
   const universe = all
@@ -715,6 +722,7 @@ export function gcCache(
     const e = universe[i];
     running += e.bytes || 0; // count the byte even when protected — it occupies space
     if (protectCaptureId !== undefined && e.captureId === protectCaptureId) continue;
+    if (now - e.ts < minEvictAgeMs) continue; // eviction floor — protect just-handed refs
 
     let reason: GcCandidate["reason"] | null = null;
     if (maxAgeMs !== null && now - e.ts > maxAgeMs) {
@@ -838,6 +846,10 @@ export function gcCache(
 const MAX_COUNT_DEFAULT = 200;
 const MAX_BYTES_DEFAULT = 256 * 1024 * 1024;
 const AUTO_PRUNE_EVERY = 32;
+/** Eviction floor (multi-LLM safety, Opus P2): retention NEVER evicts a capture
+ *  younger than this, so a just-handed ref survives long enough to be read even when
+ *  another process is flooding the shared cache. 60 s ≫ the read-within-a-turn window. */
+const MIN_EVICT_AGE_MS_DEFAULT = 60_000;
 
 /** Parse a non-negative integer env value; undefined/blank/invalid → undefined. */
 function parseNonNegIntEnv(v: string | undefined): number | undefined {

--- a/src/engine/screenshot-cache.ts
+++ b/src/engine/screenshot-cache.ts
@@ -46,7 +46,17 @@ export interface IndexEntry extends CaptureMeta {
 }
 
 export const REF_URI_PREFIX = "screenshot://by-ref/";
-const INDEX_FILE = "_index.ndjson";
+/** Metadata sidecar extension. Each capture is `{captureId}.{imgExt}` (pixels) +
+ *  `{captureId}.json` (this sidecar) — there is NO shared index file, so nothing is
+ *  ever rewritten and concurrent multi-process access cannot race (ADR-026 Phase 3). */
+const SIDECAR_EXT = "json";
+
+/** Our captureId shape: base36 millis + "-" + 16 hex (see {@link newCaptureId}). Used
+ *  to positively identify cache-OWNED image files / temp writes so the orphan sweep
+ *  NEVER reclaims an unrelated file when the cache dir is shared (Codex P2). */
+const CAPTURE_ID_RE = /^[0-9a-z]+-[0-9a-f]{16}$/;
+/** Our sidecar temp-write shape: `{captureId}.json.{hex}.tmp`. */
+const SIDECAR_TMP_RE = /^[0-9a-z]+-[0-9a-f]{16}\.json\.[0-9a-f]+\.tmp$/;
 
 /** mimeType → file extension. Derived from mimeType (no hardcoded `.webp`; seed defect #5). */
 const MIME_EXT: Record<string, string> = {
@@ -78,99 +88,64 @@ function newCaptureId(): string {
   return `${Date.now().toString(36)}-${crypto.randomBytes(8).toString("hex")}`;
 }
 
-function indexPath(root: string): string {
-  return path.join(root, INDEX_FILE);
-}
+// ── Per-capture sidecar storage (ADR-026 Phase 3) ───────────────────────────
+// There is NO shared index file. Each capture is two independent files written /
+// removed atomically: the image `{captureId}.{imgExt}` and its metadata sidecar
+// `{captureId}.json`. Liveness = both files exist. Because no two processes ever
+// write the same file and nothing is ever rewritten in place, concurrent access
+// from multiple desktop-touch processes on one PC is correct WITHOUT a lock — the
+// read-modify-rewrite race that lock/tombstone designs had to guard simply cannot
+// exist. The directory IS the index; `readIndex` folds the sidecars.
 
-// ── Index mutation lock (ADR-026 Phase 3, Codex P1) ──────────────────────────
-// The index is mutated by three paths — persistCapture (append), deleteCapture
-// (remove one), gcCache (batch remove). A bare read-modify-rename rewrite loses a
-// concurrent append from ANOTHER desktop-touch process sharing the same cache dir
-// (the appended line isn't in the rewrite's snapshot and the rename drops it,
-// orphaning a just-returned ref past the protectCaptureId invariant). An exclusive
-// lockfile serializes ALL index mutations cross-process so every rewrite reads a
-// stable index and no append is lost. Single-process (the common case) takes the
-// lock with zero contention — one create+unlink syscall pair, no sleep.
-//
-// KNOWN RESIDUAL (Codex R3 P2, accepted — ADR-026 OQ8): an mtime-based lockfile
-// cannot distinguish a crashed holder from one merely slow inside `fn`, so the
-// stale-steal could in theory unlink a still-live holder's lock after LOCK_STALE_MS
-// and let a concurrent mutation race the holder's rename. This is a non-issue here:
-// every locked `fn` is a SYNCHRONOUS sub-millisecond op (one append, or a
-// readIndex+write+rename over a count-bounded index), so reaching the 10 s window
-// implies a frozen/dead process whose lock SHOULD be stolen; and any resulting loss
-// is self-healing (the orphaned file is reclaimed by a later orphan sweep, never a
-// wrong-file delete). Closing it fully would need OS advisory locks or an async
-// heartbeat (impossible mid-sync-fn) — disproportionate for a local single-user
-// cache. Deferred as a documented limitation, not a Phase-3 blocker.
-const INDEX_LOCK_FILE = "_index.lock";
-const LOCK_STALE_MS = 10_000;
-const LOCK_RETRY_MS = 20;
-// Give-up is LONGER than the stale window on purpose (Codex R3 P2): a legitimately
-// held lock is always resolved first — either the holder releases (waiter acquires)
-// or, if the holder crashed, the lock goes stale at LOCK_STALE_MS and the waiter
-// steals it. So the unlocked-proceed backstop below is unreachable while a real
-// holder exists; it only fires if stealing itself keeps failing (pathological),
-// never as a premature give-up that would reintroduce the append-loss race.
-const LOCK_MAX_WAIT_MS = 15_000;
-
-/** Synchronous sleep (consistent with this module's sync-fs design). Only reached
- *  on cross-process lock contention — never in the single-process common path. */
-function sleepSync(ms: number): void {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+/** Per-capture metadata sidecar path: `{captureId}.json`. */
+function sidecarPath(root: string, captureId: string): string {
+  return path.join(root, `${captureId}.${SIDECAR_EXT}`);
 }
 
 /**
- * Run `fn` while holding an exclusive index lock (an `_index.lock` file created
- * with the `wx` flag). A stale lock (holder crashed) is stolen after
- * {@link LOCK_STALE_MS}. The unlocked-proceed backstop at {@link LOCK_MAX_WAIT_MS}
- * is deliberately LONGER than the stale window, so a legitimately held lock is
- * always resolved first (release → acquire, or stale → steal) — the backstop only
- * fires if stealing itself keeps failing, never as a premature give-up that would
- * let a concurrent append slip past the rewrite (Codex R3 P2). **NOT reentrant**:
- * call sites must not nest withIndexLock (they don't — persistCapture releases
- * before maybeAutoPrune; gcCache unlinks lock-free then takes one lock for the rewrite).
+ * The captureId is caller-supplied on read/delete and gets joined to a path, so it
+ * MUST be exactly one of OUR generated ids — {@link CAPTURE_ID_RE} (`base36-16hex`).
+ * This both blocks path escape (`..`, separators, NUL) AND prevents a caller from
+ * naming an unrelated `{x}.json` / `{x}.png` in a shared cache dir (e.g. a crafted
+ * `settings.json` whose JSON mimics a sidecar): only our id shape is ever accepted,
+ * so a foreign file can never be addressed (Codex P2). A legitimate caller always
+ * passes an id it got verbatim from a screenshot response, which is this shape.
  */
-function withIndexLock<T>(root: string, fn: () => T): T {
-  const lockPath = path.join(root, INDEX_LOCK_FILE);
-  const start = Date.now();
-  let held = false;
-  for (;;) {
-    try {
-      // Acquire = exclusive create ("wx"): the lock is the lockfile's existence,
-      // released by unlink in `finally`. writeFileSync+wx (not openSync+"wx") is the
-      // same secure-create pattern persistCapture/writeIndexAtomic use, which CodeQL
-      // recognizes (js/insecure-temporary-file does not model openSync's "wx").
-      fs.writeFileSync(lockPath, "", { mode: 0o600, flag: "wx" });
-      held = true;
-      break;
-    } catch (e) {
-      if ((e as NodeJS.ErrnoException).code !== "EEXIST") break; // unlockable → best-effort
-      // Lock is held — steal it ONLY if it is stale AND we actually removed it.
-      let cleared = false;
-      try {
-        const st = fs.statSync(lockPath);
-        if (Date.now() - st.mtimeMs > LOCK_STALE_MS) {
-          try { fs.unlinkSync(lockPath); cleared = true; } catch { /* can't remove → fall through */ }
-        }
-      } catch {
-        cleared = true; // lock vanished between create and stat → retry acquire immediately
-      }
-      if (cleared) continue; // lock removed/gone → retry acquire now
-      // Held-and-fresh OR stale-but-unremovable (e.g. a directory named _index.lock):
-      // wait, then hit the backstop — never `continue` past it, or a wedged lock
-      // would spin forever instead of proceeding best-effort (Codex P2).
-      if (Date.now() - start > LOCK_MAX_WAIT_MS) break; // give up → proceed best-effort
-      sleepSync(LOCK_RETRY_MS);
-    }
+function assertSafeCaptureId(captureId: string): void {
+  if (!CAPTURE_ID_RE.test(captureId)) {
+    throw new CaptureRefError("outside_cache", `invalid captureId: ${captureId}`);
+  }
+}
+
+/**
+ * Publish a capture's metadata sidecar atomically (temp→rename): a concurrent reader
+ * never observes a partial sidecar, and the capture goes "live" the instant the
+ * rename lands `{id}.json`. The temp name is per-capture (unique id) → no cross-capture
+ * race, no shared mutable file. `wx` on the temp satisfies CodeQL insecure-temp-file.
+ */
+function writeSidecarAtomic(root: string, captureId: string, entry: IndexEntry): void {
+  const tmp = path.join(root, `${captureId}.${SIDECAR_EXT}.${crypto.randomBytes(6).toString("hex")}.tmp`);
+  fs.writeFileSync(tmp, JSON.stringify(entry), { mode: 0o600, flag: "wx" });
+  fs.renameSync(tmp, sidecarPath(root, captureId));
+}
+
+/** Read + parse one capture's sidecar; null if missing/corrupt/mismatched. The
+ *  sidecar's own captureId must match (a planted `{x}.json` claiming a different id
+ *  is rejected). The referenced image is validated separately by the caller. */
+function readSidecar(root: string, captureId: string): IndexEntry | null {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(sidecarPath(root, captureId), "utf8");
+  } catch {
+    return null;
   }
   try {
-    return fn();
-  } finally {
-    if (held) {
-      try { fs.unlinkSync(lockPath); } catch { /* ignore */ }
-    }
+    const e = JSON.parse(raw) as IndexEntry;
+    if (e && e.captureId === captureId && typeof e.file === "string") return e;
+  } catch {
+    /* corrupt / partial */
   }
+  return null;
 }
 
 /** Persist capture bytes + append an index entry; returns the ref descriptor. */
@@ -199,10 +174,10 @@ export function persistCapture(
     ...(meta.processName !== undefined ? { processName: meta.processName } : {}),
     ...(meta.tag !== undefined ? { tag: meta.tag } : {}),
   };
-  // Under the index lock so this atomic append cannot interleave with a gcCache /
-  // deleteCapture rewrite that re-reads then renames (which would otherwise drop
-  // this line). Released before maybeAutoPrune so the prune can take its own lock.
-  withIndexLock(root, () => fs.appendFileSync(indexPath(root), JSON.stringify(entry) + "\n"));
+  // Publish the metadata sidecar atomically — the image is written first (above), so
+  // the capture goes live only once both files exist. No shared index → this can
+  // never race a concurrent delete/persist from another process on the same PC.
+  writeSidecarAtomic(root, captureId, entry);
 
   // Bound cache growth (R2) without the agent ever calling screenshot_gc. Throttled
   // + best-effort + protects this very captureId — a prune failure must NEVER fail a
@@ -224,24 +199,50 @@ export function persistCapture(
   };
 }
 
-/** Parse the append-only index (latest line per captureId wins). Corrupt lines are skipped (R5). */
+/**
+ * Build the current live set by folding the per-capture sidecars (the directory IS
+ * the index). A capture is live iff BOTH its `{id}.json` sidecar and its image exist;
+ * a sidecar whose image was deleted (or crashed away) is an orphan — skipped here and
+ * reclaimed by gc, never listed. Corrupt/partial sidecars and `*.tmp` writes are
+ * skipped. Stat cost is one read + one stat per live capture, bounded by auto-prune.
+ */
 export function readIndex(root: string): Map<string, IndexEntry> {
   const map = new Map<string, IndexEntry>();
-  let raw: string;
+  let names: string[];
   try {
-    raw = fs.readFileSync(indexPath(root), "utf8");
+    names = fs.readdirSync(root);
   } catch {
-    return map; // no index yet
+    return map; // no cache dir yet
   }
-  for (const line of raw.split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed) continue;
+  const suffix = `.${SIDECAR_EXT}`;
+  for (const name of names) {
+    if (!name.endsWith(suffix)) continue; // sidecars only (skips images + `*.tmp`)
+    // Ownership gate: the basename must be one of OUR generated captureIds, so a
+    // shared/overridden cache dir never surfaces a foreign `*.json` as a capture or
+    // feeds an invalid id into retention (Codex P2). Same gate as the orphan sweep.
+    const idFromName = name.slice(0, -suffix.length);
+    if (!CAPTURE_ID_RE.test(idFromName)) continue;
+    let raw: string;
     try {
-      const e = JSON.parse(trimmed) as IndexEntry;
-      if (e && typeof e.captureId === "string" && typeof e.file === "string") map.set(e.captureId, e);
+      raw = fs.readFileSync(path.join(root, name), "utf8");
     } catch {
-      // skip corrupt line
+      continue;
     }
+    let e: IndexEntry;
+    try {
+      e = JSON.parse(raw) as IndexEntry;
+    } catch {
+      continue; // partial / corrupt sidecar
+    }
+    if (!e || e.captureId !== idFromName || typeof e.file !== "string") continue;
+    if (e.file !== path.basename(e.file)) continue; // image must be a plain basename
+    // Liveness gate: the referenced image must exist (skip image-less orphan sidecars).
+    try {
+      if (!fs.statSync(path.join(root, e.file)).isFile()) continue;
+    } catch {
+      continue;
+    }
+    map.set(e.captureId, e);
   }
   return map;
 }
@@ -313,11 +314,12 @@ function openValidatedCapture(
   captureId: string,
   env: NodeJS.ProcessEnv
 ): { fd: number; real: string; entry: IndexEntry } {
+  assertSafeCaptureId(captureId); // caller-supplied id → safe path component before any join
   const root = getScreenshotCacheRoot(env);
-  const entry = readIndex(root).get(captureId);
+  const entry = readSidecar(root, captureId); // one sidecar read, not a whole-dir walk
   if (!entry) throw new CaptureRefError("not_found", `unknown captureId: ${captureId}`);
 
-  // The index stores a basename only; reject anything that is not a plain file name.
+  // The sidecar stores a basename only; reject anything that is not a plain file name.
   const file = entry.file;
   if (file !== path.basename(file) || file.includes("..") || path.isAbsolute(file)) {
     throw new CaptureRefError("outside_cache", `index file name is not a basename: ${file}`);
@@ -610,20 +612,26 @@ function unlinkValidatedCapture(
 }
 
 /**
- * Securely delete one cached capture — both its FILE and its index entry — by
- * opaque captureId. Unlinks via {@link unlinkValidatedCapture}, then drops the
- * index entry under the index lock so `screenshot_query` no longer lists a ref
- * that reads `not_found` (Codex P2) — whether the file was unlinked here or was
- * already gone. Returns `{deleted:false}` (with the index entry still cleaned)
- * for a dangling ref.
+ * Securely delete one cached capture — both its image and its metadata sidecar — by
+ * opaque captureId. Securely unlinks the image via {@link unlinkValidatedCapture},
+ * then removes the `{id}.json` sidecar so `screenshot_query` no longer lists it
+ * (Codex P2) — whether the image was unlinked here or was already gone (dangling).
+ * Both are independent files (no shared index), so this is cross-process safe.
+ * Returns `{deleted:false}` (sidecar still removed) for a dangling ref.
  */
 export function deleteCapture(
   captureId: string,
   env: NodeJS.ProcessEnv = process.env
 ): { bytes: number; deleted: boolean } {
+  assertSafeCaptureId(captureId);
   const root = getScreenshotCacheRoot(env);
+  // Is there a sidecar that is genuinely OURS (parses with this captureId)? Only then
+  // may we unlink it — never a foreign `{id}.json` a caller named by accident (Codex P2).
+  const ownSidecar = readSidecar(root, captureId) !== null;
   const result = unlinkValidatedCapture(captureId, env);
-  removeIndexEntries(root, new Set([captureId]), env);
+  if (ownSidecar) {
+    try { fs.unlinkSync(sidecarPath(root, captureId)); } catch { /* already gone */ }
+  }
   return result;
 }
 
@@ -660,48 +668,11 @@ export interface GcResult {
   remaining: { count: number; bytes: number };
 }
 
-/** Image extensions the orphan sweep considers (mirrors MIME_EXT). The index
- *  rewrite temp file (`_index.ndjson.<rand>.tmp`) is NOT an image ext, so it is
- *  never mistaken for an orphan (P3-3). */
+/** Image extensions the orphan sweep recognizes (mirrors MIME_EXT). Sidecars
+ *  (`.json`) and partial sidecar writes (`.json.<rand>.tmp`) are NOT image exts —
+ *  the sweep classifies those separately. */
 const ORPHAN_IMAGE_EXTS = new Set(["png", "webp", "jpg", "bin"]);
 const ORPHAN_GRACE_MS_DEFAULT = 5 * 60 * 1000;
-
-/** Atomically replace the index with `entries` (temp→rename). Temp name is
- *  `_index.ndjson.<rand>.tmp` — excluded from the orphan sweep's ext filter. */
-function writeIndexAtomic(root: string, entries: IndexEntry[]): void {
-  const tmp = path.join(root, `${INDEX_FILE}.${crypto.randomBytes(6).toString("hex")}.tmp`);
-  const body = entries.map((e) => JSON.stringify(e)).join("\n") + (entries.length ? "\n" : "");
-  // Exclusive create ("wx"): refuse to follow a pre-planted file/symlink at the
-  // temp path (CodeQL js/insecure-temporary-file). The 6 random bytes make a real
-  // collision astronomically unlikely; mirrors persistCapture's write-side flag.
-  fs.writeFileSync(tmp, body, { mode: 0o600, flag: "wx" });
-  fs.renameSync(tmp, indexPath(root));
-}
-
-/**
- * Drop the given captureIds from the index, under the index lock so the fresh
- * read + rewrite cannot lose a concurrent cross-process append (Codex P1). A
- * no-op when none of the ids are currently present (avoids a pointless rewrite).
- *
- * NEVER throws (plan §3.3 best-effort): the entire lock+read+rewrite is wrapped, so
- * a failed rewrite (or any fs error) leaves stale entries that read as `not_found`
- * (AC3) and self-heal on the next gc. This is what lets the unguarded call sites
- * (`deleteCapture`, `gcCache`) stay correct — `deleteCapture` must not throw after a
- * successful unlink, and `gcCache` must still return its reclaimed-bytes summary
- * (Opus R3 P2-1).
- */
-function removeIndexEntries(root: string, ids: Set<string>, _env: NodeJS.ProcessEnv): void {
-  if (ids.size === 0) return;
-  try {
-    withIndexLock(root, () => {
-      const all = [...readIndex(root).values()];
-      if (!all.some((e) => ids.has(e.captureId))) return;
-      writeIndexAtomic(root, all.filter((e) => !ids.has(e.captureId)));
-    });
-  } catch {
-    // Best-effort — see the doc comment above. Index cleanup never propagates.
-  }
-}
 
 /**
  * Reclaim cached captures by retention policy (ADR-026 §5 / R2 / R11).
@@ -758,18 +729,19 @@ export function gcCache(
     }
   }
 
-  // Orphan sweep — aggregate only (P2-2). Carries the scanned dev/ino so the
-  // unlink can verify it is still the same inode (identity gate, Codex P2-788).
+  // Orphan sweep — aggregate only (P2-2). Reclaims dead-weight files: an image with
+  // no live sidecar pairing (crash between image-write and sidecar-publish, or a
+  // half-deleted capture, R11), a sidecar whose image is gone, and stale `*.tmp`
+  // partial sidecar writes. Each carries the scanned dev/ino so the unlink verifies
+  // it is still the same inode (identity gate, Codex P2-788). The grace is a FIXED
+  // short window (a file written moments ago whose sibling write is imminent), NOT
+  // scaled by the retention maxAgeMs — these files are unreadable dead weight.
   const orphanFiles: { file: string; bytes: number; dev: number; ino: number }[] = [];
   if (includeOrphans) {
-    const referenced = new Set(all.map((e) => e.file));
-    // Orphans have NO index entry and are therefore unreadable (a ref read returns
-    // not_found), so they are pure dead weight to reclaim ASAP. The grace is ONLY
-    // the short append-race window (a file written moments ago whose index append
-    // is imminent) — a FIXED constant, NOT scaled by the capture-retention maxAgeMs.
-    // `Math.max(maxAgeMs, …)` would let a multi-day retention policy keep unreadable
-    // residue on disk for days, defeating the sweep's purpose (Codex P2).
+    const liveIds = new Set(all.map((e) => e.captureId));
+    const liveImages = new Set(all.map((e) => e.file));
     const orphanGraceMs = ORPHAN_GRACE_MS_DEFAULT;
+    const suffix = `.${SIDECAR_EXT}`;
     let names: string[];
     try {
       names = fs.readdirSync(root);
@@ -777,11 +749,24 @@ export function gcCache(
       names = [];
     }
     for (const name of names) {
-      if (name === INDEX_FILE) continue;
+      // Only reclaim files we can POSITIVELY identify as cache-owned, so a shared /
+      // overridden cache dir never loses unrelated files like `settings.json` (Codex P2).
       const dot = name.lastIndexOf(".");
       const ext = dot >= 0 ? name.slice(dot + 1).toLowerCase() : "";
-      if (!ORPHAN_IMAGE_EXTS.has(ext)) continue; // skips _index.ndjson.<rand>.tmp + non-image
-      if (referenced.has(name)) continue; // has an index entry → handled above
+      let isOrphan = false;
+      if (ORPHAN_IMAGE_EXTS.has(ext) && CAPTURE_ID_RE.test(name.slice(0, name.length - ext.length - 1))) {
+        // An image named like a captureId, with no live sidecar pairing.
+        isOrphan = !liveImages.has(name);
+      } else if (name.endsWith(suffix) && CAPTURE_ID_RE.test(name.slice(0, -suffix.length))) {
+        // A sidecar NAMED like our captureId (ownership gate, same as the image/temp
+        // branches) whose image is gone AND which still parses as our sidecar — so a
+        // foreign `*.json` (even a crafted one) in a shared cache dir is left alone.
+        const id = name.slice(0, -suffix.length);
+        if (!liveIds.has(id) && readSidecar(root, id) !== null) isOrphan = true;
+      } else if (SIDECAR_TMP_RE.test(name)) {
+        isOrphan = true; // OUR stale partial sidecar write
+      }
+      if (!isOrphan) continue;
       let st: fs.Stats;
       try {
         st = fs.lstatSync(path.join(root, name));
@@ -789,7 +774,7 @@ export function gcCache(
         continue;
       }
       if (st.isSymbolicLink() || !st.isFile()) continue;
-      if (now - st.mtimeMs < orphanGraceMs) continue; // too fresh — index-append may be imminent
+      if (now - st.mtimeMs < orphanGraceMs) continue; // too fresh — a sibling write may be in flight
       orphanFiles.push({ file: name, bytes: st.size, dev: st.dev, ino: st.ino });
     }
   }
@@ -800,23 +785,18 @@ export function gcCache(
   const removedIds = new Set<string>();
 
   if (!dryRun) {
-    // Unlink the FILES first (lock-free), collecting the ids to drop from the
-    // index, then rewrite the index ONCE under the lock (removeIndexEntries) — so
-    // the O(N) candidate deletes cost a single locked rewrite, not N.
+    // Securely unlink the candidate IMAGE, then remove its sidecar (de-list). Both
+    // are independent files — no shared index to rewrite, no append to lose.
     for (const c of candidates) {
       try {
         const r = unlinkValidatedCapture(c.captureId, env);
         if (r.deleted) { reclaimedBytes += r.bytes; deleted++; }
-        // whether unlinked now or already gone, drop the (dead) index entry.
         removedIds.add(c.captureId);
+        try { fs.unlinkSync(sidecarPath(root, c.captureId)); } catch { /* already gone */ }
       } catch {
         // a single failed delete must not abort the whole gc; leave its entry.
       }
     }
-    // Remove the deleted entries from the index under the lock — the fresh read
-    // happens INSIDE the lock, and persist appends also hold the lock, so no
-    // concurrent cross-process append can be lost by the rewrite (Codex P1).
-    removeIndexEntries(root, removedIds, env);
     for (const o of orphanFiles) {
       try {
         const { real, st } = validateCacheFileForDelete(root, o.file);

--- a/src/engine/screenshot-cache.ts
+++ b/src/engine/screenshot-cache.ts
@@ -134,10 +134,15 @@ function sleepSync(ms: number): void {
 function withIndexLock<T>(root: string, fn: () => T): T {
   const lockPath = path.join(root, INDEX_LOCK_FILE);
   const start = Date.now();
-  let fd: number | null = null;
+  let held = false;
   for (;;) {
     try {
-      fd = fs.openSync(lockPath, "wx");
+      // Acquire = exclusive create ("wx"): the lock is the lockfile's existence,
+      // released by unlink in `finally`. writeFileSync+wx (not openSync+"wx") is the
+      // same secure-create pattern persistCapture/writeIndexAtomic use, which CodeQL
+      // recognizes (js/insecure-temporary-file does not model openSync's "wx").
+      fs.writeFileSync(lockPath, "", { mode: 0o600, flag: "wx" });
+      held = true;
       break;
     } catch (e) {
       if ((e as NodeJS.ErrnoException).code !== "EEXIST") break; // unlockable → best-effort
@@ -149,9 +154,9 @@ function withIndexLock<T>(root: string, fn: () => T): T {
           try { fs.unlinkSync(lockPath); cleared = true; } catch { /* can't remove → fall through */ }
         }
       } catch {
-        cleared = true; // lock vanished between open and stat → retry acquire immediately
+        cleared = true; // lock vanished between create and stat → retry acquire immediately
       }
-      if (cleared) continue; // lock removed/gone → retry openSync now
+      if (cleared) continue; // lock removed/gone → retry acquire now
       // Held-and-fresh OR stale-but-unremovable (e.g. a directory named _index.lock):
       // wait, then hit the backstop — never `continue` past it, or a wedged lock
       // would spin forever instead of proceeding best-effort (Codex P2).
@@ -162,8 +167,7 @@ function withIndexLock<T>(root: string, fn: () => T): T {
   try {
     return fn();
   } finally {
-    if (fd !== null) {
-      try { fs.closeSync(fd); } catch { /* ignore */ }
+    if (held) {
       try { fs.unlinkSync(lockPath); } catch { /* ignore */ }
     }
   }
@@ -759,7 +763,13 @@ export function gcCache(
   const orphanFiles: { file: string; bytes: number; dev: number; ino: number }[] = [];
   if (includeOrphans) {
     const referenced = new Set(all.map((e) => e.file));
-    const orphanGraceMs = Math.max(maxAgeMs ?? 0, ORPHAN_GRACE_MS_DEFAULT);
+    // Orphans have NO index entry and are therefore unreadable (a ref read returns
+    // not_found), so they are pure dead weight to reclaim ASAP. The grace is ONLY
+    // the short append-race window (a file written moments ago whose index append
+    // is imminent) — a FIXED constant, NOT scaled by the capture-retention maxAgeMs.
+    // `Math.max(maxAgeMs, …)` would let a multi-day retention policy keep unreadable
+    // residue on disk for days, defeating the sweep's purpose (Codex P2).
+    const orphanGraceMs = ORPHAN_GRACE_MS_DEFAULT;
     let names: string[];
     try {
       names = fs.readdirSync(root);

--- a/src/engine/screenshot-cache.ts
+++ b/src/engine/screenshot-cache.ts
@@ -82,6 +82,68 @@ function indexPath(root: string): string {
   return path.join(root, INDEX_FILE);
 }
 
+// ── Index mutation lock (ADR-026 Phase 3, Codex P1) ──────────────────────────
+// The index is mutated by three paths — persistCapture (append), deleteCapture
+// (remove one), gcCache (batch remove). A bare read-modify-rename rewrite loses a
+// concurrent append from ANOTHER desktop-touch process sharing the same cache dir
+// (the appended line isn't in the rewrite's snapshot and the rename drops it,
+// orphaning a just-returned ref past the protectCaptureId invariant). An exclusive
+// lockfile serializes ALL index mutations cross-process so every rewrite reads a
+// stable index and no append is lost. Single-process (the common case) takes the
+// lock with zero contention — one create+unlink syscall pair, no sleep.
+const INDEX_LOCK_FILE = "_index.lock";
+const LOCK_STALE_MS = 10_000;
+const LOCK_RETRY_MS = 20;
+const LOCK_MAX_WAIT_MS = 2_000;
+
+/** Synchronous sleep (consistent with this module's sync-fs design). Only reached
+ *  on cross-process lock contention — never in the single-process common path. */
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
+ * Run `fn` while holding an exclusive index lock (an `_index.lock` file created
+ * with the `wx` flag). Best-effort: a stale lock (holder crashed) is stolen after
+ * {@link LOCK_STALE_MS}, and if the lock can't be acquired within
+ * {@link LOCK_MAX_WAIT_MS} it proceeds anyway to avoid a deadlock — the worst case
+ * degrades to the pre-lock behavior, never worse. **NOT reentrant**: call sites
+ * must not nest withIndexLock (they don't — persistCapture releases before
+ * maybeAutoPrune; gcCache unlinks lock-free then takes one lock for the rewrite).
+ */
+function withIndexLock<T>(root: string, fn: () => T): T {
+  const lockPath = path.join(root, INDEX_LOCK_FILE);
+  const start = Date.now();
+  let fd: number | null = null;
+  for (;;) {
+    try {
+      fd = fs.openSync(lockPath, "wx");
+      break;
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== "EEXIST") break; // unlockable → best-effort
+      try {
+        const st = fs.statSync(lockPath);
+        if (Date.now() - st.mtimeMs > LOCK_STALE_MS) {
+          try { fs.unlinkSync(lockPath); } catch { /* raced another stealer */ }
+          continue;
+        }
+      } catch {
+        continue; // lock vanished between open and stat → retry immediately
+      }
+      if (Date.now() - start > LOCK_MAX_WAIT_MS) break; // give up → proceed best-effort
+      sleepSync(LOCK_RETRY_MS);
+    }
+  }
+  try {
+    return fn();
+  } finally {
+    if (fd !== null) {
+      try { fs.closeSync(fd); } catch { /* ignore */ }
+      try { fs.unlinkSync(lockPath); } catch { /* ignore */ }
+    }
+  }
+}
+
 /** Persist capture bytes + append an index entry; returns the ref descriptor. */
 export function persistCapture(
   data: Buffer,
@@ -108,7 +170,10 @@ export function persistCapture(
     ...(meta.processName !== undefined ? { processName: meta.processName } : {}),
     ...(meta.tag !== undefined ? { tag: meta.tag } : {}),
   };
-  fs.appendFileSync(indexPath(root), JSON.stringify(entry) + "\n");
+  // Under the index lock so this atomic append cannot interleave with a gcCache /
+  // deleteCapture rewrite that re-reads then renames (which would otherwise drop
+  // this line). Released before maybeAutoPrune so the prune can take its own lock.
+  withIndexLock(root, () => fs.appendFileSync(indexPath(root), JSON.stringify(entry) + "\n"));
 
   // Bound cache growth (R2) without the agent ever calling screenshot_gc. Throttled
   // + best-effort + protects this very captureId — a prune failure must NEVER fail a
@@ -452,16 +517,18 @@ function validateCacheFileForDelete(root: string, file: string): { real: string;
 }
 
 /**
- * Securely delete one cached capture by opaque captureId (ADR-026 §4 delete note).
+ * Securely unlink one cached capture's FILE by opaque captureId (does NOT touch
+ * the index — see {@link deleteCapture} / {@link gcCache} for the index update).
  *
  * Runs the full {@link openValidatedCapture} gauntlet to pin the file's dev/ino
  * identity, releases the handle, then — immediately before unlink — re-validates
  * (re-lstat symlink reject + re-containment + identity re-check) to minimize the
  * realpath→unlink TOCTOU window Windows cannot close via fd. Never unlinks
  * anything outside the canonical cache root. Returns `{deleted:false}` when the
- * file is already gone (dangling ref).
+ * file is already gone (dangling ref). Kept index-free so a batch GC can rewrite
+ * the index once instead of once per file.
  */
-export function deleteCapture(
+function unlinkValidatedCapture(
   captureId: string,
   env: NodeJS.ProcessEnv = process.env
 ): { bytes: number; deleted: boolean } {
@@ -513,6 +580,24 @@ export function deleteCapture(
   return { bytes, deleted: true };
 }
 
+/**
+ * Securely delete one cached capture — both its FILE and its index entry — by
+ * opaque captureId. Unlinks via {@link unlinkValidatedCapture}, then drops the
+ * index entry under the index lock so `screenshot_query` no longer lists a ref
+ * that reads `not_found` (Codex P2) — whether the file was unlinked here or was
+ * already gone. Returns `{deleted:false}` (with the index entry still cleaned)
+ * for a dangling ref.
+ */
+export function deleteCapture(
+  captureId: string,
+  env: NodeJS.ProcessEnv = process.env
+): { bytes: number; deleted: boolean } {
+  const root = getScreenshotCacheRoot(env);
+  const result = unlinkValidatedCapture(captureId, env);
+  removeIndexEntries(root, new Set([captureId]), env);
+  return result;
+}
+
 export interface GcPolicy {
   /** delete entries older than this (ms). */
   maxAgeMs?: number;
@@ -559,6 +644,20 @@ function writeIndexAtomic(root: string, entries: IndexEntry[]): void {
   const body = entries.map((e) => JSON.stringify(e)).join("\n") + (entries.length ? "\n" : "");
   fs.writeFileSync(tmp, body, { mode: 0o600 });
   fs.renameSync(tmp, indexPath(root));
+}
+
+/**
+ * Drop the given captureIds from the index, under the index lock so the fresh
+ * read + rewrite cannot lose a concurrent cross-process append (Codex P1). A
+ * no-op when none of the ids are currently present (avoids a pointless rewrite).
+ */
+function removeIndexEntries(root: string, ids: Set<string>, _env: NodeJS.ProcessEnv): void {
+  if (ids.size === 0) return;
+  withIndexLock(root, () => {
+    const all = [...readIndex(root).values()];
+    if (!all.some((e) => ids.has(e.captureId))) return;
+    writeIndexAtomic(root, all.filter((e) => !ids.has(e.captureId)));
+  });
 }
 
 /**
@@ -651,31 +750,23 @@ export function gcCache(
   const removedIds = new Set<string>();
 
   if (!dryRun) {
+    // Unlink the FILES first (lock-free), collecting the ids to drop from the
+    // index, then rewrite the index ONCE under the lock (removeIndexEntries) — so
+    // the O(N) candidate deletes cost a single locked rewrite, not N.
     for (const c of candidates) {
       try {
-        const r = deleteCapture(c.captureId, env);
-        if (r.deleted) reclaimedBytes += r.bytes;
-        // whether deleted now or already gone, drop the index entry.
+        const r = unlinkValidatedCapture(c.captureId, env);
+        if (r.deleted) { reclaimedBytes += r.bytes; deleted++; }
+        // whether unlinked now or already gone, drop the (dead) index entry.
         removedIds.add(c.captureId);
-        if (r.deleted) deleted++;
       } catch {
         // a single failed delete must not abort the whole gc; leave its entry.
       }
     }
-    if (removedIds.size > 0) {
-      // Re-read the index immediately before the atomic rewrite and merge: a
-      // capture another process persisted AFTER our initial `all` snapshot is in
-      // the fresh read, so the rename preserves it instead of dropping its line —
-      // which would orphan a just-returned ref (and a later orphan sweep could
-      // then delete it past the protectCaptureId invariant, Codex P1). The
-      // residual fresh-read→rename gap is a single-process synchronous window.
-      const rewriteSurvivors = [...readIndex(root).values()].filter((e) => !removedIds.has(e.captureId));
-      try {
-        writeIndexAtomic(root, rewriteSurvivors);
-      } catch {
-        // best-effort; a failed rewrite leaves stale entries → read surfaces not_found (AC3)
-      }
-    }
+    // Remove the deleted entries from the index under the lock — the fresh read
+    // happens INSIDE the lock, and persist appends also hold the lock, so no
+    // concurrent cross-process append can be lost by the rewrite (Codex P1).
+    removeIndexEntries(root, removedIds, env);
     for (const o of orphanFiles) {
       try {
         const { real } = validateCacheFileForDelete(root, o.file);

--- a/src/engine/screenshot-cache.ts
+++ b/src/engine/screenshot-cache.ts
@@ -94,7 +94,13 @@ function indexPath(root: string): string {
 const INDEX_LOCK_FILE = "_index.lock";
 const LOCK_STALE_MS = 10_000;
 const LOCK_RETRY_MS = 20;
-const LOCK_MAX_WAIT_MS = 2_000;
+// Give-up is LONGER than the stale window on purpose (Codex R3 P2): a legitimately
+// held lock is always resolved first — either the holder releases (waiter acquires)
+// or, if the holder crashed, the lock goes stale at LOCK_STALE_MS and the waiter
+// steals it. So the unlocked-proceed backstop below is unreachable while a real
+// holder exists; it only fires if stealing itself keeps failing (pathological),
+// never as a premature give-up that would reintroduce the append-loss race.
+const LOCK_MAX_WAIT_MS = 15_000;
 
 /** Synchronous sleep (consistent with this module's sync-fs design). Only reached
  *  on cross-process lock contention — never in the single-process common path. */
@@ -104,12 +110,14 @@ function sleepSync(ms: number): void {
 
 /**
  * Run `fn` while holding an exclusive index lock (an `_index.lock` file created
- * with the `wx` flag). Best-effort: a stale lock (holder crashed) is stolen after
- * {@link LOCK_STALE_MS}, and if the lock can't be acquired within
- * {@link LOCK_MAX_WAIT_MS} it proceeds anyway to avoid a deadlock — the worst case
- * degrades to the pre-lock behavior, never worse. **NOT reentrant**: call sites
- * must not nest withIndexLock (they don't — persistCapture releases before
- * maybeAutoPrune; gcCache unlinks lock-free then takes one lock for the rewrite).
+ * with the `wx` flag). A stale lock (holder crashed) is stolen after
+ * {@link LOCK_STALE_MS}. The unlocked-proceed backstop at {@link LOCK_MAX_WAIT_MS}
+ * is deliberately LONGER than the stale window, so a legitimately held lock is
+ * always resolved first (release → acquire, or stale → steal) — the backstop only
+ * fires if stealing itself keeps failing, never as a premature give-up that would
+ * let a concurrent append slip past the rewrite (Codex R3 P2). **NOT reentrant**:
+ * call sites must not nest withIndexLock (they don't — persistCapture releases
+ * before maybeAutoPrune; gcCache unlinks lock-free then takes one lock for the rewrite).
  */
 function withIndexLock<T>(root: string, fn: () => T): T {
   const lockPath = path.join(root, INDEX_LOCK_FILE);

--- a/tests/unit/screenshot-cache-query-gc.test.ts
+++ b/tests/unit/screenshot-cache-query-gc.test.ts
@@ -50,7 +50,9 @@ function seed(
   const mimeType = e.mimeType ?? "image/png";
   const ext = mimeType === "image/webp" ? "webp" : mimeType === "image/jpeg" ? "jpg" : "png";
   const file = `${e.captureId}.${ext}`;
-  fs.writeFileSync(path.join(root, file), Buffer.alloc(e.bytes), { mode: 0o600 });
+  // flag:"wx" = exclusive create — refuse to follow a pre-planted file/symlink
+  // in the shared temp dir (CodeQL js/insecure-temporary-file, Phase 1 pattern).
+  fs.writeFileSync(path.join(root, file), Buffer.alloc(e.bytes), { mode: 0o600, flag: "wx" });
   const entry: IndexEntry = {
     captureId: e.captureId, ts: e.ts, bytes: e.bytes, file, mimeType, width: 4, height: 4,
     ...(e.tag !== undefined ? { tag: e.tag } : {}),
@@ -233,7 +235,7 @@ describe("deleteCapture — secure delete (AC3)", () => {
     const root = getScreenshotCacheRoot(env);
     const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "dt-qg-outside-"));
     const victim = path.join(outsideDir, "victim.png");
-    fs.writeFileSync(victim, Buffer.alloc(3));
+    fs.writeFileSync(victim, Buffer.alloc(3), { flag: "wx" });
     const rel = path.relative(root, victim); // ..\..\<tmp>\victim.png
     fs.appendFileSync(
       path.join(root, "_index.ndjson"),
@@ -260,6 +262,25 @@ describe("deleteCapture — secure delete (AC3)", () => {
     try { deleteCapture("t", env); } catch (e) { msg = (e as Error).message; }
     expect(msg).not.toContain(cacheDir);
   });
+
+  // POSIX-only: chmod 0o000 denies the owner read on Linux/macOS (non-root) →
+  // openSync(O_RDONLY) → EACCES. Windows ignores 000 for the owner, so skip there.
+  it.skipIf(process.platform === "win32")(
+    "a non-ENOENT read failure (EACCES) coerces to opaque `unreadable`, no path leaked (R9)",
+    () => {
+      const root = getScreenshotCacheRoot(env);
+      const e = seed(root, { captureId: "noperm", ts: NOW, bytes: 8 });
+      const file = path.join(root, e.file);
+      fs.chmodSync(file, 0o000); // owner loses read → openSync(O_RDONLY) → EACCES
+      let err: unknown;
+      try { readCaptureBytes("noperm", env); } catch (x) { err = x; }
+      try { fs.chmodSync(file, 0o600); } catch { /* restore so afterEach rm works */ }
+      if (err === undefined) return; // running as root → EACCES unenforceable, skip the assertion
+      expect(err).toBeInstanceOf(CaptureRefError);
+      expect((err as CaptureRefError).code).toBe("unreadable");
+      expect((err as Error).message).not.toContain(cacheDir);
+    },
+  );
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -268,7 +289,7 @@ describe("gcCache — orphan sweep (R11)", () => {
     const root = getScreenshotCacheRoot(env);
     // a true orphan: file on disk, NOT in the index (crash residue / fold orphan).
     const orphan = path.join(root, "orphan123.png");
-    fs.writeFileSync(orphan, Buffer.alloc(64));
+    fs.writeFileSync(orphan, Buffer.alloc(64), { flag: "wx" });
     const old = (NOW - 60 * 60 * 1000) / 1000; // 1h old (> 5min grace)
     fs.utimesSync(orphan, old, old);
 
@@ -283,7 +304,7 @@ describe("gcCache — orphan sweep (R11)", () => {
   it("does NOT reclaim a fresh orphan (within the grace window — index-append may be imminent)", () => {
     const root = getScreenshotCacheRoot(env);
     const fresh = path.join(root, "fresh999.png");
-    fs.writeFileSync(fresh, Buffer.alloc(10));
+    fs.writeFileSync(fresh, Buffer.alloc(10), { flag: "wx" });
     fs.utimesSync(fresh, NOW / 1000, NOW / 1000); // mtime == now
     const r = gcCache({ dryRun: false, policy: {}, includeOrphans: true, now: NOW }, env);
     expect(r.orphans.count).toBe(0);

--- a/tests/unit/screenshot-cache-query-gc.test.ts
+++ b/tests/unit/screenshot-cache-query-gc.test.ts
@@ -1,0 +1,335 @@
+/**
+ * ADR-026 Phase 3 — `screenshot-cache.ts` query / gc / retention engine tests.
+ *
+ * Hermetic: every test runs against a throwaway `DESKTOP_TOUCH_SCREENSHOTS_DIR`
+ * and disables auto-prune unless the test is specifically about it, so the index
+ * reflects exactly what was seeded. Covers AC3 (secure delete — no out-of-cache
+ * unlink), AC4 (query index walk + case-folded tag), R2 (auto-prune bounding),
+ * R11 (orphan-file reclaim), and the P1-1 keep-newest invariant.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+
+import {
+  persistCapture,
+  readCaptureBytes,
+  readIndex,
+  getScreenshotCacheRoot,
+  queryCaptures,
+  deleteCapture,
+  gcCache,
+  normalizeCacheTag,
+  envDefaultPolicy,
+  CaptureRefError,
+  _resetAutoPruneCounterForTest,
+  type IndexEntry,
+} from "../../src/engine/screenshot-cache.js";
+
+let cacheDir: string;
+let env: NodeJS.ProcessEnv;
+
+beforeEach(() => {
+  cacheDir = path.join(os.tmpdir(), `dt-qg-test-${crypto.randomBytes(6).toString("hex")}`);
+  // Auto-prune OFF by default so seeded counts are deterministic.
+  env = { DESKTOP_TOUCH_SCREENSHOTS_DIR: cacheDir, DESKTOP_TOUCH_SCREENSHOT_AUTOPRUNE: "0" };
+  _resetAutoPruneCounterForTest();
+});
+afterEach(() => {
+  try { fs.rmSync(cacheDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+/** Seed a real, deletable capture: write a file of `bytes` length + append the
+ *  raw index entry with explicit ts (deterministic ordering). Returns the entry. */
+function seed(
+  root: string,
+  e: { captureId: string; ts: number; bytes: number; tag?: string; windowUuid?: string; processName?: string; mimeType?: string },
+): IndexEntry {
+  const mimeType = e.mimeType ?? "image/png";
+  const ext = mimeType === "image/webp" ? "webp" : mimeType === "image/jpeg" ? "jpg" : "png";
+  const file = `${e.captureId}.${ext}`;
+  fs.writeFileSync(path.join(root, file), Buffer.alloc(e.bytes), { mode: 0o600 });
+  const entry: IndexEntry = {
+    captureId: e.captureId, ts: e.ts, bytes: e.bytes, file, mimeType, width: 4, height: 4,
+    ...(e.tag !== undefined ? { tag: e.tag } : {}),
+    ...(e.windowUuid !== undefined ? { windowUuid: e.windowUuid } : {}),
+    ...(e.processName !== undefined ? { processName: e.processName } : {}),
+  };
+  fs.appendFileSync(path.join(root, "_index.ndjson"), JSON.stringify(entry) + "\n");
+  return entry;
+}
+
+const NOW = 1_000_000_000_000;
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("normalizeCacheTag (seed defect #9)", () => {
+  it("folds case + trims so query/gc agree on tag identity", () => {
+    expect(normalizeCacheTag("  Chrome.EXE  ")).toBe("chrome.exe");
+    expect(normalizeCacheTag("roi-View5")).toBe(normalizeCacheTag("ROI-view5"));
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("queryCaptures (AC4 — index walk, filters, no path leak)", () => {
+  it("lists newest-first with whole-cache stats and an opaque uri (no file/abs path)", () => {
+    const root = getScreenshotCacheRoot(env);
+    seed(root, { captureId: "a", ts: NOW - 300, bytes: 10 });
+    seed(root, { captureId: "b", ts: NOW - 100, bytes: 20 });
+    seed(root, { captureId: "c", ts: NOW - 200, bytes: 30 });
+
+    const r = queryCaptures({}, env);
+    expect(r.total).toBe(3);
+    expect(r.count).toBe(3);
+    expect(r.captures.map((x) => x.captureId)).toEqual(["b", "c", "a"]); // newest-first
+    expect(r.cache).toEqual({ totalCaptures: 3, totalBytes: 60 });
+
+    const first = r.captures[0]!;
+    expect(first.uri).toBe(`screenshot://by-ref/${first.captureId}`);
+    // opaque-ref model: no `file` basename, no absolute cache path anywhere.
+    expect("file" in first).toBe(false);
+    expect(JSON.stringify(r).includes(cacheDir)).toBe(false);
+  });
+
+  it("tag filter is case-insensitive and still walks the full index (seed defect #8)", () => {
+    const root = getScreenshotCacheRoot(env);
+    seed(root, { captureId: "a", ts: NOW - 1, bytes: 1, tag: "Roi-5" });
+    seed(root, { captureId: "b", ts: NOW - 2, bytes: 1, tag: "other" });
+    const r = queryCaptures({ tag: "ROI-5" }, env);
+    expect(r.captures.map((x) => x.captureId)).toEqual(["a"]);
+  });
+
+  it("windowUuid / since / until / limit / offset are all honored", () => {
+    const root = getScreenshotCacheRoot(env);
+    seed(root, { captureId: "old", ts: NOW - 1000, bytes: 1, windowUuid: "w1" });
+    seed(root, { captureId: "mid", ts: NOW - 500, bytes: 1, windowUuid: "w1" });
+    seed(root, { captureId: "new", ts: NOW - 100, bytes: 1, windowUuid: "w2" });
+
+    expect(queryCaptures({ windowUuid: "w1" }, env).captures.map((x) => x.captureId).sort())
+      .toEqual(["mid", "old"]);
+    expect(queryCaptures({ since: NOW - 600, until: NOW - 200 }, env).captures.map((x) => x.captureId))
+      .toEqual(["mid"]);
+    // limit/offset over the newest-first ordering [new, mid, old]
+    expect(queryCaptures({ limit: 1, offset: 1 }, env).captures.map((x) => x.captureId)).toEqual(["mid"]);
+    expect(queryCaptures({ limit: 1 }, env).total).toBe(3); // total is pre-page
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("gcCache — retention policy union (R2)", () => {
+  it("maxCount keeps the newest N and lists the rest as candidates (dryRun: no delete)", () => {
+    const root = getScreenshotCacheRoot(env);
+    seed(root, { captureId: "n1", ts: NOW - 100, bytes: 1 });
+    seed(root, { captureId: "n2", ts: NOW - 200, bytes: 1 });
+    seed(root, { captureId: "n3", ts: NOW - 300, bytes: 1 });
+
+    const r = gcCache({ dryRun: true, policy: { maxCount: 1 }, includeOrphans: false, now: NOW }, env);
+    expect(r.candidates.map((c) => c.captureId).sort()).toEqual(["n2", "n3"]);
+    expect(r.candidates.every((c) => c.reason === "max_count")).toBe(true);
+    expect(r.deleted).toBe(0); // dryRun
+    expect(readIndex(root).size).toBe(3); // nothing removed
+    expect(fs.existsSync(path.join(root, "n2.png"))).toBe(true);
+  });
+
+  it("maxAgeMs marks entries older than the window", () => {
+    const root = getScreenshotCacheRoot(env);
+    seed(root, { captureId: "fresh", ts: NOW - 1000, bytes: 1 });
+    seed(root, { captureId: "stale", ts: NOW - 60_000, bytes: 1 });
+    const r = gcCache({ dryRun: true, policy: { maxAgeMs: 10_000 }, includeOrphans: false, now: NOW }, env);
+    expect(r.candidates.map((c) => c.captureId)).toEqual(["stale"]);
+    expect(r.candidates[0]!.reason).toBe("max_age");
+  });
+
+  it("tag scope only ever considers the matching tag's captures", () => {
+    const root = getScreenshotCacheRoot(env);
+    seed(root, { captureId: "k1", ts: NOW - 100, bytes: 1, tag: "keep" });
+    seed(root, { captureId: "d1", ts: NOW - 200, bytes: 1, tag: "DROP" });
+    seed(root, { captureId: "d2", ts: NOW - 300, bytes: 1, tag: "drop" });
+    // age cap CAN clear the whole tag (unlike count/byte which keep the newest);
+    // case-folded 'drop' scope must leave 'keep' entirely untouched.
+    const r = gcCache({ dryRun: true, policy: { maxAgeMs: 0, tag: "drop" }, includeOrphans: false, now: NOW }, env);
+    expect(r.candidates.map((c) => c.captureId).sort()).toEqual(["d1", "d2"]);
+  });
+
+  it("count/byte caps keep the newest of a tag scope; age cap can clear it (keep-newest asymmetry)", () => {
+    const root = getScreenshotCacheRoot(env);
+    seed(root, { captureId: "d1", ts: NOW - 200, bytes: 1, tag: "drop" });
+    seed(root, { captureId: "d2", ts: NOW - 300, bytes: 1, tag: "drop" });
+    // maxCount:0 is clamped to max(1,0) → newest of the tag (d1) is kept.
+    const r = gcCache({ dryRun: true, policy: { maxCount: 0, tag: "drop" }, includeOrphans: false, now: NOW }, env);
+    expect(r.candidates.map((c) => c.captureId)).toEqual(["d2"]);
+  });
+
+  it("dryRun:false actually deletes, rewrites the index, and query no longer returns them", () => {
+    const root = getScreenshotCacheRoot(env);
+    seed(root, { captureId: "n1", ts: NOW - 100, bytes: 5 });
+    seed(root, { captureId: "n2", ts: NOW - 200, bytes: 7 });
+    seed(root, { captureId: "n3", ts: NOW - 300, bytes: 9 });
+
+    const r = gcCache({ dryRun: false, policy: { maxCount: 1 }, includeOrphans: false, now: NOW }, env);
+    expect(r.deleted).toBe(2);
+    expect(r.reclaimedBytes).toBe(16); // 7 + 9
+    expect(fs.existsSync(path.join(root, "n2.png"))).toBe(false);
+    expect(fs.existsSync(path.join(root, "n1.png"))).toBe(true);
+    expect(queryCaptures({}, env).captures.map((x) => x.captureId)).toEqual(["n1"]);
+    expect(r.remaining.count).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("gcCache — keep-newest invariant (P1-1)", () => {
+  it("byte cap NEVER deletes the newest entry, even when it alone exceeds the cap", () => {
+    const root = getScreenshotCacheRoot(env);
+    seed(root, { captureId: "solo", ts: NOW, bytes: 100 });
+    const r = gcCache({ dryRun: true, policy: { maxTotalBytes: 50 }, includeOrphans: false, now: NOW }, env);
+    expect(r.candidates).toEqual([]); // rank 0 is structurally kept
+  });
+
+  it("byte cap reduces older entries while keeping rank 0 + the running cap", () => {
+    const root = getScreenshotCacheRoot(env);
+    seed(root, { captureId: "new", ts: NOW - 100, bytes: 100 });
+    seed(root, { captureId: "mid", ts: NOW - 200, bytes: 100 });
+    seed(root, { captureId: "old", ts: NOW - 300, bytes: 100 });
+    // cap 150: keep new (rank0, sum 100<=150); mid rank1 sum 200>150 → drop; old drop.
+    const r = gcCache({ dryRun: true, policy: { maxTotalBytes: 150 }, includeOrphans: false, now: NOW }, env);
+    expect(r.candidates.map((c) => c.captureId).sort()).toEqual(["mid", "old"]);
+    expect(r.candidates.every((c) => c.reason === "max_total_bytes")).toBe(true);
+  });
+
+  it("protectCaptureId excludes a specific id from ALL caps", () => {
+    const root = getScreenshotCacheRoot(env);
+    seed(root, { captureId: "new", ts: NOW - 100, bytes: 100 });
+    seed(root, { captureId: "mid", ts: NOW - 200, bytes: 100 });
+    seed(root, { captureId: "old", ts: NOW - 300, bytes: 100 });
+    const r = gcCache(
+      { dryRun: true, policy: { maxTotalBytes: 150 }, includeOrphans: false, now: NOW, protectCaptureId: "old" },
+      env,
+    );
+    expect(r.candidates.map((c) => c.captureId)).toEqual(["mid"]); // old protected
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("deleteCapture — secure delete (AC3)", () => {
+  it("deletes a real capture and reports the reclaimed bytes", () => {
+    const root = getScreenshotCacheRoot(env);
+    seed(root, { captureId: "x", ts: NOW, bytes: 42 });
+    const r = deleteCapture("x", env);
+    expect(r).toEqual({ bytes: 42, deleted: true });
+    expect(fs.existsSync(path.join(root, "x.png"))).toBe(false);
+  });
+
+  it("a dangling captureId (file already gone) → {deleted:false}, never throws", () => {
+    const root = getScreenshotCacheRoot(env);
+    fs.appendFileSync(
+      path.join(root, "_index.ndjson"),
+      JSON.stringify({ captureId: "gone", ts: 1, bytes: 1, file: "gone.png", mimeType: "image/png", width: 1, height: 1 }) + "\n",
+    );
+    expect(deleteCapture("gone", env)).toEqual({ bytes: 0, deleted: false });
+  });
+
+  it("an index entry pointing outside the cache (traversal) is never unlinked", () => {
+    const root = getScreenshotCacheRoot(env);
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "dt-qg-outside-"));
+    const victim = path.join(outsideDir, "victim.png");
+    fs.writeFileSync(victim, Buffer.alloc(3));
+    const rel = path.relative(root, victim); // ..\..\<tmp>\victim.png
+    fs.appendFileSync(
+      path.join(root, "_index.ndjson"),
+      JSON.stringify({ captureId: "evil", ts: 1, bytes: 1, file: rel, mimeType: "image/png", width: 1, height: 1 }) + "\n",
+    );
+    try {
+      expect(() => deleteCapture("evil", env)).toThrow(CaptureRefError);
+      expect(fs.existsSync(victim)).toBe(true); // the out-of-cache file is untouched
+    } finally {
+      fs.rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
+
+  it("no thrown cache error message leaks the absolute cache path (R9 intent)", () => {
+    getScreenshotCacheRoot(env);
+    let msg = "";
+    try { deleteCapture("not-a-real-id", env); } catch (e) { msg = (e as Error).message; }
+    // unknown id is {deleted:false} not a throw, so assert via a traversal entry:
+    const root = getScreenshotCacheRoot(env);
+    fs.appendFileSync(
+      path.join(root, "_index.ndjson"),
+      JSON.stringify({ captureId: "t", ts: 1, bytes: 1, file: "../x.png", mimeType: "image/png", width: 1, height: 1 }) + "\n",
+    );
+    try { deleteCapture("t", env); } catch (e) { msg = (e as Error).message; }
+    expect(msg).not.toContain(cacheDir);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("gcCache — orphan sweep (R11)", () => {
+  it("reclaims an on-disk image file with no index entry once older than the grace window", () => {
+    const root = getScreenshotCacheRoot(env);
+    // a true orphan: file on disk, NOT in the index (crash residue / fold orphan).
+    const orphan = path.join(root, "orphan123.png");
+    fs.writeFileSync(orphan, Buffer.alloc(64));
+    const old = (NOW - 60 * 60 * 1000) / 1000; // 1h old (> 5min grace)
+    fs.utimesSync(orphan, old, old);
+
+    const r = gcCache({ dryRun: false, policy: {}, includeOrphans: true, now: NOW }, env);
+    expect(r.orphans.count).toBe(1);
+    expect(r.orphans.bytes).toBe(64);
+    expect(fs.existsSync(orphan)).toBe(false);
+    // orphans are aggregate-only — no basename in the result JSON (P2-2).
+    expect(JSON.stringify(r).includes("orphan123")).toBe(false);
+  });
+
+  it("does NOT reclaim a fresh orphan (within the grace window — index-append may be imminent)", () => {
+    const root = getScreenshotCacheRoot(env);
+    const fresh = path.join(root, "fresh999.png");
+    fs.writeFileSync(fresh, Buffer.alloc(10));
+    fs.utimesSync(fresh, NOW / 1000, NOW / 1000); // mtime == now
+    const r = gcCache({ dryRun: false, policy: {}, includeOrphans: true, now: NOW }, env);
+    expect(r.orphans.count).toBe(0);
+    expect(fs.existsSync(fresh)).toBe(true);
+  });
+
+  it("ignores the index file and never treats it as an orphan", () => {
+    const root = getScreenshotCacheRoot(env);
+    seed(root, { captureId: "real", ts: NOW, bytes: 1 });
+    const r = gcCache({ dryRun: false, policy: {}, includeOrphans: true, now: NOW }, env);
+    expect(r.orphans.count).toBe(0);
+    expect(fs.existsSync(path.join(root, "_index.ndjson"))).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("envDefaultPolicy + auto-prune (R2 / §3.6)", () => {
+  it("defaults: count + bytes caps active, age cap opt-in (absent)", () => {
+    expect(envDefaultPolicy({})).toEqual({ maxCount: 200, maxTotalBytes: 256 * 1024 * 1024 });
+    const p = envDefaultPolicy({ DESKTOP_TOUCH_SCREENSHOT_MAX_AGE_MS: "5000", DESKTOP_TOUCH_SCREENSHOT_MAX_COUNT: "3" });
+    expect(p).toEqual({ maxCount: 3, maxTotalBytes: 256 * 1024 * 1024, maxAgeMs: 5000 });
+  });
+
+  it("persistCapture auto-prune fires on the first persist of the process and bounds the cache", () => {
+    const pruneEnv: NodeJS.ProcessEnv = {
+      DESKTOP_TOUCH_SCREENSHOTS_DIR: cacheDir,
+      DESKTOP_TOUCH_SCREENSHOT_MAX_COUNT: "2",
+      // auto-prune ENABLED (no AUTOPRUNE=0)
+    };
+    const root = getScreenshotCacheRoot(pruneEnv);
+    // pre-seed 5 older captures (prior-session cruft).
+    for (let i = 0; i < 5; i++) seed(root, { captureId: `seed${i}`, ts: NOW - 10_000 - i, bytes: 1 });
+    _resetAutoPruneCounterForTest();
+
+    const fresh = persistCapture(Buffer.from([0x89, 0x50, 0x4e, 0x47, 1, 2, 3, 4]), { mimeType: "image/png", width: 2, height: 2 }, pruneEnv);
+    // first persist (counter 0) → auto-prune with maxCount:2 → keep newest 2.
+    expect(readIndex(root).size).toBe(2);
+    // the just-written ref MUST survive (keep-newest / protectCaptureId).
+    expect(() => readCaptureBytes(fresh.captureId, pruneEnv)).not.toThrow();
+  });
+
+  it("DESKTOP_TOUCH_SCREENSHOT_AUTOPRUNE=0 disables auto-prune", () => {
+    const root = getScreenshotCacheRoot(env); // env has AUTOPRUNE=0
+    for (let i = 0; i < 5; i++) seed(root, { captureId: `s${i}`, ts: NOW - i, bytes: 1 });
+    _resetAutoPruneCounterForTest();
+    persistCapture(Buffer.from([0x89, 0x50, 0x4e, 0x47, 1, 2, 3, 4]), { mimeType: "image/png", width: 1, height: 1 }, { ...env, DESKTOP_TOUCH_SCREENSHOT_MAX_COUNT: "2" });
+    expect(readIndex(root).size).toBe(6); // 5 seeded + 1, nothing pruned
+  });
+});

--- a/tests/unit/screenshot-cache-query-gc.test.ts
+++ b/tests/unit/screenshot-cache-query-gc.test.ts
@@ -37,8 +37,13 @@ beforeEach(() => {
   // mkdtempSync (not path.join + random) so the cache dir is a securely-created
   // temp dir — CodeQL js/insecure-temporary-file is satisfied for writes into it.
   cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "dt-qg-test-"));
-  // Auto-prune OFF by default so seeded counts are deterministic.
-  env = { DESKTOP_TOUCH_SCREENSHOTS_DIR: cacheDir, DESKTOP_TOUCH_SCREENSHOT_AUTOPRUNE: "0" };
+  // Auto-prune OFF + eviction floor OFF by default so seeded counts/policies are
+  // deterministic (a dedicated test exercises the floor with it enabled).
+  env = {
+    DESKTOP_TOUCH_SCREENSHOTS_DIR: cacheDir,
+    DESKTOP_TOUCH_SCREENSHOT_AUTOPRUNE: "0",
+    DESKTOP_TOUCH_SCREENSHOT_MIN_EVICT_AGE_MS: "0",
+  };
   _resetAutoPruneCounterForTest();
 });
 afterEach(() => {
@@ -228,6 +233,18 @@ describe("gcCache — keep-newest invariant (P1-1)", () => {
       env,
     );
     expect(r.candidates.map((c) => c.captureId)).toEqual([cid("mid")]); // old protected
+  });
+
+  it("eviction floor spares a recent capture retention would otherwise evict (Opus P2, multi-LLM)", () => {
+    const root = getScreenshotCacheRoot(env);
+    const floorEnv = { ...env, DESKTOP_TOUCH_SCREENSHOT_MIN_EVICT_AGE_MS: "60000" };
+    seed(root, { captureId: cid("newest"), ts: NOW - 500, bytes: 1 });   // rank 0
+    seed(root, { captureId: cid("recent"), ts: NOW - 2_000, bytes: 1 }); // rank 1, < 60s floor
+    seed(root, { captureId: cid("old"), ts: NOW - 200_000, bytes: 1 });  // rank 2, > floor
+    // maxCount:1 would evict ranks 1 AND 2; the floor protects the recent rank-1 one,
+    // so a ref another LLM was just handed cannot be auto-pruned before it is read.
+    const r = gcCache({ dryRun: true, policy: { maxCount: 1 }, includeOrphans: false, now: NOW }, floorEnv);
+    expect(r.candidates.map((c) => c.captureId)).toEqual([cid("old")]);
   });
 });
 

--- a/tests/unit/screenshot-cache-query-gc.test.ts
+++ b/tests/unit/screenshot-cache-query-gc.test.ts
@@ -362,6 +362,17 @@ describe("gcCache — orphan sweep (R11)", () => {
     expect(fs.existsSync(path.join(root, `${id}.json`))).toBe(false);
   });
 
+  it("reclaims a stale partial sidecar write ({id}.json.<hex>.tmp) older than grace", () => {
+    const root = getScreenshotCacheRoot(env);
+    const tmp = path.join(root, "abcd1234-0000000000000001.json.deadbeef.tmp");
+    fs.writeFileSync(tmp, "{partial", { flag: "wx" });
+    const old = (NOW - 60 * 60 * 1000) / 1000;
+    fs.utimesSync(tmp, old, old);
+    const r = gcCache({ dryRun: false, policy: {}, includeOrphans: true, now: NOW }, env);
+    expect(r.orphans.count).toBe(1);
+    expect(fs.existsSync(tmp)).toBe(false);
+  });
+
   it("NEVER reclaims foreign files in a shared cache dir (settings.json / other.tmp / non-id image) — Codex P2", () => {
     const root = getScreenshotCacheRoot(env);
     fs.writeFileSync(path.join(root, "settings.json"), JSON.stringify({ theme: "dark" }), { flag: "wx" });

--- a/tests/unit/screenshot-cache-query-gc.test.ts
+++ b/tests/unit/screenshot-cache-query-gc.test.ts
@@ -11,7 +11,6 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import crypto from "node:crypto";
 
 import {
   persistCapture,
@@ -32,7 +31,9 @@ let cacheDir: string;
 let env: NodeJS.ProcessEnv;
 
 beforeEach(() => {
-  cacheDir = path.join(os.tmpdir(), `dt-qg-test-${crypto.randomBytes(6).toString("hex")}`);
+  // mkdtempSync (not path.join + random) so the cache dir is a securely-created
+  // temp dir — CodeQL js/insecure-temporary-file is satisfied for writes into it.
+  cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "dt-qg-test-"));
   // Auto-prune OFF by default so seeded counts are deterministic.
   env = { DESKTOP_TOUCH_SCREENSHOTS_DIR: cacheDir, DESKTOP_TOUCH_SCREENSHOT_AUTOPRUNE: "0" };
   _resetAutoPruneCounterForTest();
@@ -220,6 +221,26 @@ describe("deleteCapture — secure delete (AC3)", () => {
     const r = deleteCapture("x", env);
     expect(r).toEqual({ bytes: 42, deleted: true });
     expect(fs.existsSync(path.join(root, "x.png"))).toBe(false);
+  });
+
+  it("removes the index entry too, so query stops listing it (Codex P2)", () => {
+    const root = getScreenshotCacheRoot(env);
+    seed(root, { captureId: "g1", ts: NOW, bytes: 5 });
+    seed(root, { captureId: "g2", ts: NOW - 1, bytes: 5 });
+    expect(deleteCapture("g1", env).deleted).toBe(true);
+    expect(readIndex(root).has("g1")).toBe(false);
+    expect(queryCaptures({}, env).captures.map((c) => c.captureId)).toEqual(["g2"]);
+  });
+
+  it("cleans a dangling index entry (file already gone) so query stops listing it", () => {
+    const root = getScreenshotCacheRoot(env);
+    fs.appendFileSync(
+      path.join(root, "_index.ndjson"),
+      JSON.stringify({ captureId: "dang", ts: 1, bytes: 1, file: "dang.png", mimeType: "image/png", width: 1, height: 1 }) + "\n",
+    );
+    expect(readIndex(root).has("dang")).toBe(true);
+    expect(deleteCapture("dang", env)).toEqual({ bytes: 0, deleted: false });
+    expect(readIndex(root).has("dang")).toBe(false); // stale entry cleaned (R2 P2)
   });
 
   it("a dangling captureId (file already gone) → {deleted:false}, never throws", () => {

--- a/tests/unit/screenshot-cache-query-gc.test.ts
+++ b/tests/unit/screenshot-cache-query-gc.test.ts
@@ -339,6 +339,22 @@ describe("gcCache — orphan sweep (R11)", () => {
     expect(r.orphans.count).toBe(0);
     expect(fs.existsSync(path.join(root, "_index.ndjson"))).toBe(true);
   });
+
+  it("orphan grace is FIXED, not raised by maxAgeMs (Codex P2)", () => {
+    // A multi-day capture-retention policy must NOT keep unreadable orphan residue
+    // on disk for days — the orphan grace is only the short append-race window.
+    const root = getScreenshotCacheRoot(env);
+    const orphan = path.join(root, "orphanX.png");
+    fs.writeFileSync(orphan, Buffer.alloc(32), { flag: "wx" });
+    const old = (NOW - 60 * 60 * 1000) / 1000; // 1h old: > 5min grace, << maxAgeMs(7d)
+    fs.utimesSync(orphan, old, old);
+    const r = gcCache(
+      { dryRun: false, policy: { maxAgeMs: 7 * 24 * 3600 * 1000 }, includeOrphans: true, now: NOW },
+      env,
+    );
+    expect(r.orphans.count).toBe(1); // reclaimed despite the 7-day retention policy
+    expect(fs.existsSync(orphan)).toBe(false);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/unit/screenshot-cache-query-gc.test.ts
+++ b/tests/unit/screenshot-cache-query-gc.test.ts
@@ -27,6 +27,9 @@ import {
   type IndexEntry,
 } from "../../src/engine/screenshot-cache.js";
 
+/** 短いラベル → strict captureId (base36 + 16 hex)。CAPTURE_ID_RE 準拠。 */
+const cid = (label: string): string => `${label}-0000000000000000`;
+
 let cacheDir: string;
 let env: NodeJS.ProcessEnv;
 
@@ -42,8 +45,9 @@ afterEach(() => {
   try { fs.rmSync(cacheDir, { recursive: true, force: true }); } catch { /* ignore */ }
 });
 
-/** Seed a real, deletable capture: write a file of `bytes` length + append the
- *  raw index entry with explicit ts (deterministic ordering). Returns the entry. */
+/** Seed a real, deletable capture: write the image of `bytes` length + its metadata
+ *  sidecar `{id}.json` with explicit ts (deterministic ordering). Returns the entry.
+ *  flag:"wx" = exclusive create (CodeQL js/insecure-temporary-file, Phase 1 pattern). */
 function seed(
   root: string,
   e: { captureId: string; ts: number; bytes: number; tag?: string; windowUuid?: string; processName?: string; mimeType?: string },
@@ -51,8 +55,6 @@ function seed(
   const mimeType = e.mimeType ?? "image/png";
   const ext = mimeType === "image/webp" ? "webp" : mimeType === "image/jpeg" ? "jpg" : "png";
   const file = `${e.captureId}.${ext}`;
-  // flag:"wx" = exclusive create — refuse to follow a pre-planted file/symlink
-  // in the shared temp dir (CodeQL js/insecure-temporary-file, Phase 1 pattern).
   fs.writeFileSync(path.join(root, file), Buffer.alloc(e.bytes), { mode: 0o600, flag: "wx" });
   const entry: IndexEntry = {
     captureId: e.captureId, ts: e.ts, bytes: e.bytes, file, mimeType, width: 4, height: 4,
@@ -60,8 +62,24 @@ function seed(
     ...(e.windowUuid !== undefined ? { windowUuid: e.windowUuid } : {}),
     ...(e.processName !== undefined ? { processName: e.processName } : {}),
   };
-  fs.appendFileSync(path.join(root, "_index.ndjson"), JSON.stringify(entry) + "\n");
+  fs.writeFileSync(path.join(root, `${e.captureId}.json`), JSON.stringify(entry), { mode: 0o600, flag: "wx" });
   return entry;
+}
+
+/** Write a raw metadata sidecar directly (for security tests that need a controlled
+ *  or hostile entry whose image may not exist). */
+function writeRawSidecar(root: string, captureId: string, entry: Record<string, unknown>): void {
+  fs.writeFileSync(path.join(root, `${captureId}.json`), JSON.stringify(entry), { mode: 0o600, flag: "wx" });
+}
+
+function expectRefCode(fn: () => unknown, code: string): void {
+  try {
+    fn();
+    throw new Error(`expected CaptureRefError(${code}) but nothing threw`);
+  } catch (e) {
+    expect(e).toBeInstanceOf(CaptureRefError);
+    expect((e as CaptureRefError).code).toBe(code);
+  }
 }
 
 const NOW = 1_000_000_000_000;
@@ -78,14 +96,14 @@ describe("normalizeCacheTag (seed defect #9)", () => {
 describe("queryCaptures (AC4 — index walk, filters, no path leak)", () => {
   it("lists newest-first with whole-cache stats and an opaque uri (no file/abs path)", () => {
     const root = getScreenshotCacheRoot(env);
-    seed(root, { captureId: "a", ts: NOW - 300, bytes: 10 });
-    seed(root, { captureId: "b", ts: NOW - 100, bytes: 20 });
-    seed(root, { captureId: "c", ts: NOW - 200, bytes: 30 });
+    seed(root, { captureId: cid("a"), ts: NOW - 300, bytes: 10 });
+    seed(root, { captureId: cid("b"), ts: NOW - 100, bytes: 20 });
+    seed(root, { captureId: cid("c"), ts: NOW - 200, bytes: 30 });
 
     const r = queryCaptures({}, env);
     expect(r.total).toBe(3);
     expect(r.count).toBe(3);
-    expect(r.captures.map((x) => x.captureId)).toEqual(["b", "c", "a"]); // newest-first
+    expect(r.captures.map((x) => x.captureId)).toEqual([cid("b"), cid("c"), cid("a")]); // newest-first
     expect(r.cache).toEqual({ totalCaptures: 3, totalBytes: 60 });
 
     const first = r.captures[0]!;
@@ -97,24 +115,24 @@ describe("queryCaptures (AC4 — index walk, filters, no path leak)", () => {
 
   it("tag filter is case-insensitive and still walks the full index (seed defect #8)", () => {
     const root = getScreenshotCacheRoot(env);
-    seed(root, { captureId: "a", ts: NOW - 1, bytes: 1, tag: "Roi-5" });
-    seed(root, { captureId: "b", ts: NOW - 2, bytes: 1, tag: "other" });
+    seed(root, { captureId: cid("a"), ts: NOW - 1, bytes: 1, tag: "Roi-5" });
+    seed(root, { captureId: cid("b"), ts: NOW - 2, bytes: 1, tag: "other" });
     const r = queryCaptures({ tag: "ROI-5" }, env);
-    expect(r.captures.map((x) => x.captureId)).toEqual(["a"]);
+    expect(r.captures.map((x) => x.captureId)).toEqual([cid("a")]);
   });
 
   it("windowUuid / since / until / limit / offset are all honored", () => {
     const root = getScreenshotCacheRoot(env);
-    seed(root, { captureId: "old", ts: NOW - 1000, bytes: 1, windowUuid: "w1" });
-    seed(root, { captureId: "mid", ts: NOW - 500, bytes: 1, windowUuid: "w1" });
-    seed(root, { captureId: "new", ts: NOW - 100, bytes: 1, windowUuid: "w2" });
+    seed(root, { captureId: cid("old"), ts: NOW - 1000, bytes: 1, windowUuid: "w1" });
+    seed(root, { captureId: cid("mid"), ts: NOW - 500, bytes: 1, windowUuid: "w1" });
+    seed(root, { captureId: cid("new"), ts: NOW - 100, bytes: 1, windowUuid: "w2" });
 
     expect(queryCaptures({ windowUuid: "w1" }, env).captures.map((x) => x.captureId).sort())
-      .toEqual(["mid", "old"]);
+      .toEqual([cid("mid"), cid("old")]);
     expect(queryCaptures({ since: NOW - 600, until: NOW - 200 }, env).captures.map((x) => x.captureId))
-      .toEqual(["mid"]);
+      .toEqual([cid("mid")]);
     // limit/offset over the newest-first ordering [new, mid, old]
-    expect(queryCaptures({ limit: 1, offset: 1 }, env).captures.map((x) => x.captureId)).toEqual(["mid"]);
+    expect(queryCaptures({ limit: 1, offset: 1 }, env).captures.map((x) => x.captureId)).toEqual([cid("mid")]);
     expect(queryCaptures({ limit: 1 }, env).total).toBe(3); // total is pre-page
   });
 });
@@ -123,59 +141,59 @@ describe("queryCaptures (AC4 — index walk, filters, no path leak)", () => {
 describe("gcCache — retention policy union (R2)", () => {
   it("maxCount keeps the newest N and lists the rest as candidates (dryRun: no delete)", () => {
     const root = getScreenshotCacheRoot(env);
-    seed(root, { captureId: "n1", ts: NOW - 100, bytes: 1 });
-    seed(root, { captureId: "n2", ts: NOW - 200, bytes: 1 });
-    seed(root, { captureId: "n3", ts: NOW - 300, bytes: 1 });
+    seed(root, { captureId: cid("n1"), ts: NOW - 100, bytes: 1 });
+    seed(root, { captureId: cid("n2"), ts: NOW - 200, bytes: 1 });
+    seed(root, { captureId: cid("n3"), ts: NOW - 300, bytes: 1 });
 
     const r = gcCache({ dryRun: true, policy: { maxCount: 1 }, includeOrphans: false, now: NOW }, env);
-    expect(r.candidates.map((c) => c.captureId).sort()).toEqual(["n2", "n3"]);
+    expect(r.candidates.map((c) => c.captureId).sort()).toEqual([cid("n2"), cid("n3")]);
     expect(r.candidates.every((c) => c.reason === "max_count")).toBe(true);
     expect(r.deleted).toBe(0); // dryRun
     expect(readIndex(root).size).toBe(3); // nothing removed
-    expect(fs.existsSync(path.join(root, "n2.png"))).toBe(true);
+    expect(fs.existsSync(path.join(root, `${cid("n2")}.png`))).toBe(true);
   });
 
   it("maxAgeMs marks entries older than the window", () => {
     const root = getScreenshotCacheRoot(env);
-    seed(root, { captureId: "fresh", ts: NOW - 1000, bytes: 1 });
-    seed(root, { captureId: "stale", ts: NOW - 60_000, bytes: 1 });
+    seed(root, { captureId: cid("fresh"), ts: NOW - 1000, bytes: 1 });
+    seed(root, { captureId: cid("stale"), ts: NOW - 60_000, bytes: 1 });
     const r = gcCache({ dryRun: true, policy: { maxAgeMs: 10_000 }, includeOrphans: false, now: NOW }, env);
-    expect(r.candidates.map((c) => c.captureId)).toEqual(["stale"]);
+    expect(r.candidates.map((c) => c.captureId)).toEqual([cid("stale")]);
     expect(r.candidates[0]!.reason).toBe("max_age");
   });
 
   it("tag scope only ever considers the matching tag's captures", () => {
     const root = getScreenshotCacheRoot(env);
-    seed(root, { captureId: "k1", ts: NOW - 100, bytes: 1, tag: "keep" });
-    seed(root, { captureId: "d1", ts: NOW - 200, bytes: 1, tag: "DROP" });
-    seed(root, { captureId: "d2", ts: NOW - 300, bytes: 1, tag: "drop" });
+    seed(root, { captureId: cid("k1"), ts: NOW - 100, bytes: 1, tag: "keep" });
+    seed(root, { captureId: cid("d1"), ts: NOW - 200, bytes: 1, tag: "DROP" });
+    seed(root, { captureId: cid("d2"), ts: NOW - 300, bytes: 1, tag: "drop" });
     // age cap CAN clear the whole tag (unlike count/byte which keep the newest);
     // case-folded 'drop' scope must leave 'keep' entirely untouched.
     const r = gcCache({ dryRun: true, policy: { maxAgeMs: 0, tag: "drop" }, includeOrphans: false, now: NOW }, env);
-    expect(r.candidates.map((c) => c.captureId).sort()).toEqual(["d1", "d2"]);
+    expect(r.candidates.map((c) => c.captureId).sort()).toEqual([cid("d1"), cid("d2")]);
   });
 
   it("count/byte caps keep the newest of a tag scope; age cap can clear it (keep-newest asymmetry)", () => {
     const root = getScreenshotCacheRoot(env);
-    seed(root, { captureId: "d1", ts: NOW - 200, bytes: 1, tag: "drop" });
-    seed(root, { captureId: "d2", ts: NOW - 300, bytes: 1, tag: "drop" });
+    seed(root, { captureId: cid("d1"), ts: NOW - 200, bytes: 1, tag: "drop" });
+    seed(root, { captureId: cid("d2"), ts: NOW - 300, bytes: 1, tag: "drop" });
     // maxCount:0 is clamped to max(1,0) → newest of the tag (d1) is kept.
     const r = gcCache({ dryRun: true, policy: { maxCount: 0, tag: "drop" }, includeOrphans: false, now: NOW }, env);
-    expect(r.candidates.map((c) => c.captureId)).toEqual(["d2"]);
+    expect(r.candidates.map((c) => c.captureId)).toEqual([cid("d2")]);
   });
 
   it("dryRun:false actually deletes, rewrites the index, and query no longer returns them", () => {
     const root = getScreenshotCacheRoot(env);
-    seed(root, { captureId: "n1", ts: NOW - 100, bytes: 5 });
-    seed(root, { captureId: "n2", ts: NOW - 200, bytes: 7 });
-    seed(root, { captureId: "n3", ts: NOW - 300, bytes: 9 });
+    seed(root, { captureId: cid("n1"), ts: NOW - 100, bytes: 5 });
+    seed(root, { captureId: cid("n2"), ts: NOW - 200, bytes: 7 });
+    seed(root, { captureId: cid("n3"), ts: NOW - 300, bytes: 9 });
 
     const r = gcCache({ dryRun: false, policy: { maxCount: 1 }, includeOrphans: false, now: NOW }, env);
     expect(r.deleted).toBe(2);
     expect(r.reclaimedBytes).toBe(16); // 7 + 9
-    expect(fs.existsSync(path.join(root, "n2.png"))).toBe(false);
-    expect(fs.existsSync(path.join(root, "n1.png"))).toBe(true);
-    expect(queryCaptures({}, env).captures.map((x) => x.captureId)).toEqual(["n1"]);
+    expect(fs.existsSync(path.join(root, `${cid("n2")}.png`))).toBe(false);
+    expect(fs.existsSync(path.join(root, `${cid("n1")}.png`))).toBe(true);
+    expect(queryCaptures({}, env).captures.map((x) => x.captureId)).toEqual([cid("n1")]);
     expect(r.remaining.count).toBe(1);
   });
 });
@@ -184,32 +202,32 @@ describe("gcCache — retention policy union (R2)", () => {
 describe("gcCache — keep-newest invariant (P1-1)", () => {
   it("byte cap NEVER deletes the newest entry, even when it alone exceeds the cap", () => {
     const root = getScreenshotCacheRoot(env);
-    seed(root, { captureId: "solo", ts: NOW, bytes: 100 });
+    seed(root, { captureId: cid("solo"), ts: NOW, bytes: 100 });
     const r = gcCache({ dryRun: true, policy: { maxTotalBytes: 50 }, includeOrphans: false, now: NOW }, env);
     expect(r.candidates).toEqual([]); // rank 0 is structurally kept
   });
 
   it("byte cap reduces older entries while keeping rank 0 + the running cap", () => {
     const root = getScreenshotCacheRoot(env);
-    seed(root, { captureId: "new", ts: NOW - 100, bytes: 100 });
-    seed(root, { captureId: "mid", ts: NOW - 200, bytes: 100 });
-    seed(root, { captureId: "old", ts: NOW - 300, bytes: 100 });
+    seed(root, { captureId: cid("new"), ts: NOW - 100, bytes: 100 });
+    seed(root, { captureId: cid("mid"), ts: NOW - 200, bytes: 100 });
+    seed(root, { captureId: cid("old"), ts: NOW - 300, bytes: 100 });
     // cap 150: keep new (rank0, sum 100<=150); mid rank1 sum 200>150 → drop; old drop.
     const r = gcCache({ dryRun: true, policy: { maxTotalBytes: 150 }, includeOrphans: false, now: NOW }, env);
-    expect(r.candidates.map((c) => c.captureId).sort()).toEqual(["mid", "old"]);
+    expect(r.candidates.map((c) => c.captureId).sort()).toEqual([cid("mid"), cid("old")]);
     expect(r.candidates.every((c) => c.reason === "max_total_bytes")).toBe(true);
   });
 
   it("protectCaptureId excludes a specific id from ALL caps", () => {
     const root = getScreenshotCacheRoot(env);
-    seed(root, { captureId: "new", ts: NOW - 100, bytes: 100 });
-    seed(root, { captureId: "mid", ts: NOW - 200, bytes: 100 });
-    seed(root, { captureId: "old", ts: NOW - 300, bytes: 100 });
+    seed(root, { captureId: cid("new"), ts: NOW - 100, bytes: 100 });
+    seed(root, { captureId: cid("mid"), ts: NOW - 200, bytes: 100 });
+    seed(root, { captureId: cid("old"), ts: NOW - 300, bytes: 100 });
     const r = gcCache(
-      { dryRun: true, policy: { maxTotalBytes: 150 }, includeOrphans: false, now: NOW, protectCaptureId: "old" },
+      { dryRun: true, policy: { maxTotalBytes: 150 }, includeOrphans: false, now: NOW, protectCaptureId: cid("old") },
       env,
     );
-    expect(r.candidates.map((c) => c.captureId)).toEqual(["mid"]); // old protected
+    expect(r.candidates.map((c) => c.captureId)).toEqual([cid("mid")]); // old protected
   });
 });
 
@@ -217,53 +235,46 @@ describe("gcCache — keep-newest invariant (P1-1)", () => {
 describe("deleteCapture — secure delete (AC3)", () => {
   it("deletes a real capture and reports the reclaimed bytes", () => {
     const root = getScreenshotCacheRoot(env);
-    seed(root, { captureId: "x", ts: NOW, bytes: 42 });
-    const r = deleteCapture("x", env);
+    seed(root, { captureId: cid("x"), ts: NOW, bytes: 42 });
+    const r = deleteCapture(cid("x"), env);
     expect(r).toEqual({ bytes: 42, deleted: true });
-    expect(fs.existsSync(path.join(root, "x.png"))).toBe(false);
+    expect(fs.existsSync(path.join(root, `${cid("x")}.png`))).toBe(false);
   });
 
   it("removes the index entry too, so query stops listing it (Codex P2)", () => {
     const root = getScreenshotCacheRoot(env);
-    seed(root, { captureId: "g1", ts: NOW, bytes: 5 });
-    seed(root, { captureId: "g2", ts: NOW - 1, bytes: 5 });
-    expect(deleteCapture("g1", env).deleted).toBe(true);
-    expect(readIndex(root).has("g1")).toBe(false);
-    expect(queryCaptures({}, env).captures.map((c) => c.captureId)).toEqual(["g2"]);
+    seed(root, { captureId: cid("g1"), ts: NOW, bytes: 5 });
+    seed(root, { captureId: cid("g2"), ts: NOW - 1, bytes: 5 });
+    expect(deleteCapture(cid("g1"), env).deleted).toBe(true);
+    expect(readIndex(root).has(cid("g1"))).toBe(false);
+    expect(queryCaptures({}, env).captures.map((c) => c.captureId)).toEqual([cid("g2")]);
   });
 
-  it("cleans a dangling index entry (file already gone) so query stops listing it", () => {
+  it("a dangling sidecar (image gone) is never listed, and delete removes the sidecar (R2 P2)", () => {
     const root = getScreenshotCacheRoot(env);
-    fs.appendFileSync(
-      path.join(root, "_index.ndjson"),
-      JSON.stringify({ captureId: "dang", ts: 1, bytes: 1, file: "dang.png", mimeType: "image/png", width: 1, height: 1 }) + "\n",
-    );
-    expect(readIndex(root).has("dang")).toBe(true);
-    expect(deleteCapture("dang", env)).toEqual({ bytes: 0, deleted: false });
-    expect(readIndex(root).has("dang")).toBe(false); // stale entry cleaned (R2 P2)
+    writeRawSidecar(root, cid("dang"), { captureId: cid("dang"), ts: 1, bytes: 1, file: `${cid("dang")}.png`, mimeType: "image/png", width: 1, height: 1 });
+    // readIndex excludes a sidecar whose image is missing — query never shows a dead ref.
+    expect(readIndex(root).has(cid("dang"))).toBe(false);
+    expect(fs.existsSync(path.join(root, `${cid("dang")}.json`))).toBe(true);
+    expect(deleteCapture(cid("dang"), env)).toEqual({ bytes: 0, deleted: false });
+    expect(fs.existsSync(path.join(root, `${cid("dang")}.json`))).toBe(false); // orphan sidecar cleaned
   });
 
-  it("a dangling captureId (file already gone) → {deleted:false}, never throws", () => {
+  it("a dangling captureId (image already gone) → {deleted:false}, never throws", () => {
     const root = getScreenshotCacheRoot(env);
-    fs.appendFileSync(
-      path.join(root, "_index.ndjson"),
-      JSON.stringify({ captureId: "gone", ts: 1, bytes: 1, file: "gone.png", mimeType: "image/png", width: 1, height: 1 }) + "\n",
-    );
-    expect(deleteCapture("gone", env)).toEqual({ bytes: 0, deleted: false });
+    writeRawSidecar(root, cid("gone"), { captureId: cid("gone"), ts: 1, bytes: 1, file: `${cid("gone")}.png`, mimeType: "image/png", width: 1, height: 1 });
+    expect(deleteCapture(cid("gone"), env)).toEqual({ bytes: 0, deleted: false });
   });
 
-  it("an index entry pointing outside the cache (traversal) is never unlinked", () => {
+  it("a sidecar whose image path escapes the cache (traversal) never unlinks the victim", () => {
     const root = getScreenshotCacheRoot(env);
     const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "dt-qg-outside-"));
     const victim = path.join(outsideDir, "victim.png");
     fs.writeFileSync(victim, Buffer.alloc(3), { flag: "wx" });
     const rel = path.relative(root, victim); // ..\..\<tmp>\victim.png
-    fs.appendFileSync(
-      path.join(root, "_index.ndjson"),
-      JSON.stringify({ captureId: "evil", ts: 1, bytes: 1, file: rel, mimeType: "image/png", width: 1, height: 1 }) + "\n",
-    );
+    writeRawSidecar(root, cid("evil"), { captureId: cid("evil"), ts: 1, bytes: 1, file: rel, mimeType: "image/png", width: 1, height: 1 });
     try {
-      expect(() => deleteCapture("evil", env)).toThrow(CaptureRefError);
+      expect(() => deleteCapture(cid("evil"), env)).toThrow(CaptureRefError);
       expect(fs.existsSync(victim)).toBe(true); // the out-of-cache file is untouched
     } finally {
       fs.rmSync(outsideDir, { recursive: true, force: true });
@@ -273,14 +284,11 @@ describe("deleteCapture — secure delete (AC3)", () => {
   it("no thrown cache error message leaks the absolute cache path (R9 intent)", () => {
     getScreenshotCacheRoot(env);
     let msg = "";
-    try { deleteCapture("not-a-real-id", env); } catch (e) { msg = (e as Error).message; }
-    // unknown id is {deleted:false} not a throw, so assert via a traversal entry:
+    try { deleteCapture(cid("notarealid"), env); } catch (e) { msg = (e as Error).message; }
+    // unknown id is {deleted:false} not a throw, so assert via a traversal sidecar:
     const root = getScreenshotCacheRoot(env);
-    fs.appendFileSync(
-      path.join(root, "_index.ndjson"),
-      JSON.stringify({ captureId: "t", ts: 1, bytes: 1, file: "../x.png", mimeType: "image/png", width: 1, height: 1 }) + "\n",
-    );
-    try { deleteCapture("t", env); } catch (e) { msg = (e as Error).message; }
+    writeRawSidecar(root, cid("tt"), { captureId: cid("tt"), ts: 1, bytes: 1, file: "../x.png", mimeType: "image/png", width: 1, height: 1 });
+    try { deleteCapture(cid("tt"), env); } catch (e) { msg = (e as Error).message; }
     expect(msg).not.toContain(cacheDir);
   });
 
@@ -290,11 +298,11 @@ describe("deleteCapture — secure delete (AC3)", () => {
     "a non-ENOENT read failure (EACCES) coerces to opaque `unreadable`, no path leaked (R9)",
     () => {
       const root = getScreenshotCacheRoot(env);
-      const e = seed(root, { captureId: "noperm", ts: NOW, bytes: 8 });
+      const e = seed(root, { captureId: cid("noperm"), ts: NOW, bytes: 8 });
       const file = path.join(root, e.file);
       fs.chmodSync(file, 0o000); // owner loses read → openSync(O_RDONLY) → EACCES
       let err: unknown;
-      try { readCaptureBytes("noperm", env); } catch (x) { err = x; }
+      try { readCaptureBytes(cid("noperm"), env); } catch (x) { err = x; }
       try { fs.chmodSync(file, 0o600); } catch { /* restore so afterEach rm works */ }
       if (err === undefined) return; // running as root → EACCES unenforceable, skip the assertion
       expect(err).toBeInstanceOf(CaptureRefError);
@@ -308,8 +316,9 @@ describe("deleteCapture — secure delete (AC3)", () => {
 describe("gcCache — orphan sweep (R11)", () => {
   it("reclaims an on-disk image file with no index entry once older than the grace window", () => {
     const root = getScreenshotCacheRoot(env);
-    // a true orphan: file on disk, NOT in the index (crash residue / fold orphan).
-    const orphan = path.join(root, "orphan123.png");
+    // a true orphan IMAGE named like a real captureId, NOT paired with a sidecar.
+    const orphanId = "orphan1-0000000000000064";
+    const orphan = path.join(root, `${orphanId}.png`);
     fs.writeFileSync(orphan, Buffer.alloc(64), { flag: "wx" });
     const old = (NOW - 60 * 60 * 1000) / 1000; // 1h old (> 5min grace)
     fs.utimesSync(orphan, old, old);
@@ -319,12 +328,12 @@ describe("gcCache — orphan sweep (R11)", () => {
     expect(r.orphans.bytes).toBe(64);
     expect(fs.existsSync(orphan)).toBe(false);
     // orphans are aggregate-only — no basename in the result JSON (P2-2).
-    expect(JSON.stringify(r).includes("orphan123")).toBe(false);
+    expect(JSON.stringify(r).includes(orphanId)).toBe(false);
   });
 
-  it("does NOT reclaim a fresh orphan (within the grace window — index-append may be imminent)", () => {
+  it("does NOT reclaim a fresh orphan (within the grace window — a sibling write may be imminent)", () => {
     const root = getScreenshotCacheRoot(env);
-    const fresh = path.join(root, "fresh999.png");
+    const fresh = path.join(root, "fresh01-000000000000000a.png");
     fs.writeFileSync(fresh, Buffer.alloc(10), { flag: "wx" });
     fs.utimesSync(fresh, NOW / 1000, NOW / 1000); // mtime == now
     const r = gcCache({ dryRun: false, policy: {}, includeOrphans: true, now: NOW }, env);
@@ -332,19 +341,53 @@ describe("gcCache — orphan sweep (R11)", () => {
     expect(fs.existsSync(fresh)).toBe(true);
   });
 
-  it("ignores the index file and never treats it as an orphan", () => {
+  it("a live capture's image + sidecar are never treated as orphans", () => {
     const root = getScreenshotCacheRoot(env);
-    seed(root, { captureId: "real", ts: NOW, bytes: 1 });
+    seed(root, { captureId: cid("real"), ts: NOW, bytes: 1 });
     const r = gcCache({ dryRun: false, policy: {}, includeOrphans: true, now: NOW }, env);
     expect(r.orphans.count).toBe(0);
-    expect(fs.existsSync(path.join(root, "_index.ndjson"))).toBe(true);
+    expect(fs.existsSync(path.join(root, `${cid("real")}.png`))).toBe(true);
+    expect(fs.existsSync(path.join(root, `${cid("real")}.json`))).toBe(true);
+  });
+
+  it("reclaims an orphan SIDECAR whose image is gone (older than grace)", () => {
+    const root = getScreenshotCacheRoot(env);
+    // a captureId-named sidecar with no image (crash during a delete, or half-write).
+    const id = "orphsc1-000000000000003c";
+    writeRawSidecar(root, id, { captureId: id, ts: 1, bytes: 1, file: `${id}.png`, mimeType: "image/png", width: 1, height: 1 });
+    const old = (NOW - 60 * 60 * 1000) / 1000;
+    fs.utimesSync(path.join(root, `${id}.json`), old, old);
+    const r = gcCache({ dryRun: false, policy: {}, includeOrphans: true, now: NOW }, env);
+    expect(r.orphans.count).toBe(1);
+    expect(fs.existsSync(path.join(root, `${id}.json`))).toBe(false);
+  });
+
+  it("NEVER reclaims foreign files in a shared cache dir (settings.json / other.tmp / non-id image) — Codex P2", () => {
+    const root = getScreenshotCacheRoot(env);
+    fs.writeFileSync(path.join(root, "settings.json"), JSON.stringify({ theme: "dark" }), { flag: "wx" });
+    fs.writeFileSync(path.join(root, "other.tmp"), "x", { flag: "wx" });
+    fs.writeFileSync(path.join(root, "photo.png"), Buffer.alloc(5), { flag: "wx" }); // not a captureId name
+    const old = (NOW - 60 * 60 * 1000) / 1000;
+    for (const n of ["settings.json", "other.tmp", "photo.png"]) fs.utimesSync(path.join(root, n), old, old);
+    const r = gcCache({ dryRun: false, policy: {}, includeOrphans: true, now: NOW }, env);
+    expect(r.orphans.count).toBe(0);
+    expect(fs.existsSync(path.join(root, "settings.json"))).toBe(true);
+    expect(fs.existsSync(path.join(root, "other.tmp"))).toBe(true);
+    expect(fs.existsSync(path.join(root, "photo.png"))).toBe(true);
+  });
+
+  it("deleteCapture NEVER unlinks a foreign {id}.json (Codex P2)", () => {
+    const root = getScreenshotCacheRoot(env);
+    fs.writeFileSync(path.join(root, "settings.json"), JSON.stringify({ theme: "dark" }), { flag: "wx" });
+    expect(deleteCapture(cid("settings"), env)).toEqual({ bytes: 0, deleted: false });
+    expect(fs.existsSync(path.join(root, "settings.json"))).toBe(true);
   });
 
   it("orphan grace is FIXED, not raised by maxAgeMs (Codex P2)", () => {
     // A multi-day capture-retention policy must NOT keep unreadable orphan residue
     // on disk for days — the orphan grace is only the short append-race window.
     const root = getScreenshotCacheRoot(env);
-    const orphan = path.join(root, "orphanX.png");
+    const orphan = path.join(root, "orphan2-0000000000000020.png");
     fs.writeFileSync(orphan, Buffer.alloc(32), { flag: "wx" });
     const old = (NOW - 60 * 60 * 1000) / 1000; // 1h old: > 5min grace, << maxAgeMs(7d)
     fs.utimesSync(orphan, old, old);
@@ -358,19 +401,43 @@ describe("gcCache — orphan sweep (R11)", () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-describe("index lock — stale steal (Codex P1/P2)", () => {
-  it("steals a stale lock past the stale window instead of waiting/hanging", () => {
+describe("per-capture sidecar storage (lock-free cross-process correctness)", () => {
+  it("a delete removes BOTH the image and its sidecar (no shared index to rewrite)", () => {
     const root = getScreenshotCacheRoot(env);
-    // Plant a stale lock file (mtime well past the 10s stale window).
-    const lockPath = path.join(root, "_index.lock");
-    fs.writeFileSync(lockPath, "", { flag: "wx" });
-    const old = (Date.now() - 60_000) / 1000;
-    fs.utimesSync(lockPath, old, old);
-    // A persist takes the index lock for its append — it must steal the stale lock
-    // and complete promptly (not spin on the wedged-lock path), and the entry must
-    // be indexed (the append ran under the stolen lock).
+    seed(root, { captureId: cid("t1"), ts: NOW, bytes: 5 });
+    expect(fs.existsSync(path.join(root, `${cid("t1")}.png`))).toBe(true);
+    expect(fs.existsSync(path.join(root, `${cid("t1")}.json`))).toBe(true);
+    deleteCapture(cid("t1"), env);
+    expect(fs.existsSync(path.join(root, `${cid("t1")}.png`))).toBe(false);
+    expect(fs.existsSync(path.join(root, `${cid("t1")}.json`))).toBe(false);
+    expect(readIndex(root).has(cid("t1"))).toBe(false);
+  });
+
+  it("a delete and a concurrent persist touch disjoint files — neither can lose the other", () => {
+    // The race lock/tombstone designs had to guard does not exist: there is no shared
+    // mutable file. Deleting 'drop' only unlinks drop.{png,json}; persisting writes a
+    // brand-new {id}.{png,json} pair — they cannot interfere even across processes.
+    const root = getScreenshotCacheRoot(env);
+    seed(root, { captureId: cid("drop"), ts: NOW, bytes: 5 });
+    deleteCapture(cid("drop"), env);
+    const fresh = persistCapture(Buffer.from([0x89, 0x50, 0x4e, 0x47, 1, 2, 3, 4]), { mimeType: "image/png", width: 4, height: 4 }, env);
+    const idx = readIndex(root);
+    expect(idx.has(cid("drop"))).toBe(false);
+    expect(idx.has(fresh.captureId)).toBe(true); // a fresh ref is never collateral to a delete
+  });
+
+  it("the sidecar is published atomically — readIndex never sees a partial write (no .tmp listed)", () => {
+    const root = getScreenshotCacheRoot(env);
     const r = persistCapture(Buffer.from([0x89, 0x50, 0x4e, 0x47, 1, 2, 3, 4]), { mimeType: "image/png", width: 4, height: 4 }, env);
+    // the live capture is listed; no leftover temp file remains in the dir.
     expect(readIndex(root).has(r.captureId)).toBe(true);
+    expect(fs.readdirSync(root).some((n) => n.endsWith(".tmp"))).toBe(false);
+  });
+
+  it("an invalid captureId (path traversal) is rejected before any fs join", () => {
+    getScreenshotCacheRoot(env);
+    expectRefCode(() => deleteCapture("../evil", env), "outside_cache");
+    expectRefCode(() => readCaptureBytes("a/b", env), "outside_cache");
   });
 });
 
@@ -389,7 +456,7 @@ describe("envDefaultPolicy + auto-prune (R2 / §3.6)", () => {
     };
     const root = getScreenshotCacheRoot(pruneEnv);
     // pre-seed 5 older captures (prior-session cruft).
-    for (let i = 0; i < 5; i++) seed(root, { captureId: `seed${i}`, ts: NOW - 10_000 - i, bytes: 1 });
+    for (let i = 0; i < 5; i++) seed(root, { captureId: cid(`seed${i}`), ts: NOW - 10_000 - i, bytes: 1 });
     _resetAutoPruneCounterForTest();
 
     const fresh = persistCapture(Buffer.from([0x89, 0x50, 0x4e, 0x47, 1, 2, 3, 4]), { mimeType: "image/png", width: 2, height: 2 }, pruneEnv);
@@ -401,7 +468,7 @@ describe("envDefaultPolicy + auto-prune (R2 / §3.6)", () => {
 
   it("DESKTOP_TOUCH_SCREENSHOT_AUTOPRUNE=0 disables auto-prune", () => {
     const root = getScreenshotCacheRoot(env); // env has AUTOPRUNE=0
-    for (let i = 0; i < 5; i++) seed(root, { captureId: `s${i}`, ts: NOW - i, bytes: 1 });
+    for (let i = 0; i < 5; i++) seed(root, { captureId: cid(`s${i}`), ts: NOW - i, bytes: 1 });
     _resetAutoPruneCounterForTest();
     persistCapture(Buffer.from([0x89, 0x50, 0x4e, 0x47, 1, 2, 3, 4]), { mimeType: "image/png", width: 1, height: 1 }, { ...env, DESKTOP_TOUCH_SCREENSHOT_MAX_COUNT: "2" });
     expect(readIndex(root).size).toBe(6); // 5 seeded + 1, nothing pruned

--- a/tests/unit/screenshot-cache-query-gc.test.ts
+++ b/tests/unit/screenshot-cache-query-gc.test.ts
@@ -342,6 +342,22 @@ describe("gcCache — orphan sweep (R11)", () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+describe("index lock — stale steal (Codex P1/P2)", () => {
+  it("steals a stale lock past the stale window instead of waiting/hanging", () => {
+    const root = getScreenshotCacheRoot(env);
+    // Plant a stale lock file (mtime well past the 10s stale window).
+    const lockPath = path.join(root, "_index.lock");
+    fs.writeFileSync(lockPath, "", { flag: "wx" });
+    const old = (Date.now() - 60_000) / 1000;
+    fs.utimesSync(lockPath, old, old);
+    // A persist takes the index lock for its append — it must steal the stale lock
+    // and complete promptly (not spin on the wedged-lock path), and the entry must
+    // be indexed (the append ran under the stolen lock).
+    const r = persistCapture(Buffer.from([0x89, 0x50, 0x4e, 0x47, 1, 2, 3, 4]), { mimeType: "image/png", width: 4, height: 4 }, env);
+    expect(readIndex(root).has(r.captureId)).toBe(true);
+  });
+});
+
 describe("envDefaultPolicy + auto-prune (R2 / §3.6)", () => {
   it("defaults: count + bytes caps active, age cap opt-in (absent)", () => {
     expect(envDefaultPolicy({})).toEqual({ maxCount: 200, maxTotalBytes: 256 * 1024 * 1024 });

--- a/tests/unit/screenshot-cache.test.ts
+++ b/tests/unit/screenshot-cache.test.ts
@@ -16,6 +16,9 @@ import {
   REF_URI_PREFIX,
 } from "../../src/engine/screenshot-cache.js";
 
+/** 短いラベル → strict captureId (base36 + 16 hex)。CAPTURE_ID_RE 準拠。 */
+const cid = (label: string): string => `${label}-0000000000000000`;
+
 let cacheDir: string;
 let env: NodeJS.ProcessEnv;
 
@@ -29,8 +32,9 @@ afterEach(() => {
 
 const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3, 4]);
 
-function appendRawIndex(root: string, entry: object): void {
-  fs.appendFileSync(path.join(root, "_index.ndjson"), JSON.stringify(entry) + "\n");
+/** Write a raw metadata sidecar `{captureId}.json` directly (controlled/hostile entry). */
+function appendRawIndex(root: string, entry: { captureId: string; [k: string]: unknown }): void {
+  fs.writeFileSync(path.join(root, `${entry.captureId}.json`), JSON.stringify(entry), { mode: 0o600, flag: "wx" });
 }
 
 function expectRefCode(fn: () => unknown, code: CaptureRefCode): void {
@@ -82,34 +86,34 @@ describe("screenshot-cache — persist + read round-trip", () => {
 describe("screenshot-cache — security (ADR-026 §4 / AC3 path traversal)", () => {
   it("unknown captureId → not_found", () => {
     getScreenshotCacheRoot(env);
-    expectRefCode(() => resolveCaptureFile("does-not-exist", env), "not_found");
+    expectRefCode(() => resolveCaptureFile(cid("doesnotexist"), env), "not_found");
   });
 
   it("index entry whose capture file was deleted (dangling ref) → not_found, not raw ENOENT", () => {
     // R7/AC3 (Codex P2): the index outlives a GC'd/deleted file. The raw ENOENT
     // from lstat must surface as the opaque not_found, never leak the abs path.
     const root = getScreenshotCacheRoot(env);
-    appendRawIndex(root, { captureId: "gone1", ts: 1, bytes: 1, file: "gone1.png", mimeType: "image/png", width: 1, height: 1 });
-    expectRefCode(() => resolveCaptureFile("gone1", env), "not_found");
+    appendRawIndex(root, { captureId: cid("gone1"), ts: 1, bytes: 1, file: `${cid("gone1")}.png`, mimeType: "image/png", width: 1, height: 1 });
+    expectRefCode(() => resolveCaptureFile(cid("gone1"), env), "not_found");
   });
 
   it("relative-traversal file name in index → outside_cache (basename rejection)", () => {
     const root = getScreenshotCacheRoot(env);
-    appendRawIndex(root, { captureId: "evil1", ts: 1, bytes: 1, file: "../evil.png", mimeType: "image/png", width: 1, height: 1 });
-    expectRefCode(() => resolveCaptureFile("evil1", env), "outside_cache");
+    appendRawIndex(root, { captureId: cid("evil1"), ts: 1, bytes: 1, file: "../evil.png", mimeType: "image/png", width: 1, height: 1 });
+    expectRefCode(() => resolveCaptureFile(cid("evil1"), env), "outside_cache");
   });
 
   it("absolute file name in index → outside_cache", () => {
     const root = getScreenshotCacheRoot(env);
     const abs = process.platform === "win32" ? "C:\\Windows\\System32\\drivers\\etc\\hosts" : "/etc/passwd";
-    appendRawIndex(root, { captureId: "evil2", ts: 1, bytes: 1, file: abs, mimeType: "image/png", width: 1, height: 1 });
-    expectRefCode(() => resolveCaptureFile("evil2", env), "outside_cache");
+    appendRawIndex(root, { captureId: cid("evil2"), ts: 1, bytes: 1, file: abs, mimeType: "image/png", width: 1, height: 1 });
+    expectRefCode(() => resolveCaptureFile(cid("evil2"), env), "outside_cache");
   });
 
   it("nested-separator file name in index → outside_cache", () => {
     const root = getScreenshotCacheRoot(env);
-    appendRawIndex(root, { captureId: "evil4", ts: 1, bytes: 1, file: "sub/evil.png", mimeType: "image/png", width: 1, height: 1 });
-    expectRefCode(() => resolveCaptureFile("evil4", env), "outside_cache");
+    appendRawIndex(root, { captureId: cid("evil4"), ts: 1, bytes: 1, file: "sub/evil.png", mimeType: "image/png", width: 1, height: 1 });
+    expectRefCode(() => resolveCaptureFile(cid("evil4"), env), "outside_cache");
   });
 
   it("isWithinRoot rejects the `screenshots_evil` sibling-prefix escape (path.relative, not startsWith)", () => {
@@ -130,8 +134,8 @@ describe("screenshot-cache — security (ADR-026 §4 / AC3 path traversal)", () 
   it("a directory whose basename is in the index → not_regular_file (not silently opened)", () => {
     const root = getScreenshotCacheRoot(env);
     fs.mkdirSync(path.join(root, "iamadir"));
-    appendRawIndex(root, { captureId: "dir1", ts: 1, bytes: 1, file: "iamadir", mimeType: "image/png", width: 1, height: 1 });
-    expectRefCode(() => resolveCaptureFile("dir1", env), "not_regular_file");
+    appendRawIndex(root, { captureId: cid("dir1"), ts: 1, bytes: 1, file: "iamadir", mimeType: "image/png", width: 1, height: 1 });
+    expectRefCode(() => resolveCaptureFile(cid("dir1"), env), "not_regular_file");
   });
 
   it("symlink inside the cache → symlink rejected (skipped where symlinks need privilege)", () => {
@@ -146,9 +150,9 @@ describe("screenshot-cache — security (ADR-026 §4 / AC3 path traversal)", () 
       fs.rmSync(outsideDir, { recursive: true, force: true });
       return; // no symlink privilege (e.g. Windows without Developer Mode) — skip
     }
-    appendRawIndex(root, { captureId: "evil3", ts: 1, bytes: 1, file: linkName, mimeType: "image/png", width: 1, height: 1 });
+    appendRawIndex(root, { captureId: cid("evil3"), ts: 1, bytes: 1, file: linkName, mimeType: "image/png", width: 1, height: 1 });
     try {
-      expectRefCode(() => resolveCaptureFile("evil3", env), "symlink");
+      expectRefCode(() => resolveCaptureFile(cid("evil3"), env), "symlink");
     } finally {
       fs.rmSync(outsideDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
ADR-026 **Phase 3a** (engine core, security-critical). Phases 1/2 routed every emitter through the by-ref model, so the cache grows unbounded. This adds the engine layer for observing (query), reclaiming (gc), self-bounding (auto-prune), and orphan recovery as a **pure addition**. The public tools (29→31) are **PR-3b (#479)**.

## Storage: per-capture sidecars (no shared index — multi-process safe by design)

Each capture is **two independent files**, written/removed atomically: the image `{captureId}.{img}` (pixels) + `{captureId}.json` (metadata sidecar). **There is no shared index file.** Liveness = both files exist; the directory IS the index and `readIndex` folds the sidecars.

Because no two processes ever write the same file and nothing is rewritten in place, **concurrent access from multiple desktop-touch processes on one PC is correct without any lock** — the read-modify-rewrite race that a shared index would need a lock to guard simply cannot exist. (Earlier iterations of this PR tried an index lock and a tombstone log; both still raced on a rewrite/compaction path, which a local `codex review` confirmed. The sidecar model removes the shared mutable state entirely.)

- **persist**: write the image (`wx`), then publish the sidecar atomically (temp→rename).
- **readIndex**: readdir sidecars; a capture is live only if both its sidecar and image exist.
- **deleteCapture / gcCache**: securely unlink the image (full validation gauntlet) + remove the sidecar — no shared rewrite, nothing to lose.
- **orphan sweep**: reclaim our own crash residue (image without sidecar, sidecar without image, stale `*.tmp`) after a fixed grace.

## Engine API (`src/engine/screenshot-cache.ts`)
- `queryCaptures(filter, env)` — read-only listing (tag case-folded; opaque captureId + uri only, never a path; whole-cache stats).
- `deleteCapture(captureId, env)` — secure delete of image + sidecar; dangling → `{deleted:false}`.
- `gcCache({dryRun,policy,includeOrphans,now,protectCaptureId}, env)` — retention union (age/count/bytes) + tag scope + orphan sweep + keep-newest invariant.
- auto-prune from `persistCapture` (throttled, env-tunable caps) + R9 opaque error coercion.

## Security
- **Strict ownership gate** `CAPTURE_ID_RE` (`base36-16hex`) at every boundary — `assertSafeCaptureId` (read/delete entry points), the `readIndex` sidecar listing, and the orphan sweep — so a shared/overridden `DESKTOP_TOUCH_SCREENSHOTS_DIR` never lists or deletes a foreign file (`settings.json`, an unrelated `*.tmp`, a non-id image).
- Image-file validation gauntlet preserved: basename assert → lstat-before-realpath symlink reject → realpath → `isWithinRoot` (never `startsWith`) → no-follow open → dev/ino identity gate (defeats lstat→open/unlink swap).

## Multi-LLM eviction floor
The sidecar model removes the cross-process race, but the retention budget (maxCount/maxBytes/auto-prune) is per-cache-dir global, so a flood of captures from one process could auto-prune a ref another process was just handed. An **eviction floor** (`DESKTOP_TOUCH_SCREENSHOT_MIN_EVICT_AGE_MS`, default 60s) never evicts a capture younger than the floor, so a just-handed ref survives long enough to be read regardless of another process's load.

## Tests / review
Engine + handler + emitter unit tests rewritten to the sidecar model with strict captureIds (atomic publish / liveness gate / foreign-file protection / disjoint delete+persist / eviction floor); build + lint clean. Local `codex review`: **P1 = 0 (race-free confirmed)**; Opus architecture review: **GO**. The new public tools (29→31), all public-surface count strings, env-var docs, and the CHANGELOG are **PR-3b / Phase 4**.

Plan: `desktop-touch-mcp-internal plan/adr-026-phase3-query-gc:docs/adr-026-phase3-query-gc-plan.md` (OQ8 → sidecar).
