### PR TITLE
feat(wgc): ADR-027 Phase 3 — capture-blocked graceful degrade (R9/AC8)

### DIFF
--- a/src/engine/image.ts
+++ b/src/engine/image.ts
@@ -211,11 +211,17 @@ export async function captureWindowBackground(
   // requests (PW_CLIENTONLY) stay on PrintWindow (Codex review R1+R2).
   const wgc = wgcMatchesFlags(printWindowFlags) ? await captureWindowRawViaWgc(hwnd) : null;
   if (wgc) {
-    // WGC frames pass the blank gate inside captureWindowRawViaWgc, so a served
-    // WGC frame is real content — not capture-blocked. Set the field explicitly
-    // (symmetry with the PrintWindow branch) so callers see a consistent shape.
+    // WGC frames pass the blank gate inside captureWindowRawViaWgc (full frame),
+    // so a served WGC frame is real content. But when a sub-region is requested
+    // the served crop could still be all-black (e.g. a DRM video area inside a
+    // non-black window) — re-check the crop so captureBlocked reflects the
+    // pixels actually sent (Codex review). With no crop the validated full
+    // frame is non-black by construction → false.
+    const captureBlocked = opts.crop
+      ? isLikelyBlankCapture(wgc.rawPixels, wgc.width, wgc.height, 4, opts.crop).isBlank
+      : false;
     const encodedWgc = await encode(wgc.rawPixels, wgc.width, wgc.height, 4, opts);
-    return { ...encodedWgc, captureBlocked: false };
+    return { ...encodedWgc, captureBlocked };
   }
   // Call printWindowToBuffer directly so the original native error (driver
   // failure, DRM-protected surface, etc.) propagates to OCR / SoM callers
@@ -230,9 +236,11 @@ export async function captureWindowBackground(
   // a genuinely-black window OR uncapturable content — DRM / secure desktop /
   // hardware overlay; pixels can't tell them apart). Flag it so the handler
   // surfaces an explicit hedged warning rather than returning a silent black
-  // frame. (Only all-black AND zero-variance frames qualify — isLikelyBlankCapture
-  // never flags a dark-but-varied editor / video as blank.)
-  const captureBlocked = isLikelyBlankCapture(data, width, height, 4).isBlank;
+  // frame. The check is crop-aware (Codex review): when a sub-region is
+  // requested it reflects the served crop, not the full window. (Only all-black
+  // AND zero-variance qualifies — isLikelyBlankCapture never flags a
+  // dark-but-varied editor / video as blank.)
+  const captureBlocked = isLikelyBlankCapture(data, width, height, 4, opts.crop).isBlank;
   const encoded = await encode(data, width, height, 4, opts);
   return { ...encoded, captureBlocked };
 }
@@ -273,17 +281,32 @@ export function captureWindowRawPrintWindow(
  *
  * Sampling: walks the buffer with a fixed stride to keep this O(1) per call,
  * regardless of resolution.
+ *
+ * `crop` (optional, ADR-027 Phase 3 / Codex review): when set, the check is
+ * restricted to that sub-rectangle of the buffer — the "pixels actually sent"
+ * when the caller requested a region. This is stride-aware (it walks the
+ * sub-rect using the full-width row stride), so a black region inside a
+ * non-black window is detected. With no `crop` the full buffer is sampled and
+ * the result is bit-identical to the original 4-arg form. The crop is clamped
+ * to the buffer bounds; an empty clamped crop returns isBlank=false.
  */
 export function isLikelyBlankCapture(
   rawPixels: Buffer,
   width: number,
   height: number,
   channels: 3 | 4,
+  crop?: { x: number; y: number; width: number; height: number },
 ): { isBlank: boolean; reason: "printwindow-all-black" | null } {
   if (width <= 0 || height <= 0 || rawPixels.length < channels) {
     return { isBlank: false, reason: null };
   }
-  const pixelCount = width * height;
+  // Region to sample: the full frame, or the requested crop clamped to bounds.
+  const rx = crop ? Math.max(0, Math.min(crop.x, width)) : 0;
+  const ry = crop ? Math.max(0, Math.min(crop.y, height)) : 0;
+  const rw = crop ? Math.min(crop.width, width - rx) : width;
+  const rh = crop ? Math.min(crop.height, height - ry) : height;
+  if (rw <= 0 || rh <= 0) return { isBlank: false, reason: null };
+  const pixelCount = rw * rh;
   // Sample at most ~4096 pixels regardless of frame size (O(1) per call).
   const sampleCount = Math.min(4096, pixelCount);
   const step = Math.max(1, Math.floor(pixelCount / sampleCount));
@@ -295,7 +318,12 @@ export function isLikelyBlankCapture(
   let allSame = true;
   let sampled = 0;
   for (let p = 0; p < pixelCount; p += step) {
-    const off = p * channels;
+    // Map the linear sample index into the (cropped) region, then to the full
+    // buffer offset via the real row stride (`width`). With no crop this is
+    // exactly `p * channels` (rx=ry=0, rw=width), so behaviour is unchanged.
+    const localY = Math.floor(p / rw);
+    const localX = p - localY * rw;
+    const off = ((ry + localY) * width + (rx + localX)) * channels;
     // RGBA / RGB: take BT.601 luma (R*0.299 + G*0.587 + B*0.114), integer-ish.
     const r = rawPixels[off] ?? 0;
     const g = rawPixels[off + 1] ?? 0;
@@ -528,11 +556,19 @@ export async function captureWindowWithFallback(
     typeof optsOrMaxDim === "number" ? { maxDimension: optsOrMaxDim } : optsOrMaxDim;
   const raw = await captureWindowRawWithFallback(hwnd, windowRect, flags);
   const encoded = await encode(raw.rawPixels, raw.width, raw.height, raw.channels, opts);
+  // ADR-027 R9/AC8 (Codex review) — captureBlocked must describe the pixels
+  // actually sent. When a sub-region is requested, encode() crops to opts.crop,
+  // so re-evaluate the blank check over that crop (a black region inside a
+  // non-black window — e.g. a DRM video area — must still flag). With no crop
+  // the full-buffer result the rung already computed is used unchanged.
+  const captureBlocked = opts.crop
+    ? isLikelyBlankCapture(raw.rawPixels, raw.width, raw.height, raw.channels, opts.crop).isBlank
+    : raw.captureBlocked;
   return {
     ...encoded,
     source: raw.source,
     fallbackReason: raw.fallbackReason,
-    captureBlocked: raw.captureBlocked,
+    captureBlocked,
   };
 }
 

--- a/src/engine/image.ts
+++ b/src/engine/image.ts
@@ -198,7 +198,7 @@ export async function captureWindowBackground(
   hwnd: unknown,
   optsOrMaxDim: CaptureOptions | number = 1280,
   printWindowFlags = 2
-): Promise<CaptureResult> {
+): Promise<CaptureResult & { captureBlocked?: boolean }> {
   const opts: CaptureOptions =
     typeof optsOrMaxDim === "number" ? { maxDimension: optsOrMaxDim } : optsOrMaxDim;
   // ADR-027 — for windows DWM is compositing (visible, non-minimised,
@@ -211,6 +211,8 @@ export async function captureWindowBackground(
   // requests (PW_CLIENTONLY) stay on PrintWindow (Codex review R1+R2).
   const wgc = wgcMatchesFlags(printWindowFlags) ? await captureWindowRawViaWgc(hwnd) : null;
   if (wgc) {
+    // WGC frames pass the blank gate inside captureWindowRawViaWgc, so a served
+    // WGC frame is real content — not capture-blocked.
     return encode(wgc.rawPixels, wgc.width, wgc.height, 4, opts);
   }
   // Call printWindowToBuffer directly so the original native error (driver
@@ -220,7 +222,16 @@ export async function captureWindowBackground(
   // back-compat entry, which should fail loudly when PrintWindow can't run.
   const { data, width, height } = printWindowToBuffer(hwnd, printWindowFlags);
   // data is already RGBA (converted in win32.ts)
-  return encode(data, width, height, 4, opts);
+  // ADR-027 R9/AC8 — background mode's rungs are WGC (when eligible) → PrintWindow.
+  // If WGC did not serve and this PrintWindow frame is all-black, every rung
+  // failed: the content is capture-blocked (DRM / secure desktop / hardware
+  // overlay). Flag it so the handler surfaces an explicit reason rather than
+  // returning a silent black frame. (Non-blank frames — including legitimately
+  // dark editors / video — are not flagged: isLikelyBlankCapture requires
+  // all-black AND zero variance.)
+  const captureBlocked = isLikelyBlankCapture(data, width, height, 4).isBlank;
+  const encoded = await encode(data, width, height, 4, opts);
+  return { ...encoded, captureBlocked };
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -370,6 +381,18 @@ export interface CaptureWindowRawResult {
   channels: 3 | 4;
   source: CaptureSource;
   fallbackReason: CaptureFallbackReason;
+  /**
+   * ADR-027 R9/AC8 — true when EVERY capture rung (PrintWindow → WGC → BitBlt)
+   * produced an all-black / zero-variance frame, i.e. the served pixels are
+   * black and are NOT the real window content. This is the terminal
+   * "capture-blocked" outcome (DRM-protected video, a secure-desktop / UAC
+   * surface, or a hardware-overlay the OS refuses to capture). The ladder is
+   * finite — it does not loop — so this flags the case where the last rung is
+   * also blank rather than silently returning a black image as if it were
+   * valid. Callers surface an explicit reason instead of the misleading
+   * "fell back to BitBlt / overlapping windows" hint.
+   */
+  captureBlocked: boolean;
 }
 
 /**
@@ -415,6 +438,7 @@ export async function captureWindowRawWithFallback(
         channels: raw.channels,
         source: "printwindow",
         fallbackReason: null,
+        captureBlocked: false,
       };
     }
     fallbackReason = blank.reason;
@@ -436,6 +460,10 @@ export async function captureWindowRawWithFallback(
       channels: wgc.channels,
       source: "wgc",
       fallbackReason,
+      // WGC frames are already run through isLikelyBlankCapture inside
+      // captureWindowRawViaWgc — a blank WGC frame returns null and we never
+      // reach here, so a served WGC frame is real content (not capture-blocked).
+      captureBlocked: false,
     };
   }
   // BitBlt fallback grabs the full window rect, NOT a sub-region. Sub-region
@@ -445,6 +473,19 @@ export async function captureWindowRawWithFallback(
   const image = await screen.grabRegion(grabRegion);
   const rgbImage = await image.toRGB();
   const channels = (rgbImage.hasAlphaChannel ? 4 : 3) as 3 | 4;
+  // ADR-027 R9/AC8 — BitBlt is the LAST rung. We only reach it because
+  // PrintWindow was blank/failed AND WGC did not serve, so if this final frame
+  // is ALSO all-black the whole ladder failed: the content is capture-blocked
+  // (DRM / secure desktop / hardware overlay). Flag it so the caller surfaces
+  // an explicit reason instead of returning a black image silently. An occluded
+  // (non-black) BitBlt of an overlapping window is NOT capture-blocked — it
+  // keeps the existing "may show overlapping windows" hint via fallbackReason.
+  const captureBlocked = isLikelyBlankCapture(
+    rgbImage.data,
+    rgbImage.width,
+    rgbImage.height,
+    channels,
+  ).isBlank;
   return {
     rawPixels: rgbImage.data,
     width: rgbImage.width,
@@ -452,6 +493,7 @@ export async function captureWindowRawWithFallback(
     channels,
     source: "bitblt-fallback",
     fallbackReason,
+    captureBlocked,
   };
 }
 
@@ -467,12 +509,23 @@ export async function captureWindowWithFallback(
   windowRect: { x: number; y: number; width: number; height: number },
   optsOrMaxDim: CaptureOptions | number = 1280,
   flags = 2,
-): Promise<CaptureResult & { source: CaptureSource; fallbackReason: CaptureFallbackReason }> {
+): Promise<
+  CaptureResult & {
+    source: CaptureSource;
+    fallbackReason: CaptureFallbackReason;
+    captureBlocked: boolean;
+  }
+> {
   const opts: CaptureOptions =
     typeof optsOrMaxDim === "number" ? { maxDimension: optsOrMaxDim } : optsOrMaxDim;
   const raw = await captureWindowRawWithFallback(hwnd, windowRect, flags);
   const encoded = await encode(raw.rawPixels, raw.width, raw.height, raw.channels, opts);
-  return { ...encoded, source: raw.source, fallbackReason: raw.fallbackReason };
+  return {
+    ...encoded,
+    source: raw.source,
+    fallbackReason: raw.fallbackReason,
+    captureBlocked: raw.captureBlocked,
+  };
 }
 
 /** Convert a raw RGBA buffer to base64 image. */

--- a/src/engine/image.ts
+++ b/src/engine/image.ts
@@ -212,8 +212,10 @@ export async function captureWindowBackground(
   const wgc = wgcMatchesFlags(printWindowFlags) ? await captureWindowRawViaWgc(hwnd) : null;
   if (wgc) {
     // WGC frames pass the blank gate inside captureWindowRawViaWgc, so a served
-    // WGC frame is real content — not capture-blocked.
-    return encode(wgc.rawPixels, wgc.width, wgc.height, 4, opts);
+    // WGC frame is real content — not capture-blocked. Set the field explicitly
+    // (symmetry with the PrintWindow branch) so callers see a consistent shape.
+    const encodedWgc = await encode(wgc.rawPixels, wgc.width, wgc.height, 4, opts);
+    return { ...encodedWgc, captureBlocked: false };
   }
   // Call printWindowToBuffer directly so the original native error (driver
   // failure, DRM-protected surface, etc.) propagates to OCR / SoM callers
@@ -223,12 +225,13 @@ export async function captureWindowBackground(
   const { data, width, height } = printWindowToBuffer(hwnd, printWindowFlags);
   // data is already RGBA (converted in win32.ts)
   // ADR-027 R9/AC8 — background mode's rungs are WGC (when eligible) → PrintWindow.
-  // If WGC did not serve and this PrintWindow frame is all-black, every rung
-  // failed: the content is capture-blocked (DRM / secure desktop / hardware
-  // overlay). Flag it so the handler surfaces an explicit reason rather than
-  // returning a silent black frame. (Non-blank frames — including legitimately
-  // dark editors / video — are not flagged: isLikelyBlankCapture requires
-  // all-black AND zero variance.)
+  // If WGC did not serve and this PrintWindow frame is all-black, no rung
+  // produced non-black pixels: the result is an unverified black image (either
+  // a genuinely-black window OR uncapturable content — DRM / secure desktop /
+  // hardware overlay; pixels can't tell them apart). Flag it so the handler
+  // surfaces an explicit hedged warning rather than returning a silent black
+  // frame. (Only all-black AND zero-variance frames qualify — isLikelyBlankCapture
+  // never flags a dark-but-varied editor / video as blank.)
   const captureBlocked = isLikelyBlankCapture(data, width, height, 4).isBlank;
   const encoded = await encode(data, width, height, 4, opts);
   return { ...encoded, captureBlocked };
@@ -383,14 +386,17 @@ export interface CaptureWindowRawResult {
   fallbackReason: CaptureFallbackReason;
   /**
    * ADR-027 R9/AC8 — true when EVERY capture rung (PrintWindow → WGC → BitBlt)
-   * produced an all-black / zero-variance frame, i.e. the served pixels are
-   * black and are NOT the real window content. This is the terminal
-   * "capture-blocked" outcome (DRM-protected video, a secure-desktop / UAC
-   * surface, or a hardware-overlay the OS refuses to capture). The ladder is
-   * finite — it does not loop — so this flags the case where the last rung is
-   * also blank rather than silently returning a black image as if it were
-   * valid. Callers surface an explicit reason instead of the misleading
-   * "fell back to BitBlt / overlapping windows" hint.
+   * produced an all-black / zero-variance frame, so NO rung produced non-black
+   * pixels. Pixels alone cannot distinguish a genuinely-black window (a dark
+   * terminal, a black / letterboxed video frame, a freshly-launched GPU app)
+   * from uncapturable content (DRM-protected video, a secure-desktop / UAC
+   * prompt, a hardware-overlay surface) — both yield a uniform black frame.
+   * So this is NOT an assertion that the content is protected; it means "the
+   * returned image is black and unverified — treat it with low confidence."
+   * The ladder is finite (it does not loop); this flags the case where the LAST
+   * rung is also blank instead of returning a black image silently. Callers
+   * surface an explicit (hedged) warning + a `captureBlocked` hint instead of
+   * the misleading "fell back to BitBlt / overlapping windows" text.
    */
   captureBlocked: boolean;
 }
@@ -475,11 +481,13 @@ export async function captureWindowRawWithFallback(
   const channels = (rgbImage.hasAlphaChannel ? 4 : 3) as 3 | 4;
   // ADR-027 R9/AC8 — BitBlt is the LAST rung. We only reach it because
   // PrintWindow was blank/failed AND WGC did not serve, so if this final frame
-  // is ALSO all-black the whole ladder failed: the content is capture-blocked
-  // (DRM / secure desktop / hardware overlay). Flag it so the caller surfaces
-  // an explicit reason instead of returning a black image silently. An occluded
-  // (non-black) BitBlt of an overlapping window is NOT capture-blocked — it
-  // keeps the existing "may show overlapping windows" hint via fallbackReason.
+  // is ALSO all-black then NO rung produced non-black pixels: the result is an
+  // unverified black image (either a genuinely-black window OR uncapturable
+  // content — DRM / secure desktop / hardware overlay; pixels can't tell them
+  // apart). Flag it so the caller surfaces an explicit hedged warning instead
+  // of returning a black image silently. An occluded (non-black) BitBlt of an
+  // overlapping window is NOT capture-blocked — it keeps the existing "may show
+  // overlapping windows" hint via fallbackReason.
   const captureBlocked = isLikelyBlankCapture(
     rgbImage.data,
     rgbImage.width,

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -940,18 +940,22 @@ export const screenshotHandler = async (args: {
         // frame (for source="wgc" it records why PrintWindow was abandoned).
         captureHints.captureFallbackReason = result.fallbackReason;
       }
-      // ADR-027 R9/AC8 — every rung (PrintWindow → WGC → BitBlt) returned an
-      // all-black frame: NO rung produced non-black pixels. Surface that
-      // explicitly and SUPERSEDE the BitBlt "overlapping windows" hint below —
-      // a uniformly black frame is not showing an occluding window. The wording
-      // is deliberately HEDGED: pixels alone cannot tell a genuinely-black
-      // window (dark terminal / video / fresh GPU app) from uncapturable content
-      // (DRM / secure desktop / hardware overlay), so we do NOT assert the
-      // content is protected (Codex + Opus review). Fixed strings only (CWE-94).
+      // ADR-027 R9/AC8 — no capture rung produced non-black pixels, so the
+      // returned image is a uniform black frame. Surface that explicitly and
+      // SUPERSEDE the BitBlt "overlapping windows" hint below — a uniformly
+      // black frame is not showing an occluding window. The wording describes
+      // only the OUTCOME (the returned image), NOT which specific rungs ran:
+      // some rungs may have failed (PrintWindow threw) or been skipped (WGC
+      // ineligible/unsupported), so enumerating "PrintWindow + WGC + BitBlt all
+      // returned black" would be a false diagnosis (Codex review). It is also
+      // HEDGED: pixels alone cannot tell a genuinely-black window (dark terminal
+      // / video / fresh GPU app) from uncapturable content (DRM / secure desktop
+      // / hardware overlay), so we do NOT assert the content is protected. Fixed
+      // strings only (CWE-94).
       if (result.captureBlocked) {
         captureHints.captureBlocked = true;
         localWarnings.push(
-          "All capture methods (PrintWindow, WGC, BitBlt) returned a uniform all-black frame. The window may legitimately be black (a dark terminal, a black or letterboxed video frame, or a freshly-launched GPU app) OR its content may be uncapturable (DRM-protected video, a secure-desktop / UAC prompt, or a hardware-overlay surface). The returned image is all-black — treat it as unverified."
+          "The captured image is a uniform all-black frame and could not be verified as real window content. The window may legitimately be black (a dark terminal, a black or letterboxed video frame, or a freshly-launched GPU app) OR its content may be uncapturable (DRM-protected video, a secure-desktop / UAC prompt, or a hardware-overlay surface) — treat the image as unverified."
         );
       } else if (result.source === "bitblt-fallback") {
         // The occlusion-risk warnings describe the BitBlt fallback ONLY. A WGC
@@ -1146,16 +1150,19 @@ export const screenshotBgHandler = async ({
       meta: { tag: foundTitle || effectiveTitle },
     });
     const allBgWarnings = warning ? [...bgWarnings, warning] : [...bgWarnings];
-    // ADR-027 R9/AC8 — background mode's rungs are WGC (when eligible) →
-    // PrintWindow. captureBlocked means BOTH returned an all-black frame: no
-    // rung produced non-black pixels. Surface it explicitly instead of returning
-    // a silent black image. Wording is HEDGED — pixels can't tell a genuinely-
-    // black window from uncapturable content (Codex + Opus review). Fixed string
-    // only (CWE-94).
+    // ADR-027 R9/AC8 — captureBlocked means no capture rung produced non-black
+    // pixels for this background capture, so the returned image is a uniform
+    // black frame. Surface it explicitly instead of returning a silent black
+    // image. The wording describes only the OUTCOME (the returned image), NOT
+    // which rungs ran — on the documented PrintWindow-only paths (fullContent=
+    // false, client-only, hidden/minimized/cloaked, WGC unsupported) WGC is
+    // never attempted, so claiming "via WGC and PrintWindow" would be misleading
+    // (Codex review). It is also HEDGED — pixels can't tell a genuinely-black
+    // window from uncapturable content. Fixed string only (CWE-94).
     const captureBlocked = result.captureBlocked === true;
     if (captureBlocked) {
       allBgWarnings.push(
-        "Capture returned a uniform all-black frame via both WGC and PrintWindow. The window may legitimately be black (a dark terminal, a black or letterboxed video frame, or a freshly-launched GPU app) OR its content may be uncapturable (DRM-protected video, a secure-desktop / UAC prompt, or a hardware-overlay surface). The returned image is all-black — treat it as unverified."
+        "The background capture is a uniform all-black frame and could not be verified as real window content. The window may legitimately be black (a dark terminal, a black or letterboxed video frame, or a freshly-launched GPU app) OR its content may be uncapturable (DRM-protected video, a secure-desktop / UAC prompt, or a hardware-overlay surface) — treat the image as unverified."
       );
     }
     return {

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -941,15 +941,17 @@ export const screenshotHandler = async (args: {
         captureHints.captureFallbackReason = result.fallbackReason;
       }
       // ADR-027 R9/AC8 — every rung (PrintWindow → WGC → BitBlt) returned an
-      // all-black frame: the content is capture-blocked (DRM / secure desktop /
-      // hardware overlay). Surface that explicitly and SUPERSEDE the BitBlt
-      // "overlapping windows" hint below — a uniformly black frame is not
-      // showing an occluding window, and "pass mode='background'" would not help
-      // (background mode hits the same black). Fixed strings only (CWE-94).
+      // all-black frame: NO rung produced non-black pixels. Surface that
+      // explicitly and SUPERSEDE the BitBlt "overlapping windows" hint below —
+      // a uniformly black frame is not showing an occluding window. The wording
+      // is deliberately HEDGED: pixels alone cannot tell a genuinely-black
+      // window (dark terminal / video / fresh GPU app) from uncapturable content
+      // (DRM / secure desktop / hardware overlay), so we do NOT assert the
+      // content is protected (Codex + Opus review). Fixed strings only (CWE-94).
       if (result.captureBlocked) {
         captureHints.captureBlocked = true;
         localWarnings.push(
-          "All capture methods (PrintWindow, WGC, BitBlt) returned an all-black frame. The target window's content is likely protected (DRM-protected video, a secure-desktop / UAC prompt, or a hardware-overlay surface) and cannot be captured — the returned image is black, not the real window content."
+          "All capture methods (PrintWindow, WGC, BitBlt) returned a uniform all-black frame. The window may legitimately be black (a dark terminal, a black or letterboxed video frame, or a freshly-launched GPU app) OR its content may be uncapturable (DRM-protected video, a secure-desktop / UAC prompt, or a hardware-overlay surface). The returned image is all-black — treat it as unverified."
         );
       } else if (result.source === "bitblt-fallback") {
         // The occlusion-risk warnings describe the BitBlt fallback ONLY. A WGC
@@ -1145,14 +1147,15 @@ export const screenshotBgHandler = async ({
     });
     const allBgWarnings = warning ? [...bgWarnings, warning] : [...bgWarnings];
     // ADR-027 R9/AC8 — background mode's rungs are WGC (when eligible) →
-    // PrintWindow. captureBlocked means BOTH returned an all-black frame: the
-    // content is capture-blocked (DRM / secure desktop / hardware overlay).
-    // Surface it explicitly instead of returning a silent black image. Fixed
-    // string only (CWE-94).
-    const captureBlocked = (result as { captureBlocked?: boolean }).captureBlocked === true;
+    // PrintWindow. captureBlocked means BOTH returned an all-black frame: no
+    // rung produced non-black pixels. Surface it explicitly instead of returning
+    // a silent black image. Wording is HEDGED — pixels can't tell a genuinely-
+    // black window from uncapturable content (Codex + Opus review). Fixed string
+    // only (CWE-94).
+    const captureBlocked = result.captureBlocked === true;
     if (captureBlocked) {
       allBgWarnings.push(
-        "Capture returned an all-black frame via both WGC and PrintWindow. The target window's content is likely protected (DRM-protected video, a secure-desktop / UAC prompt, or a hardware-overlay surface) and cannot be captured — the returned image is black, not the real window content."
+        "Capture returned a uniform all-black frame via both WGC and PrintWindow. The window may legitimately be black (a dark terminal, a black or letterboxed video frame, or a freshly-launched GPU app) OR its content may be uncapturable (DRM-protected video, a secure-desktop / UAC prompt, or a hardware-overlay surface). The returned image is all-black — treat it as unverified."
       );
     }
     return {

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -931,6 +931,7 @@ export const screenshotHandler = async (args: {
       const captureHints: {
         captureSource: CaptureSource;
         captureFallbackReason?: CaptureFallbackReason;
+        captureBlocked?: boolean;
         warnings?: string[];
       } = { captureSource: result.source };
       const localWarnings: string[] = [...screenshotWarnings];
@@ -939,11 +940,22 @@ export const screenshotHandler = async (args: {
         // frame (for source="wgc" it records why PrintWindow was abandoned).
         captureHints.captureFallbackReason = result.fallbackReason;
       }
-      // The occlusion-risk warnings describe the BitBlt fallback ONLY. A WGC
-      // rescue (source="wgc") reads the DWM composition surface and is
-      // occlusion-immune, so it must not inherit the "may show overlapping
-      // windows" text even though it carries a fallbackReason (ADR-027 Phase 2).
-      if (result.source === "bitblt-fallback") {
+      // ADR-027 R9/AC8 — every rung (PrintWindow → WGC → BitBlt) returned an
+      // all-black frame: the content is capture-blocked (DRM / secure desktop /
+      // hardware overlay). Surface that explicitly and SUPERSEDE the BitBlt
+      // "overlapping windows" hint below — a uniformly black frame is not
+      // showing an occluding window, and "pass mode='background'" would not help
+      // (background mode hits the same black). Fixed strings only (CWE-94).
+      if (result.captureBlocked) {
+        captureHints.captureBlocked = true;
+        localWarnings.push(
+          "All capture methods (PrintWindow, WGC, BitBlt) returned an all-black frame. The target window's content is likely protected (DRM-protected video, a secure-desktop / UAC prompt, or a hardware-overlay surface) and cannot be captured — the returned image is black, not the real window content."
+        );
+      } else if (result.source === "bitblt-fallback") {
+        // The occlusion-risk warnings describe the BitBlt fallback ONLY. A WGC
+        // rescue (source="wgc") reads the DWM composition surface and is
+        // occlusion-immune, so it must not inherit the "may show overlapping
+        // windows" text even though it carries a fallbackReason (ADR-027 Phase 2).
         // Fixed strings only (no variable interpolation — CWE-94 guidance).
         if (result.fallbackReason === "printwindow-failed") {
           localWarnings.push(
@@ -1131,12 +1143,23 @@ export const screenshotBgHandler = async ({
       wantInline: true,
       meta: { tag: foundTitle || effectiveTitle },
     });
-    const allBgWarnings = warning ? [...bgWarnings, warning] : bgWarnings;
+    const allBgWarnings = warning ? [...bgWarnings, warning] : [...bgWarnings];
+    // ADR-027 R9/AC8 — background mode's rungs are WGC (when eligible) →
+    // PrintWindow. captureBlocked means BOTH returned an all-black frame: the
+    // content is capture-blocked (DRM / secure desktop / hardware overlay).
+    // Surface it explicitly instead of returning a silent black image. Fixed
+    // string only (CWE-94).
+    const captureBlocked = (result as { captureBlocked?: boolean }).captureBlocked === true;
+    if (captureBlocked) {
+      allBgWarnings.push(
+        "Capture returned an all-black frame via both WGC and PrintWindow. The target window's content is likely protected (DRM-protected video, a secure-desktop / UAC prompt, or a hardware-overlay surface) and cannot be captured — the returned image is black, not the real window content."
+      );
+    }
     return {
       content: [
         ...blocks,
         { type: "text" as const, text: dimensionText },
-        ...(allBgWarnings.length > 0 ? [{ type: "text" as const, text: JSON.stringify({ hints: { warnings: allBgWarnings } }) }] : []),
+        ...(allBgWarnings.length > 0 ? [{ type: "text" as const, text: JSON.stringify({ hints: { ...(captureBlocked ? { captureBlocked: true } : {}), warnings: allBgWarnings } }) }] : []),
       ],
     };
   } catch (err) {

--- a/tests/fixtures/failwith-callsite-shapes.json
+++ b/tests/fixtures/failwith-callsite-shapes.json
@@ -459,14 +459,14 @@
     },
     {
       "file": "src/tools/screenshot.ts",
-      "line": 1144,
+      "line": 1167,
       "tool": "screenshot",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/screenshot.ts",
-      "line": 1267,
+      "line": 1290,
       "tool": "get_screen_info",
       "errKind": "identifier",
       "contextShape": "none"

--- a/tests/fixtures/failwith-callsite-shapes.json
+++ b/tests/fixtures/failwith-callsite-shapes.json
@@ -459,14 +459,14 @@
     },
     {
       "file": "src/tools/screenshot.ts",
-      "line": 1167,
+      "line": 1170,
       "tool": "screenshot",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/screenshot.ts",
-      "line": 1290,
+      "line": 1293,
       "tool": "get_screen_info",
       "errKind": "identifier",
       "contextShape": "none"

--- a/tests/fixtures/failwith-callsite-shapes.json
+++ b/tests/fixtures/failwith-callsite-shapes.json
@@ -459,14 +459,14 @@
     },
     {
       "file": "src/tools/screenshot.ts",
-      "line": 1170,
+      "line": 1177,
       "tool": "screenshot",
       "errKind": "identifier",
       "contextShape": "none"
     },
     {
       "file": "src/tools/screenshot.ts",
-      "line": 1293,
+      "line": 1300,
       "tool": "get_screen_info",
       "errKind": "identifier",
       "contextShape": "none"

--- a/tests/unit/screenshot-emitters-ref.test.ts
+++ b/tests/unit/screenshot-emitters-ref.test.ts
@@ -188,6 +188,9 @@ describe("capture-blocked surfacing — normal path (ADR-027 Phase 3 / AC8)", ()
     expect(warnings).toMatch(/all-black frame/i);
     expect(warnings).toMatch(/may legitimately be black/i);
     expect(warnings).toMatch(/uncapturable/i);
+    // Outcome-only wording: must NOT enumerate which specific rungs ran (some
+    // may have failed or been skipped — Codex review).
+    expect(warnings).not.toMatch(/PrintWindow, WGC, BitBlt/i);
     // SUPERSEDE: the BitBlt "overlapping windows" / "pass mode='background'"
     // hints must NOT appear — a uniform black frame is not an occluding window.
     expect(warnings).not.toMatch(/overlapping windows/i);
@@ -241,9 +244,13 @@ describe("capture-blocked surfacing — background path (ADR-027 Phase 3 / AC8)"
     const hints = readHints(result);
     expect(hints?.captureBlocked).toBe(true);
     const warnings = (hints?.warnings ?? []).join(" | ");
-    expect(warnings).toMatch(/all-black frame via both WGC and PrintWindow/i);
+    expect(warnings).toMatch(/all-black frame/i);
+    expect(warnings).toMatch(/could not be verified/i);
     expect(warnings).toMatch(/may legitimately be black/i);
     expect(warnings).toMatch(/uncapturable/i);
+    // Outcome-only: must NOT claim WGC participated (PrintWindow-only paths
+    // never attempt WGC — Codex review).
+    expect(warnings).not.toMatch(/via both WGC and PrintWindow/i);
   });
 
   it("captureBlocked absent (real pixels) → no capture-blocked warning", async () => {

--- a/tests/unit/screenshot-emitters-ref.test.ts
+++ b/tests/unit/screenshot-emitters-ref.test.ts
@@ -16,7 +16,7 @@ import path from "node:path";
 import crypto from "node:crypto";
 
 // ─── Hoisted mocks ────────────────────────────────────────────────────────────
-const { mockEnumWindowsInZOrder, mockGetWindowTitleW, mockHasBuffer, mockCaptureAllLayers, mockCaptureAndDiff, mockUpdateWindowCache, mockSaveSnapshot, mockGetWindows, mockResolveWindowTarget, mockCaptureWindowBackground } = vi.hoisted(() => ({
+const { mockEnumWindowsInZOrder, mockGetWindowTitleW, mockHasBuffer, mockCaptureAllLayers, mockCaptureAndDiff, mockUpdateWindowCache, mockSaveSnapshot, mockGetWindows, mockResolveWindowTarget, mockCaptureWindowBackground, mockCaptureWindowWithFallback } = vi.hoisted(() => ({
   mockEnumWindowsInZOrder: vi.fn(),
   mockGetWindowTitleW: vi.fn(),
   mockHasBuffer: vi.fn(),
@@ -27,6 +27,7 @@ const { mockEnumWindowsInZOrder, mockGetWindowTitleW, mockHasBuffer, mockCapture
   mockGetWindows: vi.fn(),
   mockResolveWindowTarget: vi.fn(),
   mockCaptureWindowBackground: vi.fn(),
+  mockCaptureWindowWithFallback: vi.fn(),
 }));
 
 vi.mock("../../src/engine/win32.js", async (importOriginal) => {
@@ -57,7 +58,7 @@ vi.mock("../../src/engine/image.js", () => ({
   captureWindowBackground: mockCaptureWindowBackground,
   captureScreen: vi.fn(),
   captureDisplay: vi.fn(),
-  captureWindowWithFallback: vi.fn(),
+  captureWindowWithFallback: mockCaptureWindowWithFallback,
 }));
 
 const { screenshotHandler, screenshotBgHandler } = await import("../../src/tools/screenshot.js");
@@ -134,5 +135,126 @@ describe("mode='background' — ADR-026 §3 inline + ref", () => {
     // §2.2(c) exception: mode='background' is itself the pixel request — inline FIRST, then ref.
     expect(result.content[0].type).toBe("image");
     expect(result.content.some((c) => c.type === "resource_link")).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ADR-027 Phase 3 — capture-blocked handler surfacing (R9/AC8)
+//
+// Pins the actual AC8 deliverable to the LLM: the hints.captureBlocked flag, the
+// hedged warning text, the SUPERSEDE of the BitBlt "overlapping windows" warning
+// in the normal path, and the background-path warning. Engine-level tests pin
+// the boolean; these pin the surfacing.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Find and parse the `{ hints: ... }` JSON text block in a tool response. */
+function readHints(result: { content: Array<{ type: string; text?: string }> }): {
+  captureSource?: string;
+  captureFallbackReason?: string;
+  captureBlocked?: boolean;
+  warnings?: string[];
+} | null {
+  for (const c of result.content) {
+    if (c.type === "text" && typeof c.text === "string" && c.text.includes("\"hints\"")) {
+      try {
+        const parsed = JSON.parse(c.text) as { hints?: Record<string, unknown> };
+        if (parsed.hints) return parsed.hints as ReturnType<typeof readHints>;
+      } catch { /* not the hints block */ }
+    }
+  }
+  return null;
+}
+
+describe("capture-blocked surfacing — normal path (ADR-027 Phase 3 / AC8)", () => {
+  function wireWindow() {
+    mockResolveWindowTarget.mockResolvedValue({ title: "My App", hwnd: 999n });
+    mockEnumWindowsInZOrder.mockReturnValue([
+      { hwnd: 999n, title: "My App", region: { x: 0, y: 0, width: 800, height: 600 }, zOrder: 0, isActive: true },
+    ]);
+  }
+
+  it("captureBlocked=true → hints.captureBlocked + hedged warning, SUPERSEDES the overlapping-windows hint", async () => {
+    wireWindow();
+    mockCaptureWindowWithFallback.mockResolvedValue({
+      base64: B64, mimeType: "image/png", width: 800, height: 600,
+      source: "bitblt-fallback", fallbackReason: "printwindow-all-black", captureBlocked: true,
+    });
+
+    const result = await screenshotHandler({ ...baseArgs, windowTitle: "My App", detail: "image", confirmImage: false });
+    const hints = readHints(result);
+    expect(hints?.captureBlocked).toBe(true);
+    const warnings = (hints?.warnings ?? []).join(" | ");
+    // Hedged wording: does NOT assert the content is definitely protected.
+    expect(warnings).toMatch(/all-black frame/i);
+    expect(warnings).toMatch(/may legitimately be black/i);
+    expect(warnings).toMatch(/uncapturable/i);
+    // SUPERSEDE: the BitBlt "overlapping windows" / "pass mode='background'"
+    // hints must NOT appear — a uniform black frame is not an occluding window.
+    expect(warnings).not.toMatch(/overlapping windows/i);
+    expect(warnings).not.toMatch(/pass mode='background'/i);
+  });
+
+  it("captureBlocked=false + bitblt-fallback all-black → keeps the existing 'pass mode=background' hint, no captureBlocked", async () => {
+    wireWindow();
+    mockCaptureWindowWithFallback.mockResolvedValue({
+      base64: B64, mimeType: "image/png", width: 800, height: 600,
+      source: "bitblt-fallback", fallbackReason: "printwindow-all-black", captureBlocked: false,
+    });
+
+    const result = await screenshotHandler({ ...baseArgs, windowTitle: "My App", detail: "image", confirmImage: false });
+    const hints = readHints(result);
+    expect(hints?.captureBlocked).toBeUndefined();
+    const warnings = (hints?.warnings ?? []).join(" | ");
+    expect(warnings).toMatch(/pass mode='background'/i);
+  });
+
+  it("captureBlocked=false + printwindow source → no capture warning, no captureBlocked hint", async () => {
+    wireWindow();
+    mockCaptureWindowWithFallback.mockResolvedValue({
+      base64: B64, mimeType: "image/png", width: 800, height: 600,
+      source: "printwindow", fallbackReason: null, captureBlocked: false,
+    });
+
+    const result = await screenshotHandler({ ...baseArgs, windowTitle: "My App", detail: "image", confirmImage: false });
+    const hints = readHints(result);
+    expect(hints?.captureBlocked).toBeUndefined();
+    expect(hints?.captureSource).toBe("printwindow");
+  });
+});
+
+describe("capture-blocked surfacing — background path (ADR-027 Phase 3 / AC8)", () => {
+  function wireBgWindow() {
+    mockResolveWindowTarget.mockResolvedValue({ title: "My App", hwnd: 999n });
+    mockGetWindows.mockResolvedValue([
+      { windowHandle: 999, title: Promise.resolve("My App"), region: Promise.resolve({ left: 0, top: 0, width: 800, height: 600 }) },
+    ]);
+    mockGetWindowTitleW.mockReturnValue("My App");
+  }
+
+  it("captureBlocked=true → hints.captureBlocked + hedged warning in background response", async () => {
+    wireBgWindow();
+    mockCaptureWindowBackground.mockResolvedValue({ base64: B64, mimeType: "image/png", width: 800, height: 600, captureBlocked: true });
+
+    const result = await screenshotBgHandler({
+      windowTitle: "My App", maxDimension: 768, dotByDot: false, grayscale: false, webpQuality: 60, fullContent: true,
+    });
+    const hints = readHints(result);
+    expect(hints?.captureBlocked).toBe(true);
+    const warnings = (hints?.warnings ?? []).join(" | ");
+    expect(warnings).toMatch(/all-black frame via both WGC and PrintWindow/i);
+    expect(warnings).toMatch(/may legitimately be black/i);
+    expect(warnings).toMatch(/uncapturable/i);
+  });
+
+  it("captureBlocked absent (real pixels) → no capture-blocked warning", async () => {
+    wireBgWindow();
+    mockCaptureWindowBackground.mockResolvedValue({ base64: B64, mimeType: "image/png", width: 800, height: 600 });
+
+    const result = await screenshotBgHandler({
+      windowTitle: "My App", maxDimension: 768, dotByDot: false, grayscale: false, webpQuality: 60, fullContent: true,
+    });
+    const hints = readHints(result);
+    // No hints block at all (no warnings) OR a hints block without captureBlocked.
+    expect(hints?.captureBlocked).toBeUndefined();
   });
 });

--- a/tests/unit/screenshot-printwindow-default.test.ts
+++ b/tests/unit/screenshot-printwindow-default.test.ts
@@ -553,6 +553,20 @@ describe("captureWindowRawWithFallback — capture-blocked (ADR-027 Phase 3 / AC
     expect(result.source).toBe("wgc");
     expect(result.captureBlocked).toBe(false);
   });
+
+  it("PrintWindow black + WGC eligible-but-ALSO-black + BitBlt black → captureBlocked=true (full rung exhaustion)", async () => {
+    // The WGC-rejected → BitBlt convergence: WGC is attempted (eligible) but
+    // returns black (rejected by blank-safety), then BitBlt is also black.
+    mockPrintWindowToBuffer.mockReturnValue({ data: makeUniformRgba(64, 64, 0, 0, 0), width: 64, height: 64 });
+    mockCanUseWgc.mockReturnValue(true);
+    mockCaptureWindowWgc.mockResolvedValue({ data: makeUniformRgba(64, 64, 0, 0, 0), width: 64, height: 64 });
+    mockGrabRegion.mockResolvedValue(makeNutjsImage(64, 64, { r: 0, g: 0, b: 0 }));
+
+    const result = await captureWindowRawWithFallback(hwnd, region);
+    expect(result.source).toBe("bitblt-fallback");
+    expect(mockCaptureWindowWgc).toHaveBeenCalledTimes(1); // WGC attempted then rejected
+    expect(result.captureBlocked).toBe(true);
+  });
 });
 
 describe("captureWindowBackground — capture-blocked (ADR-027 Phase 3 / AC8)", () => {

--- a/tests/unit/screenshot-printwindow-default.test.ts
+++ b/tests/unit/screenshot-printwindow-default.test.ts
@@ -65,6 +65,22 @@ function makeUniformRgba(width: number, height: number, r: number, g: number, b:
   return buf;
 }
 
+/** White frame with an all-black rectangle (for crop-aware blank tests). */
+function makeWhiteWithBlackRect(
+  width: number,
+  height: number,
+  rect: { x: number; y: number; width: number; height: number },
+): Buffer {
+  const buf = makeUniformRgba(width, height, 255, 255, 255);
+  for (let y = rect.y; y < rect.y + rect.height; y++) {
+    for (let x = rect.x; x < rect.x + rect.width; x++) {
+      const off = (y * width + x) * 4;
+      buf[off] = 0; buf[off + 1] = 0; buf[off + 2] = 0; buf[off + 3] = 255;
+    }
+  }
+  return buf;
+}
+
 function makeGradientRgba(width: number, height: number): Buffer {
   const buf = Buffer.alloc(width * height * 4);
   for (let y = 0; y < height; y++) {
@@ -145,6 +161,32 @@ describe("isLikelyBlankCapture", () => {
   it("zero-size buffer is NOT flagged blank (treated as no-data, caller decides)", () => {
     const result = isLikelyBlankCapture(Buffer.alloc(0), 0, 0, 4);
     expect(result.isBlank).toBe(false);
+  });
+
+  // ADR-027 Phase 3 / Codex review — crop-aware sampling.
+  it("crop into an all-black sub-region of a non-black frame → isBlank=true", () => {
+    // White window with a black rectangle (e.g. a DRM video area). The full
+    // frame is non-black, but the cropped region is all-black.
+    const buf = makeWhiteWithBlackRect(80, 80, { x: 20, y: 20, width: 30, height: 30 });
+    expect(isLikelyBlankCapture(buf, 80, 80, 4).isBlank).toBe(false); // full = non-black
+    expect(isLikelyBlankCapture(buf, 80, 80, 4, { x: 20, y: 20, width: 30, height: 30 }).isBlank).toBe(true);
+  });
+
+  it("crop into a non-black sub-region → isBlank=false", () => {
+    const buf = makeWhiteWithBlackRect(80, 80, { x: 20, y: 20, width: 30, height: 30 });
+    // A crop entirely in the white area is not blank.
+    expect(isLikelyBlankCapture(buf, 80, 80, 4, { x: 60, y: 60, width: 15, height: 15 }).isBlank).toBe(false);
+  });
+
+  it("no crop is bit-identical to the 4-arg form (full all-black still flagged)", () => {
+    const black = makeUniformRgba(64, 64, 0, 0, 0);
+    expect(isLikelyBlankCapture(black, 64, 64, 4, undefined)).toEqual(isLikelyBlankCapture(black, 64, 64, 4));
+    expect(isLikelyBlankCapture(black, 64, 64, 4, undefined).isBlank).toBe(true);
+  });
+
+  it("crop clamped out of bounds (empty) → isBlank=false", () => {
+    const black = makeUniformRgba(64, 64, 0, 0, 0);
+    expect(isLikelyBlankCapture(black, 64, 64, 4, { x: 200, y: 200, width: 10, height: 10 }).isBlank).toBe(false);
   });
 });
 
@@ -612,5 +654,61 @@ describe("captureWindowBackground — capture-blocked (ADR-027 Phase 3 / AC8)", 
 
     const result = await captureWindowBackground(hwnd, 1280);
     expect((result as { captureBlocked?: boolean }).captureBlocked).toBeFalsy();
+  });
+
+  // ADR-027 Phase 3 / Codex review — crop-aware: captureBlocked reflects the
+  // SERVED crop, not the full window (a black region inside a non-black window).
+  it("PrintWindow non-black full + crop into a BLACK region → captureBlocked=true", async () => {
+    mockCanUseWgc.mockReturnValue(false);
+    mockPrintWindowToBuffer.mockReturnValue({ data: makeWhiteWithBlackRect(80, 80, { x: 10, y: 10, width: 40, height: 40 }), width: 80, height: 80 });
+
+    const result = await captureWindowBackground(hwnd, { maxDimension: 1280, crop: { x: 10, y: 10, width: 40, height: 40 } });
+    expect((result as { captureBlocked?: boolean }).captureBlocked).toBe(true);
+  });
+
+  it("PrintWindow non-black full + crop into a NON-black region → captureBlocked=false", async () => {
+    mockCanUseWgc.mockReturnValue(false);
+    mockPrintWindowToBuffer.mockReturnValue({ data: makeWhiteWithBlackRect(80, 80, { x: 10, y: 10, width: 40, height: 40 }), width: 80, height: 80 });
+
+    const result = await captureWindowBackground(hwnd, { maxDimension: 1280, crop: { x: 60, y: 60, width: 15, height: 15 } });
+    expect((result as { captureBlocked?: boolean }).captureBlocked).toBeFalsy();
+  });
+
+  it("WGC serves a non-black full frame + crop into a BLACK region → captureBlocked=true", async () => {
+    mockCanUseWgc.mockReturnValue(true);
+    mockCaptureWindowWgc.mockResolvedValue({ data: makeWhiteWithBlackRect(80, 80, { x: 10, y: 10, width: 40, height: 40 }), width: 80, height: 80 });
+
+    const result = await captureWindowBackground(hwnd, { maxDimension: 1280, crop: { x: 10, y: 10, width: 40, height: 40 } });
+    expect(mockCaptureWindowWgc).toHaveBeenCalledTimes(1);
+    expect((result as { captureBlocked?: boolean }).captureBlocked).toBe(true);
+  });
+});
+
+describe("captureWindowWithFallback — crop-aware capture-blocked (ADR-027 Phase 3 / Codex review)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetWgcSupportForTest();
+    mockCanUseWgc.mockReturnValue(false);
+  });
+
+  const fullWindow = { x: 0, y: 0, width: 80, height: 80 };
+  const hwnd = 12345n;
+
+  it("PrintWindow non-black full + crop into a BLACK region → source='printwindow', captureBlocked=true", async () => {
+    // The DRM-video-region case: PrintWindow captures the window fine, but the
+    // requested sub-region is all-black. captureBlocked reflects the sent crop.
+    mockPrintWindowToBuffer.mockReturnValue({ data: makeWhiteWithBlackRect(80, 80, { x: 10, y: 10, width: 40, height: 40 }), width: 80, height: 80 });
+
+    const result = await captureWindowWithFallback(hwnd, fullWindow, { maxDimension: 200, crop: { x: 10, y: 10, width: 40, height: 40 } });
+    expect(result.source).toBe("printwindow");
+    expect(result.captureBlocked).toBe(true);
+  });
+
+  it("PrintWindow non-black full + crop into a NON-black region → captureBlocked=false", async () => {
+    mockPrintWindowToBuffer.mockReturnValue({ data: makeWhiteWithBlackRect(80, 80, { x: 10, y: 10, width: 40, height: 40 }), width: 80, height: 80 });
+
+    const result = await captureWindowWithFallback(hwnd, fullWindow, { maxDimension: 200, crop: { x: 60, y: 60, width: 15, height: 15 } });
+    expect(result.source).toBe("printwindow");
+    expect(result.captureBlocked).toBe(false);
   });
 });

--- a/tests/unit/screenshot-printwindow-default.test.ts
+++ b/tests/unit/screenshot-printwindow-default.test.ts
@@ -477,3 +477,126 @@ describe("captureWindowBackground — WGC primary (ADR-027 Phase 2)", () => {
     expect(mockPrintWindowToBuffer).toHaveBeenCalledTimes(1); // WGC blank rejected → PrintWindow
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ADR-027 Phase 3 — R9/AC8 capture-blocked (every rung returns all-black)
+//
+// The ladder is finite (PrintWindow → WGC → BitBlt). captureBlocked flags the
+// case where the LAST rung is ALSO all-black, so the served pixels are black
+// and NOT the real content (DRM video / secure desktop / hardware overlay). The
+// caller surfaces an explicit reason instead of a silent black image. An
+// occluding (non-black) BitBlt frame is NOT capture-blocked — it keeps the
+// existing "overlapping windows" hint.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("captureWindowRawWithFallback — capture-blocked (ADR-027 Phase 3 / AC8)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetWgcSupportForTest();
+    mockCanUseWgc.mockReturnValue(false);
+  });
+
+  const region = { x: 100, y: 200, width: 64, height: 64 };
+  const hwnd = 12345n;
+
+  it("PrintWindow all-black + WGC ineligible + BitBlt ALSO all-black → captureBlocked=true", async () => {
+    mockPrintWindowToBuffer.mockReturnValue({ data: makeUniformRgba(64, 64, 0, 0, 0), width: 64, height: 64 });
+    mockCanUseWgc.mockReturnValue(false);
+    mockGrabRegion.mockResolvedValue(makeNutjsImage(64, 64, { r: 0, g: 0, b: 0 }));
+
+    const result = await captureWindowRawWithFallback(hwnd, region);
+    expect(result.source).toBe("bitblt-fallback");
+    expect(result.captureBlocked).toBe(true);
+    // fallbackReason is preserved as a diagnostic (records why PrintWindow was abandoned).
+    expect(result.fallbackReason).toBe("printwindow-all-black");
+  });
+
+  it("PrintWindow throws + WGC ineligible + BitBlt all-black → captureBlocked=true (printwindow-failed reason)", async () => {
+    mockPrintWindowToBuffer.mockImplementation(() => { throw new Error("PrintWindow native error"); });
+    mockCanUseWgc.mockReturnValue(false);
+    mockGrabRegion.mockResolvedValue(makeNutjsImage(64, 64, { r: 0, g: 0, b: 0 }));
+
+    const result = await captureWindowRawWithFallback(hwnd, region);
+    expect(result.source).toBe("bitblt-fallback");
+    expect(result.captureBlocked).toBe(true);
+    expect(result.fallbackReason).toBe("printwindow-failed");
+  });
+
+  it("PrintWindow all-black + BitBlt shows an OCCLUDING (non-black) window → captureBlocked=false", async () => {
+    // The headline non-capture-blocked case: an occluding window's pixels are
+    // real (just the wrong window). Keep the "overlapping windows" hint, do NOT
+    // claim capture-blocked.
+    mockPrintWindowToBuffer.mockReturnValue({ data: makeUniformRgba(64, 64, 0, 0, 0), width: 64, height: 64 });
+    mockCanUseWgc.mockReturnValue(false);
+    mockGrabRegion.mockResolvedValue(makeNutjsImage(64, 64, { r: 80, g: 90, b: 100 }));
+
+    const result = await captureWindowRawWithFallback(hwnd, region);
+    expect(result.source).toBe("bitblt-fallback");
+    expect(result.captureBlocked).toBe(false);
+    expect(result.fallbackReason).toBe("printwindow-all-black");
+  });
+
+  it("PrintWindow returns real pixels → captureBlocked=false (no rung exhaustion)", async () => {
+    mockPrintWindowToBuffer.mockReturnValue({ data: makeGradientRgba(64, 64), width: 64, height: 64 });
+
+    const result = await captureWindowRawWithFallback(hwnd, region);
+    expect(result.source).toBe("printwindow");
+    expect(result.captureBlocked).toBe(false);
+  });
+
+  it("WGC rescue serves real pixels → captureBlocked=false", async () => {
+    mockPrintWindowToBuffer.mockReturnValue({ data: makeUniformRgba(64, 64, 0, 0, 0), width: 64, height: 64 });
+    mockCanUseWgc.mockReturnValue(true);
+    mockCaptureWindowWgc.mockResolvedValue({ data: makeGradientRgba(64, 64), width: 64, height: 64 });
+
+    const result = await captureWindowRawWithFallback(hwnd, region);
+    expect(result.source).toBe("wgc");
+    expect(result.captureBlocked).toBe(false);
+  });
+});
+
+describe("captureWindowBackground — capture-blocked (ADR-027 Phase 3 / AC8)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetWgcSupportForTest();
+    mockCanUseWgc.mockReturnValue(false);
+  });
+
+  const hwnd = 12345n;
+
+  it("WGC ineligible + PrintWindow all-black → captureBlocked=true", async () => {
+    mockCanUseWgc.mockReturnValue(false);
+    mockPrintWindowToBuffer.mockReturnValue({ data: makeUniformRgba(80, 60, 0, 0, 0), width: 80, height: 60 });
+
+    const result = await captureWindowBackground(hwnd, 1280);
+    expect((result as { captureBlocked?: boolean }).captureBlocked).toBe(true);
+  });
+
+  it("WGC eligible but all-black + PrintWindow ALSO all-black → captureBlocked=true (both rungs failed)", async () => {
+    mockCanUseWgc.mockReturnValue(true);
+    mockCaptureWindowWgc.mockResolvedValue({ data: makeUniformRgba(80, 60, 0, 0, 0), width: 80, height: 60 });
+    mockPrintWindowToBuffer.mockReturnValue({ data: makeUniformRgba(80, 60, 0, 0, 0), width: 80, height: 60 });
+
+    const result = await captureWindowBackground(hwnd, 1280);
+    expect(mockCaptureWindowWgc).toHaveBeenCalledTimes(1);
+    expect(mockPrintWindowToBuffer).toHaveBeenCalledTimes(1);
+    expect((result as { captureBlocked?: boolean }).captureBlocked).toBe(true);
+  });
+
+  it("WGC serves real pixels → not capture-blocked", async () => {
+    mockCanUseWgc.mockReturnValue(true);
+    mockCaptureWindowWgc.mockResolvedValue({ data: makeGradientRgba(80, 60), width: 80, height: 60 });
+
+    const result = await captureWindowBackground(hwnd, 1280);
+    expect((result as { captureBlocked?: boolean }).captureBlocked).toBeFalsy();
+    expect(mockPrintWindowToBuffer).not.toHaveBeenCalled();
+  });
+
+  it("PrintWindow serves real pixels → not capture-blocked", async () => {
+    mockCanUseWgc.mockReturnValue(false);
+    mockPrintWindowToBuffer.mockReturnValue({ data: makeGradientRgba(80, 60), width: 80, height: 60 });
+
+    const result = await captureWindowBackground(hwnd, 1280);
+    expect((result as { captureBlocked?: boolean }).captureBlocked).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## ADR-027 Phase 3 — capture-blocked graceful degrade (R9/AC8)

The WGC capture ladder (PrintWindow → WGC → BitBlt) is finite and does not loop, but until now the **final rung's all-black frame was returned silently**:

- **normal mode**: BitBlt's frame was returned unchecked, with a misleading "fell back to BitBlt / may show overlapping windows" hint and a "pass mode='background'" suggestion that would hit the same black.
- **background mode**: the final PrintWindow black frame was returned with **no warning and no reason at all** (fully silent).

Phase 3 adds a **terminal capture-blocked signal**: when *every* rung returns an all-black / zero-variance frame, surface an explicit `hints.captureBlocked: true` flag and a distinct warning instead of returning a black image as if it were valid content.

### What changed
- **`image.ts`**: `CaptureWindowRawResult` gains `captureBlocked: boolean`. The last rung (BitBlt in normal mode, PrintWindow in background mode) is run through `isLikelyBlankCapture`; an all-black final frame sets `captureBlocked=true`. PrintWindow/WGC success and a non-black (occluding-window) BitBlt frame are **not** capture-blocked. `captureWindowBackground` returns `CaptureResult & { captureBlocked?: boolean }` (additive — OCR/SoM callers ignore it).
- **`screenshot.ts`**: surfaces a `captureBlocked: true` hint + a distinct fixed-string warning (CWE-94 safe) in both paths. In normal mode it **supersedes** the BitBlt overlapping-windows hint — a uniformly black frame is not showing an occluding window.

### Hedged wording (review-driven)
The warning is deliberately **hedged**: pixels alone cannot tell a genuinely-black window (dark terminal, black/letterboxed video, freshly-launched GPU app) from uncapturable content (DRM-protected video, secure-desktop/UAC prompt, hardware-overlay surface) — both yield a uniform black frame. So it does **not** assert the content is protected; it says "the returned image is all-black — treat it as unverified."

### Tests
- Engine: 6 capture-blocked ladder cases (true/false across PrintWindow / WGC / BitBlt rungs + the occluding-window non-blocked case + full rung exhaustion with WGC attempted-then-rejected).
- Handler: 5 surfacing cases pinning the `hints.captureBlocked` JSON, the hedged warning text, and the supersede of the overlapping-windows hint (normal + background paths).
- Regenerated `failwith-callsite-shapes` fixture (callsite line shift).

### Live dogfood (this host)
- WGC serves real pixels: Cascadia Terminal (AtlasEngine GPU) `943x609`, Edge/Chrome video `890x648` — both non-black.
- Device reuse: 1st capture ~193ms → 2nd ~81ms.
- D3 gate excludes minimized/cloaked windows; visible windows use WGC.
- Background mode uses WGC as primary (dims match WGC, not PrintWindow); `fullContent=false` correctly stays on PrintWindow.
- D4 buffer invariant `bytes == w*h*4` holds.
- The all-rungs-black path is **not reproducible without DRM content here**, so AC8 is a defensive terminal signal pinned by hermetic tests.

### Release
**Deferred** — bundled with ADR-028; the CHANGELOG `[1.11.0]` entry accumulates and ships later. No user-facing release in this PR.

Plan / acceptance: `desktop-touch-mcp-internal:docs/adr-027-wgc-capture-layer.md` R9/AC8 + §6.3 (Phase 3 dogfood).

Reviewed locally: Codex (P2 hedged-wording fixed) + Opus phase-boundary review (P1 ADR SSOT synced, P2(a) handler tests added, P2(b) wording hedged, P3 all addressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
