### PR TITLE
ADR-014 v2 R3 Key Locker — L4 (C1): BindingStore policy field + manager typed-error wiring

### DIFF
--- a/src/engine/key-locker/binding-store.ts
+++ b/src/engine/key-locker/binding-store.ts
@@ -39,6 +39,13 @@ export interface BindingMeta {
   fpSet?: string[];
   /** ISO-8601, stamped by the caller. */
   createdAt: string;
+  /**
+   * Per-binding injection policy (L4 §1 `set_policy`): when true, the locker asks the user to confirm
+   * EVERY autofill for this binding (a per-binding opt-in — never a global no-confirm). Absent/false =
+   * the default confirm-every behaviour. The L1 plan §5.1 RESERVED this as "an L3 field, not set in L1";
+   * it is additive-optional, so it does not break the frozen L1 row shape.
+   */
+  confirmEveryInjection?: boolean;
 }
 
 export interface BindingRecord extends BindingMeta {
@@ -150,6 +157,19 @@ export class BindingStore {
   unbind(canonicalKey: string): boolean {
     if (!(canonicalKey in this.data.bindings)) return false;
     delete this.data.bindings[canonicalKey];
+    this.save();
+    return true;
+  }
+
+  /**
+   * Set the per-binding `confirmEveryInjection` policy (L4 §1 `set_policy`). Returns whether a row was
+   * updated (false = no such binding). Additive metadata only — never touches the locker secret. A
+   * per-binding opt-in; there is no global no-confirm switch.
+   */
+  setPolicy(canonicalKey: string, confirmEveryInjection: boolean): boolean {
+    const row = this.data.bindings[canonicalKey];
+    if (row === undefined) return false;
+    row.confirmEveryInjection = confirmEveryInjection;
     this.save();
     return true;
   }

--- a/src/tools/_errors.ts
+++ b/src/tools/_errors.ts
@@ -481,6 +481,20 @@ const SUGGESTS: Record<string, string[]> = {
     "Upgrade to a v1.5.0+ desktop-touch-mcp build (or run on Windows where the addon is included).",
     "If the addon IS present, verify it loaded successfully: check the stderr for `[native-engine] Rust VBA bridge loaded`.",
   ],
+
+  // ── Key locker (ADR-014 R3) — the credential store + terminal autofill surface. ────────────
+  // Only the two manager-produced codes are wired here (their producers are the KeyLocker*Error
+  // constructors in key-locker-manager.ts). The host/inject codes (KeyLockerSpawnFailed / …Rejected /
+  // …PipeUnavailable / the inject-abort family / RequiresRedaction / NoInjectorForBinding) are wired
+  // WHEN their producers land (the tool + the L3 inject loop) — the classify producer-pin invariant
+  // (issue-211) forbids a branch without a producer.
+  KeyLockerConsentRequired: [
+    "The key locker is off until you enable it once. Run key_locker with action='save' to open the enable dialog, or click Enable when it appears.",
+    "Enabling is a one-time confirmation shown by the locker itself; the assistant never sees your secret.",
+  ],
+  KeyLockerDisabled: [
+    "The key locker is turned off by DESKTOP_TOUCH_DISABLE_KEY_LOCKER=1. Remove that environment variable (and restart the MCP server) to use it.",
+  ],
 };
 
 /**
@@ -502,6 +516,19 @@ export function getSuggestsForCode(code: string): string[] {
 
 function classify(message: string): { code: string; suggest: string[] } {
   const m = message.toLowerCase();
+
+  // Key locker (ADR-014 R3) — checked FIRST: both codes carry the unique `keylocker` prefix, so a
+  // keylocker message only matches these branches, never an existing generic one (e.g. `KeyLockerDisabled`
+  // must not be swallowed by a future generic branch; and when the host codes land, `KeyLockerSpawnFailed`
+  // ⊃ `spawnfailed` / `KeyLockerTargetNotForeground` ⊃ `foreground` would be mis-routed if placed after the
+  // generic branches — Opus L4-R1 P3-7 collision check). Producers: the KeyLocker*Error constructors in
+  // key-locker-manager.ts (`super("<code>: …")`). Host/inject codes are added when their producers land.
+  if (m.includes("keylockerconsentrequired")) {
+    return { code: "KeyLockerConsentRequired", suggest: SUGGESTS.KeyLockerConsentRequired };
+  }
+  if (m.includes("keylockerdisabled")) {
+    return { code: "KeyLockerDisabled", suggest: SUGGESTS.KeyLockerDisabled };
+  }
 
   // Order matters: check more-specific patterns first, then fall back to general ones.
   // Perception guards and lens errors — check before generic "not found" patterns

--- a/tests/unit/key-locker-binding-store.test.ts
+++ b/tests/unit/key-locker-binding-store.test.ts
@@ -135,3 +135,29 @@ describe("BindingStore — file tolerance + atomic save", () => {
     );
   });
 });
+
+describe("BindingStore — set_policy (L4 §1)", () => {
+  it("setPolicy flips confirmEveryInjection, persists, and reports updated", () => {
+    const dir = freshDir();
+    const store = BindingStore.load(dir, alwaysExists);
+    store.bind("sudo://localhost/root", "aa".repeat(16), meta());
+    // Default: the field is absent (confirm-every is the implicit default).
+    expect(store.list()[0].confirmEveryInjection).toBeUndefined();
+
+    expect(store.setPolicy("sudo://localhost/root", true)).toBe(true);
+    expect(store.list()[0].confirmEveryInjection).toBe(true);
+    // Survives a reload (atomic save).
+    expect(BindingStore.load(dir, alwaysExists).list()[0].confirmEveryInjection).toBe(true);
+
+    // Can be turned back off (per-binding opt-in only).
+    expect(store.setPolicy("sudo://localhost/root", false)).toBe(true);
+    expect(store.list()[0].confirmEveryInjection).toBe(false);
+  });
+
+  it("setPolicy on an unknown binding reports false and writes nothing", () => {
+    const dir = freshDir();
+    const store = BindingStore.load(dir, alwaysExists);
+    expect(store.setPolicy("sudo://nope/root", true)).toBe(false);
+    expect(store.list()).toHaveLength(0);
+  });
+});

--- a/tests/unit/key-locker-errors-classify.test.ts
+++ b/tests/unit/key-locker-errors-classify.test.ts
@@ -1,0 +1,41 @@
+/**
+ * key-locker-errors-classify.test.ts — ADR-014 R3 L4.
+ *
+ * Pins the manager-produced KeyLocker typed-error wiring in `_errors.ts`: `KeyLockerConsentRequired`
+ * and `KeyLockerDisabled` route through `classify()` (bare + prose-suffixed message) to their own code
+ * with a non-empty SUGGESTS payload. Their producers are the `KeyLocker*Error` constructors in
+ * key-locker-manager.ts. The host/inject codes are wired when their producers land (the tool + the L3
+ * inject loop) — the classify producer-pin invariant (issue-211) forbids a branch without a producer.
+ * Mirrors the foreground-flash-keypress-classify precedent.
+ */
+import { describe, it, expect } from "vitest";
+import { failWith, getSuggestsForCode } from "../../src/tools/_errors.js";
+
+const MANAGER_CODES = ["KeyLockerConsentRequired", "KeyLockerDisabled"] as const;
+
+describe("KeyLocker manager typed-error wiring (classify + SUGGESTS)", () => {
+  for (const code of MANAGER_CODES) {
+    it(`routes a "${code}" message to its code with a non-empty suggest`, () => {
+      // The manager's typed errors prefix their message with the code: `new Error("<code>: …")`.
+      const bare = JSON.parse(failWith(new Error(code), "key_locker").content[0]!.text);
+      expect(bare.ok).toBe(false);
+      expect(bare.code).toBe(code);
+      expect(Array.isArray(bare.suggest)).toBe(true);
+      expect(bare.suggest.length).toBeGreaterThan(0);
+
+      // Prose-suffixed variant still routes (substring match), as the real messages carry a colon + prose.
+      const prose = JSON.parse(failWith(new Error(`${code}: something to explain`), "key_locker").content[0]!.text);
+      expect(prose.code).toBe(code);
+
+      // getSuggestsForCode exposes the same dictionary payload.
+      expect(getSuggestsForCode(code).length).toBeGreaterThan(0);
+    });
+  }
+
+  it("KeyLockerDisabled is not swallowed by a generic branch (checked before them)", () => {
+    // Its message would otherwise fall through to the generic ToolError tail with an empty suggest.
+    const body = JSON.parse(failWith(new Error("KeyLockerDisabled: off via env"), "key_locker").content[0]!.text);
+    expect(body.code).toBe("KeyLockerDisabled");
+    expect(body.suggest.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## What

Foundations the `key_locker` tool (next PR) consumes, split out so the tool + catalogue-cascade PR stays focused.

### BindingStore (`binding-store.ts`)
- **`confirmEveryInjection?: boolean`** on `BindingMeta` — the L1 §5.1 RESERVED per-binding policy field (additive-optional; does not break the frozen row shape). Absent/false = the default confirm-every behaviour.
- **`setPolicy(canonicalKey, confirmEveryInjection): boolean`** — flips it and persists atomically; `false` when no such binding. A per-binding opt-in only — there is no global no-confirm switch.

### `_errors.ts`
- SUGGESTS + `classify` branches for **`KeyLockerConsentRequired`** and **`KeyLockerDisabled`** (the two manager-produced codes; fixed suggest strings, no interpolation — CWE-94). Placed **first** in `classify`: the unique `keylocker` prefix means a keylocker message only matches these, and placing them after the generic branches would let `KeyLockerDisabled` fall through to the empty-suggest `ToolError` tail (and, once the host codes land, `KeyLockerSpawnFailed` ⊃ `spawnfailed` etc. would mis-route — Opus L4-R1 P3-7).

### Deferred on purpose (producer-pin invariant)
The host/inject codes (`KeyLockerSpawnFailed`/`…Rejected`/`…PipeUnavailable`, the inject-abort family, `RequiresRedaction`/`NoInjectorForBinding`) are wired **where their producers land** — the tool (next PR) and the L3 inject loop. `tests/unit/issue-211-classify-branch-producer-pin.test.ts` forbids a classify branch without a production producer, so front-loading them would fail CI. Tracked in the internal impl-handoff §3.

## Test
- `key-locker-binding-store.test.ts`: setPolicy flip / persist-across-reload / unknown-binding-false; the existing exact-keys assertion still holds (the new field is absent unless set).
- `key-locker-errors-classify.test.ts`: both manager codes round-trip through `classify` to a non-empty suggest (bare + prose-suffixed); `KeyLockerDisabled` not swallowed by a generic branch.
- `issue-211` producer-pin stays green (both codes have manager `super("<code>: …")` producers).

Build + lint clean; full unit suite green (the two e2e failures are live-env browser/terminal, unrelated to this TS-only change).

Plan: `desktop-touch-mcp-internal:docs/adr-014-v2-r3-l4-tool-surface-plan.md` §1/§4 + impl-handoff §3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
