### PR TITLE
feat(wgc): ADR-027 Phase 4 — WGC latency bench + CHANGELOG (no release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,31 @@
 # Changelog
 
-## [1.11.0] - Unreleased — Screenshots now cost a fraction of the tokens, plus tools to manage the cache
+## [1.11.0] - Unreleased — Screenshots cost a fraction of the tokens, capture real pixels from GPU-rendered & occluded windows, plus tools to manage the cache
 
 ### Added
 
+- **GPU-rendered and occluded windows now capture real pixels instead of black.**
+  Hardware-accelerated windows — Chrome / Edge, Electron apps (VS Code, Slack,
+  Discord), and many WinUI / game windows — often came back as a black rectangle
+  because the classic capture path can't read their GPU-composited surface, and
+  the on-screen fallback can only grab a window that isn't covered by another.
+  `screenshot` now adds a Windows.Graphics.Capture path that reads the same
+  composited surface the desktop shows, so those windows (including ones sitting
+  behind others) capture their actual contents. It's used automatically:
+  `mode='background'` captures eligible visible windows through it, and a normal
+  `screenshot` that comes back black is retried through it before any fallback —
+  no new options to set. Minimized, hidden, and off-desktop windows keep using
+  the existing path (they have no live composited surface to read). The on-disk
+  cache and by-ref links above are unchanged — this only changes *what* gets
+  captured, not how the image is returned.
+- **A clear signal when a window genuinely can't be captured.** If every capture
+  method still returns an all-black frame — typical of DRM-protected video, a
+  secure-desktop / UAC prompt, or a hardware-overlay surface — `screenshot` now
+  says so explicitly (a `captureBlocked` hint plus a warning) instead of quietly
+  handing back a black image as if it were the real window. The wording is
+  deliberately careful: an all-black result can also just be a genuinely black
+  window (a dark terminal, a letterboxed video), so it asks you to treat the
+  image as unverified rather than asserting the content is protected.
 - **By-ref screenshots (big token saving).** `screenshot` and the other visual
   results — SoM element overlays, diff-mode frames, scroll captures, workspace
   snapshots, and `desktop_act`'s changed-region crop — are now handed back as a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@
   `screenshot` that comes back black is retried through it before any fallback —
   no new options to set. Minimized, hidden, and off-desktop windows keep using
   the existing path (they have no live composited surface to read). The on-disk
-  cache and by-ref links above are unchanged — this only changes *what* gets
-  captured, not how the image is returned.
+  cache and by-ref links are unchanged — this only changes *what* gets captured,
+  not how the image is returned.
 - **A clear signal when a window genuinely can't be captured.** If every capture
   method still returns an all-black frame — typical of DRM-protected video, a
   secure-desktop / UAC prompt, or a hardware-overlay surface — `screenshot` now

--- a/benches/wgc_latency.mjs
+++ b/benches/wgc_latency.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+// ADR-027 Phase 4 — WGC vs PrintWindow capture-latency bench harness.
+//
+// Measures the per-capture latency of the two window-capture backends that the
+// ADR-027 ladder uses, head-to-head on the SAME live window:
+//   - WGC          (win32WgcCaptureWindow, worker thread + reused D3D device)
+//   - PrintWindow  (win32_print_window_to_buffer, flag 2 = PW_RENDERFULLCONTENT)
+//
+// Two ADR-027 acceptance points this baselines:
+//   - AC2  : WGC runs on a worker thread with a REUSED device — so the first
+//            capture pays the one-time D3D device build and later captures are
+//            much faster. The harness reports cold (1st) vs warm (median of the
+//            rest) to make the reuse effect visible.
+//   - R2   : WGC must not become a blanket primary on the hot path — this prints
+//            the WGC/PrintWindow ratio so the "WGC only for background / black
+//            rescue" placement decision (D3) stays evidence-based.
+//
+// This bench is NON-HERMETIC: it needs a live, visible, DWM-composited window
+// (the WGC D3 gate rejects minimized / hidden / cloaked windows). It is a local
+// dogfood tool only and is NOT run in CI (no live desktop on the 2-core runner).
+//
+// Usage:
+//   npm run build && node benches/wgc_latency.mjs            # auto-pick a window
+//   node benches/wgc_latency.mjs <hwnd>                      # target a specific HWND
+//   node benches/wgc_latency.mjs <hwnd> <iterations>         # default 20 iterations
+//
+// Output: a text report with cold/warm/mean/median (ms) for each backend, the
+// device-reuse speedup, and the WGC-vs-PrintWindow ratio.
+
+import {
+  enumWindowsInZOrder,
+  canCaptureWindowViaWgc,
+  captureWindowWgc,
+  printWindowToBuffer,
+} from "../dist/engine/win32.js";
+
+const argHwnd = process.argv[2] ? BigInt(process.argv[2]) : null;
+const ITER = Math.max(3, Number(process.argv[3] ?? 20) || 20);
+
+function pickWindow() {
+  if (argHwnd !== null) return { hwnd: argHwnd, title: "(explicit hwnd)" };
+  const wins = enumWindowsInZOrder();
+  // Prefer a GPU-composited window (Chromium/Edge/Electron, Windows Terminal,
+  // WinUI) that passes the WGC D3 gate.
+  const candidate = wins.find((w) => {
+    if (w.isMinimized || w.isCloaked) return false;
+    const c = (w.className || "").toLowerCase();
+    const isGpu =
+      c.includes("chrome_widgetwin") || c.includes("cascadia") ||
+      c.includes("applicationframewindow") || c.includes("qt");
+    return isGpu && canCaptureWindowViaWgc(w.hwnd);
+  }) ?? wins.find((w) => !w.isMinimized && !w.isCloaked && canCaptureWindowViaWgc(w.hwnd));
+  return candidate ? { hwnd: candidate.hwnd, title: candidate.title } : null;
+}
+
+function ms(ns) { return Number(ns) / 1e6; }
+function stats(samples) {
+  const sorted = [...samples].sort((a, b) => a - b);
+  const sum = sorted.reduce((a, b) => a + b, 0);
+  return {
+    mean: sum / sorted.length,
+    median: sorted[Math.floor(sorted.length / 2)],
+    min: sorted[0],
+    max: sorted[sorted.length - 1],
+  };
+}
+
+async function timeWgc(hwnd, n) {
+  const samples = [];
+  for (let i = 0; i < n; i++) {
+    const t0 = process.hrtime.bigint();
+    const r = await captureWindowWgc(hwnd);
+    samples.push(ms(process.hrtime.bigint() - t0));
+    if (i === 0 && (!r.data || r.width <= 0)) throw new Error("WGC returned no frame");
+  }
+  return samples;
+}
+
+function timePrintWindow(hwnd, n) {
+  const samples = [];
+  for (let i = 0; i < n; i++) {
+    const t0 = process.hrtime.bigint();
+    printWindowToBuffer(hwnd, 2); // PW_RENDERFULLCONTENT
+    samples.push(ms(process.hrtime.bigint() - t0));
+  }
+  return samples;
+}
+
+const target = pickWindow();
+if (!target) {
+  console.error("No WGC-eligible window found. Open a visible browser / terminal, or pass an HWND.");
+  process.exit(1);
+}
+console.log(`\nADR-027 WGC latency bench — target: "${String(target.title).slice(0, 60)}" (hwnd=${target.hwnd}), ${ITER} iterations\n`);
+
+const wgc = await timeWgc(target.hwnd, ITER);
+const pw = timePrintWindow(target.hwnd, ITER);
+
+const wgcWarm = stats(wgc.slice(1)); // exclude the cold device-build capture
+const wgcAll = stats(wgc);
+const pwStats = stats(pw);
+
+const fmt = (s) => `mean=${s.mean.toFixed(1)}ms median=${s.median.toFixed(1)}ms min=${s.min.toFixed(1)} max=${s.max.toFixed(1)}`;
+console.log(`WGC  cold (1st)     : ${wgc[0].toFixed(1)}ms  (one-time D3D device build)`);
+console.log(`WGC  warm (rest)    : ${fmt(wgcWarm)}   <- device reused (AC2)`);
+console.log(`WGC  all            : ${fmt(wgcAll)}`);
+console.log(`PrintWindow (flag 2): ${fmt(pwStats)}`);
+console.log(`\nDevice-reuse speedup: cold/warm = ${(wgc[0] / wgcWarm.median).toFixed(2)}x faster after the first capture`);
+console.log(`WGC warm / PrintWindow ratio (median): ${(wgcWarm.median / pwStats.median).toFixed(2)}x  (R2: keep WGC off the hot-path primary unless > PrintWindow value)`);
+console.log("");
+process.exit(0);

--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
     "build:rs": "node scripts/build-rs.mjs --release",
     "build:rs:debug": "node scripts/build-rs.mjs --debug",
     "artifacts:rs": "napi artifacts",
-    "bench:envelope-size": "node benches/l4_envelope_size.mjs"
+    "bench:envelope-size": "node benches/l4_envelope_size.mjs",
+    "bench:wgc-latency": "node benches/wgc_latency.mjs"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## ADR-027 Phase 4 (final) — WGC latency bench + CHANGELOG

The last ADR-027 phase. **No release** — the 3-channel publish is deferred and bundled with ADR-028; the `[1.11.0]` CHANGELOG entry accumulates and ships later.

### What's here
- **`benches/wgc_latency.mjs`** (+ `npm run bench:wgc-latency`): head-to-head WGC vs PrintWindow (flag 2 = PW_RENDERFULLCONTENT) capture latency on the same live window. Reports cold (1st) vs warm (device reused), mean/median, and the WGC/PrintWindow ratio. **Non-hermetic** (needs a live DWM-composited window — the D3 gate rejects minimized/hidden/cloaked), so it is a local dogfood tool, **not** a CI step.
- **`CHANGELOG.md`** `[1.11.0] - Unreleased`: two user-facing bullets — GPU-rendered / occluded windows now capture real pixels via Windows.Graphics.Capture instead of black, and an explicit `captureBlocked` signal when content genuinely can't be captured (with the hedged "could be a legitimately black window OR uncapturable" framing). Headline extended.
- **`package.json`**: `bench:wgc-latency` script.

### Bench results (this host, GPU window, 20 iterations)
| backend | latency |
|---|---|
| WGC cold (1st) | 177.3 ms (one-time D3D device build) |
| WGC warm (device reused) | mean 79.1 / **median 78.8 ms** |
| PrintWindow (flag 2) | mean 8.4 / median 8.3 ms |

- **AC2 (device reuse):** cold/warm = **2.25× faster** after the first capture — the worker thread holds the D3D device across captures.
- **R2 / D3 (quantitative backing):** WGC warm is **~9.5× slower** than PrintWindow. This is why WGC is *not* promoted to a blanket hot-path primary — it stays the `mode='background'` primary + the normal-mode black-rescue rung, where its unique value (real pixels for GPU/occluded windows PrintWindow blacks out) outweighs the cost.

### CI compile guard
No new CI code needed. `src/win32/wgc.rs` (which uses the `Graphics_Capture` windows-rs feature) is compiled by the existing `check:rs-workspace` (`cargo check`) and `check:rs-test-compile` (`cargo test --no-run`, incl. wgc.rs's `#[cfg(test)]` tests). Dropping the feature would fail those checks. Live WGC capture is non-hermetic, so compile-only is the correct guard.

No `src/` change — the capture ladder, AC8/AC9, and all tool behavior are untouched.

Plan / acceptance: `desktop-touch-mcp-internal:docs/adr-027-wgc-capture-layer.md` §6.4 (Phase 4), AC2.

Reviewed locally: Codex (clean) + Opus phase-boundary review (GO; one P3 CHANGELOG wording nit fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
