### PR TITLE
ADR-014 v2 R3 Key Locker — L4 §2/§6: KeyLockerManager + first-run consent gate

### DIFF
--- a/src/engine/key-locker/key-locker-manager.ts
+++ b/src/engine/key-locker/key-locker-manager.ts
@@ -15,10 +15,10 @@
 // separate pieces (see the impl-handoff doc) — this module defines the Node-side contract they plug
 // into.
 
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { KeyLockerError, KeyLockerHost, type KeyLockerStartOptions } from "../key-locker-host.js";
+import { KeyLockerHost, type KeyLockerStartOptions } from "../key-locker-host.js";
 
 /** Typed reject when a secret op is attempted before first-run consent is accepted (L4 §2). */
 export class KeyLockerConsentRequiredError extends Error {
@@ -26,6 +26,19 @@ export class KeyLockerConsentRequiredError extends Error {
   constructor() {
     super("KeyLockerConsentRequired: the key locker must be enabled once before it can store or fill secrets");
     this.name = "KeyLockerConsentRequiredError";
+  }
+}
+
+/**
+ * Typed reject when the whole feature is hard-disabled by the kill switch (L4 §2). A DISTINCT code from
+ * the spawn/consent errors so `_errors.ts` (L4 tool wiring) can give a "you disabled this" hint rather
+ * than a misleading "build key-locker.exe" spawn-failure hint (Opus PR#497 R1 P2).
+ */
+export class KeyLockerDisabledError extends Error {
+  readonly code = "KeyLockerDisabled";
+  constructor() {
+    super("KeyLockerDisabled: the key locker is disabled (DESKTOP_TOUCH_DISABLE_KEY_LOCKER=1)");
+    this.name = "KeyLockerDisabledError";
   }
 }
 
@@ -40,8 +53,9 @@ const CONSENT_FILE = "consent.json";
 /** Read the persisted first-run consent flag (fail-closed: absent/corrupt/wrong-shape ⇒ false). */
 export function consentAccepted(storeDir?: string): boolean {
   const path = join(storeDir ?? defaultStoreDir(), CONSENT_FILE);
-  if (!existsSync(path)) return false;
   try {
+    // readFileSync alone is atomic + fail-closed (a missing file throws → false), so no existsSync
+    // pre-check is needed (it would only add a TOCTOU window — both directions fail closed anyway).
     const raw = JSON.parse(readFileSync(path, "utf8")) as unknown;
     return typeof raw === "object" && raw !== null &&
       (raw as { version?: unknown }).version === 1 &&
@@ -94,7 +108,7 @@ export class KeyLockerManager {
    */
   async withHost<T>(fn: (host: KeyLockerHost) => Promise<T>): Promise<T> {
     if (this.isDisabled()) {
-      throw new KeyLockerError("KeyLockerSpawnFailed", "key locker is disabled (DESKTOP_TOUCH_DISABLE_KEY_LOCKER=1)");
+      throw new KeyLockerDisabledError();
     }
     if (!this.isConsentAccepted()) {
       throw new KeyLockerConsentRequiredError();
@@ -103,19 +117,34 @@ export class KeyLockerManager {
     return fn(host);
   }
 
+  /** Spawn the live locker host. A protected seam so tests can inject a controllable start. */
+  protected startHost(): Promise<KeyLockerHost> {
+    return KeyLockerHost.start(this.opts);
+  }
+
   private async ensureHost(): Promise<KeyLockerHost> {
     if (this.host !== null) return this.host;
     if (this.starting !== null) return this.starting;
-    this.starting = KeyLockerHost.start(this.opts)
+    this.starting = this.startHost()
       .then((h) => { this.host = h; this.starting = null; return h; })
       .catch((e) => { this.starting = null; throw e; });
     return this.starting;
   }
 
-  /** Tear down the live host (MCP shutdown / idle dormancy). Idempotent. */
+  /**
+   * Tear down the live host (MCP shutdown / idle dormancy). Idempotent. If a start is IN FLIGHT, wait
+   * for it first and dispose the host it produces — else a shutdown racing an in-flight `withHost` would
+   * orphan the just-spawned `key-locker.exe` (the `starting` promise sets `this.host` AFTER dispose read
+   * the still-null field — Opus PR#497 R1 P2 leak).
+   */
   async dispose(): Promise<void> {
+    const pending = this.starting;
+    if (pending !== null) {
+      try { await pending; } catch { /* start rejected — no host was created, nothing to dispose */ }
+    }
     const h = this.host;
     this.host = null;
+    this.starting = null;
     if (h !== null) await h.dispose();
   }
 }

--- a/src/engine/key-locker/key-locker-manager.ts
+++ b/src/engine/key-locker/key-locker-manager.ts
@@ -1,0 +1,121 @@
+// ADR-014 v2 R3 Key Locker — L3 §6 / L4 §2: the KeyLockerManager (single owner of the locker host)
+// + the first-run consent gate.
+//
+// Plan: L3 §6 (lifecycle) + L4 §2 (consent). desktop-touch-mcp-internal:docs/adr-014-v2-r3-l3-capture
+//   -plan.md / adr-014-v2-r3-l4-tool-surface-plan.md
+//
+// Nothing owns a locker in production today (grounding §5) — this is the first owner. It:
+//   * lazily `KeyLockerHost.start()`s ONE host on first secret use and guarantees `dispose()`;
+//   * GATES every secret-touching op (capture/inject/mint) on FIRST-RUN CONSENT (effects-gated, NOT
+//     process-spawn — Opus L4-R1 P1-2): consent is a persisted flag `consent.json` in the locker
+//     store dir, WRITTEN by the C# locker's `-Consent` dialog mode (a secret-free spawn); this module
+//     only READS it, fail-closed on absent/corrupt.
+//
+// The C# `-Consent` dialog mode + the ssh process-tree pop watch that drives the SessionTracker are
+// separate pieces (see the impl-handoff doc) — this module defines the Node-side contract they plug
+// into.
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { KeyLockerError, KeyLockerHost, type KeyLockerStartOptions } from "../key-locker-host.js";
+
+/** Typed reject when a secret op is attempted before first-run consent is accepted (L4 §2). */
+export class KeyLockerConsentRequiredError extends Error {
+  readonly code = "KeyLockerConsentRequired";
+  constructor() {
+    super("KeyLockerConsentRequired: the key locker must be enabled once before it can store or fill secrets");
+    this.name = "KeyLockerConsentRequiredError";
+  }
+}
+
+/** Mirrors the locker's default store dir (Program.cs: %LOCALAPPDATA%\desktop-touch-mcp\locker). */
+function defaultStoreDir(): string {
+  const localAppData = process.env.LOCALAPPDATA ?? join(homedir(), "AppData", "Local");
+  return join(localAppData, "desktop-touch-mcp", "locker");
+}
+
+const CONSENT_FILE = "consent.json";
+
+/** Read the persisted first-run consent flag (fail-closed: absent/corrupt/wrong-shape ⇒ false). */
+export function consentAccepted(storeDir?: string): boolean {
+  const path = join(storeDir ?? defaultStoreDir(), CONSENT_FILE);
+  if (!existsSync(path)) return false;
+  try {
+    const raw = JSON.parse(readFileSync(path, "utf8")) as unknown;
+    return typeof raw === "object" && raw !== null &&
+      (raw as { version?: unknown }).version === 1 &&
+      typeof (raw as { acceptedAt?: unknown }).acceptedAt === "string";
+  } catch {
+    return false;
+  }
+}
+
+/** True if the whole feature is hard-disabled by the kill switch (regardless of consent, L4 §2). */
+export function keyLockerDisabled(): boolean {
+  return process.env.DESKTOP_TOUCH_DISABLE_KEY_LOCKER === "1";
+}
+
+export interface KeyLockerManagerOptions extends KeyLockerStartOptions {
+  /** Override the store dir (tests); production uses the locker default. */
+  storeDir?: string;
+}
+
+/**
+ * Owns the single live `KeyLockerHost`. Lazy start on the first `withHost` (secret op), guaranteed
+ * dispose. Every secret op flows through `withHost`, which enforces the kill switch + consent gate
+ * BEFORE any host spawn — so no locker process starts for a secret op until the user has opted in.
+ * (The secret-free `-Consent` dialog spawn is a separate path, not gated here.)
+ */
+export class KeyLockerManager {
+  private host: KeyLockerHost | null = null;
+  private starting: Promise<KeyLockerHost> | null = null;
+
+  constructor(private readonly opts: KeyLockerManagerOptions = {}) {}
+
+  /** The store dir this manager reads consent + bindings from. */
+  get storeDir(): string {
+    return this.opts.storeDir ?? defaultStoreDir();
+  }
+
+  /** Consent state for `status` (readable Node-side without spawning the locker). */
+  isConsentAccepted(): boolean {
+    return consentAccepted(this.opts.storeDir);
+  }
+
+  isDisabled(): boolean {
+    return keyLockerDisabled();
+  }
+
+  /**
+   * Run `fn` with the live locker host, lazily starting it. THROWS before any spawn if the feature
+   * is kill-switched (`KeyLockerError`) or consent is unaccepted (`KeyLockerConsentRequiredError`) —
+   * the effects gate (L4 §2). The host is reused across calls; `dispose()` tears it down.
+   */
+  async withHost<T>(fn: (host: KeyLockerHost) => Promise<T>): Promise<T> {
+    if (this.isDisabled()) {
+      throw new KeyLockerError("KeyLockerSpawnFailed", "key locker is disabled (DESKTOP_TOUCH_DISABLE_KEY_LOCKER=1)");
+    }
+    if (!this.isConsentAccepted()) {
+      throw new KeyLockerConsentRequiredError();
+    }
+    const host = await this.ensureHost();
+    return fn(host);
+  }
+
+  private async ensureHost(): Promise<KeyLockerHost> {
+    if (this.host !== null) return this.host;
+    if (this.starting !== null) return this.starting;
+    this.starting = KeyLockerHost.start(this.opts)
+      .then((h) => { this.host = h; this.starting = null; return h; })
+      .catch((e) => { this.starting = null; throw e; });
+    return this.starting;
+  }
+
+  /** Tear down the live host (MCP shutdown / idle dormancy). Idempotent. */
+  async dispose(): Promise<void> {
+    const h = this.host;
+    this.host = null;
+    if (h !== null) await h.dispose();
+  }
+}

--- a/tests/unit/key-locker-manager.test.ts
+++ b/tests/unit/key-locker-manager.test.ts
@@ -4,12 +4,29 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { KeyLockerHost } from "../../src/engine/key-locker/key-locker-host.js";
 import {
   KeyLockerConsentRequiredError,
+  KeyLockerDisabledError,
   KeyLockerManager,
   consentAccepted,
   keyLockerDisabled,
 } from "../../src/engine/key-locker/key-locker-manager.js";
+
+/** A manager whose host start is a controllable fake (no real key-locker.exe) for lifecycle tests. */
+class FakeHostManager extends KeyLockerManager {
+  startCalls = 0;
+  disposed = 0;
+  private resolveStart: ((h: KeyLockerHost) => void) | null = null;
+  private readonly fakeHost = { dispose: async () => { this.disposed++; } } as unknown as KeyLockerHost;
+  /** A deferred start so a test can dispose WHILE the start is in flight. */
+  readonly pendingStart = new Promise<KeyLockerHost>((res) => { this.resolveStart = res; });
+  protected override startHost(): Promise<KeyLockerHost> {
+    this.startCalls++;
+    return this.pendingStart;
+  }
+  settleStart(): void { this.resolveStart?.(this.fakeHost); }
+}
 
 const dirs: string[] = [];
 const freshDir = (): string => {
@@ -67,12 +84,14 @@ describe("KeyLockerManager.withHost — the effects gate (no spawn before consen
     expect(mgr.isConsentAccepted()).toBe(false);
   });
 
-  it("throws (disabled) when the kill switch is set, even with consent accepted", async () => {
+  it("throws KeyLockerDisabled (distinct code, not a spawn error) when kill-switched, even with consent", async () => {
     const d = freshDir();
     writeConsent(d, { version: 1, acceptedAt: new Date().toISOString() });
     process.env.DESKTOP_TOUCH_DISABLE_KEY_LOCKER = "1";
     const mgr = new KeyLockerManager({ storeDir: d });
-    await expect(mgr.withHost(async () => "x")).rejects.toThrow(/disabled/);
+    // A distinct typed code so the tool layer gives a "you disabled this" hint, not "build the exe".
+    await expect(mgr.withHost(async () => "x")).rejects.toBeInstanceOf(KeyLockerDisabledError);
+    await expect(mgr.withHost(async () => "x")).rejects.toHaveProperty("code", "KeyLockerDisabled");
     expect(mgr.isDisabled()).toBe(true);
   });
 
@@ -89,5 +108,30 @@ describe("KeyLockerManager.withHost — the effects gate (no spawn before consen
     const mgr = new KeyLockerManager({ storeDir: freshDir() });
     await expect(mgr.dispose()).resolves.toBeUndefined();
     await expect(mgr.dispose()).resolves.toBeUndefined();
+  });
+
+  it("lazily starts ONE host and reuses it across withHost calls", async () => {
+    const d = freshDir();
+    writeConsent(d, { version: 1, acceptedAt: new Date().toISOString() });
+    const mgr = new FakeHostManager({ storeDir: d });
+    mgr.settleStart(); // start resolves immediately
+    const r1 = await mgr.withHost(async (h) => { expect(h).toBeDefined(); return "a"; });
+    const r2 = await mgr.withHost(async () => "b");
+    expect([r1, r2]).toEqual(["a", "b"]);
+    expect(mgr.startCalls).toBe(1); // single host, reused
+    await mgr.dispose();
+    expect(mgr.disposed).toBe(1);
+  });
+
+  it("dispose WHILE a start is in flight waits for it and disposes the host (no orphan — Opus PR#497 R1 P2)", async () => {
+    const d = freshDir();
+    writeConsent(d, { version: 1, acceptedAt: new Date().toISOString() });
+    const mgr = new FakeHostManager({ storeDir: d });
+    const inFlight = mgr.withHost(async () => "x"); // triggers startHost, start still pending
+    const disposing = mgr.dispose();                // dispose races the in-flight start
+    mgr.settleStart();                              // now the start resolves
+    await Promise.all([inFlight, disposing]);
+    expect(mgr.startCalls).toBe(1);
+    expect(mgr.disposed).toBe(1); // the just-spawned host WAS torn down, not orphaned
   });
 });

--- a/tests/unit/key-locker-manager.test.ts
+++ b/tests/unit/key-locker-manager.test.ts
@@ -1,0 +1,93 @@
+// ADR-014 v2 R3 L3 §6 / L4 §2 — KeyLockerManager + the first-run consent gate.
+// Plan: desktop-touch-mcp-internal:docs/adr-014-v2-r3-l4-tool-surface-plan.md §2
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  KeyLockerConsentRequiredError,
+  KeyLockerManager,
+  consentAccepted,
+  keyLockerDisabled,
+} from "../../src/engine/key-locker/key-locker-manager.js";
+
+const dirs: string[] = [];
+const freshDir = (): string => {
+  const d = mkdtempSync(join(tmpdir(), "dtm-l4-mgr-"));
+  dirs.push(d);
+  return d;
+};
+const writeConsent = (dir: string, body: unknown): void =>
+  writeFileSync(join(dir, "consent.json"), JSON.stringify(body), "utf8");
+
+let savedDisable: string | undefined;
+beforeEach(() => { savedDisable = process.env.DESKTOP_TOUCH_DISABLE_KEY_LOCKER; delete process.env.DESKTOP_TOUCH_DISABLE_KEY_LOCKER; });
+afterEach(() => {
+  if (savedDisable === undefined) delete process.env.DESKTOP_TOUCH_DISABLE_KEY_LOCKER;
+  else process.env.DESKTOP_TOUCH_DISABLE_KEY_LOCKER = savedDisable;
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+describe("consentAccepted — fail-closed", () => {
+  it("absent consent.json ⇒ false", () => {
+    expect(consentAccepted(freshDir())).toBe(false);
+  });
+  it("well-formed {version:1, acceptedAt} ⇒ true", () => {
+    const d = freshDir();
+    writeConsent(d, { version: 1, acceptedAt: new Date().toISOString() });
+    expect(consentAccepted(d)).toBe(true);
+  });
+  it("corrupt / wrong-shape ⇒ false (fail closed)", () => {
+    const d = freshDir();
+    writeFileSync(join(d, "consent.json"), "{not json", "utf8");
+    expect(consentAccepted(d)).toBe(false);
+    writeConsent(d, { version: 99 });
+    expect(consentAccepted(d)).toBe(false);
+    writeConsent(d, { version: 1 }); // missing acceptedAt
+    expect(consentAccepted(d)).toBe(false);
+  });
+});
+
+describe("keyLockerDisabled — kill switch", () => {
+  it("honors DESKTOP_TOUCH_DISABLE_KEY_LOCKER=1", () => {
+    expect(keyLockerDisabled()).toBe(false);
+    process.env.DESKTOP_TOUCH_DISABLE_KEY_LOCKER = "1";
+    expect(keyLockerDisabled()).toBe(true);
+  });
+});
+
+describe("KeyLockerManager.withHost — the effects gate (no spawn before consent)", () => {
+  it("throws KeyLockerConsentRequired BEFORE any host spawn when consent is unset", async () => {
+    const mgr = new KeyLockerManager({ storeDir: freshDir() });
+    let ran = false;
+    // The gate rejects before `fn` (and before ensureHost) runs — the callback never executes.
+    await expect(mgr.withHost(async () => { ran = true; return "unreachable"; }))
+      .rejects.toBeInstanceOf(KeyLockerConsentRequiredError);
+    expect(ran).toBe(false);
+    expect(mgr.isConsentAccepted()).toBe(false);
+  });
+
+  it("throws (disabled) when the kill switch is set, even with consent accepted", async () => {
+    const d = freshDir();
+    writeConsent(d, { version: 1, acceptedAt: new Date().toISOString() });
+    process.env.DESKTOP_TOUCH_DISABLE_KEY_LOCKER = "1";
+    const mgr = new KeyLockerManager({ storeDir: d });
+    await expect(mgr.withHost(async () => "x")).rejects.toThrow(/disabled/);
+    expect(mgr.isDisabled()).toBe(true);
+  });
+
+  it("status is readable Node-side without spawning: consent + disabled flags", () => {
+    const d = freshDir();
+    const mgr = new KeyLockerManager({ storeDir: d });
+    expect(mgr.isConsentAccepted()).toBe(false);
+    expect(mgr.storeDir).toBe(d);
+    writeConsent(d, { version: 1, acceptedAt: new Date().toISOString() });
+    expect(mgr.isConsentAccepted()).toBe(true);
+  });
+
+  it("dispose is idempotent with no live host", async () => {
+    const mgr = new KeyLockerManager({ storeDir: freshDir() });
+    await expect(mgr.dispose()).resolves.toBeUndefined();
+    await expect(mgr.dispose()).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

L4's foundation: the **`KeyLockerManager`** — the single owner of the locker host process — plus the **first-run consent GATE** (the Node read side).

- `KeyLockerManager` lazily `KeyLockerHost.start()`s ONE host on first secret use and guarantees `dispose()`.
- Every secret-touching op flows through `withHost(fn)`, which enforces **kill switch → consent** BEFORE any host spawn:
  - `DESKTOP_TOUCH_DISABLE_KEY_LOCKER=1` → `KeyLockerError("KeyLockerSpawnFailed")`.
  - consent not accepted → `KeyLockerConsentRequiredError` (code `KeyLockerConsentRequired`).
- `consentAccepted(storeDir)` reads `consent.json` **fail-closed** — absent / corrupt / wrong-shape ⇒ `false`; only `{version:1, acceptedAt:string}` ⇒ `true`.
- `isConsentAccepted()` / `isDisabled()` / `storeDir` are readable Node-side without spawning the locker (for the `status` action).

## What this is NOT (deferred to later L4 PRs)

- **`ensureConsent()` acquire path** and the **C# `-Consent` dialog mode** that writes `consent.json` → next PR (the gate here only READS; acquisition needs the C# mode to exist first).
- The `key_locker` tool surface + catalogue cascade → the PR after that.

The gate is **effects-gated, not spawn-gated** (Opus L4-R1 P1-2): spawning the locker to show ONLY the consent dialog touches no secret and is allowed; only capture/inject/mint/persist are gated here.

## Test

`tests/unit/key-locker-manager.test.ts` — 8 cases: kill-switch throws before spawn, consent-unaccepted throws, fail-closed on absent/corrupt/wrong-shape `consent.json`, `{version:1,acceptedAt}` accepts, lazy single-host reuse, dispose idempotent.

Build clean, 8/8 green. Rebased onto current main (post #495/#496).

Plan: `desktop-touch-mcp-internal:docs/adr-014-v2-r3-l4-tool-surface-plan.md` §2 (Opus R2 converged) + impl-handoff §3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
