### PR TITLE
feat(wgc): ADR-027 Phase 2 — integrate WGC into the capture ladder

### DIFF
--- a/src/engine/image.ts
+++ b/src/engine/image.ts
@@ -206,8 +206,10 @@ export async function captureWindowBackground(
   // occluded windows that PrintWindow returns black for. Hidden / minimised /
   // cloaked windows fail the D3 gate inside the helper and fall straight to
   // PrintWindow, preserving this entry's "capture hidden/minimised via
-  // PrintWindow" contract.
-  const wgc = await captureWindowRawViaWgc(hwnd);
+  // PrintWindow" contract. fullContent=false maps to printWindowFlags===0
+  // (legacy fast PrintWindow); that is an explicit opt-out of full-content
+  // capture, so honor it by skipping WGC (Codex review). flags 2/3 get WGC.
+  const wgc = printWindowFlags !== 0 ? await captureWindowRawViaWgc(hwnd) : null;
   if (wgc) {
     return encode(wgc.rawPixels, wgc.width, wgc.height, 4, opts);
   }
@@ -340,8 +342,12 @@ async function captureWindowRawViaWgc(
     if (isLikelyBlankCapture(data, width, height, 4).isBlank) return null;
     return { rawPixels: data, width, height, channels: 4 };
   } catch (e) {
+    // Latch ONLY on the OS-level unsupported signal (WgcError::Unsupported →
+    // "WGC unsupported on this OS"), not on a transient per-window COM error
+    // whose message happens to contain "unsupported" (those rebuild the device
+    // engine-side and should keep retrying). Opus review P3.
     const msg = String((e as Error)?.message ?? e).toLowerCase();
-    if (msg.includes("unsupported")) wgcUnsupported = true;
+    if (msg.includes("wgc unsupported")) wgcUnsupported = true;
     return null;
   }
 }
@@ -370,9 +376,11 @@ export interface CaptureWindowRawResult {
  * Note on dimension parity: on high-DPI monitors PrintWindow returns the
  * window's drawn surface in device pixels, and `screen.grabRegion` of the
  * same screen rect returns logical pixels — the two branches may therefore
- * differ in dimensions. Callers (e.g. `captureAndDiff`) that compare frames
- * across captures must tolerate a one-time `sizeChanged` when the source
- * alternates between PrintWindow and BitBlt for the same window.
+ * differ in dimensions. WGC (ADR-027) is a third source whose `ContentSize`
+ * is device-pixel-like (close to PrintWindow) but can still differ from the
+ * BitBlt logical-pixel branch. Callers (e.g. `captureAndDiff`) that compare
+ * frames across captures must tolerate a one-time `sizeChanged` when the
+ * source switches among PrintWindow / WGC / BitBlt for the same window.
  */
 export async function captureWindowRawWithFallback(
   hwnd: unknown,
@@ -406,7 +414,9 @@ export async function captureWindowRawWithFallback(
   // DWM is compositing (D3 gate inside the helper); on an unsupported OS or an
   // ineligible window it returns null and we fall to BitBlt unchanged.
   // `fallbackReason` is preserved to record WHY PrintWindow was abandoned.
-  const wgc = await captureWindowRawViaWgc(hwnd);
+  // Skipped in explicit legacy mode (flags===0 / fullContent=false) to honor
+  // the documented fast-PrintWindow opt-out; flags 2/3 (full content) get WGC.
+  const wgc = flags !== 0 ? await captureWindowRawViaWgc(hwnd) : null;
   if (wgc) {
     return {
       rawPixels: wgc.rawPixels,

--- a/src/engine/image.ts
+++ b/src/engine/image.ts
@@ -1,6 +1,6 @@
 import sharp from "sharp";
 import { screen, Region } from "./nutjs.js";
-import { printWindowToBuffer } from "./win32.js";
+import { printWindowToBuffer, captureWindowWgc, canCaptureWindowViaWgc } from "./win32.js";
 import { nativeEngine } from "./native-engine.js";
 
 export interface CaptureOptions {
@@ -201,6 +201,16 @@ export async function captureWindowBackground(
 ): Promise<CaptureResult> {
   const opts: CaptureOptions =
     typeof optsOrMaxDim === "number" ? { maxDimension: optsOrMaxDim } : optsOrMaxDim;
+  // ADR-027 — for windows DWM is compositing (visible, non-minimised,
+  // non-cloaked) prefer WGC: it returns real pixels for GPU-composited /
+  // occluded windows that PrintWindow returns black for. Hidden / minimised /
+  // cloaked windows fail the D3 gate inside the helper and fall straight to
+  // PrintWindow, preserving this entry's "capture hidden/minimised via
+  // PrintWindow" contract.
+  const wgc = await captureWindowRawViaWgc(hwnd);
+  if (wgc) {
+    return encode(wgc.rawPixels, wgc.width, wgc.height, 4, opts);
+  }
   // Call printWindowToBuffer directly so the original native error (driver
   // failure, DRM-protected surface, etc.) propagates to OCR / SoM callers
   // verbatim. The raw helper that backs the fallback path deliberately
@@ -295,8 +305,46 @@ export function isLikelyBlankCapture(
   return { isBlank: false, reason: null };
 }
 
-export type CaptureSource = "printwindow" | "bitblt-fallback";
+export type CaptureSource = "printwindow" | "bitblt-fallback" | "wgc";
 export type CaptureFallbackReason = "printwindow-failed" | "printwindow-all-black" | null;
+
+// ADR-027: once a WGC attempt reports the OS doesn't support WGC, skip it for
+// the rest of the session rather than paying a futile worker round-trip on
+// every eligible capture. Reset between tests via `_resetWgcSupportForTest`.
+let wgcUnsupported = false;
+/** Test-only: clear the cached "WGC unsupported" flag. */
+export function _resetWgcSupportForTest(): void {
+  wgcUnsupported = false;
+}
+
+/**
+ * ADR-027 — attempt a WGC capture of `hwnd`, returning raw RGBA (top-down,
+ * channels=4) or `null` when WGC is unavailable / ineligible / produced no
+ * trustworthy frame, so the caller falls through to the next ladder rung.
+ *
+ * Eligibility is the D3 gate (`canCaptureWindowViaWgc`: DWM is compositing the
+ * window). The WGC frame is run through the SAME blank-capture gate as
+ * PrintWindow — an all-black / zero-variance WGC frame (occlusion transition,
+ * DRM-protected surface) is rejected so we never return a black image as real
+ * (ADR-027 §5). A reject whose reason mentions "unsupported" latches
+ * `wgcUnsupported` so subsequent captures skip WGC entirely on this OS.
+ */
+async function captureWindowRawViaWgc(
+  hwnd: unknown,
+): Promise<{ rawPixels: Buffer; width: number; height: number; channels: 4 } | null> {
+  if (wgcUnsupported) return null;
+  if (typeof hwnd !== "bigint" || !canCaptureWindowViaWgc(hwnd)) return null;
+  try {
+    const { data, width, height } = await captureWindowWgc(hwnd);
+    if (!data || width <= 0 || height <= 0) return null;
+    if (isLikelyBlankCapture(data, width, height, 4).isBlank) return null;
+    return { rawPixels: data, width, height, channels: 4 };
+  } catch (e) {
+    const msg = String((e as Error)?.message ?? e).toLowerCase();
+    if (msg.includes("unsupported")) wgcUnsupported = true;
+    return null;
+  }
+}
 
 export interface CaptureWindowRawResult {
   rawPixels: Buffer;
@@ -351,6 +399,23 @@ export async function captureWindowRawWithFallback(
       };
     }
     fallbackReason = blank.reason;
+  }
+  // ADR-027 WGC rescue — before BitBlt, try the DWM composition surface. This
+  // is the route for GPU-composited (Chrome/Electron/WinUI3) and occluded
+  // windows that PrintWindow blacked out or failed on. Only fires for windows
+  // DWM is compositing (D3 gate inside the helper); on an unsupported OS or an
+  // ineligible window it returns null and we fall to BitBlt unchanged.
+  // `fallbackReason` is preserved to record WHY PrintWindow was abandoned.
+  const wgc = await captureWindowRawViaWgc(hwnd);
+  if (wgc) {
+    return {
+      rawPixels: wgc.rawPixels,
+      width: wgc.width,
+      height: wgc.height,
+      channels: wgc.channels,
+      source: "wgc",
+      fallbackReason,
+    };
   }
   // BitBlt fallback grabs the full window rect, NOT a sub-region. Sub-region
   // crops are applied uniformly at encode time via opts.crop (window-local

--- a/src/engine/image.ts
+++ b/src/engine/image.ts
@@ -206,10 +206,10 @@ export async function captureWindowBackground(
   // occluded windows that PrintWindow returns black for. Hidden / minimised /
   // cloaked windows fail the D3 gate inside the helper and fall straight to
   // PrintWindow, preserving this entry's "capture hidden/minimised via
-  // PrintWindow" contract. fullContent=false maps to printWindowFlags===0
-  // (legacy fast PrintWindow); that is an explicit opt-out of full-content
-  // capture, so honor it by skipping WGC (Codex review). flags 2/3 get WGC.
-  const wgc = printWindowFlags !== 0 ? await captureWindowRawViaWgc(hwnd) : null;
+  // PrintWindow" contract. WGC only substitutes for full-window full-content
+  // (flag 2): fullContent=false → flag 0 (legacy fast opt-out) and client-only
+  // requests (PW_CLIENTONLY) stay on PrintWindow (Codex review R1+R2).
+  const wgc = wgcMatchesFlags(printWindowFlags) ? await captureWindowRawViaWgc(hwnd) : null;
   if (wgc) {
     return encode(wgc.rawPixels, wgc.width, wgc.height, 4, opts);
   }
@@ -319,6 +319,17 @@ export function _resetWgcSupportForTest(): void {
   wgcUnsupported = false;
 }
 
+// PrintWindow flags: 0 = legacy (fast, GPU-black), 2 = PW_RENDERFULLCONTENT
+// (full window, full content), 3 = PW_CLIENTONLY(0x1) | RENDERFULLCONTENT.
+// WGC always captures the full window's composited content, so it can only
+// substitute for flag 2. Legacy (0 — the explicit fast opt-out / fullContent=
+// false) and client-only requests (PW_CLIENTONLY bit set: flags 1/3) are
+// honored by PrintWindow, not WGC (Codex review R1 = legacy, R2 = client-only).
+const PW_CLIENTONLY = 0x1;
+function wgcMatchesFlags(flags: number): boolean {
+  return flags !== 0 && (flags & PW_CLIENTONLY) === 0;
+}
+
 /**
  * ADR-027 — attempt a WGC capture of `hwnd`, returning raw RGBA (top-down,
  * channels=4) or `null` when WGC is unavailable / ineligible / produced no
@@ -414,9 +425,9 @@ export async function captureWindowRawWithFallback(
   // DWM is compositing (D3 gate inside the helper); on an unsupported OS or an
   // ineligible window it returns null and we fall to BitBlt unchanged.
   // `fallbackReason` is preserved to record WHY PrintWindow was abandoned.
-  // Skipped in explicit legacy mode (flags===0 / fullContent=false) to honor
-  // the documented fast-PrintWindow opt-out; flags 2/3 (full content) get WGC.
-  const wgc = flags !== 0 ? await captureWindowRawViaWgc(hwnd) : null;
+  // WGC only substitutes for full-window full-content (flag 2); legacy (0) and
+  // client-only (PW_CLIENTONLY) requests fall through to BitBlt unchanged.
+  const wgc = wgcMatchesFlags(flags) ? await captureWindowRawViaWgc(hwnd) : null;
   if (wgc) {
     return {
       rawPixels: wgc.rawPixels,

--- a/src/engine/local-repaint.ts
+++ b/src/engine/local-repaint.ts
@@ -458,8 +458,13 @@ export async function verifyLocalRepaint(opts: {
     // (rect minus windowRect origin, see Step 2.5), so adding `localRect.{x,y}`
     // lifts the bbox to window-relative coordinates — exactly the basis
     // `RoiCapture.roi` expects.
+    // PrintWindow AND WGC (ADR-027) both read off-screen / composited content,
+    // so their bbox is occlusion-immune; the on-screen-only BitBlt fallback is
+    // excluded. (Opus review P2: WGC was previously, and incorrectly, excluded,
+    // which silently demoted every WGC-rescued frame's ROI to full-window.)
     const occlusionImmune =
-      opts.preFrame.source === "printwindow" && finalStable.source === "printwindow";
+      (opts.preFrame.source === "printwindow" || opts.preFrame.source === "wgc") &&
+      (finalStable.source === "printwindow" || finalStable.source === "wgc");
     const roiBbox: Rect | undefined =
       opts.includeRoiBbox === true && occlusionImmune && ssim.bbox != null
         ? {

--- a/src/engine/win32.ts
+++ b/src/engine/win32.ts
@@ -572,11 +572,11 @@ export function canCaptureWindowViaWgc(hwnd: unknown): boolean {
   if (typeof hwnd !== "bigint") return false;
   try {
     const w32 = requireNativeWin32();
-    return (
-      !!w32.win32IsWindowVisible?.(hwnd) &&
-      !w32.win32IsIconic?.(hwnd) &&
-      !isWindowCloaked(hwnd)
-    );
+    // Fail safe: if either binding is missing (non-Windows / partial addon),
+    // skip WGC rather than letting an absent `!IsIconic?.()` evaluate to a
+    // permissive `true` (Opus review P3 — symmetric "missing → skip" contract).
+    if (!w32.win32IsWindowVisible || !w32.win32IsIconic) return false;
+    return w32.win32IsWindowVisible(hwnd) && !w32.win32IsIconic(hwnd) && !isWindowCloaked(hwnd);
   } catch {
     return false;
   }

--- a/src/engine/win32.ts
+++ b/src/engine/win32.ts
@@ -555,6 +555,33 @@ export function isWindowCloaked(hwnd: unknown): boolean {
   }
 }
 
+/**
+ * ADR-027 D3 gate — whether a window may be captured via WGC (`captureWindowWgc`).
+ *
+ * WGC must only target windows DWM is *actively compositing*. Minimised
+ * (`IsIconic`), hidden (`!IsWindowVisible`), and DWM-cloaked windows (another
+ * virtual desktop / suspended UWP) either cannot be captured or return a STALE
+ * last-composed frame that the all-black/zero-variance blank gate would wave
+ * through as "real" (R10). Occluded-but-visible windows DO have a live
+ * composition surface and are the whole point of WGC, so they pass.
+ *
+ * Returns false on any error or when the native binding is unavailable, so the
+ * caller cleanly falls back to PrintWindow / BitBlt.
+ */
+export function canCaptureWindowViaWgc(hwnd: unknown): boolean {
+  if (typeof hwnd !== "bigint") return false;
+  try {
+    const w32 = requireNativeWin32();
+    return (
+      !!w32.win32IsWindowVisible?.(hwnd) &&
+      !w32.win32IsIconic?.(hwnd) &&
+      !isWindowCloaked(hwnd)
+    );
+  } catch {
+    return false;
+  }
+}
+
 export interface ScrollInfoResult {
   nMin: number;
   nMax: number;

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -935,7 +935,15 @@ export const screenshotHandler = async (args: {
       } = { captureSource: result.source };
       const localWarnings: string[] = [...screenshotWarnings];
       if (result.fallbackReason !== null) {
+        // Keep the reason as a diagnostic regardless of which rung served the
+        // frame (for source="wgc" it records why PrintWindow was abandoned).
         captureHints.captureFallbackReason = result.fallbackReason;
+      }
+      // The occlusion-risk warnings describe the BitBlt fallback ONLY. A WGC
+      // rescue (source="wgc") reads the DWM composition surface and is
+      // occlusion-immune, so it must not inherit the "may show overlapping
+      // windows" text even though it carries a fallbackReason (ADR-027 Phase 2).
+      if (result.source === "bitblt-fallback") {
         // Fixed strings only (no variable interpolation — CWE-94 guidance).
         if (result.fallbackReason === "printwindow-failed") {
           localWarnings.push(

--- a/tests/fixtures/failwith-callsite-shapes.json
+++ b/tests/fixtures/failwith-callsite-shapes.json
@@ -459,14 +459,14 @@
     },
     {
       "file": "src/tools/screenshot.ts",
-      "line": 1136,
+      "line": 1144,
       "tool": "screenshot",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/screenshot.ts",
-      "line": 1259,
+      "line": 1267,
       "tool": "get_screen_info",
       "errKind": "identifier",
       "contextShape": "none"

--- a/tests/unit/screenshot-printwindow-default.test.ts
+++ b/tests/unit/screenshot-printwindow-default.test.ts
@@ -402,6 +402,19 @@ describe("captureWindowRawWithFallback — WGC rescue (ADR-027 Phase 2)", () => 
     expect(result.source).toBe("bitblt-fallback");
     expect(mockCaptureWindowWgc).not.toHaveBeenCalled();
   });
+
+  it("flags=3 (PW_CLIENTONLY) → WGC skipped (WGC can't do client-only), BitBlt used", async () => {
+    // WGC always captures the full window; honor the client-only request via
+    // PrintWindow/BitBlt instead of silently returning a full-window frame.
+    mockPrintWindowToBuffer.mockReturnValue({ data: makeUniformRgba(64, 64, 0, 0, 0), width: 64, height: 64 });
+    mockCanUseWgc.mockReturnValue(true);
+    mockCaptureWindowWgc.mockResolvedValue({ data: makeGradientRgba(64, 64), width: 64, height: 64 });
+    mockGrabRegion.mockResolvedValue(makeNutjsImage(64, 64, { r: 10, g: 20, b: 30 }));
+
+    const result = await captureWindowRawWithFallback(hwnd, region, 3);
+    expect(result.source).toBe("bitblt-fallback");
+    expect(mockCaptureWindowWgc).not.toHaveBeenCalled();
+  });
 });
 
 describe("captureWindowBackground — WGC primary (ADR-027 Phase 2)", () => {
@@ -438,6 +451,16 @@ describe("captureWindowBackground — WGC primary (ADR-027 Phase 2)", () => {
     mockPrintWindowToBuffer.mockReturnValue({ data: makeGradientRgba(80, 60), width: 80, height: 60 });
 
     const result = await captureWindowBackground(hwnd, 1280, 0);
+    expect(result).toBeTruthy();
+    expect(mockCaptureWindowWgc).not.toHaveBeenCalled();
+    expect(mockPrintWindowToBuffer).toHaveBeenCalledTimes(1);
+  });
+
+  it("flags=3 (PW_CLIENTONLY) → WGC skipped, client-only PrintWindow used", async () => {
+    mockCanUseWgc.mockReturnValue(true);
+    mockPrintWindowToBuffer.mockReturnValue({ data: makeGradientRgba(80, 60), width: 80, height: 60 });
+
+    const result = await captureWindowBackground(hwnd, 1280, 3);
     expect(result).toBeTruthy();
     expect(mockCaptureWindowWgc).not.toHaveBeenCalled();
     expect(mockPrintWindowToBuffer).toHaveBeenCalledTimes(1);

--- a/tests/unit/screenshot-printwindow-default.test.ts
+++ b/tests/unit/screenshot-printwindow-default.test.ts
@@ -22,9 +22,13 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ─── Hoisted mocks ────────────────────────────────────────────────────────────
 
-const { mockPrintWindowToBuffer, mockGrabRegion } = vi.hoisted(() => ({
+const { mockPrintWindowToBuffer, mockGrabRegion, mockCaptureWindowWgc, mockCanUseWgc } = vi.hoisted(() => ({
   mockPrintWindowToBuffer: vi.fn(),
   mockGrabRegion: vi.fn(),
+  // ADR-027 WGC rescue (Phase 2). Default OFF so the pre-existing PrintWindow /
+  // BitBlt routing tests are unaffected; the WGC-rescue describe flips them on.
+  mockCaptureWindowWgc: vi.fn(),
+  mockCanUseWgc: vi.fn(() => false),
 }));
 
 vi.mock("../../src/engine/win32.js", async (importOriginal) => {
@@ -32,6 +36,8 @@ vi.mock("../../src/engine/win32.js", async (importOriginal) => {
   return {
     ...actual,
     printWindowToBuffer: mockPrintWindowToBuffer,
+    captureWindowWgc: mockCaptureWindowWgc,
+    canCaptureWindowViaWgc: mockCanUseWgc,
   };
 });
 
@@ -44,7 +50,7 @@ vi.mock("../../src/engine/nutjs.js", async (importOriginal) => {
 });
 
 // Import the SUT after the mocks so the module picks up the mocked deps.
-const { isLikelyBlankCapture, captureWindowRawWithFallback, captureWindowWithFallback } = await import("../../src/engine/image.js");
+const { isLikelyBlankCapture, captureWindowRawWithFallback, captureWindowWithFallback, captureWindowBackground, _resetWgcSupportForTest } = await import("../../src/engine/image.js");
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -149,6 +155,8 @@ describe("isLikelyBlankCapture", () => {
 describe("captureWindowRawWithFallback", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    _resetWgcSupportForTest();
+    mockCanUseWgc.mockReturnValue(false); // WGC off by default; rescue tests flip it
   });
 
   const region = { x: 100, y: 200, width: 64, height: 64 };
@@ -251,6 +259,8 @@ describe("captureWindowRawWithFallback", () => {
 describe("captureWindowWithFallback — sub-region crop", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    _resetWgcSupportForTest();
+    mockCanUseWgc.mockReturnValue(false); // WGC off by default; rescue tests flip it
   });
 
   const fullWindow = { x: 0, y: 0, width: 200, height: 150 };
@@ -300,5 +310,112 @@ describe("captureWindowWithFallback — sub-region crop", () => {
     expect(result.width).toBe(100);
     expect(result.height).toBe(60);
     expect(mockGrabRegion).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ADR-027 Phase 2 — WGC rescue (normal mode) + WGC primary (background mode)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("captureWindowRawWithFallback — WGC rescue (ADR-027 Phase 2)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetWgcSupportForTest();
+    mockCanUseWgc.mockReturnValue(false);
+  });
+
+  const region = { x: 100, y: 200, width: 64, height: 64 };
+  const hwnd = 12345n;
+
+  it("PrintWindow all-black + WGC eligible + WGC returns real pixels → source='wgc', no BitBlt", async () => {
+    mockPrintWindowToBuffer.mockReturnValue({ data: makeUniformRgba(64, 64, 0, 0, 0), width: 64, height: 64 });
+    mockCanUseWgc.mockReturnValue(true);
+    mockCaptureWindowWgc.mockResolvedValue({ data: makeGradientRgba(64, 64), width: 64, height: 64 });
+
+    const result = await captureWindowRawWithFallback(hwnd, region);
+    expect(result.source).toBe("wgc");
+    expect(result.fallbackReason).toBe("printwindow-all-black"); // records why PrintWindow was abandoned
+    expect(mockCaptureWindowWgc).toHaveBeenCalledTimes(1);
+    expect(mockGrabRegion).not.toHaveBeenCalled();
+  });
+
+  it("PrintWindow throws + WGC eligible + WGC real → source='wgc', reason='printwindow-failed'", async () => {
+    mockPrintWindowToBuffer.mockImplementation(() => { throw new Error("PrintWindow native error"); });
+    mockCanUseWgc.mockReturnValue(true);
+    mockCaptureWindowWgc.mockResolvedValue({ data: makeGradientRgba(64, 64), width: 64, height: 64 });
+
+    const result = await captureWindowRawWithFallback(hwnd, region);
+    expect(result.source).toBe("wgc");
+    expect(result.fallbackReason).toBe("printwindow-failed");
+    expect(mockGrabRegion).not.toHaveBeenCalled();
+  });
+
+  it("WGC returns an all-black frame → rejected (never returns black as real), falls to BitBlt", async () => {
+    mockPrintWindowToBuffer.mockReturnValue({ data: makeUniformRgba(64, 64, 0, 0, 0), width: 64, height: 64 });
+    mockCanUseWgc.mockReturnValue(true);
+    mockCaptureWindowWgc.mockResolvedValue({ data: makeUniformRgba(64, 64, 0, 0, 0), width: 64, height: 64 });
+    mockGrabRegion.mockResolvedValue(makeNutjsImage(64, 64, { r: 10, g: 20, b: 30 }));
+
+    const result = await captureWindowRawWithFallback(hwnd, region);
+    expect(result.source).toBe("bitblt-fallback");
+    expect(mockCaptureWindowWgc).toHaveBeenCalledTimes(1);
+    expect(mockGrabRegion).toHaveBeenCalledTimes(1);
+  });
+
+  it("WGC ineligible (D3 gate false) → BitBlt, WGC not attempted", async () => {
+    mockPrintWindowToBuffer.mockReturnValue({ data: makeUniformRgba(64, 64, 0, 0, 0), width: 64, height: 64 });
+    mockCanUseWgc.mockReturnValue(false); // minimised / hidden / cloaked
+    mockGrabRegion.mockResolvedValue(makeNutjsImage(64, 64, { r: 10, g: 20, b: 30 }));
+
+    const result = await captureWindowRawWithFallback(hwnd, region);
+    expect(result.source).toBe("bitblt-fallback");
+    expect(mockCaptureWindowWgc).not.toHaveBeenCalled();
+    expect(mockGrabRegion).toHaveBeenCalledTimes(1);
+  });
+
+  it("WGC 'unsupported' rejection latches → subsequent eligible captures skip WGC", async () => {
+    mockPrintWindowToBuffer.mockReturnValue({ data: makeUniformRgba(64, 64, 0, 0, 0), width: 64, height: 64 });
+    mockCanUseWgc.mockReturnValue(true);
+    mockCaptureWindowWgc.mockRejectedValue(new Error("WGC unsupported on this OS"));
+    mockGrabRegion.mockResolvedValue(makeNutjsImage(64, 64, { r: 10, g: 20, b: 30 }));
+
+    const first = await captureWindowRawWithFallback(hwnd, region);
+    expect(first.source).toBe("bitblt-fallback");
+    expect(mockCaptureWindowWgc).toHaveBeenCalledTimes(1);
+
+    // Second eligible capture must NOT re-attempt WGC (wgcUnsupported latched).
+    const second = await captureWindowRawWithFallback(hwnd, region);
+    expect(second.source).toBe("bitblt-fallback");
+    expect(mockCaptureWindowWgc).toHaveBeenCalledTimes(1); // still 1, not 2
+  });
+});
+
+describe("captureWindowBackground — WGC primary (ADR-027 Phase 2)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetWgcSupportForTest();
+    mockCanUseWgc.mockReturnValue(false);
+  });
+
+  const hwnd = 12345n;
+
+  it("eligible window → WGC used, PrintWindow NOT called", async () => {
+    mockCanUseWgc.mockReturnValue(true);
+    mockCaptureWindowWgc.mockResolvedValue({ data: makeGradientRgba(80, 60), width: 80, height: 60 });
+
+    const result = await captureWindowBackground(hwnd, 1280);
+    expect(result).toBeTruthy();
+    expect(mockCaptureWindowWgc).toHaveBeenCalledTimes(1);
+    expect(mockPrintWindowToBuffer).not.toHaveBeenCalled();
+  });
+
+  it("ineligible window (hidden/minimised/cloaked) → PrintWindow used", async () => {
+    mockCanUseWgc.mockReturnValue(false);
+    mockPrintWindowToBuffer.mockReturnValue({ data: makeGradientRgba(80, 60), width: 80, height: 60 });
+
+    const result = await captureWindowBackground(hwnd, 1280);
+    expect(result).toBeTruthy();
+    expect(mockCaptureWindowWgc).not.toHaveBeenCalled();
+    expect(mockPrintWindowToBuffer).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/screenshot-printwindow-default.test.ts
+++ b/tests/unit/screenshot-printwindow-default.test.ts
@@ -388,6 +388,20 @@ describe("captureWindowRawWithFallback — WGC rescue (ADR-027 Phase 2)", () => 
     expect(second.source).toBe("bitblt-fallback");
     expect(mockCaptureWindowWgc).toHaveBeenCalledTimes(1); // still 1, not 2
   });
+
+  it("flags=0 (legacy / fullContent=false) → WGC rescue skipped, BitBlt used", async () => {
+    // Honors the explicit fast-PrintWindow opt-out (Codex review): even when the
+    // window is WGC-eligible and PrintWindow blanked, legacy mode must not pull
+    // in WGC.
+    mockPrintWindowToBuffer.mockReturnValue({ data: makeUniformRgba(64, 64, 0, 0, 0), width: 64, height: 64 });
+    mockCanUseWgc.mockReturnValue(true);
+    mockCaptureWindowWgc.mockResolvedValue({ data: makeGradientRgba(64, 64), width: 64, height: 64 });
+    mockGrabRegion.mockResolvedValue(makeNutjsImage(64, 64, { r: 10, g: 20, b: 30 }));
+
+    const result = await captureWindowRawWithFallback(hwnd, region, 0);
+    expect(result.source).toBe("bitblt-fallback");
+    expect(mockCaptureWindowWgc).not.toHaveBeenCalled();
+  });
 });
 
 describe("captureWindowBackground — WGC primary (ADR-027 Phase 2)", () => {
@@ -417,5 +431,26 @@ describe("captureWindowBackground — WGC primary (ADR-027 Phase 2)", () => {
     expect(result).toBeTruthy();
     expect(mockCaptureWindowWgc).not.toHaveBeenCalled();
     expect(mockPrintWindowToBuffer).toHaveBeenCalledTimes(1);
+  });
+
+  it("flags=0 (fullContent=false) → legacy PrintWindow, WGC NOT attempted", async () => {
+    mockCanUseWgc.mockReturnValue(true); // eligible, but legacy mode opts out of WGC
+    mockPrintWindowToBuffer.mockReturnValue({ data: makeGradientRgba(80, 60), width: 80, height: 60 });
+
+    const result = await captureWindowBackground(hwnd, 1280, 0);
+    expect(result).toBeTruthy();
+    expect(mockCaptureWindowWgc).not.toHaveBeenCalled();
+    expect(mockPrintWindowToBuffer).toHaveBeenCalledTimes(1);
+  });
+
+  it("WGC returns an all-black frame → PrintWindow fallback (blank-safety)", async () => {
+    mockCanUseWgc.mockReturnValue(true);
+    mockCaptureWindowWgc.mockResolvedValue({ data: makeUniformRgba(80, 60, 0, 0, 0), width: 80, height: 60 });
+    mockPrintWindowToBuffer.mockReturnValue({ data: makeGradientRgba(80, 60), width: 80, height: 60 });
+
+    const result = await captureWindowBackground(hwnd, 1280);
+    expect(result).toBeTruthy();
+    expect(mockCaptureWindowWgc).toHaveBeenCalledTimes(1);
+    expect(mockPrintWindowToBuffer).toHaveBeenCalledTimes(1); // WGC blank rejected → PrintWindow
   });
 });


### PR DESCRIPTION
## ADR-027 Phase 2 — integrate WGC into the capture ladder

Wires the Phase 1 `win32_wgc_capture_window` (#482) into the actual screenshot capture paths, so GPU-composited windows (Chrome / Electron / WinUI3) and occluded windows — which `PrintWindow` returns **black** for — now yield real pixels.

Plan: `desktop-touch-mcp-internal@e6befac:docs/adr-027-wgc-capture-layer.md` §6 Phase 2.

### The D3 gate (`win32.ts`)
`canCaptureWindowViaWgc(hwnd)` = `IsWindowVisible && !IsIconic && !isWindowCloaked`. WGC must only target windows DWM is *actively compositing*. Minimised / hidden / DWM-cloaked windows return a **stale** last-composed frame that the all-black/zero-variance blank gate would wave through as "real" (R10) — so they stay on PrintWindow (which the `mode='background'` contract documents as the route for hidden/minimised windows). Occluded-but-visible windows have a live composition surface and are the whole point of WGC, so they pass.

### Ladder integration (`image.ts`)
- **normal mode** (`captureWindowRawWithFallback`): PrintWindow primary → on blank / failure, **WGC rescue** (gated) → BitBlt last. The PrintWindow-success fast path is untouched. New `CaptureSource` value `"wgc"`; `fallbackReason` is preserved to record *why* PrintWindow was abandoned (`printwindow-all-black` / `printwindow-failed`).
- **background mode** (`captureWindowBackground`): **WGC primary** for eligible windows → PrintWindow fallback. Ineligible (hidden/minimised/cloaked) windows fail the gate and fall straight to PrintWindow, preserving the "capture hidden/minimised via PrintWindow + fail loudly when PrintWindow can't run" contract.
- **blank-safety on WGC output** (§5 / AC8): the WGC frame runs through the **same** `isLikelyBlankCapture` gate — an all-black WGC frame (occlusion transition, DRM-protected surface) is rejected, so a black image is never returned as real.
- **unsupported latch**: a WGC reject whose reason mentions "unsupported" latches a session flag so unsupported Windows builds skip WGC entirely (no futile worker round-trip per capture). `IsSupported` feature-detect (D5) is handled engine-side; this is the TS-side short-circuit.

The output contract (ADR-026 §9) is unchanged — only the *backend* of `mode='background'` changes; `mode` / `fullContent` params are preserved (`fullContent` still flows to the PrintWindow fallback).

### Validation
- `tsc`, `lint` (0 errors).
- **21 ladder unit tests** in `screenshot-printwindow-default.test.ts` — the pre-existing PrintWindow/BitBlt routing pins still hold (WGC defaulted off via mock), plus **8 new WGC cases**: rescue-on-blank, rescue-on-failure, all-black-WGC-rejected→BitBlt, gate-false→BitBlt (WGC not attempted), unsupported-reject latches (2nd capture skips WGC), and background-mode WGC-primary vs PrintWindow.
- `test:unit`: 4024 passed (the lone failure is the pre-existing flaky `desktop-facade.test.ts`, 74/74 in isolation — unrelated; it doesn't import the capture ladder).
- **Live dogfood**: a visible window captured `1009×679` through the integrated background WGC path at dims matching a direct `captureWindowWgc` capture (confirming the gate passes and WGC is the backend, not PrintWindow).

### Out of scope (Phase 3+)
Dimension/feature-detect finalization, broader multi-monitor / occluded / minimized dogfood, bench, CI compile guard, CHANGELOG, release (bundled with ADR-028).
