### PR TITLE
ADR-014 v2 R3 Key Locker — L4 consent acquisition: C# -Consent mode + ensureConsent()

### DIFF
--- a/src/engine/key-locker-host.ts
+++ b/src/engine/key-locker-host.ts
@@ -40,7 +40,8 @@ import { join, dirname } from "node:path";
 import { registerExcludedPid, unregisterExcludedPid } from "./tool-exclusion.js";
 
 // dist/engine/ -> ../../bin/key-locker.exe (same resolution as bridge-host.ts / ocr-bridge.ts).
-const HELPER_EXE = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "bin", "key-locker.exe");
+// Exported so KeyLockerManager's `-Consent` spawn resolves the SAME exe (single source of truth).
+export const HELPER_EXE = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "bin", "key-locker.exe");
 
 /** Wire protocol version the MCP understands; must match the helper's `hello.v`. */
 export const KEY_LOCKER_PROTOCOL_VERSION = "1";

--- a/src/engine/key-locker/key-locker-manager.ts
+++ b/src/engine/key-locker/key-locker-manager.ts
@@ -15,10 +15,11 @@
 // separate pieces (see the impl-handoff doc) — this module defines the Node-side contract they plug
 // into.
 
+import { spawn } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { KeyLockerHost, type KeyLockerStartOptions } from "../key-locker-host.js";
+import { HELPER_EXE, KeyLockerHost, type KeyLockerStartOptions } from "../key-locker-host.js";
 
 /** Typed reject when a secret op is attempted before first-run consent is accepted (L4 §2). */
 export class KeyLockerConsentRequiredError extends Error {
@@ -84,6 +85,7 @@ export interface KeyLockerManagerOptions extends KeyLockerStartOptions {
 export class KeyLockerManager {
   private host: KeyLockerHost | null = null;
   private starting: Promise<KeyLockerHost> | null = null;
+  private consenting: Promise<void> | null = null; // in-flight `-Consent` dialog (dedupes concurrent prompts)
 
   constructor(private readonly opts: KeyLockerManagerOptions = {}) {}
 
@@ -115,6 +117,35 @@ export class KeyLockerManager {
     }
     const host = await this.ensureHost();
     return fn(host);
+  }
+
+  /**
+   * Acquire first-run consent, prompting the user if needed (the ACQUIRE path; `withHost` only GATES).
+   * The tool's `save` action calls this before capture. Idempotent: if consent is already accepted,
+   * returns true WITHOUT spawning. Otherwise spawns the locker's SECRET-FREE `-Consent` dialog (allowed
+   * pre-consent — the gate is on secret effects, not this spawn), waits for it, and RE-READS the flag as
+   * the source of truth (the C# locker is the sole writer; Node never writes consent.json). Kill-switched
+   * ⇒ throws `KeyLockerDisabledError` and never prompts. Concurrent calls share ONE dialog.
+   */
+  async ensureConsent(): Promise<boolean> {
+    if (this.isDisabled()) throw new KeyLockerDisabledError();
+    if (this.isConsentAccepted()) return true;
+    this.consenting ??= this.spawnConsentDialog().finally(() => { this.consenting = null; });
+    await this.consenting;
+    return this.isConsentAccepted();
+  }
+
+  /**
+   * Spawn `key-locker.exe -Consent` and resolve when it exits (exit code is ignored — `ensureConsent`
+   * re-reads consent.json as the source of truth). A protected seam so tests inject a controllable
+   * dialog without a real exe / GUI.
+   */
+  protected spawnConsentDialog(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const child = spawn(HELPER_EXE, ["-Consent", "-StoreDir", this.storeDir], { windowsHide: false });
+      child.once("error", reject);            // exe missing / spawn failure
+      child.once("exit", () => resolve());     // dialog closed (accepted or declined) — re-read decides
+    });
   }
 
   /** Spawn the live locker host. A protected seam so tests can inject a controllable start. */

--- a/tests/unit/key-locker-manager.test.ts
+++ b/tests/unit/key-locker-manager.test.ts
@@ -13,7 +13,7 @@ import {
   keyLockerDisabled,
 } from "../../src/engine/key-locker/key-locker-manager.js";
 
-/** A manager whose host start is a controllable fake (no real key-locker.exe) for lifecycle tests. */
+/** A manager whose host start + consent dialog are controllable fakes (no real key-locker.exe / GUI). */
 class FakeHostManager extends KeyLockerManager {
   startCalls = 0;
   disposed = 0;
@@ -26,6 +26,19 @@ class FakeHostManager extends KeyLockerManager {
     return this.pendingStart;
   }
   settleStart(): void { this.resolveStart?.(this.fakeHost); }
+
+  // Consent-dialog fake: counts spawns; `onConsent` (test hook) simulates what the C# -Consent dialog
+  // would do on [Enable] (write consent.json); a deferred promise lets a test race concurrent calls.
+  consentCalls = 0;
+  onConsent: (() => void) | null = null;
+  private resolveConsent: (() => void) | null = null;
+  readonly pendingConsent = new Promise<void>((res) => { this.resolveConsent = res; });
+  protected override spawnConsentDialog(): Promise<void> {
+    this.consentCalls++;
+    return this.pendingConsent;
+  }
+  /** Simulate the dialog closing: run the [Enable] side effect (if any), then resolve the spawn. */
+  settleConsent(): void { this.onConsent?.(); this.resolveConsent?.(); }
 }
 
 const dirs: string[] = [];
@@ -133,5 +146,53 @@ describe("KeyLockerManager.withHost — the effects gate (no spawn before consen
     await Promise.all([inFlight, disposing]);
     expect(mgr.startCalls).toBe(1);
     expect(mgr.disposed).toBe(1); // the just-spawned host WAS torn down, not orphaned
+  });
+});
+
+describe("KeyLockerManager.ensureConsent — the acquire path", () => {
+  it("already accepted ⇒ returns true WITHOUT spawning the dialog", async () => {
+    const d = freshDir();
+    writeConsent(d, { version: 1, acceptedAt: new Date().toISOString() });
+    const mgr = new FakeHostManager({ storeDir: d });
+    await expect(mgr.ensureConsent()).resolves.toBe(true);
+    expect(mgr.consentCalls).toBe(0); // no dialog when consent already exists
+  });
+
+  it("unaccepted ⇒ spawns the dialog; [Enable] writes consent.json ⇒ returns true (re-read is source of truth)", async () => {
+    const d = freshDir();
+    const mgr = new FakeHostManager({ storeDir: d });
+    mgr.onConsent = () => writeConsent(d, { version: 1, acceptedAt: new Date().toISOString() }); // simulate [Enable]
+    const p = mgr.ensureConsent();
+    mgr.settleConsent();
+    await expect(p).resolves.toBe(true);
+    expect(mgr.consentCalls).toBe(1);
+  });
+
+  it("unaccepted ⇒ [Not now] writes nothing ⇒ returns false (fail-closed)", async () => {
+    const d = freshDir();
+    const mgr = new FakeHostManager({ storeDir: d });
+    // onConsent left null → the dialog wrote no consent.json (declined)
+    const p = mgr.ensureConsent();
+    mgr.settleConsent();
+    await expect(p).resolves.toBe(false);
+    expect(mgr.consentCalls).toBe(1);
+  });
+
+  it("concurrent ensureConsent calls share ONE dialog (deduped)", async () => {
+    const d = freshDir();
+    const mgr = new FakeHostManager({ storeDir: d });
+    mgr.onConsent = () => writeConsent(d, { version: 1, acceptedAt: new Date().toISOString() });
+    const p1 = mgr.ensureConsent();
+    const p2 = mgr.ensureConsent();
+    mgr.settleConsent();
+    await expect(Promise.all([p1, p2])).resolves.toEqual([true, true]);
+    expect(mgr.consentCalls).toBe(1); // a single -Consent spawn served both callers
+  });
+
+  it("kill-switched ⇒ throws KeyLockerDisabled and never prompts", async () => {
+    process.env.DESKTOP_TOUCH_DISABLE_KEY_LOCKER = "1";
+    const mgr = new FakeHostManager({ storeDir: freshDir() });
+    await expect(mgr.ensureConsent()).rejects.toBeInstanceOf(KeyLockerDisabledError);
+    expect(mgr.consentCalls).toBe(0);
   });
 });

--- a/tools/key-locker/Program.cs
+++ b/tools/key-locker/Program.cs
@@ -55,6 +55,7 @@ internal static class KeyLocker
         string? storeDir = null;
         var selfTest = false;
         var selfTestL2 = false;
+        var consent = false;
         for (var i = 0; i < args.Length; i++)
         {
             switch (args[i])
@@ -64,12 +65,21 @@ internal static class KeyLocker
                 case "-StoreDir" when i + 1 < args.Length: storeDir = args[++i]; break;
                 case "-SelfTest": selfTest = true; break;
                 case "-SelfTestL2": selfTestL2 = true; break;
+                case "-Consent": consent = true; break;
             }
         }
 
         storeDir ??= Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "desktop-touch-mcp", "locker");
+
+        // First-run consent dialog (L4 §2) — a SECRET-FREE spawn: it shows ONLY the consent dialog and,
+        // on [Enable], writes consent.json itself. No pipe, no store, no capture. The manager's
+        // effects-gate (capture/inject/mint) stays closed until this file exists, so spawning this to
+        // ASK is allowed pre-consent (the gate is on secret effects, not process spawn). Runs before the
+        // store is even opened.
+        if (consent) return RunConsent(storeDir);
+
         _store = new LockerStore(storeDir);
         _serving = new ServingRegistry(_store);
 
@@ -288,6 +298,40 @@ internal static class KeyLocker
         return ok ? 0 : 1;
     }
 
+    /// First-run consent (L4 §2). Shows ONLY the consent dialog; on [Enable] writes consent.json
+    /// atomically (tmp + rename, mirroring LockerStore.Save) with the EXACT shape the Node
+    /// `consentAccepted()` reader keys on — `{ "version": 1, "acceptedAt": "<ISO-8601>" }` (version is a
+    /// NUMBER, acceptedAt a STRING; keep byte-compatible with key-locker-manager.ts consentAccepted).
+    /// [Not now] / close writes nothing (fail-closed stays unaccepted). Returns 0=accepted, 1=declined,
+    /// 3=write failed. The locker is the sole writer (Node only READS), so the flag is set by the same
+    /// trusted component that owns the secrets.
+    private static int RunConsent(string storeDir)
+    {
+        if (!ConsentDialog.Prompt()) return 1; // declined — write nothing
+
+        try
+        {
+            Directory.CreateDirectory(storeDir);
+            var path = Path.Combine(storeDir, "consent.json");
+            var json = JsonSerializer.Serialize(new ConsentShape { version = 1, acceptedAt = DateTime.UtcNow.ToString("o") });
+            var tmp = path + ".tmp";
+            File.WriteAllText(tmp, json);
+            File.Move(tmp, path, overwrite: true); // atomic replace
+            return 0;
+        }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($"key-locker: consent write failed: {e.Message}");
+            return 3;
+        }
+    }
+
+    private sealed class ConsentShape
+    {
+        public int version { get; set; }
+        public string acceptedAt { get; set; } = "";
+    }
+
     private static void WriteFrameReplyCaptured(Stream s, long id, bool captured, bool rt)
         => WriteFrame(s, $"{{\"id\":{id},\"ok\":true,\"r\":\"\",\"captured\":{(captured ? "true" : "false")},\"rt\":{(rt ? "true" : "false")}}}");
 
@@ -470,5 +514,54 @@ internal static class SecureDialog
         win.Loaded += (_, _) => { win.Activate(); pwd.Focus(); };
         var dr = win.ShowDialog();
         return dr == true ? result : null;
+    }
+}
+
+/// The first-run consent dialog (L4 §2) — a plain explain-and-confirm WPF window, no secret entry.
+/// Returns true iff the user clicks [Enable]. Runs on the process's STA main thread ([STAThread] Main).
+internal static class ConsentDialog
+{
+    public static bool Prompt()
+    {
+        // A bare Window.ShowDialog needs an Application for theme/resource resolution; create one only
+        // if the process doesn't already have it (the pipe path makes its own).
+        _ = Application.Current ?? new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
+
+        var accepted = false;
+        var enable = new Button { Content = "Enable", Width = 110, Margin = new Thickness(4), IsDefault = true };
+        var notNow = new Button { Content = "Not now", Width = 110, Margin = new Thickness(4), IsCancel = true };
+
+        var buttons = new StackPanel { Orientation = Orientation.Horizontal, HorizontalAlignment = HorizontalAlignment.Right };
+        buttons.Children.Add(enable);
+        buttons.Children.Add(notNow);
+
+        var panel = new StackPanel { Margin = new Thickness(16), MaxWidth = 460 };
+        panel.Children.Add(new Label { Content = "Enable the desktop-touch key locker?", FontWeight = FontWeights.Bold, FontSize = 15 });
+        panel.Children.Add(new TextBlock
+        {
+            Text = "The key locker stores credentials you choose (SSH key passphrases, sudo / login passwords) " +
+                   "encrypted on THIS machine (Windows DPAPI, current user) and types them for you when a " +
+                   "terminal prompts — so a secret is entered once here and is never shown to the assistant. " +
+                   "Nothing is stored or filled until you enable this, once. You can disable it any time with " +
+                   "DESKTOP_TOUCH_DISABLE_KEY_LOCKER=1.",
+            Margin = new Thickness(4, 8, 4, 12),
+            TextWrapping = TextWrapping.Wrap,
+        });
+        panel.Children.Add(buttons);
+
+        var win = new Window
+        {
+            Title = "desktop-touch key locker",
+            Content = panel,
+            SizeToContent = SizeToContent.WidthAndHeight,
+            ResizeMode = ResizeMode.NoResize,
+            WindowStartupLocation = WindowStartupLocation.CenterScreen,
+            Topmost = true,
+            ShowInTaskbar = false,
+        };
+        enable.Click += (_, _) => { accepted = true; win.DialogResult = true; };
+        win.Loaded += (_, _) => { win.Activate(); enable.Focus(); };
+        win.ShowDialog();
+        return accepted;
     }
 }


### PR DESCRIPTION
## What

The consent **gate** (`KeyLockerManager`, merged in #497) only READS `consent.json` — nothing could ever OPEN it. This PR adds the **acquire path**.

### C# — new `-Consent` headless mode (`tools/key-locker/Program.cs`)
A **secret-free** spawn alongside `-SelfTest`: no pipe, no store, no capture — it shows ONLY the consent dialog. On **[Enable]** the locker writes `consent.json` **atomically** (tmp + rename, mirroring `LockerStore.Save`) with the EXACT shape the Node reader keys on:
```json
{ "version": 1, "acceptedAt": "<ISO-8601>" }
```
(`version` a NUMBER, `acceptedAt` a STRING — byte-compatible with `consentAccepted()`.) On **[Not now]** / close it writes nothing (fail-closed stays unaccepted). Exit `0`=accepted / `1`=declined / `3`=write-failed. The locker is the **sole writer**; Node only reads. `ConsentDialog` is a plain explain-and-confirm WPF window (no PasswordBox) on the `[STAThread]` Main.

### Node — `KeyLockerManager.ensureConsent()`
The ACQUIRE path the `save` tool action will call before capture (`withHost` stays **gate-only**). Idempotent: already accepted ⇒ `true` without spawning. Else spawns `key-locker.exe -Consent`, waits, and **re-reads the flag as source of truth** (exit code ignored). Kill-switched ⇒ throws `KeyLockerDisabledError`, never prompts. Concurrent calls share ONE dialog (a `consenting` in-flight promise). Exported `HELPER_EXE` from `key-locker-host` so the spawn resolves the same exe (single source of truth); added a protected `spawnConsentDialog()` seam for tests.

## Why effects-gated (not spawn-gated)

Consent is SHOWN by the locker dialog, which needs the locker to start — a naïve "don't start the locker until consent" is circular. So the gate is on secret **effects** (capture/inject/mint/persist), and spawning the locker to only ASK touches no secret and is allowed.

## Test

`tests/unit/key-locker-manager.test.ts` (+5, now 15): already-accepted no-spawn; [Enable] writes → `true`; [Not now] → `false` (fail-closed); concurrent calls share one dialog; kill-switched throws without prompting. A `FakeHostManager` overrides `spawnConsentDialog` (no real exe/GUI).

Build + lint clean; C# builds (0 warn/err); `-SelfTest` + `-SelfTestL2` green on the freshly-built exe (additive mode, no regression to L0/L2).

## Not in this PR
The `key_locker` tool surface + catalogue cascade 31→32 + `_errors.ts` wiring → the next PR (which consumes `ensureConsent` in the `save` action).

Plan: `desktop-touch-mcp-internal:docs/adr-014-v2-r3-l4-tool-surface-plan.md` §2 + impl-handoff §3 steps 1-2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
