### PR TITLE
ADR-014 v2 R3 Key Locker — L3 §4: InjectTarget assembly

### DIFF
--- a/src/engine/key-locker-host.ts
+++ b/src/engine/key-locker-host.ts
@@ -97,7 +97,7 @@ export interface LockerReply {
 
 // L2 wire contracts (the locker owns these frame shapes; the injector orchestrator consumes them).
 
-/** The dedicated-conhost target of a SendInput (`inject`) — §2.1 of the L2 plan. */
+/** The dedicated-console target of a SendInput (`inject`) — §2.1 of the L2 plan. */
 export interface InjectTarget {
   /** The console window HWND (decimal string). */
   hwnd: string;
@@ -413,7 +413,7 @@ export class KeyLockerHost {
   }
 
   /**
-   * SendInput the secret stored under `key` into a dedicated conhost `target`, AFTER the locker
+   * SendInput the secret stored under `key` into a dedicated console `target`, AFTER the locker
    * re-verifies the target at the injection instant (§2.2: HWND/consolePid, ConsoleWindowClass,
    * foreground, titleFp). The secret NEVER crosses the pipe — only {injected, verified} come back;
    * an abort returns the typed reason.

--- a/src/engine/key-locker-host.ts
+++ b/src/engine/key-locker-host.ts
@@ -101,7 +101,13 @@ export interface LockerReply {
 export interface InjectTarget {
   /** The console window HWND (decimal string). */
   hwnd: string;
-  /** The console-HOST (conhost.exe) pid that owns the window — NOT the child pid (§2.2). */
+  /**
+   * The pid that OWNS the console window — whatever `GetWindowThreadProcessId(hwnd)` returns for the
+   * `ConsoleWindowClass` window. L3 supplies `getWindowProcessId(hwnd)` and the locker re-verifies
+   * with the SAME API on the same hwnd, so the value matches by CONSTRUCTION (L3 plan §4). The
+   * `ConsoleWindowClass` allowlist is what excludes a WT multiplexer; this is the window-owning pid,
+   * not asserted to be a specific conhost-vs-shell process (Opus R1 P3-1).
+   */
   consolePid: number;
   /** Opaque hash of the expected pane identity (secondary anchor). */
   titleFp: string;

--- a/src/engine/key-locker/inject-target.ts
+++ b/src/engine/key-locker/inject-target.ts
@@ -1,0 +1,55 @@
+// ADR-014 v2 R3 Key Locker — L3 §4: InjectTarget assembly for the `pane` (SendInput) channel.
+//
+// Plan: desktop-touch-mcp-internal@<plan>:docs/adr-014-v2-r3-l3-capture-plan.md (§4, THE LOCKED
+// CONTRACT #4)
+//
+// For a pane SendInput injection L3 must hand the locker an `InjectTarget {hwnd, consolePid, titleFp,
+// submit}` (L2 §2.1). The hwnd is already in hand — the terminal/tool layer that observed the
+// credential prompt located the console window — so this module only reads the two derived fields
+// (consolePid, titleFp) via the SAME Win32 APIs the locker re-verifies with, so both match by
+// CONSTRUCTION (no TOCTOU on the identity, only the intended abort if the window changes between
+// derive and inject):
+//   * consolePid = getWindowProcessId(hwnd)          — the window-owning pid (shell for a pseudoconsole)
+//   * titleFp    = sha256hex(utf8(GetWindowTextW))   — byte-identical to Injection.cs `TitleFp`
+//
+// This module holds no secret and does no I/O beyond the two read-only Win32 queries. Channel
+// selection (pane vs askpass vs git-credential) and `submit` classification are the capture-loop's
+// job (§4 second half / §5 detection); this module is handed the resolved hwnd + submit flag.
+
+import { createHash } from "node:crypto";
+import { getWindowProcessId, getWindowTitleW } from "../win32.js";
+import type { InjectTarget } from "../key-locker-host.js";
+
+/**
+ * The window-title fingerprint the C# locker recomputes at the injection instant
+ * (`Injection.cs` `TitleFp`): the lowercase hex SHA-256 of the UTF-8 bytes of `GetWindowTextW(hwnd)`.
+ *
+ * This MUST stay byte-identical to the C# side (`Convert.ToHexString(SHA256.HashData(
+ * Encoding.UTF8.GetBytes(title))).ToLowerInvariant()`) — a divergence would abort every injection
+ * with `target_mismatch`. Both sides read the title with `GetWindowTextW`, so the input string is the
+ * same; both hash its UTF-8 bytes; `digest("hex")` is already lowercase. Non-secret.
+ */
+export function titleFingerprint(title: string): string {
+  return createHash("sha256").update(title, "utf8").digest("hex");
+}
+
+/**
+ * Assemble the `pane` InjectTarget for a resolved console window (L3 plan §4). Returns `null` when the
+ * window is gone / the hwnd is invalid (`getWindowProcessId` yields 0 — PID 0 never owns a console
+ * window): there is no valid target, so the caller DECLINES rather than round-tripping a garbage
+ * target (whose `titleFp` would be `sha256("")`) to the locker.
+ *
+ * `hwnd` is serialized as a DECIMAL integer string (the `InjectTarget.hwnd` contract; the locker's
+ * `ParseLong` accepts a decimal string or number). `submit` appends Enter after the secret for a
+ * line-oriented echo-off prompt; it is only emitted when true (the field is optional).
+ */
+export function assembleInjectTarget(hwnd: bigint, submit: boolean): InjectTarget | null {
+  const consolePid = getWindowProcessId(hwnd);
+  if (consolePid === 0) return null; // window gone / invalid hwnd — no target, caller declines
+  return {
+    hwnd: hwnd.toString(10),
+    consolePid,
+    titleFp: titleFingerprint(getWindowTitleW(hwnd)),
+    ...(submit ? { submit: true } : {}),
+  };
+}

--- a/src/engine/key-locker/injector.ts
+++ b/src/engine/key-locker/injector.ts
@@ -5,7 +5,7 @@
 //
 // Three injectors (D4(iii) has two transports — askpass stdout + git credential protocol — that share
 // machinery) behind one decision:
-//   * SendInput → pane  — the LOCKER types the secret into a dedicated conhost after an injection-
+//   * SendInput → pane  — the LOCKER types the secret into a dedicated console after an injection-
 //     instant re-verify (secret never leaves the locker).
 //   * askpass streaming — a compiled helper streams the secret locker→consumer off the MCP path,
 //     authorized by a single-use ticket; the engine only assembles the env/git-config.

--- a/src/win32/window.rs
+++ b/src/win32/window.rs
@@ -13,8 +13,8 @@ use windows::core::{BOOL, PCWSTR};
 use windows::Win32::Foundation::{HWND, LPARAM, RECT};
 use windows::Win32::UI::WindowsAndMessaging::{
     EnumWindows, FindWindowExW, GetAncestor, GetClassNameW, GetForegroundWindow,
-    GetWindowLongPtrW, GetWindowRect, GetWindowTextW, GetWindowThreadProcessId, IsIconic,
-    IsWindowVisible, IsZoomed, GA_ROOT, WINDOW_LONG_PTR_INDEX,
+    GetWindowLongPtrW, GetWindowRect, GetWindowTextLengthW, GetWindowTextW, GetWindowThreadProcessId,
+    IsIconic, IsWindowVisible, IsZoomed, GA_ROOT, WINDOW_LONG_PTR_INDEX,
 };
 
 use super::safety::{napi_safe_call, PANIC_COUNTER};
@@ -208,10 +208,19 @@ pub fn win32_get_window_long_ptr_w(hwnd: BigInt, n_index: i32) -> napi::Result<i
 /// Get a window's title via `GetWindowTextW`. Returns `""` on failure or
 /// when the window has no title.
 ///
-/// Buffer is 512 wchars to match the existing TS behaviour (Windows itself
-/// truncates very long titles at 256-512 chars in practice).
+/// The buffer is sized from `GetWindowTextLengthW`, NOT a fixed 512 wchars, so a
+/// long title is read in FULL. This matches the key-locker's `TitleFp`
+/// (`tools/key-locker/Injection.cs`), which sizes its buffer the same way and
+/// hashes the whole title: a truncated read here would hash differently and abort
+/// every SendInput injection with `target_mismatch` for a long-titled console
+/// (Codex #496 P2). `GetWindowTextLengthW` may over-report, so the actual count
+/// returned by `GetWindowTextW` remains authoritative for the slice.
 pub(crate) fn get_window_text(hwnd: HWND) -> String {
-    let mut buf = [0u16; 512];
+    let text_len = unsafe { GetWindowTextLengthW(hwnd) };
+    if text_len <= 0 {
+        return String::new();
+    }
+    let mut buf = vec![0u16; text_len as usize + 1]; // +1 for the NUL GetWindowTextW writes
     let len = unsafe { GetWindowTextW(hwnd, &mut buf) };
     if len <= 0 {
         String::new()

--- a/tests/unit/key-locker-inject-target.test.ts
+++ b/tests/unit/key-locker-inject-target.test.ts
@@ -1,0 +1,79 @@
+// ADR-014 v2 R3 Key Locker — L3 §4 InjectTarget assembly. Two concerns:
+//   1. `titleFingerprint` is byte-identical to the C# locker's `Injection.cs` `TitleFp` — pinned
+//      against expected hex computed INDEPENDENTLY with .NET (`[SHA256]::HashData(UTF8.GetBytes(t))`,
+//      lowercased hex), so a divergence in the algorithm/encoding is caught here rather than as a
+//      `target_mismatch` abort at inject time.
+//   2. `assembleInjectTarget` reads consolePid/titleFp via win32 and declines (null) on a gone window.
+// Plan: desktop-touch-mcp-internal@<plan>:docs/adr-014-v2-r3-l3-capture-plan.md (§4)
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const getWindowProcessId = vi.fn<(hwnd: unknown) => number>();
+const getWindowTitleW = vi.fn<(hwnd: unknown) => string>();
+
+vi.mock("../../src/engine/win32.js", () => ({
+  getWindowProcessId: (hwnd: unknown) => getWindowProcessId(hwnd),
+  getWindowTitleW: (hwnd: unknown) => getWindowTitleW(hwnd),
+}));
+
+const { titleFingerprint, assembleInjectTarget } = await import(
+  "../../src/engine/key-locker/inject-target.js"
+);
+
+// Expected values computed independently with .NET (the C# side):
+//   [Convert]::ToHexString([SHA256]::HashData([Text.Encoding]::UTF8.GetBytes($t))).ToLowerInvariant()
+// The empty-string digest is the well-known SHA-256 of empty input.
+const KNOWN_TITLE_FP: Array<[string, string]> = [
+  ["", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"],
+  ["Administrator: Windows PowerShell", "d26d14f0263a47f3a31d10eb995fa1d073a63eb79c6f7502e3bd8902cd7ea13f"],
+  ["ターミナル - pwsh", "154bdccbdbfb05d09049830ffafa8380f4b93e0d7487ad985978afbe54f69c57"],
+  ["user@host:~/work$ ", "c3cdc582763da3938b23333ed6cb3f5dbe75808c7df035009ef9bbd945b6c6bb"],
+];
+
+describe("titleFingerprint — byte-identical to C# Injection.cs TitleFp", () => {
+  for (const [title, expected] of KNOWN_TITLE_FP) {
+    it(`sha256(utf8(${JSON.stringify(title)})) === ${expected.slice(0, 12)}…`, () => {
+      expect(titleFingerprint(title)).toBe(expected);
+    });
+  }
+
+  it("is lowercase hex (locker compares case-sensitively)", () => {
+    const fp = titleFingerprint("MixedCase Title");
+    expect(fp).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("assembleInjectTarget — §4 pane target", () => {
+  beforeEach(() => {
+    getWindowProcessId.mockReset();
+    getWindowTitleW.mockReset();
+  });
+
+  it("assembles {hwnd(decimal), consolePid, titleFp} from the SAME win32 reads the locker re-verifies", () => {
+    getWindowProcessId.mockReturnValue(4242);
+    getWindowTitleW.mockReturnValue("Administrator: Windows PowerShell");
+    const t = assembleInjectTarget(0x1234n, false);
+    expect(t).toEqual({
+      hwnd: "4660", // 0x1234 in decimal — the InjectTarget.hwnd contract
+      consolePid: 4242,
+      titleFp: "d26d14f0263a47f3a31d10eb995fa1d073a63eb79c6f7502e3bd8902cd7ea13f",
+    });
+    // consolePid + titleFp both read from the SAME hwnd the caller passed.
+    expect(getWindowProcessId).toHaveBeenCalledWith(0x1234n);
+    expect(getWindowTitleW).toHaveBeenCalledWith(0x1234n);
+  });
+
+  it("emits submit:true only when requested (optional field otherwise omitted)", () => {
+    getWindowProcessId.mockReturnValue(100);
+    getWindowTitleW.mockReturnValue("t");
+    expect(assembleInjectTarget(1n, true)).toMatchObject({ submit: true });
+    expect(assembleInjectTarget(1n, false)).not.toHaveProperty("submit");
+  });
+
+  it("declines (null) when the window is gone / hwnd invalid (getWindowProcessId === 0)", () => {
+    getWindowProcessId.mockReturnValue(0);
+    getWindowTitleW.mockReturnValue("stale");
+    expect(assembleInjectTarget(0xdeadn, true)).toBeNull();
+    // A gone window must NOT round-trip a garbage target (sha256("") titleFp) to the locker.
+    expect(getWindowTitleW).not.toHaveBeenCalled();
+  });
+});

--- a/tools/key-locker/Injection.cs
+++ b/tools/key-locker/Injection.cs
@@ -17,7 +17,10 @@ using System.Text.Json;
 // Global namespace (matches Program.cs's `internal static class KeyLocker`; a `namespace KeyLocker`
 // here would collide with that class name).
 
-/// The dedicated-conhost target of a SendInput, parsed off the `inject` frame's `t` field (§2.1).
+/// The dedicated-console target of a SendInput, parsed off the `inject` frame's `t` field (§2.1).
+/// `ConsolePid` is the WINDOW-OWNING pid (`GetWindowThreadProcessId(hwnd)`) — L3 sends
+/// `getWindowProcessId(hwnd)` and this side re-reads the same API on the same hwnd, so it matches by
+/// construction (not asserted to be a specific conhost-vs-shell process).
 internal readonly record struct InjectTarget(nint Hwnd, uint ConsolePid, string TitleFp, bool Submit);
 
 /// The abort reasons the re-verify predicate can raise (§2.2); null = passed.
@@ -59,7 +62,7 @@ internal static class Win32Input
 
     /// Re-verify the target at the injection instant (§2.2). Returns an InjectAbort code on any
     /// mismatch, or null if all predicates pass. POSITIVE allowlist: the window MUST be the classic
-    /// console class AND owned by the tracked conhost pid — anything else is `target_multiplexed`.
+    /// console class AND owned by the tracked window-owning pid — anything else is `target_multiplexed`.
     private static string? ReVerify(in InjectTarget t)
     {
         if (t.Hwnd == 0 || !IsWindow(t.Hwnd)) return InjectAbort.Gone;

--- a/tools/key-locker/Injection.cs
+++ b/tools/key-locker/Injection.cs
@@ -37,7 +37,7 @@ internal static class InjectAbort
 /// target be re-checked at the SEND instant, inside the locker, immediately before the first key.
 internal static class Win32Input
 {
-    private const string ConsoleClass = "ConsoleWindowClass"; // the classic conhost window class
+    private const string ConsoleClass = "ConsoleWindowClass"; // the console window-class name (class-name origin, not a pid claim — intentionally retained through the R1 P3-1 conhost doc-fix)
 
     [StructLayout(LayoutKind.Sequential)]
     private struct INPUT { public uint type; public InputUnion U; }


### PR DESCRIPTION
## What

L3 §4 (LOCKED CONTRACT #4) — the `pane` SendInput target assembly for the Key Locker capture-on-use loop. One small engine module + unit tests.

`assembleInjectTarget(hwnd, submit): InjectTarget | null`
- `hwnd` → decimal string (the `InjectTarget.hwnd` contract; the locker's `ParseLong` accepts a decimal string).
- `consolePid` = `getWindowProcessId(hwnd)` — the window-owning pid.
- `titleFp` = `sha256hex(utf8(GetWindowTextW(hwnd)))` — read via the SAME Win32 APIs the locker re-verifies with, so both match by construction (a title change between derive and inject aborts `target_mismatch`).
- Declines (`null`) when the window is gone / hwnd invalid (`getWindowProcessId === 0`) — no garbage target (whose `titleFp` would be `sha256("")`) is round-tripped to the locker.

`titleFingerprint(title)` is **byte-identical to `Injection.cs` `TitleFp`** — pinned in the test against expected hex computed **independently with .NET** (`[SHA256]::HashData([Text.Encoding]::UTF8.GetBytes(t))`, lowercased hex), including a CJK title, so an encoding/algorithm drift is caught here rather than as a silent inject-time abort.

## Scope / design notes

- Channel selection (`pane`/`askpass`/`git-credential`) and `submit` classification stay in the capture-loop (§4 second half / §5 detection); this module is handed the resolved hwnd + submit flag.
- **No engine→tools import**: the tool layer that observed the credential prompt already located the console window, so it passes the hwnd down — `inject-target.ts` does not import `findTerminalWindow` from `src/tools/`.

## Tests

`tests/unit/key-locker-inject-target.test.ts` — 8 tests: 4 cross-language byte-match fingerprints (incl. empty + CJK) + lowercase-hex shape + assembly (decimal hwnd, same-hwnd reads, optional `submit`, gone-window decline).

Build clean, lint clean, 8/8 green.

Plan: `desktop-touch-mcp-internal@<sha>:docs/adr-014-v2-r3-l3-capture-plan.md` (§4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)