### PR TITLE
docs(site): add v1.11 milestone — by-ref screenshots, WGC capture, cache tools

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -102,6 +102,10 @@
             <h2>Project Milestones</h2>
             <p>As the project evolves, we document major architectural shifts and milestones here.</p>
             <div class="three-up">
+              <a class="mini-card" href="https://github.com/Harusame64/desktop-touch-mcp/releases/tag/v1.11.0">
+                <h3>v1.11: Screenshots That Cost Less and See More</h3>
+                <p>Screenshots stop inlining their pixels into every response: <code>screenshot</code> (and the Set-of-Mark, diff, scroll, workspace, and <code>desktop_act</code> crop results) now return a cheap <code>screenshot://by-ref/{id}</code> link to an image saved on disk, so routine look-act-confirm loops cost a fraction of the tokens — pixels are spent only when the link is opened. A Windows.Graphics.Capture path lets GPU-rendered and occluded windows return real pixels instead of black, with a <code>captureBlocked</code> signal when content genuinely can't be captured, and two new tools — <code>screenshot_query</code> and <code>screenshot_gc</code> (31 tools total) — inspect and prune the self-bounding cache.</p>
+              </a>
               <a class="mini-card" href="./articles/v1.10-milestone.html">
                 <h3>v1.10: A Visual-Only Act That Confirms Itself</h3>
                 <p>On a target the accessibility tree can't describe — Electron, PWA, game, custom canvas, Remote Desktop — a successful <code>desktop_act</code> can bundle a <code>roiCapture</code>: a PNG crop of <em>just the region that changed</em> plus a lease-less preview of the controls now visible there. It folds "act → <code>desktop_state</code> → <code>screenshot</code>" into a single call. On by default for a visible change; <code>returnCapture:"never"</code> suppresses it. Never attached on structured targets, where <code>desktop_state</code> is cheaper and exact.</p>

--- a/site/index.md
+++ b/site/index.md
@@ -98,6 +98,10 @@ It is trying to document an active line of engineering and research.
 
 As the project evolves, we document major architectural shifts and milestones here.
 
+### v1.11: Screenshots That Cost Less and See More
+Screenshots stop inlining their pixels into every response. `screenshot` — and the Set-of-Mark overlays, diff frames, scroll captures, workspace snapshots, and `desktop_act`'s changed-region crop — now hand back a cheap `screenshot://by-ref/{id}` link to an image saved on disk, so routine look-act-confirm loops cost a fraction of the tokens; the agent spends them on pixels only when it actually opens the link. The same release adds a Windows.Graphics.Capture path so GPU-rendered and occluded windows return real pixels instead of black (with a `captureBlocked` signal when content genuinely can't be captured), plus two new tools — `screenshot_query` and `screenshot_gc` (31 tools total) — to inspect and prune the self-bounding on-disk cache.
+- [v1.11.0 release notes](https://github.com/Harusame64/desktop-touch-mcp/releases/tag/v1.11.0)
+
 ### v1.10: A Visual-Only Act That Confirms Itself
 On a target the accessibility tree can't describe — an Electron or PWA app, a game, a custom-drawn canvas, a Remote Desktop window — a successful `desktop_act` can now bundle a `roiCapture`: a PNG crop of *just the region that changed* plus a lease-less preview of the controls now visible there. That folds the old "act → `desktop_state` → `screenshot`" confirmation loop into a **single call** — confirm the result and find the next target in the same response. Controlled by `returnCapture` (`on-change` / `always` / `never`); never attached on structured targets, where `desktop_state` and `desktop_discover` are cheaper and exact.
 - [Read the v1.10 Milestone Article](./articles/v1.10-milestone.html)


### PR DESCRIPTION
## Site update for v1.11.0

Adds a **v1.11 milestone** to the Project Milestones section (top of the list), mirrored in both the Markdown source and the served HTML.

### What it covers (user-facing wording)
- **By-ref screenshots** — `screenshot` and the other visual results return a cheap `screenshot://by-ref/{id}` link to an on-disk image instead of inlining the pixels every time, so routine look-act-confirm loops cost a fraction of the tokens.
- **Windows.Graphics.Capture** — GPU-rendered and occluded windows return real pixels instead of black, with a `captureBlocked` signal when content genuinely can't be captured.
- **`screenshot_query` / `screenshot_gc`** — two new tools (31 total) to inspect and prune the self-bounding cache.

Links to the [v1.11.0 release notes](https://github.com/Harusame64/desktop-touch-mcp/releases/tag/v1.11.0) (no separate milestone article, mirroring the v1.9 pattern).

### Scope
- `site/index.md` + `site/index.html` only (the dual-managed Milestones section).
- Nav "Milestones" link unchanged — it points to the most recent milestone *article* (v1.10), which is still the latest article.
- Historical "28 tools" references in older milestone cards are intentionally preserved (count history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
