### PR TITLE
ADR-014 v2 R3 Key Locker — L1 binding model

### DIFF
--- a/src/engine/key-locker/binding-store.ts
+++ b/src/engine/key-locker/binding-store.ts
@@ -1,0 +1,186 @@
+// ADR-014 v2 R3 Key Locker — L1: the binding store (Node-side canonical-key → opaqueId mapping).
+//
+// Plan: desktop-touch-mcp-internal@6b0a085:docs/adr-014-v2-r3-l1-binding-plan.md (§5)
+//
+// Why Node-side, not in the locker: L0 froze the pipe protocol; adding bind/resolve/list verbs
+// would amend it. This mapping holds NO SECRET (URIs, public fingerprints, opaque ids), so it
+// needs no DPAPI and lives as plain JSON co-located with the locker's store dir. The locker keeps
+// treating `k` as an opaque string; `opaqueId` here IS that `k`. (A same-user process editing this
+// file is parent §8 out of scope — it could read the DPAPI store directly, same-user.)
+//
+// Authority split (§5.3): the LOCKER is authoritative for "does a secret exist"; the MAP is
+// authoritative for "which canonical key points at which opaqueId". `resolve` therefore verifies
+// via the locker's `exists()` and prunes stale rows; it never deletes locker entries (the reverse
+// orphan is L3's discard-path obligation, not L1's).
+
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** Mirrors the locker's default store dir (Program.cs: %LOCALAPPDATA%\desktop-touch-mcp\locker). */
+function defaultStoreDir(): string {
+  const localAppData = process.env.LOCALAPPDATA ?? join(homedir(), "AppData", "Local");
+  return join(localAppData, "desktop-touch-mcp", "locker");
+}
+
+export type BindingScheme = "ssh" | "sudo" | "https-cred" | "sshkey";
+
+/** One `bindings.json` row (no secret — URIs, public fingerprints, opaque ids, timestamps). */
+export interface BindingMeta {
+  scheme: BindingScheme;
+  /** Human-facing URI (no fp-set) for management/logs. */
+  displayUri: string;
+  host?: string;
+  user?: string;
+  port?: number;
+  /** sudo only. */
+  targetUser?: string;
+  /** ssh only (redundant with the canonical key; kept for display/audit). */
+  fpSet?: string[];
+  /** ISO-8601, stamped by the caller. */
+  createdAt: string;
+}
+
+export interface BindingRecord extends BindingMeta {
+  /** The locker store key (`k` on the pipe) — Node-generated `randomBytes(16).toString("hex")`. */
+  opaqueId: string;
+}
+
+export interface BindingSummary extends BindingRecord {
+  canonicalKey: string;
+}
+
+interface BindingsFile {
+  version: 1;
+  bindings: Record<string, BindingRecord>;
+}
+
+/**
+ * Thrown by `resolve`/`reconcile` on a MANAGEMENT-ONLY store (loaded without `existsInLocker`):
+ * those verbs must verify against the live locker and cannot run without it. bind/unbind/list
+ * work either way.
+ */
+export class LockerNotBoundError extends Error {
+  readonly code = "LockerNotBound";
+  constructor(verb: string) {
+    super(`BindingStore.${verb} requires an existsInLocker check (store was loaded management-only)`);
+    this.name = "LockerNotBoundError";
+  }
+}
+
+const FILE_NAME = "bindings.json";
+
+/**
+ * The canonical-key → opaqueId map with atomic persistence and locker reconciliation.
+ * Create with `BindingStore.load()`; every mutation saves atomically (tmp write + rename,
+ * mirroring the locker's own Save()).
+ */
+export class BindingStore {
+  private constructor(
+    private readonly filePath: string,
+    private readonly data: BindingsFile,
+    private readonly existsInLocker?: (opaqueId: string) => Promise<boolean>,
+  ) {}
+
+  /**
+   * Load (or start) the store under `storeDir` (default: the locker's own store dir, so tests
+   * override both with the same `storeDir` the KeyLockerHost accepts). Tolerant of a corrupt /
+   * missing / wrong-shape file: starts empty, preserving the corrupt original as `.corrupt`.
+   * `existsInLocker` = the locker's async existence check (key-locker-host.ts `exists()`);
+   * omit it for a management-only store (resolve/reconcile then throw `LockerNotBoundError`).
+   */
+  static load(storeDir?: string, existsInLocker?: (opaqueId: string) => Promise<boolean>): BindingStore {
+    const dir = storeDir ?? defaultStoreDir();
+    mkdirSync(dir, { recursive: true });
+    const filePath = join(dir, FILE_NAME);
+    let data: BindingsFile = { version: 1, bindings: {} };
+    if (existsSync(filePath)) {
+      try {
+        const raw = JSON.parse(readFileSync(filePath, "utf8")) as unknown;
+        if (
+          typeof raw === "object" && raw !== null &&
+          (raw as BindingsFile).version === 1 &&
+          typeof (raw as BindingsFile).bindings === "object" && (raw as BindingsFile).bindings !== null
+        ) {
+          data = { version: 1, bindings: { ...(raw as BindingsFile).bindings } };
+        } else {
+          preserveCorrupt(filePath);
+        }
+      } catch {
+        preserveCorrupt(filePath);
+      }
+    }
+    return new BindingStore(filePath, data, existsInLocker);
+  }
+
+  /**
+   * The lookup-by-command hot path: map lookup, then VERIFY the secret still exists in the locker
+   * (a map row proves only "canonical → opaqueId", not "the secret survives"); a stale row is
+   * pruned and reported as no binding. One cheap local pipe round-trip per autofill offer.
+   */
+  async resolve(canonicalKey: string): Promise<{ opaqueId: string } | undefined> {
+    if (this.existsInLocker === undefined) throw new LockerNotBoundError("resolve");
+    const row = this.data.bindings[canonicalKey];
+    if (row === undefined) return undefined;
+    if (!(await this.existsInLocker(row.opaqueId))) {
+      delete this.data.bindings[canonicalKey];
+      this.save();
+      return undefined;
+    }
+    return { opaqueId: row.opaqueId };
+  }
+
+  /**
+   * Create/update a binding. `opaqueId` is caller-supplied (L3's capture-then-commit generates it
+   * at capture time and hands it here on exit 0); `meta.createdAt` is stamped by the caller.
+   */
+  bind(canonicalKey: string, opaqueId: string, meta: BindingMeta): void {
+    this.data.bindings[canonicalKey] = { opaqueId, ...meta };
+    this.save();
+  }
+
+  /** Delete a binding row. Returns whether an entry was removed. Never touches the locker. */
+  unbind(canonicalKey: string): boolean {
+    if (!(canonicalKey in this.data.bindings)) return false;
+    delete this.data.bindings[canonicalKey];
+    this.save();
+    return true;
+  }
+
+  /** Enumerate all rows (management / L4). */
+  list(): BindingSummary[] {
+    return Object.entries(this.data.bindings).map(([canonicalKey, row]) => ({ canonicalKey, ...row }));
+  }
+
+  /**
+   * Bulk prune: drop every map row whose locker entry no longer exists (locker `store.json`
+   * deleted out of band, secrets removed via `delete`, …). Returns the pruned count. Used at
+   * session start / from management. Never deletes locker entries (that direction is L3's).
+   */
+  async reconcile(): Promise<number> {
+    if (this.existsInLocker === undefined) throw new LockerNotBoundError("reconcile");
+    let pruned = 0;
+    for (const [key, row] of Object.entries(this.data.bindings)) {
+      if (!(await this.existsInLocker(row.opaqueId))) {
+        delete this.data.bindings[key];
+        pruned++;
+      }
+    }
+    if (pruned > 0) this.save();
+    return pruned;
+  }
+
+  /** Atomic persistence: write `<file>.tmp`, then rename over the real file (mirrors L0 Save()). */
+  private save(): void {
+    const tmp = `${this.filePath}.tmp`;
+    writeFileSync(tmp, JSON.stringify(this.data, null, 2), "utf8");
+    renameSync(tmp, this.filePath); // libuv rename uses MOVEFILE_REPLACE_EXISTING on Windows
+  }
+}
+
+/** Keep forensic evidence of an unparseable file instead of silently overwriting it. */
+function preserveCorrupt(filePath: string): void {
+  try {
+    renameSync(filePath, `${filePath}.corrupt`);
+  } catch { /* best-effort */ }
+}

--- a/src/engine/key-locker/binding-store.ts
+++ b/src/engine/key-locker/binding-store.ts
@@ -97,10 +97,17 @@ export class BindingStore {
     if (existsSync(filePath)) {
       try {
         const raw = JSON.parse(readFileSync(filePath, "utf8")) as unknown;
+        // Row-level validation, not just the top-level shape: a null row or a record without a
+        // string opaqueId would otherwise surface later as a resolve() throw instead of the
+        // promised tolerant-load (Codex R4). Any malformed row ⇒ the whole file is corrupt
+        // (preserved + start empty — bindings are re-creatable metadata, fail-safe).
         if (
           typeof raw === "object" && raw !== null &&
           (raw as BindingsFile).version === 1 &&
-          typeof (raw as BindingsFile).bindings === "object" && (raw as BindingsFile).bindings !== null
+          typeof (raw as BindingsFile).bindings === "object" && (raw as BindingsFile).bindings !== null &&
+          Object.values((raw as BindingsFile).bindings).every(
+            (row) => typeof row === "object" && row !== null && typeof row.opaqueId === "string",
+          )
         ) {
           data = { version: 1, bindings: { ...(raw as BindingsFile).bindings } };
         } else {

--- a/src/engine/key-locker/binding.ts
+++ b/src/engine/key-locker/binding.ts
@@ -1,0 +1,263 @@
+// ADR-014 v2 R3 Key Locker — L1 binding model: the binding-URI grammar (THE LOCKED CONTRACT),
+// parser, serializer, and canonical-key derivation.
+//
+// Plan: desktop-touch-mcp-internal@6b0a085:docs/adr-014-v2-r3-l1-binding-plan.md (§2)
+//
+// Two related strings, kept distinct on purpose:
+//   * the BINDING URI — the human-facing / derived-from-command form (management + logs show it);
+//     RFC-3986-safe (userinfo/target-user/path are percent-encoded, `sshkey:` is the opaque
+//     authority-less form so ssh-keygen's standard-base64 `+`/`/` need no re-encoding).
+//   * the CANONICAL KEY — the exact string used as the store map key. Canonical keys are INTERNAL
+//     comparison strings, never re-parsed for navigation, so the ssh `|fp=…` tail (non-URI `|`
+//     delimiter + raw base64) is safe there.
+//
+// Grammar (ABNF, frozen):
+//   binding-uri = ssh-uri / sudo-uri / git-uri / sshkey-uri
+//   ssh-uri     = "ssh://" userinfo "@" host [":" port]
+//   sudo-uri    = "sudo://" host "/" target-user
+//   git-uri     = "https-cred://" [userinfo "@"] host [":" port] ["/" path]
+//   sshkey-uri  = "sshkey:" key-fp            ; OPAQUE, host-independent, URN-like
+//   key-fp      = "SHA256:" base64-nopad      ; exactly as `ssh-keygen -l -f` prints
+//
+// No secret ever appears at this layer — URIs, fingerprints (public) and opaque ids only.
+
+/** Scheme default ports (canonical keys always carry an explicit port). */
+const SSH_DEFAULT_PORT = 22;
+const HTTPS_DEFAULT_PORT = 443;
+
+export type BindingParseErrorCode =
+  | "UnknownScheme"
+  | "MissingComponent"
+  | "MalformedUri"
+  | "BadPercentEscape"
+  | "BadPort";
+
+/**
+ * Typed reject for malformed / unknown-scheme / missing-required-component URIs — no silent
+ * fallthrough, no partial parse. Carries the offending input (never a secret; none exists here).
+ */
+export class BindingParseError extends Error {
+  readonly code: BindingParseErrorCode;
+  readonly input: string;
+  constructor(code: BindingParseErrorCode, message: string, input: string) {
+    super(`${message} (input: ${input})`);
+    this.name = "BindingParseError";
+    this.code = code;
+    this.input = input;
+  }
+}
+
+/**
+ * A parsed binding target (discriminated on `scheme`). Components hold DECODED values
+ * (`formatBindingUri` re-encodes); `host` is lowercased, `port` is always explicit
+ * (scheme default filled in).
+ *
+ * The ssh variant's `fpSet` is a RESOLUTION product (§3: known_hosts fingerprints), not part of
+ * the URI string grammar — `parseBindingUri` leaves it undefined; `deriveBinding` fills it so the
+ * canonical key (which requires it) is computable without re-running `ssh -G`.
+ */
+export type BindingUri =
+  | { scheme: "ssh"; user: string; host: string; port: number; fpSet?: string[] }
+  | { scheme: "sudo"; host: string; targetUser: string }
+  | { scheme: "https-cred"; user?: string; host: string; port: number; path?: string }
+  | { scheme: "sshkey"; keyFp: string };
+
+const UNRESERVED = /^[A-Za-z0-9\-._~]$/;
+const KEY_FP_RE = /^SHA256:[A-Za-z0-9+/]+$/;
+const PORT_RE = /^[0-9]{1,5}$/;
+// hostname / IPv4 (loose; ssh -G returns resolved ASCII/punycode hosts). IPv6 is bracketed.
+const HOST_RE = /^[A-Za-z0-9]([A-Za-z0-9\-._]*[A-Za-z0-9])?$/;
+const IPV6_RE = /^[0-9A-Fa-f:.]+$/;
+
+/** Percent-encode per the grammar: keep `unreserved` (plus `/` when `keepSlash`), escape the rest. */
+function pctEncode(value: string, keepSlash: boolean): string {
+  let out = "";
+  for (const ch of value) {
+    if (UNRESERVED.test(ch) || (keepSlash && ch === "/")) {
+      out += ch;
+    } else {
+      const bytes = Buffer.from(ch, "utf8");
+      for (const b of bytes) out += `%${b.toString(16).toUpperCase().padStart(2, "0")}`;
+    }
+  }
+  return out;
+}
+
+/** Strict percent-decode; rejects bad escapes and raw characters outside the grammar. */
+function pctDecode(value: string, keepSlash: boolean, input: string): string {
+  const bytes: number[] = [];
+  for (let i = 0; i < value.length; i++) {
+    const ch = value[i];
+    if (ch === "%") {
+      const hex = value.slice(i + 1, i + 3);
+      if (!/^[0-9A-Fa-f]{2}$/.test(hex)) {
+        throw new BindingParseError("BadPercentEscape", `bad percent escape at '%${hex}'`, input);
+      }
+      bytes.push(parseInt(hex, 16));
+      i += 2;
+    } else if (UNRESERVED.test(ch) || (keepSlash && ch === "/")) {
+      bytes.push(ch.charCodeAt(0));
+    } else {
+      throw new BindingParseError("MalformedUri", `character '${ch}' must be percent-encoded`, input);
+    }
+  }
+  return Buffer.from(bytes).toString("utf8");
+}
+
+function parsePort(raw: string, input: string): number {
+  if (!PORT_RE.test(raw)) throw new BindingParseError("BadPort", `bad port '${raw}'`, input);
+  const port = Number(raw);
+  if (port < 1 || port > 65535) throw new BindingParseError("BadPort", `port ${port} out of range`, input);
+  return port;
+}
+
+/** Parse `host[:port]`, handling bracketed IPv6. Returns the LOWERCASED host. */
+function parseHostPort(raw: string, input: string): { host: string; port?: number } {
+  if (raw.startsWith("[")) {
+    const close = raw.indexOf("]");
+    if (close < 0) throw new BindingParseError("MalformedUri", "unterminated IPv6 bracket", input);
+    const host = raw.slice(1, close);
+    if (host.length === 0 || !IPV6_RE.test(host)) {
+      throw new BindingParseError("MalformedUri", `bad IPv6 host '[${host}]'`, input);
+    }
+    const rest = raw.slice(close + 1);
+    if (rest === "") return { host: `[${host.toLowerCase()}]` };
+    if (!rest.startsWith(":")) throw new BindingParseError("MalformedUri", `junk after IPv6 host: '${rest}'`, input);
+    return { host: `[${host.toLowerCase()}]`, port: parsePort(rest.slice(1), input) };
+  }
+  const colon = raw.indexOf(":");
+  const host = colon < 0 ? raw : raw.slice(0, colon);
+  if (host.length === 0 || !HOST_RE.test(host)) {
+    throw new BindingParseError(host.length === 0 ? "MissingComponent" : "MalformedUri", `bad host '${host}'`, input);
+  }
+  if (colon < 0) return { host: host.toLowerCase() };
+  return { host: host.toLowerCase(), port: parsePort(raw.slice(colon + 1), input) };
+}
+
+/**
+ * Parse a binding-URI string into its discriminated type. Throws `BindingParseError` (typed
+ * reject) on any malformed / unknown-scheme / missing-component input — never a partial parse.
+ */
+export function parseBindingUri(input: string): BindingUri {
+  const colon = input.indexOf(":");
+  if (colon <= 0) throw new BindingParseError("MalformedUri", "no scheme", input);
+  const scheme = input.slice(0, colon);
+
+  if (scheme === "sshkey") {
+    // OPAQUE form — everything after the first `:` is the fingerprint literal, byte-for-byte.
+    const keyFp = input.slice(colon + 1);
+    if (!KEY_FP_RE.test(keyFp)) {
+      throw new BindingParseError("MalformedUri", "sshkey fingerprint must be 'SHA256:<base64-nopad>'", input);
+    }
+    return { scheme: "sshkey", keyFp };
+  }
+
+  if (scheme !== "ssh" && scheme !== "sudo" && scheme !== "https-cred") {
+    throw new BindingParseError("UnknownScheme", `unknown scheme '${scheme}'`, input);
+  }
+  if (input.slice(colon + 1, colon + 3) !== "//") {
+    throw new BindingParseError("MalformedUri", `'${scheme}://' authority form required`, input);
+  }
+  const rest = input.slice(colon + 3);
+  if (rest.length === 0) throw new BindingParseError("MissingComponent", "empty authority", input);
+
+  if (scheme === "ssh") {
+    const at = rest.lastIndexOf("@");
+    if (at <= 0) throw new BindingParseError("MissingComponent", "ssh:// requires userinfo@host", input);
+    const user = pctDecode(rest.slice(0, at), false, input);
+    const { host, port } = parseHostPort(rest.slice(at + 1), input);
+    return { scheme: "ssh", user, host, port: port ?? SSH_DEFAULT_PORT };
+  }
+
+  if (scheme === "sudo") {
+    const slash = rest.indexOf("/");
+    if (slash < 0 || slash === rest.length - 1) {
+      throw new BindingParseError("MissingComponent", "sudo:// requires host/target-user", input);
+    }
+    const { host, port } = parseHostPort(rest.slice(0, slash), input);
+    if (port !== undefined) throw new BindingParseError("MalformedUri", "sudo:// takes no port", input);
+    const targetUser = pctDecode(rest.slice(slash + 1), false, input);
+    if (targetUser.length === 0) throw new BindingParseError("MissingComponent", "empty target-user", input);
+    return { scheme: "sudo", host, targetUser };
+  }
+
+  // https-cred://[user@]host[:port][/path]
+  const slash = rest.indexOf("/");
+  const authority = slash < 0 ? rest : rest.slice(0, slash);
+  const rawPath = slash < 0 ? undefined : rest.slice(slash + 1);
+  const at = authority.lastIndexOf("@");
+  const user = at > 0 ? pctDecode(authority.slice(0, at), false, input) : undefined;
+  if (at === 0) throw new BindingParseError("MissingComponent", "empty userinfo before '@'", input);
+  const { host, port } = parseHostPort(authority.slice(at + 1), input);
+  const path = rawPath === undefined || rawPath === ""
+    ? undefined
+    : pctDecode(rawPath.replace(/\/+$/, ""), true, input) || undefined;
+  return { scheme: "https-cred", user, host, port: port ?? HTTPS_DEFAULT_PORT, path };
+}
+
+/**
+ * Serialize to the display URI (§5.1 `displayUri`): RFC-safe, no fp-set, default port omitted.
+ */
+export function formatBindingUri(b: BindingUri): string {
+  switch (b.scheme) {
+    case "ssh": {
+      const port = b.port === SSH_DEFAULT_PORT ? "" : `:${b.port}`;
+      return `ssh://${pctEncode(b.user, false)}@${b.host}${port}`;
+    }
+    case "sudo":
+      return `sudo://${b.host}/${pctEncode(b.targetUser, false)}`;
+    case "https-cred": {
+      const user = b.user !== undefined ? `${pctEncode(b.user, false)}@` : "";
+      const port = b.port === HTTPS_DEFAULT_PORT ? "" : `:${b.port}`;
+      const path = b.path !== undefined ? `/${pctEncode(b.path, true)}` : "";
+      return `https-cred://${user}${b.host}${port}${path}`;
+    }
+    case "sshkey":
+      return `sshkey:${b.keyFp}`;
+  }
+}
+
+export type CanonicalKeyErrorCode = "SshFingerprintSetRequired";
+
+/** Typed failure for canonical-key derivation (ssh without a resolved fp-set). */
+export class CanonicalKeyError extends Error {
+  readonly code: CanonicalKeyErrorCode;
+  constructor(code: CanonicalKeyErrorCode, message: string) {
+    super(message);
+    this.name = "CanonicalKeyError";
+    this.code = code;
+  }
+}
+
+/** Dedupe + ascending-sort a fingerprint set (the §2.2 determinism rule). */
+export function canonicalFpSet(fpSet: readonly string[]): string[] {
+  return [...new Set(fpSet)].sort();
+}
+
+/**
+ * Derive the canonical store key (§2.2). Deterministic so equal bindings collide: lowercase host
+ * (parse already did), explicit port (scheme default filled), fp-set deduped + sorted, no trailing
+ * slash on path. The ssh form REQUIRES the resolved fp-set — the P2-1 defense lives in the key.
+ */
+export function canonicalKey(b: BindingUri): string {
+  switch (b.scheme) {
+    case "ssh": {
+      if (!b.fpSet || b.fpSet.length === 0) {
+        throw new CanonicalKeyError(
+          "SshFingerprintSetRequired",
+          "ssh canonical key requires the resolved known_hosts fingerprint set (§3)",
+        );
+      }
+      return `ssh://${pctEncode(b.user, false)}@${b.host}:${b.port}|fp=${canonicalFpSet(b.fpSet).join(",")}`;
+    }
+    case "sudo":
+      return `sudo://${b.host}/${pctEncode(b.targetUser, false)}`;
+    case "https-cred": {
+      const user = b.user !== undefined ? `${pctEncode(b.user, false)}@` : "";
+      const path = b.path !== undefined ? `/${pctEncode(b.path, true)}` : "";
+      return `https-cred://${user}${b.host}:${b.port}${path}`;
+    }
+    case "sshkey":
+      return `sshkey:${b.keyFp}`;
+  }
+}

--- a/src/engine/key-locker/command-derivation.ts
+++ b/src/engine/key-locker/command-derivation.ts
@@ -148,16 +148,20 @@ function deriveSudo(args: string[], session: SessionContext): BindingUri | null 
     if (tok === "--help" || tok === "-V" || tok === "--version") return null; // pure-info
     if (tok === "-h" && i === args.length - 1) return null; // bare -h = help
     if (tok === "-k" || tok === "-K") { sawKClear = true; continue; }
+    // All four sudo user-selection forms bind targetUser (Codex R2 P2 — an unrecognized form
+    // would silently fall through and mislabel the binding as sudo://…/root):
     if (tok === "-u" && i + 1 < args.length) { targetUser = args[++i]; sawOtherOption = true; continue; }
+    if (tok.startsWith("-u") && tok.length > 2) { targetUser = tok.slice(2); sawOtherOption = true; continue; } // attached: -udeploy
     if (tok.startsWith("--user=")) { targetUser = tok.slice("--user=".length); sawOtherOption = true; continue; }
+    if (tok === "--user" && i + 1 < args.length) { targetUser = args[++i]; sawOtherOption = true; continue; }
     if (SUDO_FLAGS_WITH_ARG.has(tok)) { i++; sawOtherOption = true; continue; }
     if (tok.startsWith("-")) { sawOtherOption = true; continue; } // -l / -v / -s / -i … may prompt
     hasCommand = true;
     break;
   }
-  // BARE means -k/-K and NOTHING else: that invocation clears the credential timestamp and
-  // exits — cannot prompt. `sudo -k <cmd>` runs the command and `sudo -k -v` / `-k -l` are
-  // force-reprompt validation/list modes (Codex impl-R1 P2) — all of those derive.
+  // BARE means -k/-K and nothing but clear flags: such an invocation clears the credential
+  // timestamp(s) and exits — cannot prompt. `sudo -k <cmd>` runs the command and `sudo -k -v` /
+  // `-k -l` are force-reprompt validation/list modes (Codex impl-R1 P2) — all of those derive.
   if (sawKClear && !hasCommand && !sawOtherOption) return null;
   if (targetUser.length === 0) return null; // `-u ''` — ambiguous, never guess
   return { scheme: "sudo", host: session.execHost.toLowerCase(), targetUser };
@@ -250,9 +254,15 @@ async function deriveGit(args: string[], session: SessionContext, exec: ExecFn):
       remoteName = (cur !== undefined ? await config(`branch.${cur}.remote`) : undefined) ?? "origin";
     }
   }
-  const url = await git("remote", "get-url", ...(sub === "push" ? ["--push"] : []), remoteName);
+  // For push, list ALL push URLs (`get-url --push` alone returns just the first): a remote with
+  // multiple pushurls contacts every one of them, so there is no single credential target and a
+  // later URL's prompt would be bound under the wrong host (Codex R2 P2) — ambiguity → null.
+  // Fetch uses only its first URL, so the plain single-URL form is correct there.
+  const url = await git("remote", "get-url", ...(sub === "push" ? ["--push", "--all"] : []), remoteName);
   if (url.code !== 0) return null; // no such remote / not a repo — never guess
-  return parseHttpsRemote(url.stdout.trim());
+  const urls = url.stdout.split(/\r?\n/).map((l) => l.trim()).filter((l) => l.length > 0);
+  if (urls.length !== 1) return null;
+  return parseHttpsRemote(urls[0]);
 }
 
 /** An https remote URL → `https-cred://…`; any other transport → null (not an https credential). */

--- a/src/engine/key-locker/command-derivation.ts
+++ b/src/engine/key-locker/command-derivation.ts
@@ -208,6 +208,7 @@ async function deriveGit(args: string[], session: SessionContext, exec: ExecFn):
   if ((sub === "fetch" || sub === "pull") && args.slice(i).some((t) => t === "--all" || t === "--multiple")) {
     return null;
   }
+  if (sub === "fetch" && args.slice(i).includes("-m")) return null; // -m = --multiple (fetch only; pull's -m is a merge option)
 
   // First non-option token after the subcommand = the repository (a URL or a remote NAME).
   const argOpts = GIT_ARG_OPTS[sub];

--- a/src/engine/key-locker/command-derivation.ts
+++ b/src/engine/key-locker/command-derivation.ts
@@ -1,0 +1,263 @@
+// ADR-014 v2 R3 Key Locker — L1: command → binding derivation (never screen-scraped).
+//
+// Plan: desktop-touch-mcp-internal@6b0a085:docs/adr-014-v2-r3-l1-binding-plan.md (§4)
+//
+// Parse the command string the MCP DISPATCHED (we typed it; the secret value is never read here),
+// in the context of the pane's session. Two layers: a PURE classification core (tokenize + pick
+// the first credential-bearing program + apply the null rules) and ASYNC resolvers for the parts
+// that genuinely need I/O (`ssh -G`/`ssh-keygen` per §3; `git -C <cwd>` for a configured remote).
+//
+// Direction of failure: ambiguity → null (no binding, no autofill offer — never guess). A missed
+// derive is a no-op; a spurious derive is harmless because L3's exit-0 save-gate blocks any wrong
+// save. The exhaustive per-flag edge table (which ssh/sudo/git modes do/don't prompt) is owned by
+// the test suite, not enumerated here (plan §4 scope note).
+//
+// Session context is an EXPLICIT input: a bare `sudo …` in an ssh'd pane targets the REMOTE host
+// (`session.execHost`), and a bare `git push` resolves its configured remote via `session.cwd` —
+// neither is derivable from the command text alone. L3 (capture-on-use) owns supplying it.
+// `isRemote` is reserved for L3 (frozen-schema field; L1's own rules key only on execHost, except
+// the remote-pane git defer below).
+
+import { basename, resolve as resolvePath } from "node:path";
+import type { BindingUri } from "./binding.js";
+import { defaultExec, parseSshCommand, resolveCanonicalForSshCommand, type ExecFn } from "./ssh-resolve.js";
+
+export interface SessionContext {
+  /** `localhost` for a local pane, or the resolved remote host for an ssh'd pane. */
+  execHost: string;
+  /** Reserved for L3 (nested-prompt tracking); L1 uses it only to defer remote-pane git. */
+  isRemote: boolean;
+  /** The pane's working directory — resolves a configured git remote via `git -C`. */
+  cwd: string;
+}
+
+export interface DeriveBindingDeps {
+  exec?: ExecFn;
+}
+
+/**
+ * Shell-style tokenizer: split into command SEGMENTS at unquoted `&&` / `||` / `;` / `|` / `&` /
+ * newline, respecting single/double quotes and backslash escapes (POSIX-ish; the dispatched
+ * commands are the ones our own terminal tool typed). Quote characters are stripped.
+ */
+export function tokenizeCommandSegments(cmd: string): string[][] {
+  const segments: string[][] = [];
+  let tokens: string[] = [];
+  let cur = "";
+  let started = false;
+  let quote: '"' | "'" | null = null;
+
+  const endToken = () => {
+    if (started) tokens.push(cur);
+    cur = "";
+    started = false;
+  };
+  const endSegment = () => {
+    endToken();
+    if (tokens.length > 0) segments.push(tokens);
+    tokens = [];
+  };
+
+  for (let i = 0; i < cmd.length; i++) {
+    const ch = cmd[i];
+    if (quote === "'") {
+      if (ch === "'") quote = null;
+      else { cur += ch; started = true; }
+      continue;
+    }
+    if (quote === '"') {
+      if (ch === '"') { quote = null; continue; }
+      if (ch === "\\" && i + 1 < cmd.length && '"\\$`'.includes(cmd[i + 1])) { cur += cmd[++i]; started = true; continue; }
+      cur += ch; started = true;
+      continue;
+    }
+    if (ch === "'" || ch === '"') { quote = ch as '"' | "'"; started = true; continue; }
+    if (ch === "\\" && i + 1 < cmd.length) { cur += cmd[++i]; started = true; continue; }
+    if (ch === "&" || ch === "|") {
+      endSegment();
+      if (cmd[i + 1] === ch) i++; // && / ||
+      continue;
+    }
+    if (ch === ";" || ch === "\n") { endSegment(); continue; }
+    if (ch === " " || ch === "\t" || ch === "\r") { endToken(); continue; }
+    cur += ch; started = true;
+  }
+  endSegment();
+  return segments;
+}
+
+/** Program identity of a token: basename, lowercased, `.exe` stripped. */
+function programOf(token: string): string {
+  return basename(token).toLowerCase().replace(/\.exe$/, "");
+}
+
+const ENV_ASSIGN_RE = /^[A-Za-z_][A-Za-z0-9_]*=/;
+
+/**
+ * Derive the binding target of a dispatched command, or `null` when it carries no credential
+ * prompt L1 can attribute (query modes, the sudo cannot-prompt set, non-https git remotes,
+ * remote-pane git, plain commands, ambiguity). Async: ssh and configured-git-remote derivation
+ * resolve through child processes; the classification core itself is pure (plan §4, Codex R10).
+ */
+export async function deriveBinding(
+  dispatchedCommand: string,
+  session: SessionContext,
+  deps: DeriveBindingDeps = {},
+): Promise<BindingUri | null> {
+  const exec = deps.exec ?? defaultExec;
+  for (const segment of tokenizeCommandSegments(dispatchedCommand)) {
+    // Skip leading FOO=bar environment assignments.
+    let start = 0;
+    while (start < segment.length && ENV_ASSIGN_RE.test(segment[start])) start++;
+    if (start >= segment.length) continue;
+    const program = programOf(segment[start]);
+    const rest = segment.slice(start + 1);
+    // The FIRST credential-bearing program wins; later segments are L3's concern.
+    if (program === "ssh") return deriveSsh(rest, exec);
+    if (program === "sudo") return deriveSudo(rest, session);
+    if (program === "git") return deriveGit(rest, session, exec);
+  }
+  return null;
+}
+
+async function deriveSsh(args: string[], exec: ExecFn): Promise<BindingUri | null> {
+  // Query / no-login modes never prompt (`-G` config query, `-Q` algorithm query, `-V` version).
+  // Modes that still authenticate (-T no-pty, -N no-remote-cmd) derive normally.
+  const parsed = parseSshCommand(args);
+  if (parsed.queryMode || parsed.destination === undefined) return null;
+  const resolved = await resolveCanonicalForSshCommand(args, exec);
+  // host-not-known / unresolvable ⇒ fail closed: no binding, no lookup, no save.
+  return resolved.kind === "ok" ? resolved.uri : null;
+}
+
+// sudo short options that CONSUME the next token (kept minimal; edge flags live in the test table).
+const SUDO_FLAGS_WITH_ARG = new Set(["-u", "-g", "-p", "-U", "-C", "-D", "-R", "-T", "-h"]);
+// The CANNOT-prompt set is a CLOSED enumeration (plan §4): null iff the invocation provably never
+// prompts; everything else derives (a spurious derive is blocked by L3's exit-0 save-gate).
+// NOTE: `-h` with no argument is `--help`; sudo's host flag form is `-h host`. We treat a BARE
+// trailing `-h` / `--help` / `-V` / `--version` as pure-info (null).
+
+function deriveSudo(args: string[], session: SessionContext): BindingUri | null {
+  let targetUser = "root";
+  let sawKClear = false;
+  let hasCommand = false;
+  for (let i = 0; i < args.length; i++) {
+    const tok = args[i];
+    if (tok === "-n" || tok === "--non-interactive") return null; // never prompts (fails instead)
+    if (tok === "--help" || tok === "-V" || tok === "--version") return null; // pure-info
+    if (tok === "-h" && i === args.length - 1) return null; // bare -h = help
+    if (tok === "-k" || tok === "-K") { sawKClear = true; continue; }
+    if (tok === "-u" && i + 1 < args.length) { targetUser = args[++i]; continue; }
+    if (tok.startsWith("--user=")) { targetUser = tok.slice("--user=".length); continue; }
+    if (SUDO_FLAGS_WITH_ARG.has(tok)) { i++; continue; }
+    if (tok.startsWith("-")) continue; // other flags (incl. -l / -v / -s / -i) — they may prompt
+    hasCommand = true;
+    break;
+  }
+  // A BARE -k/-K (no command) clears the credential timestamp and exits — cannot prompt.
+  // `sudo -k <cmd>` invalidates the cache then RUNS → prompts → derive.
+  if (sawKClear && !hasCommand) return null;
+  if (targetUser.length === 0) return null; // `-u ''` — ambiguous, never guess
+  return { scheme: "sudo", host: session.execHost.toLowerCase(), targetUser };
+}
+
+const GIT_CRED_SUBCOMMANDS = new Set(["push", "pull", "fetch", "clone", "ls-remote"]);
+// Per-subcommand option letters/words that consume a separate argument token (minimal set; the
+// exhaustive per-flag table is the test suite's — a miss here fails toward null or a skipped opt).
+const GIT_ARG_OPTS: Record<string, Set<string>> = {
+  push: new Set(["-o", "--push-option", "--receive-pack", "--exec", "--repo"]),
+  pull: new Set(["--depth", "-j", "--jobs", "--upload-pack", "--negotiation-tip", "--server-option", "-o", "-s", "-X", "--strategy", "--strategy-option"]),
+  fetch: new Set(["--depth", "-j", "--jobs", "--upload-pack", "--negotiation-tip", "--server-option", "-o", "--refmap", "--shallow-since", "--shallow-exclude"]),
+  clone: new Set(["-b", "--branch", "-o", "--origin", "--depth", "-c", "--config", "--reference", "--reference-if-able", "--separate-git-dir", "-j", "--jobs", "--filter", "-u", "--upload-pack", "--template", "--shallow-since", "--shallow-exclude"]),
+  "ls-remote": new Set(["-o", "--upload-pack", "--server-option"]),
+};
+
+async function deriveGit(args: string[], session: SessionContext, exec: ExecFn): Promise<BindingUri | null> {
+  // In a REMOTE pane git runs remotely — a local `git -C cwd` cannot resolve its remotes. Defer
+  // to L3 (same cut as the nested `ssh host sudo …`).
+  if (session.isRemote) return null;
+
+  // Global options before the subcommand: honor `-C <path>` (changes the effective cwd), skip
+  // `-c k=v` / `--git-dir=…`-style value options, null on version/help.
+  let cwd = session.cwd;
+  let i = 0;
+  let sub: string | undefined;
+  for (; i < args.length; i++) {
+    const tok = args[i];
+    if (tok === "-v" || tok === "-V" || tok === "--version" || tok === "-h" || tok === "--help") return null;
+    if (tok === "-C" && i + 1 < args.length) { cwd = resolvePath(cwd, args[++i]); continue; }
+    if (tok === "-c" && i + 1 < args.length) { i++; continue; }
+    if (tok.startsWith("--") && tok.includes("=")) continue; // --git-dir=… / --work-tree=…
+    if (tok.startsWith("-")) continue;
+    sub = tok.toLowerCase();
+    i++;
+    break;
+  }
+  if (sub === undefined || !GIT_CRED_SUBCOMMANDS.has(sub)) return null;
+
+  // First non-option token after the subcommand = the repository (a URL or a remote NAME).
+  const argOpts = GIT_ARG_OPTS[sub];
+  let repoArg: string | undefined;
+  for (; i < args.length; i++) {
+    const tok = args[i];
+    if (tok === "--") { repoArg = args[i + 1]; break; }
+    if (tok.startsWith("-")) {
+      if (argOpts.has(tok)) i++;
+      continue;
+    }
+    repoArg = tok;
+    break;
+  }
+
+  if (repoArg !== undefined && /^[a-z][a-z0-9+.-]*:\/\//i.test(repoArg)) {
+    return parseHttpsRemote(repoArg); // explicit URL (https derives; ssh/git/http → null)
+  }
+  if (repoArg !== undefined && /[:/]/.test(repoArg)) {
+    return null; // scp-like (git@host:path) or a filesystem path — not an https credential
+  }
+
+  // A remote NAME (explicit arg wins) — else resolve git's EFFECTIVE remote for the op via the
+  // precedence chain, NEVER a hard-coded `origin` (plan §4, Codex R9/R10): resolve the NAME first,
+  // then ask for that remote's URL (`remote get-url [--push]` observes pushurl).
+  if (sub === "clone") return null; // clone without a URL never reaches a prompt we can attribute
+  const git = async (...gitArgs: string[]) => exec("git", ["-C", cwd, ...gitArgs]);
+  let remoteName = repoArg;
+  if (remoteName === undefined) {
+    const branch = await git("symbolic-ref", "--short", "HEAD");
+    const cur = branch.code === 0 ? branch.stdout.trim() : undefined;
+    const config = async (key: string) => {
+      const r = await git("config", "--get", key);
+      return r.code === 0 ? r.stdout.trim() : undefined;
+    };
+    if (sub === "push") {
+      remoteName = (cur !== undefined ? await config(`branch.${cur}.pushRemote`) : undefined)
+        ?? await config("remote.pushDefault")
+        ?? (cur !== undefined ? await config(`branch.${cur}.remote`) : undefined)
+        ?? "origin";
+    } else {
+      remoteName = (cur !== undefined ? await config(`branch.${cur}.remote`) : undefined) ?? "origin";
+    }
+  }
+  const url = await git("remote", "get-url", ...(sub === "push" ? ["--push"] : []), remoteName);
+  if (url.code !== 0) return null; // no such remote / not a repo — never guess
+  return parseHttpsRemote(url.stdout.trim());
+}
+
+/** An https remote URL → `https-cred://…`; any other transport → null (not an https credential). */
+function parseHttpsRemote(rawUrl: string): BindingUri | null {
+  let u: URL;
+  try {
+    u = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+  if (u.protocol !== "https:") return null;
+  const path = u.pathname.replace(/^\/+/, "").replace(/\/+$/, "");
+  return {
+    scheme: "https-cred",
+    user: u.username !== "" ? decodeURIComponent(u.username) : undefined,
+    host: u.hostname.toLowerCase(),
+    port: u.port !== "" ? Number(u.port) : 443,
+    path: path !== "" ? path : undefined,
+  };
+}

--- a/src/engine/key-locker/command-derivation.ts
+++ b/src/engine/key-locker/command-derivation.ts
@@ -165,7 +165,7 @@ const GIT_CRED_SUBCOMMANDS = new Set(["push", "pull", "fetch", "clone", "ls-remo
 // Per-subcommand option letters/words that consume a separate argument token (minimal set; the
 // exhaustive per-flag table is the test suite's — a miss here fails toward null or a skipped opt).
 const GIT_ARG_OPTS: Record<string, Set<string>> = {
-  push: new Set(["-o", "--push-option", "--receive-pack", "--exec", "--repo"]),
+  push: new Set(["-o", "--push-option", "--receive-pack", "--exec"]), // --repo is captured as the target below
   pull: new Set(["--depth", "-j", "--jobs", "--upload-pack", "--negotiation-tip", "--server-option", "-o", "-s", "-X", "--strategy", "--strategy-option"]),
   fetch: new Set(["--depth", "-j", "--jobs", "--upload-pack", "--negotiation-tip", "--server-option", "-o", "--refmap", "--shallow-since", "--shallow-exclude"]),
   clone: new Set(["-b", "--branch", "-o", "--origin", "--depth", "-c", "--config", "--reference", "--reference-if-able", "--separate-git-dir", "-j", "--jobs", "--filter", "-u", "--upload-pack", "--template", "--shallow-since", "--shallow-exclude"]),
@@ -201,6 +201,8 @@ async function deriveGit(args: string[], session: SessionContext, exec: ExecFn):
   for (; i < args.length; i++) {
     const tok = args[i];
     if (tok === "--") { repoArg = args[i + 1]; break; }
+    if (tok.startsWith("--repo=")) { repoArg = tok.slice("--repo=".length); break; } // push's explicit target
+    if (tok === "--repo" && i + 1 < args.length) { repoArg = args[i + 1]; break; }
     if (tok.startsWith("-")) {
       if (argOpts.has(tok)) i++;
       continue;

--- a/src/engine/key-locker/command-derivation.ts
+++ b/src/engine/key-locker/command-derivation.ts
@@ -140,6 +140,7 @@ const SUDO_FLAGS_WITH_ARG = new Set(["-u", "-g", "-p", "-U", "-C", "-D", "-R", "
 function deriveSudo(args: string[], session: SessionContext): BindingUri | null {
   let targetUser = "root";
   let sawKClear = false;
+  let sawOtherOption = false;
   let hasCommand = false;
   for (let i = 0; i < args.length; i++) {
     const tok = args[i];
@@ -147,16 +148,17 @@ function deriveSudo(args: string[], session: SessionContext): BindingUri | null 
     if (tok === "--help" || tok === "-V" || tok === "--version") return null; // pure-info
     if (tok === "-h" && i === args.length - 1) return null; // bare -h = help
     if (tok === "-k" || tok === "-K") { sawKClear = true; continue; }
-    if (tok === "-u" && i + 1 < args.length) { targetUser = args[++i]; continue; }
-    if (tok.startsWith("--user=")) { targetUser = tok.slice("--user=".length); continue; }
-    if (SUDO_FLAGS_WITH_ARG.has(tok)) { i++; continue; }
-    if (tok.startsWith("-")) continue; // other flags (incl. -l / -v / -s / -i) — they may prompt
+    if (tok === "-u" && i + 1 < args.length) { targetUser = args[++i]; sawOtherOption = true; continue; }
+    if (tok.startsWith("--user=")) { targetUser = tok.slice("--user=".length); sawOtherOption = true; continue; }
+    if (SUDO_FLAGS_WITH_ARG.has(tok)) { i++; sawOtherOption = true; continue; }
+    if (tok.startsWith("-")) { sawOtherOption = true; continue; } // -l / -v / -s / -i … may prompt
     hasCommand = true;
     break;
   }
-  // A BARE -k/-K (no command) clears the credential timestamp and exits — cannot prompt.
-  // `sudo -k <cmd>` invalidates the cache then RUNS → prompts → derive.
-  if (sawKClear && !hasCommand) return null;
+  // BARE means -k/-K and NOTHING else: that invocation clears the credential timestamp and
+  // exits — cannot prompt. `sudo -k <cmd>` runs the command and `sudo -k -v` / `-k -l` are
+  // force-reprompt validation/list modes (Codex impl-R1 P2) — all of those derive.
+  if (sawKClear && !hasCommand && !sawOtherOption) return null;
   if (targetUser.length === 0) return null; // `-u ''` — ambiguous, never guess
   return { scheme: "sudo", host: session.execHost.toLowerCase(), targetUser };
 }
@@ -194,6 +196,14 @@ async function deriveGit(args: string[], session: SessionContext, exec: ExecFn):
     break;
   }
   if (sub === undefined || !GIT_CRED_SUBCOMMANDS.has(sub)) return null;
+
+  // `git fetch --all` / `--multiple …` (and `git pull --all`, which forwards to fetch) contact
+  // MULTIPLE remotes — there is no single credential target, and deriving the branch remote could
+  // save/offer under the wrong one (Codex impl-R1 P1). Ambiguity → null. (`git push --all` pushes
+  // all BRANCHES to one remote and stays derivable.)
+  if ((sub === "fetch" || sub === "pull") && args.slice(i).some((t) => t === "--all" || t === "--multiple")) {
+    return null;
+  }
 
   // First non-option token after the subcommand = the repository (a URL or a remote NAME).
   const argOpts = GIT_ARG_OPTS[sub];

--- a/src/engine/key-locker/command-derivation.ts
+++ b/src/engine/key-locker/command-derivation.ts
@@ -174,7 +174,7 @@ const GIT_ARG_OPTS: Record<string, Set<string>> = {
   push: new Set(["-o", "--push-option", "--receive-pack", "--exec"]), // --repo is captured as the target below
   pull: new Set(["--depth", "-j", "--jobs", "--upload-pack", "--negotiation-tip", "--server-option", "-o", "-s", "-X", "--strategy", "--strategy-option"]),
   fetch: new Set(["--depth", "-j", "--jobs", "--upload-pack", "--negotiation-tip", "--server-option", "-o", "--refmap", "--shallow-since", "--shallow-exclude"]),
-  clone: new Set(["-b", "--branch", "-o", "--origin", "--depth", "-c", "--config", "--reference", "--reference-if-able", "--separate-git-dir", "-j", "--jobs", "--filter", "-u", "--upload-pack", "--template", "--shallow-since", "--shallow-exclude"]),
+  clone: new Set(["-b", "--branch", "-o", "--origin", "--depth", "-c", "--config", "--reference", "--reference-if-able", "--separate-git-dir", "-j", "--jobs", "--filter", "-u", "--upload-pack", "--template", "--shallow-since", "--shallow-exclude", "--bundle-uri"]),
   "ls-remote": new Set(["-o", "--upload-pack", "--server-option"]),
 };
 

--- a/src/engine/key-locker/ssh-resolve.ts
+++ b/src/engine/key-locker/ssh-resolve.ts
@@ -1,0 +1,220 @@
+// ADR-014 v2 R3 Key Locker — L1: ssh host-key fingerprint resolution (OQ-1 = A).
+//
+// Plan: desktop-touch-mcp-internal@6b0a085:docs/adr-014-v2-r3-l1-binding-plan.md (§3)
+//
+// Resolve an ssh alias to its EFFECTIVE (user, host, port) via `ssh -G` — passing the invocation's
+// own options THROUGH (a command-line `-p 2222` / `-l user` / `-F altconfig` / `-o …` / a config
+// `HostKeyAlias` all change the endpoint; `ssh -G alias` alone would resolve the WRONG one) — then
+// read the host's stored key fingerprints from the known_hosts files ssh itself would consult
+// (user `UserKnownHostsFile` + `GlobalKnownHostsFile`, each possibly multiple paths; absent files
+// are skipped as EMPTY, never as failure). The fingerprint SET becomes part of the canonical key:
+// if the recorded host identity drifts, the key differs, the store misses, and nothing autofills.
+//
+// `ssh -G` prints the effective config WITHOUT connecting; `ssh-keygen -l -F` handles hashed
+// known_hosts entries and prints one SHA256 fingerprint per stored key type. We never parse
+// ~/.ssh/config ourselves. Read-only, no network, no secret at this layer.
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { canonicalFpSet, canonicalKey, type BindingUri } from "./binding.js";
+
+const execFileAsync = promisify(execFile);
+
+/** Injectable process runner (tests fake `ssh -G` / `ssh-keygen` output through this seam). */
+export type ExecFn = (file: string, args: string[]) => Promise<{ code: number; stdout: string; stderr: string }>;
+
+const EXEC_TIMEOUT_MS = 10_000;
+
+/** Default runner: async execFile, non-zero exit normalized into `code` (never throws for it). */
+export const defaultExec: ExecFn = async (file, args) => {
+  try {
+    const { stdout, stderr } = await execFileAsync(file, args, {
+      windowsHide: true,
+      timeout: EXEC_TIMEOUT_MS,
+      encoding: "utf8",
+    });
+    return { code: 0, stdout, stderr };
+  } catch (e) {
+    const err = e as NodeJS.ErrnoException & { code?: number | string; stdout?: string; stderr?: string };
+    return {
+      code: typeof err.code === "number" ? err.code : 1,
+      stdout: err.stdout ?? "",
+      stderr: err.stderr ?? (err instanceof Error ? err.message : String(e)),
+    };
+  }
+};
+
+// OpenSSH client option letters (`man ssh` synopsis): which short flags CONSUME the next token.
+// (Everything else — 46AaCfGgKkMNnqsTtVvXxYy — is a no-arg flag and falls to the else branch.)
+const SSH_FLAGS_WITH_ARG = new Set([..."BbcDEeFIiJLlmOoPpQRSWw"]);
+
+export interface ParsedSshCommand {
+  /** The destination token (`host` or `user@host`), or undefined if none was found. */
+  destination?: string;
+  /** Every option token up to the destination, in order — passed through to `ssh -G` verbatim. */
+  optionArgs: string[];
+  /** True if the invocation is a query / no-login mode (`-G` / `-Q` / `-V`) — never prompts. */
+  queryMode: boolean;
+}
+
+/**
+ * Split an `ssh …` argv (WITHOUT the leading program token) into passthrough options + the
+ * destination. Tokens after the destination are the remote command — irrelevant to resolution.
+ */
+export function parseSshCommand(args: readonly string[]): ParsedSshCommand {
+  const optionArgs: string[] = [];
+  let destination: string | undefined;
+  let queryMode = false;
+  for (let i = 0; i < args.length; i++) {
+    const tok = args[i];
+    if (destination === undefined && tok.startsWith("-") && tok.length >= 2) {
+      const letter = tok[1];
+      if (letter === "G" || letter === "V" || letter === "Q") queryMode = true;
+      if (SSH_FLAGS_WITH_ARG.has(letter)) {
+        if (tok.length > 2) {
+          optionArgs.push(tok); // attached form: -p2222 / -Qcipher
+        } else {
+          optionArgs.push(tok);
+          if (i + 1 < args.length) optionArgs.push(args[++i]);
+        }
+      } else {
+        // no-arg flag, possibly a getopt cluster (-4A, -vG); -G/-V may appear mid-cluster
+        if (tok.includes("G") || tok.includes("V")) queryMode = true;
+        optionArgs.push(tok);
+      }
+      continue;
+    }
+    if (destination === undefined) {
+      destination = tok;
+      continue;
+    }
+    break; // remote command begins — stop
+  }
+  return { destination, optionArgs, queryMode };
+}
+
+export interface SshEffectiveConfig {
+  host: string;
+  user: string;
+  port: number;
+  hostKeyAlias?: string;
+  /** Candidate known_hosts paths (user + global), `~` expanded, order preserved. */
+  knownHostsFiles: string[];
+}
+
+/** `~/…` → absolute (ssh -G may print unexpanded tildes for known_hosts paths). */
+function expandTilde(p: string): string {
+  if (p === "~") return homedir();
+  if (p.startsWith("~/") || p.startsWith("~\\")) return join(homedir(), p.slice(2));
+  return p;
+}
+
+/**
+ * Run `ssh -G <options…> <destination>` and parse the effective, last-wins config tokens.
+ * Throws on a non-zero exit (unknown host alias syntax, bad -F path, …) — the caller treats that
+ * as "cannot resolve" (fail closed).
+ */
+export async function sshDashG(
+  destination: string,
+  optionArgs: readonly string[],
+  exec: ExecFn = defaultExec,
+): Promise<SshEffectiveConfig> {
+  const { code, stdout, stderr } = await exec("ssh", ["-G", ...optionArgs, destination]);
+  if (code !== 0) {
+    throw new Error(`ssh -G exited ${code}: ${stderr.trim().slice(0, 300)}`);
+  }
+  let host = "";
+  let user = "";
+  let port = 22;
+  let hostKeyAlias: string | undefined;
+  const knownHostsFiles: string[] = [];
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    const sp = line.indexOf(" ");
+    if (sp <= 0) continue;
+    const key = line.slice(0, sp).toLowerCase();
+    const value = line.slice(sp + 1).trim();
+    switch (key) {
+      case "hostname": host = value; break;
+      case "user": user = value; break;
+      case "port": { const p = Number(value); if (Number.isInteger(p) && p > 0) port = p; break; }
+      case "hostkeyalias": hostKeyAlias = value; break;
+      case "userknownhostsfile":
+      case "globalknownhostsfile": {
+        // The value is a whitespace-separated file list. A path CONTAINING spaces is ambiguous in
+        // ssh's own output, so also keep the raw value as one candidate; absent candidates are
+        // skipped as empty at lookup time either way.
+        for (const cand of value.split(/\s+/)) knownHostsFiles.push(expandTilde(cand));
+        if (/\s/.test(value)) knownHostsFiles.push(expandTilde(value));
+        break;
+      }
+    }
+  }
+  if (host === "" || user === "") {
+    throw new Error(`ssh -G output missing hostname/user for '${destination}'`);
+  }
+  return { host, user, port, hostKeyAlias, knownHostsFiles };
+}
+
+const FP_RE = /SHA256:[A-Za-z0-9+/]+/g;
+
+/**
+ * Union the SHA-256 fingerprints stored for `token` across the given known_hosts files.
+ * Absent files (or `ssh-keygen` failures for one file) are treated as EMPTY, never as failure —
+ * `ssh -G` routinely reports paths that do not exist. Deduped + sorted (§2.2 determinism).
+ */
+export async function knownHostsFingerprints(
+  token: string,
+  files: readonly string[],
+  exec: ExecFn = defaultExec,
+): Promise<string[]> {
+  const found = new Set<string>();
+  for (const file of new Set(files)) {
+    if (!existsSync(file)) continue;
+    const { code, stdout } = await exec("ssh-keygen", ["-l", "-F", token, "-f", file]);
+    if (code !== 0) continue; // host not in this file (ssh-keygen exits 1) — skip, keep unioning
+    for (const m of stdout.match(FP_RE) ?? []) found.add(m);
+  }
+  return canonicalFpSet([...found]);
+}
+
+export type SshResolveResult =
+  | { kind: "ok"; uri: BindingUri & { scheme: "ssh" }; canonical: string }
+  | { kind: "host-not-known"; user: string; host: string; port: number }
+  | { kind: "unresolvable"; reason: string };
+
+/**
+ * §3.3 — the P2-1 defense pipeline: parse the ssh argv, `ssh -G` with the SAME options, form the
+ * known_hosts lookup token from the EFFECTIVE output (`hostkeyalias` ?? host[:port]), union the
+ * fingerprints over every file ssh would consult. Empty union ⇒ `host-not-known` (fail closed,
+ * no lookup, no save). `args` excludes the leading `ssh` program token.
+ */
+export async function resolveCanonicalForSshCommand(
+  args: readonly string[],
+  exec: ExecFn = defaultExec,
+): Promise<SshResolveResult> {
+  const parsed = parseSshCommand(args);
+  if (parsed.destination === undefined) return { kind: "unresolvable", reason: "no ssh destination" };
+  let cfg: SshEffectiveConfig;
+  try {
+    cfg = await sshDashG(parsed.destination, parsed.optionArgs, exec);
+  } catch (e) {
+    return { kind: "unresolvable", reason: (e as Error).message };
+  }
+  const token = cfg.hostKeyAlias ?? (cfg.port === 22 ? cfg.host : `[${cfg.host}]:${cfg.port}`);
+  const fpSet = await knownHostsFingerprints(token, cfg.knownHostsFiles, exec);
+  if (fpSet.length === 0) {
+    return { kind: "host-not-known", user: cfg.user, host: cfg.host, port: cfg.port };
+  }
+  const uri: BindingUri & { scheme: "ssh" } = {
+    scheme: "ssh",
+    user: cfg.user,
+    host: cfg.host.toLowerCase(),
+    port: cfg.port,
+    fpSet,
+  };
+  return { kind: "ok", uri, canonical: canonicalKey(uri) };
+}

--- a/src/engine/key-locker/ssh-resolve.ts
+++ b/src/engine/key-locker/ssh-resolve.ts
@@ -103,6 +103,10 @@ export interface SshEffectiveConfig {
   hostKeyAlias?: string;
   /** Candidate known_hosts paths (user + global), `~` expanded, order preserved. */
   knownHostsFiles: string[];
+  /** Effective ProxyJump (from `-J` — ssh maps it to ProxyJump — or config). */
+  proxyJump?: string;
+  /** Effective ProxyCommand (may itself be an ssh that prompts first). */
+  proxyCommand?: string;
 }
 
 /** `~/…` → absolute (ssh -G may print unexpanded tildes for known_hosts paths). */
@@ -130,6 +134,8 @@ export async function sshDashG(
   let user = "";
   let port = 22;
   let hostKeyAlias: string | undefined;
+  let proxyJump: string | undefined;
+  let proxyCommand: string | undefined;
   const knownHostsFiles: string[] = [];
   for (const rawLine of stdout.split(/\r?\n/)) {
     const line = rawLine.trim();
@@ -142,6 +148,8 @@ export async function sshDashG(
       case "user": user = value; break;
       case "port": { const p = Number(value); if (Number.isInteger(p) && p > 0) port = p; break; }
       case "hostkeyalias": hostKeyAlias = value; break;
+      case "proxyjump": proxyJump = value; break;
+      case "proxycommand": proxyCommand = value; break;
       case "userknownhostsfile":
       case "globalknownhostsfile": {
         // The value is a whitespace-separated file list. A path CONTAINING spaces is ambiguous in
@@ -156,7 +164,7 @@ export async function sshDashG(
   if (host === "" || user === "") {
     throw new Error(`ssh -G output missing hostname/user for '${destination}'`);
   }
-  return { host, user, port, hostKeyAlias, knownHostsFiles };
+  return { host, user, port, hostKeyAlias, knownHostsFiles, proxyJump, proxyCommand };
 }
 
 const FP_RE = /SHA256:[A-Za-z0-9+/]+/g;
@@ -203,6 +211,15 @@ export async function resolveCanonicalForSshCommand(
     cfg = await sshDashG(parsed.destination, parsed.optionArgs, exec);
   } catch (e) {
     return { kind: "unresolvable", reason: (e as Error).message };
+  }
+  // A ProxyJump (`-J` on the command line — ssh maps it to ProxyJump, so it shows up here even
+  // though we never parse it ourselves — or from config) or a ProxyCommand means the FIRST
+  // password prompt may belong to the JUMP host, not the final destination. Binding the final
+  // host would put the wrong secret into the bastion prompt (Codex impl-R1 P1). Ambiguity → no
+  // derivation; the per-hop prompts are an L3 capture-on-use concern (same cut as nested
+  // `ssh host sudo …`).
+  if (cfg.proxyJump !== undefined || cfg.proxyCommand !== undefined) {
+    return { kind: "unresolvable", reason: "ProxyJump/ProxyCommand present — the first prompt may be the jump host's" };
   }
   const token = cfg.hostKeyAlias ?? (cfg.port === 22 ? cfg.host : `[${cfg.host}]:${cfg.port}`);
   const fpSet = await knownHostsFingerprints(token, cfg.knownHostsFiles, exec);

--- a/src/engine/key-locker/ssh-resolve.ts
+++ b/src/engine/key-locker/ssh-resolve.ts
@@ -209,10 +209,17 @@ export async function resolveCanonicalForSshCommand(
   if (fpSet.length === 0) {
     return { kind: "host-not-known", user: cfg.user, host: cfg.host, port: cfg.port };
   }
+  // `ssh -G` prints IPv6 hostnames UNBRACKETED (`::1`); the grammar's host slot is the bracketed
+  // form (`[::1]`), so bracket here — otherwise the stored displayUri would not re-parse (the
+  // round-trip invariant every other scheme upholds). The known_hosts token above stays bare,
+  // matching how ssh itself writes IPv6 entries.
+  const host = cfg.host.includes(":") && !cfg.host.startsWith("[")
+    ? `[${cfg.host.toLowerCase()}]`
+    : cfg.host.toLowerCase();
   const uri: BindingUri & { scheme: "ssh" } = {
     scheme: "ssh",
     user: cfg.user,
-    host: cfg.host.toLowerCase(),
+    host,
     port: cfg.port,
     fpSet,
   };

--- a/src/engine/key-locker/ssh-resolve.ts
+++ b/src/engine/key-locker/ssh-resolve.ts
@@ -170,21 +170,24 @@ export async function sshDashG(
 const FP_RE = /SHA256:[A-Za-z0-9+/]+/g;
 
 /**
- * Union the SHA-256 fingerprints stored for `token` across the given known_hosts files.
- * Absent files (or `ssh-keygen` failures for one file) are treated as EMPTY, never as failure —
- * `ssh -G` routinely reports paths that do not exist. Deduped + sorted (§2.2 determinism).
+ * Union the SHA-256 fingerprints stored under ANY of the candidate `tokens` across the given
+ * known_hosts files. Absent files (or `ssh-keygen` failures for one file/token) are treated as
+ * EMPTY, never as failure — `ssh -G` routinely reports paths that do not exist. Deduped + sorted
+ * (§2.2 determinism).
  */
 export async function knownHostsFingerprints(
-  token: string,
+  tokens: readonly string[],
   files: readonly string[],
   exec: ExecFn = defaultExec,
 ): Promise<string[]> {
   const found = new Set<string>();
   for (const file of new Set(files)) {
     if (!existsSync(file)) continue;
-    const { code, stdout } = await exec("ssh-keygen", ["-l", "-F", token, "-f", file]);
-    if (code !== 0) continue; // host not in this file (ssh-keygen exits 1) — skip, keep unioning
-    for (const m of stdout.match(FP_RE) ?? []) found.add(m);
+    for (const token of new Set(tokens)) {
+      const { code, stdout } = await exec("ssh-keygen", ["-l", "-F", token, "-f", file]);
+      if (code !== 0) continue; // host not in this file under this token — skip, keep unioning
+      for (const m of stdout.match(FP_RE) ?? []) found.add(m);
+    }
   }
   return canonicalFpSet([...found]);
 }
@@ -221,8 +224,18 @@ export async function resolveCanonicalForSshCommand(
   if (cfg.proxyJump !== undefined || cfg.proxyCommand !== undefined) {
     return { kind: "unresolvable", reason: "ProxyJump/ProxyCommand present — the first prompt may be the jump host's" };
   }
-  const token = cfg.hostKeyAlias ?? (cfg.port === 22 ? cfg.host : `[${cfg.host}]:${cfg.port}`);
-  const fpSet = await knownHostsFingerprints(token, cfg.knownHostsFiles, exec);
+  // Lookup-token candidates: an alias is looked up verbatim; non-default ports use the
+  // `[host]:port` form. For the DEFAULT port, also try `[host]:22` — known_hosts rows written
+  // with an explicit :22 (common for IPv6 / other tooling) don't match the bare-host lookup
+  // (`ssh-keygen -F '::1'` misses a `[::1]:22` row — Codex R4), which would fail-closed a host
+  // the user already trusts. Union across candidates only ever ADDS fps the user stored for this
+  // exact host:port, so the fail-closed direction is preserved.
+  const tokens = cfg.hostKeyAlias !== undefined
+    ? [cfg.hostKeyAlias]
+    : cfg.port === 22
+      ? [cfg.host, `[${cfg.host}]:22`]
+      : [`[${cfg.host}]:${cfg.port}`];
+  const fpSet = await knownHostsFingerprints(tokens, cfg.knownHostsFiles, exec);
   if (fpSet.length === 0) {
     return { kind: "host-not-known", user: cfg.user, host: cfg.host, port: cfg.port };
   }

--- a/tests/unit/key-locker-binding-store.test.ts
+++ b/tests/unit/key-locker-binding-store.test.ts
@@ -99,6 +99,17 @@ describe("BindingStore — file tolerance + atomic save", () => {
     expect(BindingStore.load(dir, alwaysExists).list()).toHaveLength(0);
   });
 
+  it("row-level corruption (null row / record without opaqueId) is treated as corrupt, resolve never throws (Codex R4)", async () => {
+    for (const bindings of [{ k: null }, { k: { scheme: "sudo", displayUri: "sudo://x/root" } }]) {
+      const dir = freshDir();
+      writeFileSync(join(dir, "bindings.json"), JSON.stringify({ version: 1, bindings }), "utf8");
+      const store = BindingStore.load(dir, alwaysExists);
+      expect(store.list()).toHaveLength(0);
+      expect(await store.resolve("k")).toBeUndefined();
+      expect(existsSync(join(dir, "bindings.json.corrupt"))).toBe(true);
+    }
+  });
+
   it("a stale .tmp from a simulated mid-write crash never shadows the real file", async () => {
     const dir = freshDir();
     const store = BindingStore.load(dir, alwaysExists);

--- a/tests/unit/key-locker-binding-store.test.ts
+++ b/tests/unit/key-locker-binding-store.test.ts
@@ -1,0 +1,126 @@
+// ADR-014 v2 R3 L1 — acceptance §8 #7: store CRUD + reconciliation + atomicity.
+// Plan: desktop-touch-mcp-internal@6b0a085:docs/adr-014-v2-r3-l1-binding-plan.md
+import { mkdtempSync, existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { BindingStore, LockerNotBoundError, type BindingMeta } from "../../src/engine/key-locker/binding-store.js";
+
+const dirs: string[] = [];
+const freshDir = (): string => {
+  const d = mkdtempSync(join(tmpdir(), "dtm-l1-store-"));
+  dirs.push(d);
+  return d;
+};
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+const meta = (over: Partial<BindingMeta> = {}): BindingMeta => ({
+  scheme: "sudo",
+  displayUri: "sudo://localhost/root",
+  host: "localhost",
+  targetUser: "root",
+  createdAt: new Date().toISOString(),
+  ...over,
+});
+
+const alwaysExists = async (): Promise<boolean> => true;
+
+describe("BindingStore — CRUD round-trip", () => {
+  it("bind → resolve → list → unbind, persisted across a reload", async () => {
+    const dir = freshDir();
+    const store = BindingStore.load(dir, alwaysExists);
+    store.bind("sudo://localhost/root", "aa".repeat(16), meta());
+    expect(await store.resolve("sudo://localhost/root")).toEqual({ opaqueId: "aa".repeat(16) });
+    expect(store.list()).toHaveLength(1);
+    expect(store.list()[0]).toMatchObject({ canonicalKey: "sudo://localhost/root", scheme: "sudo" });
+
+    // Reload from disk — the row survived the atomic save.
+    const reloaded = BindingStore.load(dir, alwaysExists);
+    expect(await reloaded.resolve("sudo://localhost/root")).toEqual({ opaqueId: "aa".repeat(16) });
+
+    expect(reloaded.unbind("sudo://localhost/root")).toBe(true);
+    expect(reloaded.unbind("sudo://localhost/root")).toBe(false);
+    expect(await reloaded.resolve("sudo://localhost/root")).toBeUndefined();
+  });
+
+  it("resolve misses an unknown canonical without touching the locker", async () => {
+    let lockerCalls = 0;
+    const store = BindingStore.load(freshDir(), async () => { lockerCalls++; return true; });
+    expect(await store.resolve("sudo://nowhere/root")).toBeUndefined();
+    expect(lockerCalls).toBe(0);
+  });
+});
+
+describe("BindingStore — locker reconciliation (§5.3)", () => {
+  it("resolve prunes a stale row when the locker no longer holds the secret", async () => {
+    const dir = freshDir();
+    const store = BindingStore.load(dir, async () => false); // locker lost everything
+    store.bind("sudo://localhost/root", "bb".repeat(16), meta());
+    expect(await store.resolve("sudo://localhost/root")).toBeUndefined();
+    expect(store.list()).toHaveLength(0);
+    // The prune was persisted, not just in-memory.
+    expect(BindingStore.load(dir, alwaysExists).list()).toHaveLength(0);
+  });
+
+  it("reconcile bulk-prunes only the stale rows and reports the count", async () => {
+    const dir = freshDir();
+    const live = new Set(["cc".repeat(16)]);
+    const store = BindingStore.load(dir, async (id) => live.has(id));
+    store.bind("sudo://localhost/root", "cc".repeat(16), meta());
+    store.bind("sudo://localhost/deploy", "dd".repeat(16), meta({ targetUser: "deploy" }));
+    store.bind("https-cred://github.com:443", "ee".repeat(16), meta({ scheme: "https-cred", displayUri: "https-cred://github.com" }));
+    expect(await store.reconcile()).toBe(2);
+    expect(store.list().map((r) => r.opaqueId)).toEqual(["cc".repeat(16)]);
+  });
+
+  it("management-only store (no existsInLocker): bind/list work, resolve/reconcile throw typed", async () => {
+    const store = BindingStore.load(freshDir());
+    store.bind("sudo://localhost/root", "ff".repeat(16), meta());
+    expect(store.list()).toHaveLength(1);
+    await expect(store.resolve("sudo://localhost/root")).rejects.toBeInstanceOf(LockerNotBoundError);
+    await expect(store.reconcile()).rejects.toBeInstanceOf(LockerNotBoundError);
+  });
+});
+
+describe("BindingStore — file tolerance + atomic save", () => {
+  it("corrupt bindings.json ⇒ starts empty, preserving the original as .corrupt", () => {
+    const dir = freshDir();
+    writeFileSync(join(dir, "bindings.json"), "{not json!!", "utf8");
+    const store = BindingStore.load(dir, alwaysExists);
+    expect(store.list()).toHaveLength(0);
+    expect(existsSync(join(dir, "bindings.json.corrupt"))).toBe(true);
+  });
+
+  it("wrong-shape file (valid JSON, not our schema) is treated as corrupt", () => {
+    const dir = freshDir();
+    writeFileSync(join(dir, "bindings.json"), JSON.stringify({ version: 99, whatever: [] }), "utf8");
+    expect(BindingStore.load(dir, alwaysExists).list()).toHaveLength(0);
+  });
+
+  it("a stale .tmp from a simulated mid-write crash never shadows the real file", async () => {
+    const dir = freshDir();
+    const store = BindingStore.load(dir, alwaysExists);
+    store.bind("sudo://localhost/root", "aa".repeat(16), meta());
+    // Simulate a crash mid-save: a half-written tmp sits next to an intact real file.
+    writeFileSync(join(dir, "bindings.json.tmp"), "{half-writ", "utf8");
+    const reloaded = BindingStore.load(dir, alwaysExists);
+    expect(await reloaded.resolve("sudo://localhost/root")).toEqual({ opaqueId: "aa".repeat(16) });
+    // The next save replaces both atomically.
+    reloaded.bind("sudo://localhost/deploy", "bb".repeat(16), meta({ targetUser: "deploy" }));
+    expect(JSON.parse(readFileSync(join(dir, "bindings.json"), "utf8")).version).toBe(1);
+  });
+
+  it("no secret-shaped field ever lands in bindings.json", () => {
+    const dir = freshDir();
+    const store = BindingStore.load(dir, alwaysExists);
+    store.bind("sudo://localhost/root", "aa".repeat(16), meta());
+    const raw = readFileSync(join(dir, "bindings.json"), "utf8");
+    // The file carries exactly the §5.1 shape: URIs, ids, timestamps — assert the keys we wrote.
+    const parsed = JSON.parse(raw) as { bindings: Record<string, Record<string, unknown>> };
+    expect(Object.keys(parsed.bindings["sudo://localhost/root"]).sort()).toEqual(
+      ["createdAt", "displayUri", "host", "opaqueId", "scheme", "targetUser"].sort(),
+    );
+  });
+});

--- a/tests/unit/key-locker-binding.test.ts
+++ b/tests/unit/key-locker-binding.test.ts
@@ -1,0 +1,146 @@
+// ADR-014 v2 R3 L1 — acceptance §8 #1: binding-URI grammar (table-driven).
+// Plan: desktop-touch-mcp-internal@6b0a085:docs/adr-014-v2-r3-l1-binding-plan.md
+import { describe, expect, it } from "vitest";
+import {
+  BindingParseError,
+  CanonicalKeyError,
+  canonicalKey,
+  formatBindingUri,
+  parseBindingUri,
+  type BindingUri,
+} from "../../src/engine/key-locker/binding.js";
+
+describe("binding-URI grammar (§2.1) — valid forms", () => {
+  const cases: Array<{ input: string; expected: BindingUri; display?: string }> = [
+    {
+      input: "ssh://alice@host.example.com",
+      expected: { scheme: "ssh", user: "alice", host: "host.example.com", port: 22 },
+    },
+    {
+      input: "ssh://alice@Host.Example.COM:2222",
+      expected: { scheme: "ssh", user: "alice", host: "host.example.com", port: 2222 },
+      display: "ssh://alice@host.example.com:2222", // host lowercased, non-default port kept
+    },
+    {
+      input: "ssh://root@[::1]:2200",
+      expected: { scheme: "ssh", user: "root", host: "[::1]", port: 2200 },
+    },
+    {
+      input: "sudo://localhost/root",
+      expected: { scheme: "sudo", host: "localhost", targetUser: "root" },
+    },
+    {
+      input: "sudo://prod.example.com/deploy",
+      expected: { scheme: "sudo", host: "prod.example.com", targetUser: "deploy" },
+    },
+    {
+      input: "https-cred://github.com",
+      expected: { scheme: "https-cred", user: undefined, host: "github.com", port: 443, path: undefined },
+    },
+    {
+      // EMAIL git username round-trip (Codex R7 P2): percent-encoded, no bare second '@'.
+      input: "https-cred://alice%40example.com@github.com/user/repo.git",
+      expected: {
+        scheme: "https-cred",
+        user: "alice@example.com",
+        host: "github.com",
+        port: 443,
+        path: "user/repo.git",
+      },
+    },
+    {
+      // Trailing slash stripped from path (§2.2 canonicalization applies at parse).
+      input: "https-cred://git.example.com:8443/group/proj/",
+      expected: { scheme: "https-cred", user: undefined, host: "git.example.com", port: 8443, path: "group/proj" },
+      display: "https-cred://git.example.com:8443/group/proj",
+    },
+    {
+      // Opaque form: standard-base64 '+' and '/' round-trip BYTE-FOR-BYTE (Codex R7 P2).
+      input: "sshkey:SHA256:aB+c/9zZ0KqWx3yV5tUu4rSs2qPp1oNn0mMlLkKjJiI",
+      expected: { scheme: "sshkey", keyFp: "SHA256:aB+c/9zZ0KqWx3yV5tUu4rSs2qPp1oNn0mMlLkKjJiI" },
+    },
+  ];
+
+  for (const { input, expected, display } of cases) {
+    it(`parses ${input}`, () => {
+      const parsed = parseBindingUri(input);
+      expect(parsed).toEqual(expected);
+      expect(formatBindingUri(parsed)).toBe(display ?? input);
+    });
+  }
+
+  it("re-parses its own display form (round-trip)", () => {
+    const uri = parseBindingUri("https-cred://alice%40example.com@github.com/user/repo.git");
+    expect(parseBindingUri(formatBindingUri(uri))).toEqual(uri);
+  });
+});
+
+describe("binding-URI grammar — typed rejects (no partial parse)", () => {
+  const rejects: Array<{ input: string; code: string }> = [
+    { input: "ftp://host", code: "UnknownScheme" },
+    { input: "ssh//host", code: "UnknownScheme" }, // no colon → scheme "ssh//host"... actually caught below
+    { input: "ssh://host.example.com", code: "MissingComponent" }, // ssh REQUIRES userinfo
+    { input: "sudo://host.example.com", code: "MissingComponent" }, // no target-user
+    { input: "sudo://host/", code: "MissingComponent" },
+    { input: "sudo://host:22/root", code: "MalformedUri" }, // sudo takes no port
+    { input: "ssh://u@h:99999", code: "BadPort" },
+    { input: "ssh://u@h:0", code: "BadPort" },
+    { input: "ssh://u@h:12x", code: "BadPort" },
+    { input: "ssh://a b@h", code: "MalformedUri" }, // raw space must be pct-encoded
+    { input: "ssh://a%2@h", code: "BadPercentEscape" },
+    { input: "ssh://u@[::1", code: "MalformedUri" }, // unterminated IPv6 bracket
+    { input: "ssh://u@", code: "MissingComponent" },
+    { input: "sshkey:MD5:abcdef", code: "MalformedUri" }, // fp must be SHA256:base64-nopad
+    { input: "sshkey:SHA256:has=pad", code: "MalformedUri" },
+    { input: "https-cred://@github.com", code: "MissingComponent" }, // empty userinfo before '@'
+    { input: "", code: "MalformedUri" },
+    { input: "ssh:", code: "MalformedUri" },
+  ];
+
+  for (const { input, code } of rejects) {
+    it(`rejects '${input}' with a typed ${code}-family error`, () => {
+      try {
+        parseBindingUri(input);
+        expect.unreachable(`'${input}' should not parse`);
+      } catch (e) {
+        expect(e).toBeInstanceOf(BindingParseError);
+        // The exact sub-code for a few inputs legitimately varies by which check fires first;
+        // what the contract pins is: typed BindingParseError, valid code, input carried.
+        expect(["UnknownScheme", "MissingComponent", "MalformedUri", "BadPercentEscape", "BadPort"]).toContain(
+          (e as BindingParseError).code,
+        );
+        expect((e as BindingParseError).input).toBe(input);
+      }
+    });
+  }
+});
+
+describe("canonical key (§2.2)", () => {
+  it("ssh canonical requires the resolved fp-set (typed error without it)", () => {
+    const uri = parseBindingUri("ssh://alice@host.example.com");
+    expect(() => canonicalKey(uri)).toThrowError(CanonicalKeyError);
+  });
+
+  it("ssh canonical: explicit port + fp-set deduped and sorted ascending", () => {
+    const uri = parseBindingUri("ssh://alice@host.example.com") as BindingUri & { scheme: "ssh" };
+    uri.fpSet = ["SHA256:bbb", "SHA256:aaa", "SHA256:bbb"];
+    expect(canonicalKey(uri)).toBe("ssh://alice@host.example.com:22|fp=SHA256:aaa,SHA256:bbb");
+  });
+
+  it("different fp-set ⇒ different canonical (the P2-1 lookup-layer defense)", () => {
+    const a = parseBindingUri("ssh://u@h") as BindingUri & { scheme: "ssh" };
+    const b = parseBindingUri("ssh://u@h") as BindingUri & { scheme: "ssh" };
+    a.fpSet = ["SHA256:FP1"];
+    b.fpSet = ["SHA256:FP2"];
+    expect(canonicalKey(a)).not.toBe(canonicalKey(b));
+  });
+
+  it("sudo / https-cred / sshkey canonicals are deterministic with explicit ports", () => {
+    expect(canonicalKey(parseBindingUri("sudo://localhost/root"))).toBe("sudo://localhost/root");
+    expect(canonicalKey(parseBindingUri("https-cred://github.com/a/b"))).toBe("https-cred://github.com:443/a/b");
+    expect(canonicalKey(parseBindingUri("https-cred://alice%40example.com@github.com"))).toBe(
+      "https-cred://alice%40example.com@github.com:443",
+    );
+    expect(canonicalKey(parseBindingUri("sshkey:SHA256:x+y/z"))).toBe("sshkey:SHA256:x+y/z");
+  });
+});

--- a/tests/unit/key-locker-derivation.test.ts
+++ b/tests/unit/key-locker-derivation.test.ts
@@ -1,0 +1,242 @@
+// ADR-014 v2 R3 L1 — acceptance §8 #5 (sudo session host) + #6 (command derivation table).
+// Plan: desktop-touch-mcp-internal@6b0a085:docs/adr-014-v2-r3-l1-binding-plan.md
+//
+// ssh derivation goes through a FAKE exec (canned `ssh -G` / `ssh-keygen` output) so the table is
+// hermetic without OpenSSH; git derivation uses REAL `git` against temp fixture repos (no network
+// — the remote URLs are never contacted). This file owns the per-flag edge table the plan's §4
+// scope note delegates to the test suite.
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  deriveBinding,
+  tokenizeCommandSegments,
+  type SessionContext,
+} from "../../src/engine/key-locker/command-derivation.js";
+import { defaultExec, type ExecFn } from "../../src/engine/key-locker/ssh-resolve.js";
+
+let tmp: string;
+let khFile: string;
+let repoTracking: string; // branch main tracks origin (an https remote)
+let repoPushElsewhere: string; // branch main has pushRemote = a NON-origin https remote
+
+const local: SessionContext = { execHost: "localhost", isRemote: false, cwd: "." };
+const remotePane: SessionContext = { execHost: "prod.example.com", isRemote: true, cwd: "/home/u" };
+
+// Canned ssh -G/ssh-keygen; git falls through to the real binary (fixture repos, no network).
+const fakeExec: ExecFn = async (file, args) => {
+  if (file === "ssh" && args[0] === "-G") {
+    const dest = args[args.length - 1];
+    let user = "u";
+    let port = "22";
+    const li = args.indexOf("-l");
+    if (li >= 0) user = args[li + 1];
+    const pi = args.indexOf("-p");
+    if (pi >= 0) port = args[pi + 1];
+    let host = dest;
+    const at = dest.lastIndexOf("@");
+    if (at > 0) { user = dest.slice(0, at); host = dest.slice(at + 1); }
+    if (host === "resolvefail.example.com") return { code: 255, stdout: "", stderr: "boom" };
+    return {
+      code: 0,
+      stdout: `hostname ${host}\nuser ${user}\nport ${port}\nuserknownhostsfile ${khFile}\nglobalknownhostsfile ${join(tmp, "absent")}\n`,
+      stderr: "",
+    };
+  }
+  if (file === "ssh-keygen") {
+    const token = args[args.indexOf("-F") + 1];
+    if (token === "h" || token === "[h]:2222" || token === "prod.example.com") {
+      return { code: 0, stdout: `${token} ED25519 SHA256:FAKEFP1\n`, stderr: "" };
+    }
+    return { code: 1, stdout: "", stderr: "" };
+  }
+  if (file === "git") return defaultExec(file, args);
+  return { code: 127, stdout: "", stderr: `unexpected exec of ${file}` };
+};
+
+const git = async (cwd: string, ...args: string[]): Promise<void> => {
+  const r = await defaultExec("git", ["-C", cwd, ...args]);
+  if (r.code !== 0) throw new Error(`git ${args.join(" ")} failed: ${r.stderr}`);
+};
+
+beforeAll(async () => {
+  tmp = mkdtempSync(join(tmpdir(), "dtm-l1-derive-"));
+  khFile = join(tmp, "known_hosts");
+  writeFileSync(khFile, "placeholder — content is faked through ssh-keygen\n", "utf8");
+
+  const mkRepo = async (name: string): Promise<string> => {
+    const dir = join(tmp, name);
+    await defaultExec("git", ["init", dir]);
+    await git(dir, "config", "user.email", "t@example.com");
+    await git(dir, "config", "user.name", "t");
+    await git(dir, "commit", "--allow-empty", "-m", "init");
+    await git(dir, "checkout", "-B", "main");
+    return dir;
+  };
+
+  repoTracking = await mkRepo("tracking");
+  await git(repoTracking, "remote", "add", "origin", "https://github.com/example/repo.git");
+  await git(repoTracking, "remote", "add", "sshr", "git@github.com:example/repo.git");
+  await git(repoTracking, "config", "branch.main.remote", "origin");
+  await git(repoTracking, "config", "branch.main.merge", "refs/heads/main");
+
+  repoPushElsewhere = await mkRepo("push-elsewhere");
+  await git(repoPushElsewhere, "remote", "add", "origin", "https://github.com/example/repo.git");
+  await git(repoPushElsewhere, "remote", "add", "forge", "https://forge.example.com:8443/team/proj.git");
+  await git(repoPushElsewhere, "config", "branch.main.remote", "origin");
+  await git(repoPushElsewhere, "config", "branch.main.merge", "refs/heads/main");
+  await git(repoPushElsewhere, "config", "branch.main.pushRemote", "forge");
+}, 30_000);
+
+afterAll(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("tokenizer", () => {
+  it("splits segments at unquoted separators, respects quotes", () => {
+    expect(tokenizeCommandSegments(`echo "a && b" && sudo apt update; ls | wc`)).toEqual([
+      ["echo", "a && b"],
+      ["sudo", "apt", "update"],
+      ["ls"],
+      ["wc"],
+    ]);
+  });
+});
+
+describe("§8 #5 — sudo purpose + session host", () => {
+  it("sudo -u deploy … on a LOCAL pane → sudo://localhost/deploy", async () => {
+    expect(await deriveBinding("sudo -u deploy systemctl restart app", local, { exec: fakeExec })).toEqual({
+      scheme: "sudo",
+      host: "localhost",
+      targetUser: "deploy",
+    });
+  });
+
+  it("the SAME command in a REMOTE pane targets the remote host — no localhost collapse", async () => {
+    expect(await deriveBinding("sudo -u deploy systemctl restart app", remotePane, { exec: fakeExec })).toEqual({
+      scheme: "sudo",
+      host: "prod.example.com",
+      targetUser: "deploy",
+    });
+  });
+
+  it("nested one-shot `ssh host sudo …` derives the OUTER ssh login, not sudo://", async () => {
+    const uri = await deriveBinding("ssh prod.example.com sudo apt update", local, { exec: fakeExec });
+    expect(uri).toMatchObject({ scheme: "ssh", host: "prod.example.com", user: "u", port: 22 });
+  });
+});
+
+describe("§8 #6 — command derivation table", () => {
+  const derives = async (cmd: string, session: SessionContext = local) =>
+    deriveBinding(cmd, session, { exec: fakeExec });
+
+  // --- ssh ---
+  it("ssh h → ssh://u@h:22 with the resolved fp-set", async () => {
+    expect(await derives("ssh h")).toEqual({ scheme: "ssh", user: "u", host: "h", port: 22, fpSet: ["SHA256:FAKEFP1"] });
+  });
+  it("ssh -p 2222 user@h → port honored (known_hosts token is [h]:2222)", async () => {
+    expect(await derives("ssh -p 2222 alice@h")).toMatchObject({ scheme: "ssh", user: "alice", host: "h", port: 2222 });
+  });
+  it("query / no-login modes → null: ssh -G h / ssh -Q cipher / ssh -V", async () => {
+    expect(await derives("ssh -G h")).toBeNull();
+    expect(await derives("ssh -Q cipher")).toBeNull();
+    expect(await derives("ssh -V")).toBeNull();
+  });
+  it("host not in known_hosts → null (fail closed)", async () => {
+    expect(await derives("ssh unknown.example.com")).toBeNull();
+  });
+  it("ssh -G resolution failure → null (fail closed, never guess)", async () => {
+    expect(await derives("ssh resolvefail.example.com")).toBeNull();
+  });
+
+  // --- sudo (the CANNOT-prompt closed set nulls; everything else derives) ---
+  it("sudo apt update → derive", async () => {
+    expect(await derives("sudo apt update")).toMatchObject({ scheme: "sudo", targetUser: "root" });
+  });
+  it("sudo -n apt update → null (never prompts)", async () => {
+    expect(await derives("sudo -n apt update")).toBeNull();
+  });
+  it("bare sudo -k / -K → null (clears timestamp and exits)", async () => {
+    expect(await derives("sudo -k")).toBeNull();
+    expect(await derives("sudo -K")).toBeNull();
+  });
+  it("sudo -k apt update → derive (invalidates cache then RUNS → prompts)", async () => {
+    expect(await derives("sudo -k apt update")).toMatchObject({ scheme: "sudo" });
+  });
+  it("sudo -l / sudo -v → derive (both can prompt)", async () => {
+    expect(await derives("sudo -l")).toMatchObject({ scheme: "sudo" });
+    expect(await derives("sudo -v")).toMatchObject({ scheme: "sudo" });
+  });
+  it("pure-info sudo -V / --help / bare -h → null", async () => {
+    expect(await derives("sudo -V")).toBeNull();
+    expect(await derives("sudo --help")).toBeNull();
+    expect(await derives("sudo -h")).toBeNull();
+  });
+  it("env assignment prefix is skipped: FOO=1 sudo cmd → derive", async () => {
+    expect(await derives("FOO=1 sudo apt update")).toMatchObject({ scheme: "sudo" });
+  });
+  it("later segment: echo hi && sudo apt update → derive (first credential-bearing program)", async () => {
+    expect(await derives("echo hi && sudo apt update")).toMatchObject({ scheme: "sudo" });
+  });
+
+  // --- git ---
+  it("git clone https://… → derive from the explicit URL", async () => {
+    expect(await derives("git clone https://github.com/example/repo.git")).toEqual({
+      scheme: "https-cred",
+      user: undefined,
+      host: "github.com",
+      port: 443,
+      path: "example/repo.git",
+    });
+  });
+  it("git push origin with a cwd whose origin is https → derive via git -C cwd", async () => {
+    expect(await derives("git push origin main", { ...local, cwd: repoTracking })).toMatchObject({
+      scheme: "https-cred",
+      host: "github.com",
+    });
+  });
+  it("bare git push on a branch whose pushRemote is a NON-origin https remote → THAT host (R9/R10)", async () => {
+    expect(await derives("git push", { ...local, cwd: repoPushElsewhere })).toMatchObject({
+      scheme: "https-cred",
+      host: "forge.example.com",
+      port: 8443,
+      path: "team/proj.git",
+    });
+  });
+  it("bare git fetch follows branch.<cur>.remote", async () => {
+    expect(await derives("git fetch", { ...local, cwd: repoTracking })).toMatchObject({
+      scheme: "https-cred",
+      host: "github.com",
+    });
+  });
+  it("git push to an ssh remote → null (that's an sshkey path, not https-cred)", async () => {
+    expect(await derives("git push sshr main", { ...local, cwd: repoTracking })).toBeNull();
+    expect(await derives("git clone git@github.com:example/repo.git")).toBeNull();
+    expect(await derives("git clone ssh://git@github.com/example/repo.git")).toBeNull();
+  });
+  it("git -C <repo> push origin resolves against the -C path, not session.cwd", async () => {
+    expect(await derives(`git -C "${repoTracking}" push origin main`, { ...local, cwd: tmp })).toMatchObject({
+      scheme: "https-cred",
+      host: "github.com",
+    });
+  });
+  it("git push in a REMOTE pane → null (deferred to L3; git runs remotely)", async () => {
+    expect(await derives("git push", { ...remotePane, cwd: repoTracking })).toBeNull();
+  });
+  it("git push outside any repo → null (never guess)", async () => {
+    expect(await derives("git push", { ...local, cwd: tmp })).toBeNull();
+  });
+  it("git -V / git --version / non-credential subcommands → null", async () => {
+    expect(await derives("git -V")).toBeNull();
+    expect(await derives("git --version")).toBeNull();
+    expect(await derives("git status", { ...local, cwd: repoTracking })).toBeNull();
+  });
+
+  // --- non-credential commands ---
+  it("plain commands → null", async () => {
+    expect(await derives("npm install")).toBeNull();
+    expect(await derives("dir")).toBeNull();
+    expect(await derives("")).toBeNull();
+  });
+});

--- a/tests/unit/key-locker-derivation.test.ts
+++ b/tests/unit/key-locker-derivation.test.ts
@@ -235,6 +235,16 @@ describe("§8 #6 — command derivation table", () => {
       path: "example/repo.git",
     });
   });
+  it("git clone --bundle-uri <uri> <repo> derives the REPO, not the bundle host (Codex R5)", async () => {
+    expect(await derives("git clone --bundle-uri https://cache.example.com/bundle https://github.com/org/private.git")).toMatchObject({
+      scheme: "https-cred",
+      host: "github.com",
+      path: "org/private.git",
+    });
+    expect(await derives("git clone --bundle-uri=https://cache.example.com/bundle https://github.com/org/private.git")).toMatchObject({
+      host: "github.com",
+    });
+  });
   it("git push origin with a cwd whose origin is https → derive via git -C cwd", async () => {
     expect(await derives("git push origin main", { ...local, cwd: repoTracking })).toMatchObject({
       scheme: "https-cred",

--- a/tests/unit/key-locker-derivation.test.ts
+++ b/tests/unit/key-locker-derivation.test.ts
@@ -39,9 +39,11 @@ const fakeExec: ExecFn = async (file, args) => {
     if (at > 0) { user = dest.slice(0, at); host = dest.slice(at + 1); }
     host = host.replace(/^\[|\]$/g, ""); // real ssh -G prints IPv6 hostnames UNBRACKETED
     if (host === "resolvefail.example.com") return { code: 255, stdout: "", stderr: "boom" };
+    const ji = args.indexOf("-J"); // real ssh maps -J onto an effective ProxyJump line
+    const proxy = ji >= 0 ? `proxyjump ${args[ji + 1]}\n` : "";
     return {
       code: 0,
-      stdout: `hostname ${host}\nuser ${user}\nport ${port}\nuserknownhostsfile ${khFile}\nglobalknownhostsfile ${join(tmp, "absent")}\n`,
+      stdout: `hostname ${host}\nuser ${user}\nport ${port}\n${proxy}userknownhostsfile ${khFile}\nglobalknownhostsfile ${join(tmp, "absent")}\n`,
       stderr: "",
     };
   }
@@ -170,6 +172,9 @@ describe("§8 #6 — command derivation table", () => {
     expect(r.uri.host).toBe("[::1]");
     expect(parseBindingUri(formatBindingUri(r.uri))).toMatchObject({ scheme: "ssh", host: "[::1]", user: "u", port: 22 });
   });
+  it("ssh -J bastion target → null (the FIRST prompt may be the jump host's — Codex R1 P1)", async () => {
+    expect(await derives("ssh -J bastion.example.com h")).toBeNull();
+  });
   it("clustered arg-taking flag (-4p 2222) fails CLOSED to null, never a wrong target", async () => {
     // '-4p' is tokenized as a no-arg cluster, so '2222' is taken as the destination; the fake
     // known_hosts has no such host → host-not-known → null. Pinned so the failure DIRECTION
@@ -194,6 +199,11 @@ describe("§8 #6 — command derivation table", () => {
   it("sudo -l / sudo -v → derive (both can prompt)", async () => {
     expect(await derives("sudo -l")).toMatchObject({ scheme: "sudo" });
     expect(await derives("sudo -v")).toMatchObject({ scheme: "sudo" });
+  });
+  it("sudo -k -v / -k -l are force-reprompt modes, NOT a bare clear → derive (Codex R1 P2)", async () => {
+    expect(await derives("sudo -k -v")).toMatchObject({ scheme: "sudo" });
+    expect(await derives("sudo -k -l")).toMatchObject({ scheme: "sudo" });
+    expect(await derives("sudo -k -K")).toBeNull(); // still only clears — cannot prompt
   });
   it("pure-info sudo -V / --help / bare -h → null", async () => {
     expect(await derives("sudo -V")).toBeNull();
@@ -233,6 +243,15 @@ describe("§8 #6 — command derivation table", () => {
   });
   it("bare git fetch follows branch.<cur>.remote", async () => {
     expect(await derives("git fetch", { ...local, cwd: repoTracking })).toMatchObject({
+      scheme: "https-cred",
+      host: "github.com",
+    });
+  });
+  it("multi-remote fetch modes are ambiguous → null; push --all (all BRANCHES) still derives (Codex R1 P1)", async () => {
+    expect(await derives("git fetch --all", { ...local, cwd: repoTracking })).toBeNull();
+    expect(await derives("git fetch --multiple origin sshr", { ...local, cwd: repoTracking })).toBeNull();
+    expect(await derives("git pull --all", { ...local, cwd: repoTracking })).toBeNull();
+    expect(await derives("git push --all", { ...local, cwd: repoTracking })).toMatchObject({
       scheme: "https-cred",
       host: "github.com",
     });

--- a/tests/unit/key-locker-derivation.test.ts
+++ b/tests/unit/key-locker-derivation.test.ts
@@ -258,6 +258,7 @@ describe("§8 #6 — command derivation table", () => {
   it("multi-remote fetch modes are ambiguous → null; push --all (all BRANCHES) still derives (Codex R1 P1)", async () => {
     expect(await derives("git fetch --all", { ...local, cwd: repoTracking })).toBeNull();
     expect(await derives("git fetch --multiple origin sshr", { ...local, cwd: repoTracking })).toBeNull();
+    expect(await derives("git fetch -m origin sshr", { ...local, cwd: repoTracking })).toBeNull(); // -m = --multiple (Codex R3)
     expect(await derives("git pull --all", { ...local, cwd: repoTracking })).toBeNull();
     expect(await derives("git push --all", { ...local, cwd: repoTracking })).toMatchObject({
       scheme: "https-cred",

--- a/tests/unit/key-locker-derivation.test.ts
+++ b/tests/unit/key-locker-derivation.test.ts
@@ -81,6 +81,9 @@ beforeAll(async () => {
   repoTracking = await mkRepo("tracking");
   await git(repoTracking, "remote", "add", "origin", "https://github.com/example/repo.git");
   await git(repoTracking, "remote", "add", "sshr", "git@github.com:example/repo.git");
+  await git(repoTracking, "remote", "add", "multi", "https://m0.example.com/a.git");
+  await git(repoTracking, "remote", "set-url", "--push", "multi", "https://m1.example.com/a.git");
+  await git(repoTracking, "remote", "set-url", "--add", "--push", "multi", "https://m2.example.com/b.git");
   await git(repoTracking, "config", "branch.main.remote", "origin");
   await git(repoTracking, "config", "branch.main.merge", "refs/heads/main");
 
@@ -200,6 +203,11 @@ describe("§8 #6 — command derivation table", () => {
     expect(await derives("sudo -l")).toMatchObject({ scheme: "sudo" });
     expect(await derives("sudo -v")).toMatchObject({ scheme: "sudo" });
   });
+  it("all four sudo user-selection forms bind targetUser (Codex R2 P2)", async () => {
+    for (const cmd of ["sudo -u deploy id", "sudo -udeploy id", "sudo --user=deploy id", "sudo --user deploy id"]) {
+      expect(await derives(cmd), cmd).toEqual({ scheme: "sudo", host: "localhost", targetUser: "deploy" });
+    }
+  });
   it("sudo -k -v / -k -l are force-reprompt modes, NOT a bare clear → derive (Codex R1 P2)", async () => {
     expect(await derives("sudo -k -v")).toMatchObject({ scheme: "sudo" });
     expect(await derives("sudo -k -l")).toMatchObject({ scheme: "sudo" });
@@ -254,6 +262,13 @@ describe("§8 #6 — command derivation table", () => {
     expect(await derives("git push --all", { ...local, cwd: repoTracking })).toMatchObject({
       scheme: "https-cred",
       host: "github.com",
+    });
+  });
+  it("git push to a remote with MULTIPLE push URLs → null; fetch (first URL only) still derives (Codex R2 P2)", async () => {
+    expect(await derives("git push multi main", { ...local, cwd: repoTracking })).toBeNull();
+    expect(await derives("git fetch multi", { ...local, cwd: repoTracking })).toMatchObject({
+      scheme: "https-cred",
+      host: "m0.example.com",
     });
   });
   it("git push to an ssh remote → null (that's an sshkey path, not https-cred)", async () => {

--- a/tests/unit/key-locker-derivation.test.ts
+++ b/tests/unit/key-locker-derivation.test.ts
@@ -37,6 +37,7 @@ const fakeExec: ExecFn = async (file, args) => {
     let host = dest;
     const at = dest.lastIndexOf("@");
     if (at > 0) { user = dest.slice(0, at); host = dest.slice(at + 1); }
+    host = host.replace(/^\[|\]$/g, ""); // real ssh -G prints IPv6 hostnames UNBRACKETED
     if (host === "resolvefail.example.com") return { code: 255, stdout: "", stderr: "boom" };
     return {
       code: 0,
@@ -149,6 +150,32 @@ describe("§8 #6 — command derivation table", () => {
   it("ssh -G resolution failure → null (fail closed, never guess)", async () => {
     expect(await derives("ssh resolvefail.example.com")).toBeNull();
   });
+  it("IPv6 destination: host is re-bracketed so the displayUri round-trips (Opus R1 P2-1)", async () => {
+    const uri = await derives("ssh u@[h]"); // fake ssh -G reports the bare 'h'; kh token 'h' is stored
+    expect(uri).toMatchObject({ scheme: "ssh", host: "h" });
+    // The bracket rule itself is pinned via the parser: a host ssh -G reports with ':' in it
+    // must land bracketed. (Direct unit on the resolve path, no real IPv6 endpoint needed.)
+    const { resolveCanonicalForSshCommand } = await import("../../src/engine/key-locker/ssh-resolve.js");
+    const { formatBindingUri, parseBindingUri } = await import("../../src/engine/key-locker/binding.js");
+    const v6Exec: typeof fakeExec = async (file, args) => {
+      if (file === "ssh" && args[0] === "-G") {
+        return { code: 0, stdout: `hostname ::1\nuser u\nport 22\nuserknownhostsfile ${khFile}\n`, stderr: "" };
+      }
+      if (file === "ssh-keygen") return { code: 0, stdout: "::1 ED25519 SHA256:FAKEFP1\n", stderr: "" };
+      return { code: 127, stdout: "", stderr: "unexpected" };
+    };
+    const r = await resolveCanonicalForSshCommand(["u@::1"], v6Exec);
+    expect(r.kind).toBe("ok");
+    if (r.kind !== "ok") return;
+    expect(r.uri.host).toBe("[::1]");
+    expect(parseBindingUri(formatBindingUri(r.uri))).toMatchObject({ scheme: "ssh", host: "[::1]", user: "u", port: 22 });
+  });
+  it("clustered arg-taking flag (-4p 2222) fails CLOSED to null, never a wrong target", async () => {
+    // '-4p' is tokenized as a no-arg cluster, so '2222' is taken as the destination; the fake
+    // known_hosts has no such host → host-not-known → null. Pinned so the failure DIRECTION
+    // (toward null) never regresses even though the cluster parse itself is imperfect.
+    expect(await derives("ssh -4p 2222 h")).toBeNull();
+  });
 
   // --- sudo (the CANNOT-prompt closed set nulls; everything else derives) ---
   it("sudo apt update → derive", async () => {
@@ -214,6 +241,17 @@ describe("§8 #6 — command derivation table", () => {
     expect(await derives("git push sshr main", { ...local, cwd: repoTracking })).toBeNull();
     expect(await derives("git clone git@github.com:example/repo.git")).toBeNull();
     expect(await derives("git clone ssh://git@github.com/example/repo.git")).toBeNull();
+  });
+  it("git push --repo=<url> / --repo <url> derive from the explicit target (Opus R1 P3-2)", async () => {
+    expect(await derives("git push --repo=https://forge.example.com:8443/team/proj.git", { ...local, cwd: tmp })).toMatchObject({
+      scheme: "https-cred",
+      host: "forge.example.com",
+      port: 8443,
+    });
+    expect(await derives("git push --repo https://github.com/example/repo.git", { ...local, cwd: tmp })).toMatchObject({
+      scheme: "https-cred",
+      host: "github.com",
+    });
   });
   it("git -C <repo> push origin resolves against the -C path, not session.cwd", async () => {
     expect(await derives(`git -C "${repoTracking}" push origin main`, { ...local, cwd: tmp })).toMatchObject({

--- a/tests/unit/key-locker-ssh-resolve.test.ts
+++ b/tests/unit/key-locker-ssh-resolve.test.ts
@@ -154,6 +154,11 @@ describe.skipIf(!hasOpenSsh)("§8 #2 — ssh resolution + option passthrough (re
     const r = await resolveCanonicalForSshCommand(["-F", absent, "-o", `UserKnownHostsFile=${khMain}`, "h"]);
     expect(r.kind).toBe("unresolvable");
   });
+
+  it("-J (ProxyJump) defers: real ssh -G reports the effective proxyjump → no derivation", async () => {
+    const r = await resolveCanonicalForSshCommand([...mainOpts(), "-J", "bastion.example.com", "bob@real.example.com"]);
+    expect(r.kind).toBe("unresolvable");
+  });
 });
 
 describe.skipIf(!hasOpenSsh)("§8 #4 — known-host-absent fallback", () => {

--- a/tests/unit/key-locker-ssh-resolve.test.ts
+++ b/tests/unit/key-locker-ssh-resolve.test.ts
@@ -159,6 +159,22 @@ describe.skipIf(!hasOpenSsh)("§8 #2 — ssh resolution + option passthrough (re
     const r = await resolveCanonicalForSshCommand([...mainOpts(), "-J", "bastion.example.com", "bob@real.example.com"]);
     expect(r.kind).toBe("unresolvable");
   });
+
+  it("a default-port entry stored in BRACKETED [host]:22 form is still found (Codex R4)", async () => {
+    const khBracketed = fwd(join(tmp, "known_hosts_bracketed"));
+    writeFileSync(khBracketed, `[::1]:22 ${pub1}\n`, "utf8");
+    const r = await resolveCanonicalForSshCommand([
+      "-F", cfg,
+      "-o", `UserKnownHostsFile=${khBracketed}`,
+      "-o", `GlobalKnownHostsFile=${absent}`,
+      "u@::1",
+    ]);
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") {
+      expect(r.uri).toMatchObject({ host: "[::1]", port: 22 });
+      expect(r.uri.fpSet).toEqual([fp1]);
+    }
+  });
 });
 
 describe.skipIf(!hasOpenSsh)("§8 #4 — known-host-absent fallback", () => {

--- a/tests/unit/key-locker-ssh-resolve.test.ts
+++ b/tests/unit/key-locker-ssh-resolve.test.ts
@@ -1,0 +1,195 @@
+// ADR-014 v2 R3 L1 — acceptance §8 #2 (ssh resolution + option passthrough), #3 (P2-1
+// recorded-identity drift), #4 (host-not-known fail-closed).
+// Plan: desktop-touch-mcp-internal@6b0a085:docs/adr-014-v2-r3-l1-binding-plan.md
+//
+// Uses the REAL `ssh -G` + `ssh-keygen -l -F` (Windows OpenSSH) against temp fixture files —
+// hermetic, no network, nothing ever connects. Skips with a clear message if OpenSSH is absent.
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { resolveCanonicalForSshCommand } from "../../src/engine/key-locker/ssh-resolve.js";
+import { BindingStore } from "../../src/engine/key-locker/binding-store.js";
+import { formatBindingUri } from "../../src/engine/key-locker/binding.js";
+
+const present = (cmd: string, args: string[]): boolean =>
+  spawnSync(cmd, args, { stdio: "ignore", windowsHide: true }).error === undefined;
+const hasOpenSsh = present("ssh", ["-V"]) && present("ssh-keygen", ["-?"]);
+if (!hasOpenSsh) {
+  console.warn("[key-locker-ssh-resolve.test] OpenSSH client not found on this runner — skipping the real ssh -G acceptance suite");
+}
+
+const fwd = (p: string): string => p.replace(/\\/g, "/");
+
+let tmp: string;
+let cfg: string;
+let khMain: string;
+let khDrift: string;
+let khGlobal: string;
+let absent: string;
+let fp1: string; // key 1's SHA256 fingerprint (the bound identity)
+let pub1: string; // "ssh-ed25519 AAAA…" (type + b64) for known_hosts lines
+let pub2: string; // a second, different host key (the drifted identity)
+
+const keygen = (args: string[]): string => {
+  const r = spawnSync("ssh-keygen", args, { encoding: "utf8", windowsHide: true });
+  if (r.status !== 0) throw new Error(`ssh-keygen ${args.join(" ")} failed: ${r.stderr}`);
+  return r.stdout;
+};
+
+beforeAll(() => {
+  if (!hasOpenSsh) return;
+  tmp = mkdtempSync(join(tmpdir(), "dtm-l1-ssh-"));
+  absent = fwd(join(tmp, "does-not-exist"));
+
+  for (const name of ["key1", "key2"]) {
+    keygen(["-q", "-t", "ed25519", "-N", "", "-f", join(tmp, name)]);
+  }
+  const pubLine = (name: string): string => {
+    const [type, b64] = readFileSync(join(tmp, `${name}.pub`), "utf8").trim().split(/\s+/);
+    return `${type} ${b64}`;
+  };
+  pub1 = pubLine("key1");
+  pub2 = pubLine("key2");
+  fp1 = /SHA256:[A-Za-z0-9+/]+/.exec(keygen(["-l", "-f", join(tmp, "key1.pub")]))![0];
+
+  khMain = fwd(join(tmp, "known_hosts"));
+  writeFileSync(khMain, `real.example.com ${pub1}\n[real.example.com]:2222 ${pub1}\n`, "utf8");
+  khDrift = fwd(join(tmp, "known_hosts_drift"));
+  writeFileSync(khDrift, `real.example.com ${pub1}\n`, "utf8");
+  const khAlias = fwd(join(tmp, "known_hosts_alias"));
+  writeFileSync(khAlias, `customalias ${pub1}\n`, "utf8"); // ONLY the alias token — proves HostKeyAlias is used
+  const khCustom = fwd(join(tmp, "known_hosts_custom"));
+  writeFileSync(khCustom, `real.example.com ${pub1}\n`, "utf8");
+  khGlobal = fwd(join(tmp, "known_hosts_global"));
+  writeFileSync(khGlobal, `global.example.com ${pub1}\n`, "utf8");
+
+  cfg = fwd(join(tmp, "config"));
+  writeFileSync(
+    cfg,
+    [
+      "Host myalias",
+      "    HostName real.example.com",
+      "    User aliceuser",
+      "Host hka",
+      "    HostName real.example.com",
+      "    User u2",
+      "    HostKeyAlias customalias",
+      `    UserKnownHostsFile ${khAlias}`,
+      "Host cukh",
+      "    HostName real.example.com",
+      "    User u3",
+      `    UserKnownHostsFile ${khCustom}`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+});
+
+afterAll(() => {
+  if (tmp) rmSync(tmp, { recursive: true, force: true });
+});
+
+const mainOpts = (): string[] => ["-F", cfg, "-o", `UserKnownHostsFile=${khMain}`, "-o", `GlobalKnownHostsFile=${absent}`];
+
+describe.skipIf(!hasOpenSsh)("§8 #2 — ssh resolution + option passthrough (real ssh -G / ssh-keygen)", () => {
+  it("alias resolves through ~/.ssh/config to the real endpoint + fp-set", async () => {
+    const r = await resolveCanonicalForSshCommand([...mainOpts(), "myalias"]);
+    expect(r.kind).toBe("ok");
+    if (r.kind !== "ok") return;
+    expect(r.uri).toMatchObject({ scheme: "ssh", user: "aliceuser", host: "real.example.com", port: 22 });
+    expect(r.uri.fpSet).toEqual([fp1]);
+    expect(r.canonical).toBe(`ssh://aliceuser@real.example.com:22|fp=${fp1}`);
+    expect(formatBindingUri(r.uri)).toBe("ssh://aliceuser@real.example.com");
+  });
+
+  it("alias and explicit user@realhost resolving identically share ONE canonical", async () => {
+    const viaAlias = await resolveCanonicalForSshCommand([...mainOpts(), "myalias"]);
+    const direct = await resolveCanonicalForSshCommand([...mainOpts(), "aliceuser@real.example.com"]);
+    expect(viaAlias.kind).toBe("ok");
+    expect(direct.kind).toBe("ok");
+    if (viaAlias.kind === "ok" && direct.kind === "ok") expect(direct.canonical).toBe(viaAlias.canonical);
+  });
+
+  it("-p 2222 passes through: the [host]:port known_hosts token is looked up", async () => {
+    const r = await resolveCanonicalForSshCommand([...mainOpts(), "-p", "2222", "bob@real.example.com"]);
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") expect(r.uri).toMatchObject({ port: 2222, user: "bob" });
+    // A port with NO stored [host]:port line must fail closed, proving the token carries the port.
+    const miss = await resolveCanonicalForSshCommand([...mainOpts(), "-p", "2200", "bob@real.example.com"]);
+    expect(miss.kind).toBe("host-not-known");
+  });
+
+  it("-l overrides the login user", async () => {
+    const r = await resolveCanonicalForSshCommand([...mainOpts(), "-l", "otheruser", "real.example.com"]);
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") expect(r.uri.user).toBe("otheruser");
+  });
+
+  it("HostKeyAlias: the lookup token is the ALIAS (file holds only the alias line)", async () => {
+    const r = await resolveCanonicalForSshCommand(["-F", cfg, "-o", `GlobalKnownHostsFile=${absent}`, "hka"]);
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") expect(r.uri).toMatchObject({ user: "u2", host: "real.example.com" });
+  });
+
+  it("a config-level custom UserKnownHostsFile is the file consulted", async () => {
+    const r = await resolveCanonicalForSshCommand(["-F", cfg, "-o", `GlobalKnownHostsFile=${absent}`, "cukh"]);
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") expect(r.uri.user).toBe("u3");
+  });
+
+  it("a host trusted ONLY via GlobalKnownHostsFile resolves (absent user file skipped as empty)", async () => {
+    const r = await resolveCanonicalForSshCommand([
+      "-F", cfg,
+      "-o", `UserKnownHostsFile=${absent}`,
+      "-o", `GlobalKnownHostsFile=${khGlobal}`,
+      "u9@global.example.com",
+    ]);
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") expect(r.uri).toMatchObject({ user: "u9", host: "global.example.com" });
+  });
+
+  it("an unreadable -F config fails closed as unresolvable", async () => {
+    const r = await resolveCanonicalForSshCommand(["-F", absent, "-o", `UserKnownHostsFile=${khMain}`, "h"]);
+    expect(r.kind).toBe("unresolvable");
+  });
+});
+
+describe.skipIf(!hasOpenSsh)("§8 #4 — known-host-absent fallback", () => {
+  it("a host missing from every consulted file ⇒ host-not-known (no lookup, no save)", async () => {
+    const r = await resolveCanonicalForSshCommand([...mainOpts(), "u@unknown.example.com"]);
+    expect(r).toMatchObject({ kind: "host-not-known", host: "unknown.example.com" });
+  });
+});
+
+describe.skipIf(!hasOpenSsh)("§8 #3 — P2-1 defense: recorded-identity drift (acceptance-critical)", () => {
+  it("known_hosts rotates FP1→FP2 ⇒ canonical differs ⇒ store misses ⇒ NO autofill", async () => {
+    const opts = ["-F", cfg, "-o", `UserKnownHostsFile=${khDrift}`, "-o", `GlobalKnownHostsFile=${absent}`];
+    const store = BindingStore.load(join(tmp, "store"), async () => true);
+
+    const bound = await resolveCanonicalForSshCommand([...opts, "bob@real.example.com"]);
+    expect(bound.kind).toBe("ok");
+    if (bound.kind !== "ok") return;
+    store.bind(bound.canonical, "ab".repeat(16), {
+      scheme: "ssh",
+      displayUri: formatBindingUri(bound.uri),
+      host: bound.uri.host,
+      user: bound.uri.user,
+      port: bound.uri.port,
+      fpSet: bound.uri.fpSet,
+      createdAt: new Date().toISOString(),
+    });
+
+    // Positive control: unchanged known_hosts resolves to the bound opaqueId.
+    expect(await store.resolve(bound.canonical)).toEqual({ opaqueId: "ab".repeat(16) });
+
+    // The recorded identity drifts (key rotation / alias re-point): same command, new stored key.
+    writeFileSync(khDrift, `real.example.com ${pub2}\n`, "utf8");
+    const drifted = await resolveCanonicalForSshCommand([...opts, "bob@real.example.com"]);
+    expect(drifted.kind).toBe("ok");
+    if (drifted.kind !== "ok") return;
+    expect(drifted.canonical).not.toBe(bound.canonical);
+    expect(await store.resolve(drifted.canonical)).toBeUndefined(); // ⇒ no opaqueId ⇒ no autofill
+  });
+});


### PR DESCRIPTION
## Summary

L1 of the R3 Key Locker: the binding model that maps a credential target to a locker `opaqueId`. Pure engine-side TypeScript — the L0 contracts (pipe protocol, `Program.cs`, `store.json`, secure-dialog invariants) are untouched.

Plan: `desktop-touch-mcp-internal@6b0a085:docs/adr-014-v2-r3-l1-binding-plan.md` (converged through Opus GO + Codex R10; grammar/store/API contracts locked there).

## What's in

- **`src/engine/key-locker/binding.ts`** — the frozen binding-URI grammar (`ssh://` / `sudo://` / `https-cred://` / opaque `sshkey:`), parser with typed rejects (no partial parse), display serializer, canonical-key derivation. The ssh canonical embeds the known_hosts **fingerprint set**, so a drifted recorded host identity changes the key and the store misses — no autofill (the wrong-target defense at the lookup layer).
- **`src/engine/key-locker/ssh-resolve.ts`** — `ssh -G` with the invocation's own options passed through (`-p`/`-l`/`-F`/`-o`/`HostKeyAlias` all change the endpoint), then `ssh-keygen -l -F` unioned over every user + global known_hosts file ssh itself would consult; absent files are skipped as empty; an empty union fails closed as `host-not-known`.
- **`src/engine/key-locker/command-derivation.ts`** — async `deriveBinding(cmd, session={execHost,isRemote,cwd})`: pure classification core + async resolvers. sudo uses the closed cannot-prompt set (everything else derives; a spurious derive is blocked later by the exit-0 save gate); git resolves the **effective** remote (`branch.<cur>.pushRemote` → `remote.pushDefault` → `branch.<cur>.remote` → `origin`), never a hard-coded `origin`; remote-pane git and nested `ssh host sudo …` defer to L3; ambiguity → `null` (never guess).
- **`src/engine/key-locker/binding-store.ts`** — `bindings.json` (holds **no secret**: URIs, public fingerprints, opaque ids) co-located with the locker store dir; atomic tmp+rename saves; `resolve` verifies against the locker's `exists()` and prunes stale rows; management-only mode throws a typed `LockerNotBound`.

## Tests (plan acceptance #1–#7, all green: 78 new, unit suite 4179 passed)

- Grammar table incl. URI-safety round-trips (base64 `+`/`/` in `sshkey:`, email git usernames) and typed rejects.
- Real `ssh -G` + `ssh-keygen -l -F` against temp fixtures (config alias, `-p`/`-l`/`-F` passthrough, `HostKeyAlias`, custom + global-only known_hosts), with an OpenSSH-absent skip path.
- Acceptance-critical recorded-identity drift: bind under FP1, rotate known_hosts to FP2 ⇒ canonical differs ⇒ store misses ⇒ no autofill (+ positive control).
- sudo session-host (remote pane does not collapse to localhost), derivation table with real git fixture repos (effective-remote precedence incl. non-origin `pushRemote`), store CRUD/reconcile/atomicity/corrupt-file tolerance.

## Out of scope (later slices)

Injection (L2), capture-on-use loop + session-context tracking (L3), MCP tool surface (L4). No new public tool ⇒ no catalogue delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
