### PR TITLE
ADR-014 v2 S1: cooperative terminal bridge trunk (headless) + C# helper

### DIFF
--- a/src/engine/bridge-host.ts
+++ b/src/engine/bridge-host.ts
@@ -1,0 +1,353 @@
+// ADR-014 v2 S1 — cooperative terminal bridge, Node/MCP side (OQ #6 option (C)).
+//
+// Plan: desktop-touch-mcp-internal@HEAD:docs/adr-014-v2-s1-option-c-design.md
+//
+// The helper (bin/bridge-host.exe, a compiled C# console app) owns a
+// CurrentUserOnly named-pipe SERVER; this module is the CLIENT. S1 is HEADLESS —
+// it stands up the server + handshake + ping/version only. The dedicated console
+// window a human types sudo/ssh into (crux (a)) is S2 (a C# self-bootstrap that
+// re-execs under conhost with CREATE_NEW_CONSOLE); there is no MCP tool surface yet
+// (that is S3), so nothing here is wired into a tool.
+//
+// What S1 LOCKS (all launch-method-independent, so S2's window mechanism does not
+// perturb it): the pipe protocol (hello/ping/version/shutdown), the CurrentUserOnly
+// server, the kernel client-verify, net.connect backoff, and the typed errors.
+//
+// The threat-model §8 guarantees, and where they live:
+//   * cross-user  → the helper's CurrentUserOnly ACL (a different user cannot open
+//     the pipe at all).
+//   * casual same-user race → three launch-independent facts: (1) the pipe name is
+//     an unguessable ≥128-bit secret minted here; (2) the helper creates the server
+//     with FILE_FLAG_FIRST_PIPE_INSTANCE, so if a squatter won the name our helper's
+//     create FAILS LOUD and it exits — which we observe as the child dying and abort
+//     (BridgeHelperSpawnFailed), never connecting to the squatter; (3) the helper
+//     kernel-verifies the connected client is us (GetNamedPipeClientProcessId ==
+//     our pid) and rejects a rogue same-user client.
+// The helper's self-reported `hello.pid` is NON-LOAD-BEARING observability (liveness
+// + version), NOT a security boundary — an adversarial same-user process is out of
+// §8 scope, and the guarantees above do not depend on it.
+//
+// Wire framing: raw UTF-8 bytes, one JSON object per '\n' line, BUFFERED read.
+
+import net from "node:net";
+import { spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+// dist/engine/ -> ../../bin/bridge-host.exe (same resolution as ocr-bridge.ts).
+const HELPER_EXE = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "bin", "bridge-host.exe");
+
+/** Wire protocol version the MCP understands; must match the helper's `hello.v`. */
+export const BRIDGE_PROTOCOL_VERSION = "1";
+
+export type BridgeErrorCode =
+  | "BridgeHelperSpawnFailed"
+  | "BridgeHandshakeRejected"
+  | "BridgePipeUnavailable";
+
+/**
+ * Typed failure for the bridge. S1 defines the codes locally; S4 wires them into
+ * `src/tools/_errors.ts` (`SUGGESTS` + `classify`) when the tool surface lands.
+ */
+export class BridgeError extends Error {
+  readonly code: BridgeErrorCode;
+  constructor(code: BridgeErrorCode, message: string) {
+    super(message);
+    this.name = "BridgeError";
+    this.code = code;
+  }
+}
+
+export interface BridgeStartOptions {
+  /** Overall budget for spawn → connect → verified hello. Default 15000ms. */
+  startupTimeoutMs?: number;
+  /** Backoff between connect retries while the helper's server comes up. Default 100ms. */
+  connectBackoffMs?: number;
+}
+
+interface PendingRequest {
+  resolve: (reply: BridgeReply) => void;
+  reject: (err: Error) => void;
+  timer: NodeJS.Timeout;
+}
+
+export interface BridgeReply {
+  id: number;
+  ok: boolean;
+  r: string;
+  e?: string;
+}
+
+const DEFAULT_STARTUP_TIMEOUT_MS = 15_000;
+const DEFAULT_CONNECT_BACKOFF_MS = 100;
+const HELLO_TIMEOUT_MS = 5_000;
+const REQUEST_TIMEOUT_MS = 10_000;
+
+const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * A live cooperative-terminal session: a verified pipe connection to the helper.
+ * Create with `BridgeHost.start()`; always `dispose()` it (onclose / unsubscribe /
+ * shutdown — long-lived-resource discipline).
+ */
+export class BridgeHost {
+  private nextId = 1;
+  private readonly pending = new Map<number, PendingRequest>();
+  private buf = "";
+  private disposed = false;
+
+  private constructor(
+    private readonly socket: net.Socket,
+    /** PID to tear down on dispose (the process we spawned). 0 in test seams. */
+    private readonly killPid: number,
+    /** The helper's self-reported PID from `hello` (observability, non-load-bearing). */
+    readonly helperPid: number,
+    /** The helper's wire protocol version from `hello`. */
+    readonly protocolVersion: string,
+  ) {
+    this.socket.on("data", (d) => this.onData(d));
+    this.socket.on("close", () => this.failAllPending(new BridgeError("BridgePipeUnavailable", "pipe closed")));
+    this.socket.on("error", () => { /* surfaced via close / pending timeouts */ });
+  }
+
+  /** Launch the helper (headless), connect, read `hello`, and return a live session. */
+  static async start(opts: BridgeStartOptions = {}): Promise<BridgeHost> {
+    if (process.platform !== "win32") {
+      throw new BridgeError("BridgeHelperSpawnFailed", "bridge is Windows-only");
+    }
+    if (!existsSync(HELPER_EXE)) {
+      throw new BridgeError(
+        "BridgeHelperSpawnFailed",
+        `bridge-host.exe not found at ${HELPER_EXE}. Build: cd tools/bridge-host && dotnet publish -c Release -o ../../bin/`,
+      );
+    }
+
+    const startupTimeoutMs = opts.startupTimeoutMs ?? DEFAULT_STARTUP_TIMEOUT_MS;
+    const backoffMs = opts.connectBackoffMs ?? DEFAULT_CONNECT_BACKOFF_MS;
+    const deadline = Date.now() + startupTimeoutMs;
+
+    // Unguessable per-session name (≥128-bit) — the load-bearing per-launch secret.
+    const pipeName = `dtm-bridge-${randomBytes(16).toString("hex")}`;
+    const pipePath = `\\\\.\\pipe\\${pipeName}`;
+    const mcpPid = process.pid;
+
+    // S1: direct-spawn the helper HEADLESS (detached, no stdio redirect). It is our
+    // DIRECT child, so if it fail-louds on a non-fresh pipe (squatter won the name)
+    // we observe the exit and abort BEFORE connecting. (S2 replaces this with a C#
+    // self-bootstrap that re-execs under conhost for a dedicated window; that does
+    // NOT change this module's locked protocol/auth contract.)
+    const child = spawn(HELPER_EXE, ["-PipeName", pipeName, "-McpPid", String(mcpPid)], {
+      detached: true,
+      stdio: "ignore",
+      windowsHide: false,
+    });
+
+    // Holder object (not `let`) so the callback assignments are visible to callers
+    // without control-flow narrowing them back to their initial values.
+    const state: { helperDied: boolean; spawnError: Error | null } = { helperDied: false, spawnError: null };
+    child.on("error", (e) => { state.spawnError = e; state.helperDied = true; });
+    child.on("exit", () => { state.helperDied = true; });
+
+    const killPid = child.pid ?? 0;
+    if (child.pid === undefined) {
+      throw new BridgeError("BridgeHelperSpawnFailed", `helper spawn returned no pid: ${state.spawnError?.message ?? ""}`);
+    }
+
+    const socket = await connectWithBackoff(pipePath, deadline, backoffMs, () => ({ ...state }));
+    try {
+      return await BridgeHost.handshake(socket, killPid, deadline);
+    } catch (e) {
+      try { socket.destroy(); } catch { /* ignore */ }
+      killTree(killPid);
+      throw e;
+    }
+  }
+
+  /**
+   * TEST-ONLY seam: connect to an ALREADY-listening pipe (no spawn) and run the
+   * handshake, so a Node fake peer can exercise the client protocol (hello parse,
+   * ping/version, dispose) deterministically. Not used in production.
+   */
+  static async connectForTest(pipePath: string, o: { timeoutMs?: number } = {}): Promise<BridgeHost> {
+    const socket: net.Socket = await new Promise((resolve, reject) => {
+      const s = net.connect(pipePath);
+      s.once("connect", () => resolve(s));
+      s.once("error", reject);
+    });
+    const deadline = Date.now() + (o.timeoutMs ?? 5_000);
+    try {
+      return await BridgeHost.handshake(socket, 0, deadline);
+    } catch (e) {
+      try { socket.destroy(); } catch { /* ignore */ }
+      throw e;
+    }
+  }
+
+  /**
+   * Read the helper's first `hello` frame. Accepts any WELL-FORMED hello — the
+   * node-side security is the secret pipe name + the fail-loud liveness abort in
+   * `start()`, NOT an identity assertion on the hello (see the file header §8 note).
+   */
+  private static handshake(socket: net.Socket, killPid: number, deadline: number): Promise<BridgeHost> {
+    return new Promise<BridgeHost>((resolve, reject) => {
+      let buf = "";
+      const helloBudget = Math.max(0, Math.min(HELLO_TIMEOUT_MS, deadline - Date.now()));
+      const timer = setTimeout(() => {
+        cleanup();
+        reject(new BridgeError("BridgeHandshakeRejected", "no hello frame from helper within timeout"));
+      }, helloBudget);
+
+      const onData = (d: Buffer | string) => {
+        buf += typeof d === "string" ? d : d.toString("utf8");
+        const nl = buf.indexOf("\n");
+        if (nl < 0) return; // wait for a full first frame
+        const line = buf.slice(0, nl).replace(/\r$/, "");
+        cleanup();
+
+        let hello: { t?: string; pid?: number; v?: string };
+        try {
+          hello = JSON.parse(line);
+        } catch {
+          reject(new BridgeError("BridgeHandshakeRejected", `unparseable hello frame: ${line.slice(0, 120)}`));
+          return;
+        }
+        if (hello.t !== "hello" || typeof hello.pid !== "number" || typeof hello.v !== "string") {
+          reject(new BridgeError("BridgeHandshakeRejected", `unexpected first frame: ${line.slice(0, 120)}`));
+          return;
+        }
+
+        const bridge = new BridgeHost(socket, killPid, hello.pid, hello.v);
+        // Hand any bytes that arrived after the hello line to the live reader.
+        const rest = buf.slice(nl + 1);
+        if (rest.length > 0) bridge.onData(Buffer.from(rest, "utf8"));
+        resolve(bridge);
+      };
+
+      const cleanup = () => {
+        clearTimeout(timer);
+        socket.removeListener("data", onData);
+      };
+      socket.on("data", onData);
+    });
+  }
+
+  /** Round-trip a control request; rejects on timeout or a closed pipe. */
+  private request(method: string): Promise<BridgeReply> {
+    if (this.disposed) return Promise.reject(new BridgeError("BridgePipeUnavailable", "bridge disposed"));
+    const id = this.nextId++;
+    return new Promise<BridgeReply>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new BridgeError("BridgePipeUnavailable", `request '${method}' timed out`));
+      }, REQUEST_TIMEOUT_MS);
+      this.pending.set(id, { resolve, reject, timer });
+      try {
+        this.socket.write(`${JSON.stringify({ id, m: method })}\n`);
+      } catch (e) {
+        clearTimeout(timer);
+        this.pending.delete(id);
+        reject(new BridgeError("BridgePipeUnavailable", `write failed: ${(e as Error).message}`));
+      }
+    });
+  }
+
+  /** Liveness check → the helper's `pong`. */
+  async ping(): Promise<boolean> {
+    const reply = await this.request("ping");
+    return reply.ok && reply.r === "pong";
+  }
+
+  /** The helper's reported protocol version (also available as `protocolVersion`). */
+  async version(): Promise<string> {
+    const reply = await this.request("version");
+    return reply.r;
+  }
+
+  /** Tear down the session: best-effort `shutdown`, close the socket, kill the tree. */
+  async dispose(): Promise<void> {
+    if (this.disposed) return;
+    this.disposed = true;
+    try {
+      await Promise.race([this.request("shutdown"), delay(500)]);
+    } catch { /* best-effort */ }
+    try { this.socket.end(); this.socket.destroy(); } catch { /* ignore */ }
+    this.failAllPending(new BridgeError("BridgePipeUnavailable", "bridge disposed"));
+    if (this.killPid > 0) killTree(this.killPid);
+  }
+
+  private onData(d: Buffer | string): void {
+    this.buf += typeof d === "string" ? d : d.toString("utf8");
+    let nl: number;
+    while ((nl = this.buf.indexOf("\n")) >= 0) {
+      const line = this.buf.slice(0, nl).replace(/\r$/, "");
+      this.buf = this.buf.slice(nl + 1);
+      if (line.length === 0) continue;
+      let reply: BridgeReply;
+      try {
+        reply = JSON.parse(line);
+      } catch {
+        continue; // ignore malformed frames
+      }
+      const p = this.pending.get(reply.id);
+      if (p) {
+        clearTimeout(p.timer);
+        this.pending.delete(reply.id);
+        p.resolve(reply);
+      }
+    }
+  }
+
+  private failAllPending(err: Error): void {
+    for (const [, p] of this.pending) {
+      clearTimeout(p.timer);
+      p.reject(err);
+    }
+    this.pending.clear();
+  }
+}
+
+/** net.connect with bounded backoff; aborts early if the helper already died. */
+function connectWithBackoff(
+  pipePath: string,
+  deadline: number,
+  backoffMs: number,
+  liveness: () => { helperDied: boolean; spawnError: Error | null },
+): Promise<net.Socket> {
+  return new Promise<net.Socket>((resolve, reject) => {
+    const attempt = () => {
+      const { helperDied, spawnError } = liveness();
+      if (helperDied) {
+        reject(new BridgeError(
+          "BridgeHelperSpawnFailed",
+          `helper exited before connect${spawnError ? `: ${spawnError.message}` : " (fail-loud create?)"}`,
+        ));
+        return;
+      }
+      if (Date.now() >= deadline) {
+        reject(new BridgeError("BridgeHelperSpawnFailed", "helper did not accept a connection before startup timeout"));
+        return;
+      }
+      const sock = net.connect(pipePath);
+      const onConnect = () => { sock.removeListener("error", onError); resolve(sock); };
+      const onError = (_e: Error) => {
+        sock.removeListener("connect", onConnect);
+        sock.destroy();
+        // ENOENT (not created yet) / EPIPE-busy (max=1, servicing another) → retry.
+        setTimeout(attempt, backoffMs);
+      };
+      sock.once("connect", onConnect);
+      sock.once("error", onError);
+    };
+    attempt();
+  });
+}
+
+/** Kill a spawned helper process tree (best-effort, Windows). */
+function killTree(pid: number): void {
+  try {
+    const p = spawn("taskkill.exe", ["/PID", String(pid), "/T", "/F"], { stdio: "ignore", windowsHide: true });
+    p.unref(); // best-effort cleanup must not keep the event loop / test runner alive
+  } catch { /* ignore */ }
+}

--- a/src/engine/bridge-host.ts
+++ b/src/engine/bridge-host.ts
@@ -97,6 +97,7 @@ export class BridgeHost {
   private readonly pending = new Map<number, PendingRequest>();
   private buf = "";
   private disposed = false;
+  private disposing = false;
 
   private constructor(
     private readonly socket: net.Socket,
@@ -281,11 +282,16 @@ export class BridgeHost {
 
   /** Tear down the session: best-effort `shutdown`, close the socket, kill the tree. */
   async dispose(): Promise<void> {
-    if (this.disposed) return;
-    this.disposed = true;
+    if (this.disposing) return;
+    this.disposing = true; // re-entrancy guard; `disposed` is flipped AFTER shutdown is sent
+    // Send the graceful `shutdown` FIRST (while requests are still accepted), so the
+    // helper's shutdown handler actually runs — THEN flip `disposed` to reject further
+    // requests. (Flipping `disposed` first made `request` reject shutdown immediately,
+    // so teardown always fell through to force-kill — Codex P2.)
     try {
       await Promise.race([this.request("shutdown"), delay(500)]);
     } catch { /* best-effort */ }
+    this.disposed = true;
     try { this.socket.end(); this.socket.destroy(); } catch { /* ignore */ }
     this.failAllPending(new BridgeError("BridgePipeUnavailable", "bridge disposed"));
     if (this.killPid > 0) killTree(this.killPid);

--- a/src/engine/bridge-host.ts
+++ b/src/engine/bridge-host.ts
@@ -155,11 +155,18 @@ export class BridgeHost {
       throw new BridgeError("BridgeHelperSpawnFailed", `helper spawn returned no pid: ${state.spawnError?.message ?? ""}`);
     }
 
-    const socket = await connectWithBackoff(pipePath, deadline, backoffMs, () => ({ ...state }));
     try {
-      return await BridgeHost.handshake(socket, killPid, deadline);
+      const socket = await connectWithBackoff(pipePath, deadline, backoffMs, () => ({ ...state }));
+      try {
+        return await BridgeHost.handshake(socket, killPid, deadline);
+      } catch (e) {
+        try { socket.destroy(); } catch { /* ignore */ }
+        throw e;
+      }
     } catch (e) {
-      try { socket.destroy(); } catch { /* ignore */ }
+      // ANY startup failure must kill the child — including the alive-but-slow
+      // timeout path (helper still running), which would otherwise orphan a
+      // bridge-host.exe holding its pipe (e.g. first-run AV scan of the exe).
       killTree(killPid);
       throw e;
     }
@@ -215,6 +222,13 @@ export class BridgeHost {
         }
         if (hello.t !== "hello" || typeof hello.pid !== "number" || typeof hello.v !== "string") {
           reject(new BridgeError("BridgeHandshakeRejected", `unexpected first frame: ${line.slice(0, 120)}`));
+          return;
+        }
+        if (hello.v !== BRIDGE_PROTOCOL_VERSION) {
+          reject(new BridgeError(
+            "BridgeHandshakeRejected",
+            `helper protocol '${hello.v}' != expected '${BRIDGE_PROTOCOL_VERSION}'`,
+          ));
           return;
         }
 

--- a/tests/e2e/bridge-host.e2e.test.ts
+++ b/tests/e2e/bridge-host.e2e.test.ts
@@ -1,0 +1,87 @@
+/**
+ * bridge-host.e2e.test.ts — ADR-014 v2 S1 live smoke + negative (headless).
+ *
+ * Spawns the REAL bin/bridge-host.exe (direct, detached, headless — no window in
+ * S1), so it is gated to the e2e project. Validates the launch-independent locked
+ * contract end to end: direct-spawn -> C# CurrentUserOnly server -> kernel
+ * client-verify (GetNamedPipeClientProcessId == our pid) -> hello -> ping/version.
+ * The window + crux (a) are S2. The pure protocol is covered deterministically by
+ * tests/unit/bridge-host.test.ts.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import net from "node:net";
+import { spawn, type ChildProcess } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { join } from "node:path";
+import { existsSync } from "node:fs";
+import { BridgeHost } from "../../src/engine/bridge-host.js";
+
+const HELPER_EXE = join(process.cwd(), "bin", "bridge-host.exe");
+
+describe("bridge-host live smoke", () => {
+  const bridges: BridgeHost[] = [];
+  afterEach(async () => {
+    for (const b of bridges) { try { await b.dispose(); } catch { /* ignore */ } }
+    bridges.length = 0;
+  });
+
+  it("spawns the real headless helper, handshakes, pings and reports version", async () => {
+    expect(existsSync(HELPER_EXE)).toBe(true);
+
+    const bridge = await BridgeHost.start({ startupTimeoutMs: 20_000 });
+    bridges.push(bridge);
+
+    expect(bridge.helperPid).toBeGreaterThan(0);
+    expect(bridge.protocolVersion).toBe("1");
+    expect(await bridge.ping()).toBe(true);
+    expect(await bridge.version()).toBe("1");
+  }, 40_000);
+});
+
+describe("bridge-host rogue client rejection (kernel client-verify)", () => {
+  let child: ChildProcess | undefined;
+  afterEach(() => {
+    if (child?.pid) {
+      try { spawn("taskkill.exe", ["/PID", String(child.pid), "/T", "/F"], { stdio: "ignore", windowsHide: true }); }
+      catch { /* ignore */ }
+    }
+    child = undefined;
+  });
+
+  it("rejects a client whose PID != the helper's -McpPid", async () => {
+    expect(existsSync(HELPER_EXE)).toBe(true);
+
+    // Launch the real helper DIRECTLY (as production does) but tell it a DIFFERENT
+    // process is its MCP. Our connect (this process's pid) must be rejected by the
+    // C# kernel client-verify, so we never receive a `hello` frame. (Direct-spawn,
+    // not conhost, so the helper actually runs — a conhost launch would exit and
+    // give a false pass.)
+    const name = `dtm-bridge-rogue-${randomBytes(8).toString("hex")}`;
+    const wrongMcpPid = process.pid + 100_000; // definitely not us
+    child = spawn(HELPER_EXE, ["-PipeName", name, "-McpPid", String(wrongMcpPid)], {
+      detached: true, stdio: "ignore", windowsHide: false,
+    });
+
+    const gotHello = await new Promise<boolean>((resolve) => {
+      let settled = false;
+      const done = (v: boolean) => { if (!settled) { settled = true; resolve(v); } };
+
+      const tryConnect = (attempt: number) => {
+        const sock = net.connect(`\\\\.\\pipe\\${name}`);
+        sock.once("connect", () => {
+          sock.on("data", (d) => { if (d.toString("utf8").includes('"hello"')) { sock.destroy(); done(true); } });
+          sock.on("close", () => done(false)); // helper disconnected us (rejected)
+          setTimeout(() => { sock.destroy(); done(false); }, 4_000);
+        });
+        sock.once("error", () => {
+          sock.destroy();
+          if (attempt < 40) setTimeout(() => tryConnect(attempt + 1), 200); // pipe not up yet
+          else done(false);
+        });
+      };
+      tryConnect(0);
+    });
+
+    expect(gotHello).toBe(false);
+  }, 40_000);
+});

--- a/tests/e2e/bridge-host.e2e.test.ts
+++ b/tests/e2e/bridge-host.e2e.test.ts
@@ -1,12 +1,13 @@
 /**
- * bridge-host.e2e.test.ts — ADR-014 v2 S1 live smoke + negative (headless).
+ * bridge-host.e2e.test.ts — ADR-014 v2 S1 live smoke + negatives (headless).
  *
  * Spawns the REAL bin/bridge-host.exe (direct, detached, headless — no window in
  * S1), so it is gated to the e2e project. Validates the launch-independent locked
  * contract end to end: direct-spawn -> C# CurrentUserOnly server -> kernel
- * client-verify (GetNamedPipeClientProcessId == our pid) -> hello -> ping/version.
- * The window + crux (a) are S2. The pure protocol is covered deterministically by
- * tests/unit/bridge-host.test.ts.
+ * client-verify (GetNamedPipeClientProcessId == our pid) -> hello -> ping/version,
+ * plus the two load-bearing negatives (rogue client rejected; FIRST_PIPE_INSTANCE
+ * fail-loud). The window + crux (a) are S2. The pure protocol is covered
+ * deterministically by tests/unit/bridge-host.test.ts.
  */
 import { describe, it, expect, afterEach } from "vitest";
 import net from "node:net";
@@ -17,6 +18,13 @@ import { existsSync } from "node:fs";
 import { BridgeHost } from "../../src/engine/bridge-host.js";
 
 const HELPER_EXE = join(process.cwd(), "bin", "bridge-host.exe");
+const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+function killTree(pid?: number): void {
+  if (pid === undefined) return;
+  try { spawn("taskkill.exe", ["/PID", String(pid), "/T", "/F"], { stdio: "ignore", windowsHide: true }); }
+  catch { /* ignore */ }
+}
 
 describe("bridge-host live smoke", () => {
   const bridges: BridgeHost[] = [];
@@ -40,35 +48,29 @@ describe("bridge-host live smoke", () => {
 
 describe("bridge-host rogue client rejection (kernel client-verify)", () => {
   let child: ChildProcess | undefined;
-  afterEach(() => {
-    if (child?.pid) {
-      try { spawn("taskkill.exe", ["/PID", String(child.pid), "/T", "/F"], { stdio: "ignore", windowsHide: true }); }
-      catch { /* ignore */ }
-    }
-    child = undefined;
-  });
+  afterEach(() => { killTree(child?.pid); child = undefined; });
 
   it("rejects a client whose PID != the helper's -McpPid", async () => {
     expect(existsSync(HELPER_EXE)).toBe(true);
 
     // Launch the real helper DIRECTLY (as production does) but tell it a DIFFERENT
     // process is its MCP. Our connect (this process's pid) must be rejected by the
-    // C# kernel client-verify, so we never receive a `hello` frame. (Direct-spawn,
-    // not conhost, so the helper actually runs — a conhost launch would exit and
-    // give a false pass.)
+    // C# kernel client-verify, so we CONNECT but never receive a `hello`.
     const name = `dtm-bridge-rogue-${randomBytes(8).toString("hex")}`;
     const wrongMcpPid = process.pid + 100_000; // definitely not us
     child = spawn(HELPER_EXE, ["-PipeName", name, "-McpPid", String(wrongMcpPid)], {
       detached: true, stdio: "ignore", windowsHide: false,
     });
 
-    const gotHello = await new Promise<boolean>((resolve) => {
+    const result = await new Promise<{ connected: boolean; gotHello: boolean }>((resolve) => {
       let settled = false;
-      const done = (v: boolean) => { if (!settled) { settled = true; resolve(v); } };
+      let connected = false;
+      const done = (gotHello: boolean) => { if (!settled) { settled = true; resolve({ connected, gotHello }); } };
 
       const tryConnect = (attempt: number) => {
         const sock = net.connect(`\\\\.\\pipe\\${name}`);
         sock.once("connect", () => {
+          connected = true; // the pipe was up — the helper IS running
           sock.on("data", (d) => { if (d.toString("utf8").includes('"hello"')) { sock.destroy(); done(true); } });
           sock.on("close", () => done(false)); // helper disconnected us (rejected)
           setTimeout(() => { sock.destroy(); done(false); }, 4_000);
@@ -82,6 +84,41 @@ describe("bridge-host rogue client rejection (kernel client-verify)", () => {
       tryConnect(0);
     });
 
-    expect(gotHello).toBe(false);
+    // The assertion that makes this a REAL client-verify test (not a false pass from
+    // the helper never starting): we must have actually connected, then been rejected
+    // (closed) WITHOUT a hello.
+    expect(result.connected).toBe(true);
+    expect(result.gotHello).toBe(false);
+  }, 40_000);
+});
+
+describe("bridge-host FIRST_PIPE_INSTANCE fail-loud", () => {
+  const kids: ChildProcess[] = [];
+  afterEach(() => { for (const c of kids) killTree(c.pid); kids.length = 0; });
+
+  it("a second helper on the same pipe name fails loud and exits non-zero", async () => {
+    expect(existsSync(HELPER_EXE)).toBe(true);
+    const name = `dtm-bridge-fpi-${randomBytes(8).toString("hex")}`;
+    const mcp = String(process.pid);
+
+    // A creates the CurrentUserOnly server (holds the name) and waits for a client.
+    const a = spawn(HELPER_EXE, ["-PipeName", name, "-McpPid", mcp], {
+      detached: true, stdio: "ignore", windowsHide: false,
+    });
+    kids.push(a);
+    await delay(1_500); // let A register the pipe name (server created before WaitForConnection)
+
+    // B tries the SAME name → FILE_FLAG_FIRST_PIPE_INSTANCE (maxInstances=1) makes
+    // its create fail → the helper exits 3 (pipe-create-failed), never attaching.
+    const bExit = await new Promise<number | null>((resolve) => {
+      const b = spawn(HELPER_EXE, ["-PipeName", name, "-McpPid", mcp], {
+        detached: true, stdio: "ignore", windowsHide: false,
+      });
+      kids.push(b);
+      b.on("exit", (code) => resolve(code));
+      setTimeout(() => resolve(-999), 12_000);
+    });
+
+    expect(bExit).toBe(3);
   }, 40_000);
 });

--- a/tests/e2e/bridge-host.e2e.test.ts
+++ b/tests/e2e/bridge-host.e2e.test.ts
@@ -18,7 +18,6 @@ import { existsSync } from "node:fs";
 import { BridgeHost } from "../../src/engine/bridge-host.js";
 
 const HELPER_EXE = join(process.cwd(), "bin", "bridge-host.exe");
-const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
 function killTree(pid?: number): void {
   if (pid === undefined) return;
@@ -106,19 +105,38 @@ describe("bridge-host FIRST_PIPE_INSTANCE fail-loud", () => {
       detached: true, stdio: "ignore", windowsHide: false,
     });
     kids.push(a);
-    await delay(1_500); // let A register the pipe name (server created before WaitForConnection)
 
-    // B tries the SAME name → FILE_FLAG_FIRST_PIPE_INSTANCE (maxInstances=1) makes
-    // its create fail → the helper exits 3 (pipe-create-failed), never attaching.
-    const bExit = await new Promise<number | null>((resolve) => {
-      const b = spawn(HELPER_EXE, ["-PipeName", name, "-McpPid", mcp], {
-        detached: true, stdio: "ignore", windowsHide: false,
-      });
-      kids.push(b);
-      b.on("exit", (code) => resolve(code));
-      setTimeout(() => resolve(-999), 12_000);
+    // Poll (no fixed sleep → no AV-cold-start flake) until A's pipe accepts a
+    // connection = the name is registered; KEEP the probe open so A stays alive
+    // holding the name while B races. (We are A's McpPid, so A verifies + keeps us.)
+    const probe = await new Promise<net.Socket>((resolve, reject) => {
+      const deadline = Date.now() + 20_000;
+      const tryIt = () => {
+        const s = net.connect(`\\\\.\\pipe\\${name}`);
+        s.once("connect", () => resolve(s));
+        s.once("error", () => {
+          s.destroy();
+          if (Date.now() < deadline) setTimeout(tryIt, 150);
+          else reject(new Error("helper A never registered its pipe"));
+        });
+      };
+      tryIt();
     });
 
-    expect(bExit).toBe(3);
+    try {
+      // B tries the SAME name → FILE_FLAG_FIRST_PIPE_INSTANCE (maxInstances=1) makes
+      // its create fail → the helper exits 3 (pipe-create-failed), never attaching.
+      const bExit = await new Promise<number | null>((resolve) => {
+        const b = spawn(HELPER_EXE, ["-PipeName", name, "-McpPid", mcp], {
+          detached: true, stdio: "ignore", windowsHide: false,
+        });
+        kids.push(b);
+        b.on("exit", (code) => resolve(code));
+        setTimeout(() => resolve(-999), 12_000);
+      });
+      expect(bExit).toBe(3);
+    } finally {
+      probe.destroy();
+    }
   }, 40_000);
 });

--- a/tests/unit/bridge-host.test.ts
+++ b/tests/unit/bridge-host.test.ts
@@ -1,0 +1,120 @@
+// ADR-014 v2 S1 — unit tests for the cooperative-terminal bridge (Node/MCP side).
+//
+// S1 is headless and the node-side security is the secret pipe name + the fail-loud
+// liveness abort in start() + the helper's kernel client-verify — NOT an identity
+// assertion on `hello` (see bridge-host.ts header). So the deterministic unit layer
+// here is the CLIENT WIRE PROTOCOL against a Node fake peer standing in for
+// bin/bridge-host.exe: hello parse, ping/version round-trip, malformed-hello reject,
+// dispose. The real-process stack (spawn, kernel client-verify, fail-loud) is the
+// gated e2e smoke.
+
+import { describe, it, expect, afterEach } from "vitest";
+import net from "node:net";
+import { randomBytes } from "node:crypto";
+import { BridgeHost } from "../../src/engine/bridge-host.js";
+
+function pipePath(): string {
+  return `\\\\.\\pipe\\dtm-bridge-test-${randomBytes(8).toString("hex")}`;
+}
+
+/**
+ * A Node stand-in for the C# helper: writes a `hello` frame on connect, then
+ * answers ping/version/shutdown. `reportPid` is the pid it self-reports.
+ */
+function makeFakePeer(
+  path: string,
+  opts: { reportPid?: number; firstFrame?: string; protocol?: string },
+): net.Server {
+  const proto = opts.protocol ?? "1";
+  const reportPid = opts.reportPid ?? 4242;
+  const server = net.createServer((sock) => {
+    let buf = "";
+    const write = (o: unknown) => sock.write(JSON.stringify(o) + "\n");
+    const first = opts.firstFrame ?? JSON.stringify({ t: "hello", pid: reportPid, v: proto });
+    sock.write(first + "\n");
+    sock.on("data", (d) => {
+      buf += d.toString("utf8");
+      let nl: number;
+      while ((nl = buf.indexOf("\n")) >= 0) {
+        const line = buf.slice(0, nl);
+        buf = buf.slice(nl + 1);
+        if (!line) continue;
+        const req = JSON.parse(line) as { id: number; m: string };
+        if (req.m === "ping") write({ id: req.id, ok: true, r: "pong" });
+        else if (req.m === "version") write({ id: req.id, ok: true, r: proto });
+        else if (req.m === "shutdown") write({ id: req.id, ok: true, r: "bye" });
+        else write({ id: req.id, ok: false, r: "", e: "unknown" });
+      }
+    });
+    sock.on("error", () => { /* client may drop */ });
+  });
+  return server;
+}
+
+describe("BridgeHost client protocol (fake peer)", () => {
+  const servers: net.Server[] = [];
+  const bridges: BridgeHost[] = [];
+
+  afterEach(async () => {
+    for (const b of bridges) { try { await b.dispose(); } catch { /* ignore */ } }
+    bridges.length = 0;
+    for (const s of servers) { try { s.close(); } catch { /* ignore */ } }
+    servers.length = 0;
+  });
+
+  async function listen(server: net.Server, path: string): Promise<void> {
+    servers.push(server);
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(path, () => resolve());
+    });
+  }
+
+  it("handshakes, reports helperPid + version, pings and reports version", async () => {
+    const path = pipePath();
+    const reportPid = 424_242;
+    await listen(makeFakePeer(path, { reportPid }), path);
+
+    const bridge = await BridgeHost.connectForTest(path);
+    bridges.push(bridge);
+
+    expect(bridge.helperPid).toBe(reportPid);
+    expect(bridge.protocolVersion).toBe("1");
+    expect(await bridge.ping()).toBe(true);
+    expect(await bridge.version()).toBe("1");
+  });
+
+  it("matches concurrent requests to their replies by id", async () => {
+    const path = pipePath();
+    await listen(makeFakePeer(path, {}), path);
+    const bridge = await BridgeHost.connectForTest(path);
+    bridges.push(bridge);
+
+    const [p, v] = await Promise.all([bridge.ping(), bridge.version()]);
+    expect(p).toBe(true);
+    expect(v).toBe("1");
+  });
+
+  it("rejects a peer whose first frame is not a well-formed hello", async () => {
+    const path = pipePath();
+    await listen(
+      makeFakePeer(path, { firstFrame: JSON.stringify({ id: 1, ok: true, r: "nope" }) }),
+      path,
+    );
+    await expect(BridgeHost.connectForTest(path)).rejects.toThrow(/unexpected first frame/);
+  });
+
+  it("rejects a peer whose first frame is unparseable", async () => {
+    const path = pipePath();
+    await listen(makeFakePeer(path, { firstFrame: "{not json" }), path);
+    await expect(BridgeHost.connectForTest(path)).rejects.toThrow(/unparseable hello/);
+  });
+
+  it("fails pending requests after dispose", async () => {
+    const path = pipePath();
+    await listen(makeFakePeer(path, {}), path);
+    const bridge = await BridgeHost.connectForTest(path);
+    await bridge.dispose();
+    await expect(bridge.ping()).rejects.toThrow(/disposed/);
+  });
+});

--- a/tests/unit/bridge-host.test.ts
+++ b/tests/unit/bridge-host.test.ts
@@ -140,4 +140,30 @@ describe("BridgeHost client protocol (fake peer)", () => {
     await bridge.dispose();
     await expect(bridge.ping()).rejects.toThrow(/disposed/);
   });
+
+  it("sends a graceful shutdown frame on dispose (not just force-kill) — Codex P2", async () => {
+    const path = pipePath();
+    let gotShutdown = false;
+    const server = net.createServer((sock) => {
+      sock.write(JSON.stringify({ t: "hello", pid: 5, v: "1" }) + "\n");
+      let b = "";
+      sock.on("data", (d) => {
+        b += d.toString("utf8");
+        let nl: number;
+        while ((nl = b.indexOf("\n")) >= 0) {
+          const line = b.slice(0, nl);
+          b = b.slice(nl + 1);
+          if (!line) continue;
+          const req = JSON.parse(line) as { id: number; m: string };
+          if (req.m === "shutdown") { gotShutdown = true; sock.write(JSON.stringify({ id: req.id, ok: true, r: "bye" }) + "\n"); }
+        }
+      });
+      sock.on("error", () => { /* client drops */ });
+    });
+    await listen(server, path);
+
+    const bridge = await BridgeHost.connectForTest(path);
+    await bridge.dispose();
+    expect(gotShutdown).toBe(true);
+  });
 });

--- a/tests/unit/bridge-host.test.ts
+++ b/tests/unit/bridge-host.test.ts
@@ -23,15 +23,23 @@ function pipePath(): string {
  */
 function makeFakePeer(
   path: string,
-  opts: { reportPid?: number; firstFrame?: string; protocol?: string },
+  opts: { reportPid?: number; firstFrame?: string; protocol?: string; chunkFirst?: boolean },
 ): net.Server {
   const proto = opts.protocol ?? "1";
   const reportPid = opts.reportPid ?? 4242;
   const server = net.createServer((sock) => {
     let buf = "";
     const write = (o: unknown) => sock.write(JSON.stringify(o) + "\n");
-    const first = opts.firstFrame ?? JSON.stringify({ t: "hello", pid: reportPid, v: proto });
-    sock.write(first + "\n");
+    const first = (opts.firstFrame ?? JSON.stringify({ t: "hello", pid: reportPid, v: proto })) + "\n";
+    if (opts.chunkFirst) {
+      // Exercise the client's partial-frame path: split the first frame across two
+      // TCP-ish chunks so the handshake must buffer until the '\n' arrives.
+      const mid = Math.max(1, Math.floor(first.length / 2));
+      sock.write(first.slice(0, mid));
+      setTimeout(() => { try { sock.write(first.slice(mid)); } catch { /* dropped */ } }, 20);
+    } else {
+      sock.write(first);
+    }
     sock.on("data", (d) => {
       buf += d.toString("utf8");
       let nl: number;
@@ -43,7 +51,7 @@ function makeFakePeer(
         if (req.m === "ping") write({ id: req.id, ok: true, r: "pong" });
         else if (req.m === "version") write({ id: req.id, ok: true, r: proto });
         else if (req.m === "shutdown") write({ id: req.id, ok: true, r: "bye" });
-        else write({ id: req.id, ok: false, r: "", e: "unknown" });
+        else write({ id: req.id, ok: false, r: "", e: `unknown_method:${req.m}` }); // mirror the C# helper
       }
     });
     sock.on("error", () => { /* client may drop */ });
@@ -108,6 +116,21 @@ describe("BridgeHost client protocol (fake peer)", () => {
     const path = pipePath();
     await listen(makeFakePeer(path, { firstFrame: "{not json" }), path);
     await expect(BridgeHost.connectForTest(path)).rejects.toThrow(/unparseable hello/);
+  });
+
+  it("handshakes when the hello frame arrives split across chunks", async () => {
+    const path = pipePath();
+    await listen(makeFakePeer(path, { reportPid: 777, chunkFirst: true }), path);
+    const bridge = await BridgeHost.connectForTest(path);
+    bridges.push(bridge);
+    expect(bridge.helperPid).toBe(777);
+    expect(await bridge.ping()).toBe(true);
+  });
+
+  it("rejects a helper whose protocol version does not match", async () => {
+    const path = pipePath();
+    await listen(makeFakePeer(path, { protocol: "2" }), path);
+    await expect(BridgeHost.connectForTest(path)).rejects.toThrow(/protocol '2' != expected '1'/);
   });
 
   it("fails pending requests after dispose", async () => {

--- a/tools/bridge-host/.gitignore
+++ b/tools/bridge-host/.gitignore
@@ -1,0 +1,4 @@
+# dotnet build outputs — the published exe is committed to the repo-root bin/
+# (bin/bridge-host.exe), same as tools/win-ocr. These local build dirs are not.
+bin/
+obj/

--- a/tools/bridge-host/Program.cs
+++ b/tools/bridge-host/Program.cs
@@ -1,0 +1,256 @@
+// ADR-014 v2 S1 — cooperative terminal bridge helper (OQ #6 option (C)).
+//
+// Plan: desktop-touch-mcp-internal@HEAD:docs/adr-014-v2-s1-option-c-design.md
+//
+// This compiled C# console exe owns the CurrentUserOnly named-pipe SERVER; the
+// MCP (Node, src/engine/bridge-host.ts) connects as CLIENT. It runs inside a
+// dedicated conhost window so a human can type sudo/ssh passwords directly at the
+// pane (crux (a), re-spiked in spike/adr-014-cs-crux) — S1 only stands up the
+// server + handshake + ping/version; the interactive `run`/`cancel` child path is
+// S2.
+//
+// Auth (see the design doc §1):
+//   * Client direction (the threat-model §8 defense) = KERNEL TRUTH: the server
+//     verifies the connected client's PID == -McpPid via GetNamedPipeClientProcessId
+//     (a squatter same-user client is rejected). Together with the CurrentUserOnly
+//     ACL (cross-user block) this is what §8 rests on.
+//   * Server direction is verified on the MCP side by process topology + creation
+//     time (Node has no kernel handle for net.connect); this helper simply
+//     self-reports its own PID in the `hello` frame so the MCP can match it against
+//     the conhost child it captured at spawn.
+//
+// Wire framing: raw UTF-8 bytes, one JSON object per '\n' line (StreamReader/
+// StreamWriter over a NamedPipeStream deadlocked in the Phase 0 spike; raw byte
+// framing is reliable). Reads are BUFFERED (fill a buffer, split on '\n') so an
+// unbounded `run` payload (S2) is not thousands of 1-byte syscalls.
+//   MCP -> helper : {"id":N,"m":"ping|version|shutdown"}
+//   helper -> MCP : {"t":"hello","pid":<helperPid>,"v":"<proto>"}   (first frame)
+//                   {"id":N,"ok":true,"r":"..."}                     (replies)
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Pipes;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+
+internal static class BridgeHost
+{
+    // Protocol version — bumped when the wire contract changes. The MCP reads this
+    // from the `hello` frame and can refuse an incompatible helper.
+    private const string ProtocolVersion = "1";
+
+    // A squatter client that connects before the real MCP is rejected; bound the
+    // reject loop so a hostile local process cannot wedge the helper forever (R-C).
+    private const int MaxClientRejects = 8;
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetNamedPipeClientProcessId(IntPtr Pipe, out uint ClientProcessId);
+
+    // NOTE: S1 is HEADLESS (no console window). The MCP direct-spawns this helper
+    // detached; the pipe server + kernel client-verify + hello/ping/version are all
+    // launch-method-independent (the S1 locked contract). The DEDICATED console
+    // window a human types passwords into (crux (a)) is S2, via a C# self-bootstrap
+    // that re-execs under `conhost.exe` with CREATE_NEW_CONSOLE (a shared Windows
+    // Terminal tab, e.g. from AllocConsole, is the phase-0 a2 input-misroute case
+    // and is deliberately NOT used).
+
+    private static int Main(string[] args)
+    {
+        string? pipeName = null;
+        uint mcpPid = 0;
+        for (var i = 0; i + 1 < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "-PipeName": pipeName = args[i + 1]; break;
+                case "-McpPid": _ = uint.TryParse(args[i + 1], out mcpPid); break;
+            }
+        }
+        if (string.IsNullOrEmpty(pipeName))
+        {
+            Console.Error.WriteLine("bridge-host: missing -PipeName");
+            return 2;
+        }
+        if (mcpPid == 0)
+        {
+            Console.Error.WriteLine("bridge-host: missing/invalid -McpPid");
+            return 2;
+        }
+
+        var helperPid = Environment.ProcessId;
+        try { Console.Title = "desktop-touch bridge"; } catch { /* ignore */ }
+        Console.WriteLine($"[bridge-host] pid={helperPid} pipe={pipeName} — cooperative terminal helper (S1 headless).");
+
+        NamedPipeServerStream server;
+        try
+        {
+            // CurrentUserOnly => a different-user client cannot connect (the §8
+            // cross-user guarantee, enforced by the OS DACL). maxInstances=1 makes
+            // .NET pass FILE_FLAG_FIRST_PIPE_INSTANCE, so if a squatter already
+            // created this (unguessable) name our create FAILS LOUD here instead of
+            // silently attaching to their pipe — the MCP then sees us die and aborts.
+            server = new NamedPipeServerStream(
+                pipeName,
+                PipeDirection.InOut,
+                maxNumberOfServerInstances: 1,
+                PipeTransmissionMode.Byte,
+                PipeOptions.Asynchronous | PipeOptions.CurrentUserOnly);
+        }
+        catch (Exception e)
+        {
+            // Fail loud: most likely the name already exists (squatter) or an ACL
+            // problem. Do NOT fall back to a permissive pipe.
+            Console.Error.WriteLine($"bridge-host: pipe create failed (name taken / not fresh?): {e.Message}");
+            return 3;
+        }
+
+        try
+        {
+            if (!WaitForVerifiedClient(server, mcpPid, helperPid))
+            {
+                Console.Error.WriteLine("bridge-host: no authorized client connected; exiting.");
+                return 4;
+            }
+
+            // First frame: self-report identity so the MCP can match this PID against
+            // the conhost child it captured at spawn (server-topology verify).
+            WriteFrame(server, $"{{\"t\":\"hello\",\"pid\":{helperPid},\"v\":\"{ProtocolVersion}\"}}");
+
+            RunControlLoop(server, helperPid);
+            return 0;
+        }
+        finally
+        {
+            try { server.Dispose(); } catch { /* ignore */ }
+            Console.WriteLine("[bridge-host] exit.");
+        }
+    }
+
+    /// Accept connections until the connected client's kernel PID == mcpPid, or the
+    /// reject budget is exhausted. A squatter client that connects first is dropped.
+    private static bool WaitForVerifiedClient(NamedPipeServerStream server, uint mcpPid, int helperPid)
+    {
+        for (var attempt = 0; attempt <= MaxClientRejects; attempt++)
+        {
+            server.WaitForConnection();
+            uint clientPid = 0;
+            var ok = GetNamedPipeClientProcessId(server.SafePipeHandle.DangerousGetHandle(), out clientPid);
+            if (ok && clientPid == mcpPid)
+            {
+                Console.WriteLine($"[bridge-host] client verified: clientPid={clientPid} == McpPid.");
+                return true;
+            }
+
+            Console.Error.WriteLine(
+                $"[bridge-host] rejecting client: getOk={ok} clientPid={clientPid} expected McpPid={mcpPid} " +
+                $"(attempt {attempt + 1}/{MaxClientRejects + 1}).");
+            try { server.Disconnect(); } catch { /* ignore, loop and re-wait */ }
+        }
+        return false;
+    }
+
+    /// Read '\n'-framed JSON control requests and answer ping/version/shutdown.
+    private static void RunControlLoop(NamedPipeServerStream server, int helperPid)
+    {
+        var reader = new FramedReader(server);
+        while (true)
+        {
+            var line = reader.ReadLine();
+            if (line == null) { Console.WriteLine("[bridge-host] pipe closed by MCP."); break; }
+            if (line.Length == 0) continue;
+
+            long id = -1;
+            string method = "";
+            try
+            {
+                using var doc = JsonDocument.Parse(line);
+                var root = doc.RootElement;
+                if (root.TryGetProperty("id", out var idEl) && idEl.TryGetInt64(out var idv)) id = idv;
+                if (root.TryGetProperty("m", out var mEl)) method = mEl.GetString() ?? "";
+            }
+            catch (Exception e)
+            {
+                Console.Error.WriteLine($"[bridge-host] bad frame: {e.Message}");
+                WriteReply(server, id, false, "", "bad_json");
+                continue;
+            }
+
+            switch (method)
+            {
+                case "ping":
+                    WriteReply(server, id, true, "pong", null);
+                    break;
+                case "version":
+                    WriteReply(server, id, true, ProtocolVersion, null);
+                    break;
+                case "shutdown":
+                    WriteReply(server, id, true, "bye", null);
+                    return;
+                default:
+                    WriteReply(server, id, false, "", $"unknown_method:{method}");
+                    break;
+            }
+        }
+    }
+
+    private static void WriteReply(Stream s, long id, bool ok, string result, string? err)
+    {
+        var sb = new StringBuilder(64);
+        sb.Append("{\"id\":").Append(id).Append(",\"ok\":").Append(ok ? "true" : "false");
+        sb.Append(",\"r\":").Append(JsonEncodedString(result));
+        if (err != null) sb.Append(",\"e\":").Append(JsonEncodedString(err));
+        sb.Append('}');
+        WriteFrame(s, sb.ToString());
+    }
+
+    private static string JsonEncodedString(string v)
+    {
+        // Reuse System.Text.Json for correct escaping of arbitrary content.
+        return JsonSerializer.Serialize(v);
+    }
+
+    private static void WriteFrame(Stream s, string json)
+    {
+        var b = Encoding.UTF8.GetBytes(json + "\n");
+        s.Write(b, 0, b.Length);
+        s.Flush();
+    }
+
+    /// Buffered raw-byte line reader: fills a buffer and splits on '\n', so a large
+    /// inbound frame (S2 `run`) costs O(bytes) not O(1-byte syscalls). Strips a
+    /// trailing '\r'. Returns null on pipe close.
+    private sealed class FramedReader
+    {
+        private readonly Stream _s;
+        private readonly byte[] _buf = new byte[4096];
+        private int _len;
+        private int _pos;
+
+        public FramedReader(Stream s) { _s = s; }
+
+        public string? ReadLine()
+        {
+            var line = new List<byte>(128);
+            while (true)
+            {
+                if (_pos >= _len)
+                {
+                    _len = _s.Read(_buf, 0, _buf.Length);
+                    _pos = 0;
+                    if (_len == 0) return null; // pipe closed
+                }
+                var b = _buf[_pos++];
+                if (b == (byte)'\n')
+                {
+                    if (line.Count > 0 && line[line.Count - 1] == (byte)'\r') line.RemoveAt(line.Count - 1);
+                    return Encoding.UTF8.GetString(line.ToArray());
+                }
+                line.Add(b);
+            }
+        }
+    }
+}

--- a/tools/bridge-host/Program.cs
+++ b/tools/bridge-host/Program.cs
@@ -3,21 +3,22 @@
 // Plan: desktop-touch-mcp-internal@HEAD:docs/adr-014-v2-s1-option-c-design.md
 //
 // This compiled C# console exe owns the CurrentUserOnly named-pipe SERVER; the
-// MCP (Node, src/engine/bridge-host.ts) connects as CLIENT. It runs inside a
-// dedicated conhost window so a human can type sudo/ssh passwords directly at the
-// pane (crux (a), re-spiked in spike/adr-014-cs-crux) — S1 only stands up the
-// server + handshake + ping/version; the interactive `run`/`cancel` child path is
-// S2.
+// MCP (Node, src/engine/bridge-host.ts) connects as CLIENT. S1 is HEADLESS — it
+// only stands up the server + handshake + ping/version. The dedicated console
+// window a human types sudo/ssh passwords into (crux (a)) is S2 (a self-bootstrap
+// that re-execs under conhost with CREATE_NEW_CONSOLE); the interactive
+// `run`/`cancel` child path is also S2. See the design doc §8.
 //
-// Auth (see the design doc §1):
-//   * Client direction (the threat-model §8 defense) = KERNEL TRUTH: the server
+// Auth (see the design doc §8.3):
+//   * Client direction = KERNEL TRUTH (a load-bearing §8 defense): the server
 //     verifies the connected client's PID == -McpPid via GetNamedPipeClientProcessId
-//     (a squatter same-user client is rejected). Together with the CurrentUserOnly
-//     ACL (cross-user block) this is what §8 rests on.
-//   * Server direction is verified on the MCP side by process topology + creation
-//     time (Node has no kernel handle for net.connect); this helper simply
-//     self-reports its own PID in the `hello` frame so the MCP can match it against
-//     the conhost child it captured at spawn.
+//     (a rogue same-user client is rejected). With the CurrentUserOnly ACL
+//     (cross-user block) + the 128-bit secret pipe name + FILE_FLAG_FIRST_PIPE_INSTANCE
+//     fail-loud (below), this is what §8 rests on.
+//   * The `hello` frame self-reports this helper's PID as NON-LOAD-BEARING
+//     observability only (liveness + version) — it is NOT a security boundary. The
+//     MCP does not verify the server by process topology (that was removed; an
+//     adversarial same-user server is out of §8 scope).
 //
 // Wire framing: raw UTF-8 bytes, one JSON object per '\n' line (StreamReader/
 // StreamWriter over a NamedPipeStream deadlocked in the Phase 0 spike; raw byte
@@ -116,8 +117,8 @@ internal static class BridgeHost
                 return 4;
             }
 
-            // First frame: self-report identity so the MCP can match this PID against
-            // the conhost child it captured at spawn (server-topology verify).
+            // First frame: self-report pid + protocol version as NON-LOAD-BEARING
+            // observability (liveness/version), NOT a security claim (design §8.3).
             WriteFrame(server, $"{{\"t\":\"hello\",\"pid\":{helperPid},\"v\":\"{ProtocolVersion}\"}}");
 
             RunControlLoop(server, helperPid);
@@ -136,7 +137,16 @@ internal static class BridgeHost
     {
         for (var attempt = 0; attempt <= MaxClientRejects; attempt++)
         {
-            server.WaitForConnection();
+            try
+            {
+                server.WaitForConnection();
+            }
+            catch (Exception e)
+            {
+                // Graceful fail-loud (return 4) instead of an unhandled-exception crash.
+                Console.Error.WriteLine($"[bridge-host] WaitForConnection failed: {e.Message}");
+                return false;
+            }
             uint clientPid = 0;
             var ok = GetNamedPipeClientProcessId(server.SafePipeHandle.DangerousGetHandle(), out clientPid);
             if (ok && clientPid == mcpPid)

--- a/tools/bridge-host/bridge-host.csproj
+++ b/tools/bridge-host/bridge-host.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!--
+    ADR-014 v2 S1 — cooperative terminal bridge helper.
+
+    A compiled C# console exe (NOT a shipped .ps1) that owns the CurrentUserOnly
+    named-pipe SERVER for OQ #6 option (C): the MCP (Node) connects as CLIENT.
+    Mirrors tools/win-ocr -> bin/win-ocr.exe: built with `dotnet publish` and the
+    resulting single-file exe is committed to bin/ and shipped by release.yml's
+    existing `bin\*.exe` copy step. Being a compiled exe (no `iex` over the pipe)
+    it is not an AMSI target — the same reason win-ocr.exe is C#.
+
+    Build: cd tools/bridge-host && dotnet publish -c Release -o ../../bin/
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <Optimize>true</Optimize>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>false</SelfContained>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <AssemblyName>bridge-host</AssemblyName>
+    <RootNamespace>BridgeHost</RootNamespace>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## What
Additive **S1 trunk** for ADR-014 v2 (cooperative terminal, model B), OQ #6 option **(C)**: a compiled C# helper `bin/bridge-host.exe` owns a `CurrentUserOnly` named-pipe **server**; `src/engine/bridge-host.ts` is the Node **client**. **S1 is HEADLESS** — the launch-independent pipe protocol + auth is the locked contract; the dedicated console window a human types sudo/ssh passwords into (crux a) is **S2**.

No tool surface yet (S3), **no tool-count change (still 31)**.

## Threat-model §8 guarantees (all launch-method-independent)
- **cross-user** → `CurrentUserOnly` ACL (a different user cannot open the pipe).
- **casual same-user race** → (1) unguessable **128-bit secret pipe name**; (2) **`FILE_FLAG_FIRST_PIPE_INSTANCE`** (via `maxInstances=1`) fail-loud — a squatter-won name makes the real helper's create fail → it exits → the Node client observes its direct child exit and **aborts before connecting** (`BridgeHelperSpawnFailed`); (3) **kernel client-verify** (`GetNamedPipeClientProcessId == McpPid`) rejects a rogue same-user client.

The helper's self-reported `hello.pid` is **non-load-bearing observability**, not a security boundary (adversarial same-user is out of §8 scope).

## Why headless / why C# / why direct-spawn
- **C# exe** (not a shipped `.ps1`): mirrors `tools/win-ocr` → `bin/win-ocr.exe`; a compiled exe has no `iex` → no AMSI hazard; shipped by `release.yml`'s existing `bin\*.exe` copy (no packaging change).
- **direct-spawn, headless**: empirically `conhost.exe <exe>` is unspawnable from `child_process` (no `CREATE_NEW_CONSOLE`), and a helper-internal `AllocConsole` lands in a shared Windows Terminal tab on Win11 (the phase-0 a2 input-misroute case). So S1 direct-spawns the helper headless; the dedicated window is delivered in **S2** via a C# self-bootstrap (`CreateProcessW(conhost.exe, …, CREATE_NEW_CONSOLE)`). Server-verify is **demoted** to non-load-bearing observability so the S1 contract does not depend on a topology predicate the S2 launcher would perturb.

## Files
- `tools/bridge-host/{bridge-host.csproj,Program.cs}` → committed `bin/bridge-host.exe` (headless: CurrentUserOnly + FIRST_PIPE_INSTANCE, kernel client-verify with bounded reject, buffered `\n` read, `hello`/`ping`/`version`/`shutdown`).
- `src/engine/bridge-host.ts` (`BridgeHost`): mint 128-bit name, direct-spawn detached, connect backoff (retry ENOENT/BUSY → `BridgeHelperSpawnFailed`), fail-loud liveness abort, `hello` handshake, `ping`/`version`/`dispose`. `BridgeError` codes local (S4 wires `_errors.ts`).

## Tests (green)
- `tests/unit/bridge-host.test.ts` — **5/5** (protocol vs a Node fake peer: hello parse, id-matched ping/version, malformed/unparseable-hello reject, post-dispose failure).
- `tests/e2e/bridge-host.e2e.test.ts` — **2/2** (live smoke: real headless helper → ping/version; negative: rogue client with wrong `-McpPid` gets no `hello` = kernel client-verify).
- Guards green: build, lint, stub-catalog (29 stub tools unchanged), native-types, napi-safe, failwith-fixtures.

Plan (design + §8 impl resolution): `desktop-touch-mcp-internal@d113647:docs/adr-014-v2-s1-option-c-design.md`.

Review: production code → Opus + Codex both required. Merge is the maintainer's.
