### PR TITLE
ADR-014 v2 R3 Key Locker — L3 §2: landed-detection (two-mode save-gate)

### DIFF
--- a/src/engine/key-locker/landed-detection.ts
+++ b/src/engine/key-locker/landed-detection.ts
@@ -1,0 +1,121 @@
+// ADR-014 v2 R3 Key Locker — L3 §2: landed-detection (the TWO-MODE save-gate).
+//
+// Plan: desktop-touch-mcp-internal:docs/adr-014-v2-r3-l3-capture-plan.md (§2)
+//
+// After L3 injects a just-captured secret, it must decide whether the credential was ACCEPTED before it
+// persists the binding (Chrome-model save-gate). A credential command lands in one of two shapes and
+// both must be handled (Opus L3-R1 P1-1 — exit-0 alone breaks the interactive-login North-Star case):
+//
+//   * Mode A — ONE-SHOT (`git push`, `sudo -v`, `ssh host cmd`, `ssh-keygen -y`): runs under
+//     `terminal until:{mode:'exit'}`. accepted iff it EXITED with code 0. Any other completion
+//     (timeout / quiet / pattern / a non-exit-able command) ⇒ NOT accepted ⇒ discard (fail safe).
+//   * Mode B — INTERACTIVE LOGIN (`ssh user@host`, `sudo -i`, `sudo su`, `su -`): opens a shell and
+//     stays alive, so exit mode never returns 0 — waiting for exit would time out and discard a CORRECT
+//     secret. The landed signal is instead auth-accepted vs auth-rejected read from the pane: the
+//     hidden-input prompt CLEARED and no denial line appeared (accepted), vs a re-prompt / a denial line
+//     (rejected). It reads prompt/denial TEXT, never the secret.
+//
+// Mode B is a SAVE-GATE signal, NOT a wrong-target defense (that stays L1 fingerprint + L2 re-verify):
+// a false-accept saves a secret that simply fails next use (→ re-prompt → re-capture); a false-reject
+// discards a good secret (re-captured next time). Neither mis-fills — so the heuristic is bounded-safe.
+//
+// This module is PURE decision logic + async orchestration over INJECTED seams (the terminal exit-mode
+// run and the pane read) — no Win32, no direct terminal-tool import — so the capture-loop wires the live
+// primitives and tests drive fakes.
+
+import { tokenizeCommandSegments } from "./command-derivation.js";
+import { ENV_ASSIGN_RE, interactiveSshTarget, programOf } from "./session-tracker.js";
+
+/** Which landed-detection mode a dispatched credential command uses. */
+export type LandedMode = "one-shot" | "interactive";
+
+/** The exit-mode completion the capture-loop hands in (a subset of the terminal tool's `completion`). */
+export interface ExitCompletion {
+  /** `"exited"` only when `until:{mode:'exit'}` observed the process finish; else timeout/quiet/… */
+  reason: string;
+  /** Populated ONLY on `reason:"exited"`. */
+  exitCode?: number;
+}
+
+/** The landed verdict. `accepted` gates the SAVE; `reason` is for logging / the offer context. */
+export interface LandedResult {
+  accepted: boolean;
+  mode: LandedMode;
+  reason: string;
+}
+
+/**
+ * A denial / re-prompt line an interactive login prints on a REJECTED auth. Case-insensitive, matched
+ * against the non-secret pane tail read AFTER injection. Kept conservative — a false "no denial" only
+ * costs a re-capture next time (SP-L3-OQ-5). Covers ssh, sudo, su, and generic PAM wording.
+ */
+const AUTH_DENIAL_RE =
+  /permission denied|authentication failed(?:ure)?|auth(?:entication)? failure|sorry,? try again|access denied|incorrect password|login incorrect|too many authentication failures/i;
+
+/**
+ * Classify which landed-mode a dispatched credential command uses. Interactive = an ssh INTERACTIVE
+ * login (reuses the SAME `interactiveSshTarget` that pushes a session frame, so classification and
+ * frame-push agree), a `sudo -i`/`-s`/`--login`/`--shell` (starts a shell), or any `su` form (`su`,
+ * `su -`, `su user` all open an interactive shell). Everything else — a one-shot `ssh host cmd`, a
+ * plain `sudo <cmd>`, `git push`, `ssh-keygen` — is one-shot (Mode A, exit-gated).
+ *
+ * The redirect-before-program edge (`>log ssh host`) is intentionally NOT handled here: a mis-classified
+ * mode is bounded-safe (a good secret is discarded and re-captured, never mis-filled), so a simple
+ * env-assign skip + first-program check suffices.
+ */
+export function classifyLandedMode(command: string): LandedMode {
+  for (const segment of tokenizeCommandSegments(command)) {
+    let start = 0;
+    while (start < segment.length && ENV_ASSIGN_RE.test(segment[start])) start++;
+    const program = programOf(segment[start]);
+    const rest = segment.slice(start + 1);
+    if (program === "ssh" && interactiveSshTarget(rest) !== null) return "interactive";
+    if (program === "sudo" && rest.some((a) => a === "-i" || a === "-s" || a === "--login" || a === "--shell")) return "interactive";
+    if (program === "su") return "interactive";
+  }
+  return "one-shot";
+}
+
+/** Mode A accept: the one-shot command EXITED with code 0. Anything else is not-accepted (fail safe). */
+export function isExitAccepted(completion: ExitCompletion): boolean {
+  return completion.reason === "exited" && completion.exitCode === 0;
+}
+
+/**
+ * Mode B accept: the auth prompt CLEARED and no denial line appeared. `paneTailAfterInject` is the
+ * non-secret pane read after injecting; `stillHiddenPrompt` is whether a hidden-input prompt is STILL on
+ * the cursor row (a re-prompt = rejected). A denial line always rejects, even if the prompt cleared.
+ */
+export function isAuthAccepted(paneTailAfterInject: string, stillHiddenPrompt: boolean): boolean {
+  if (AUTH_DENIAL_RE.test(paneTailAfterInject)) return false; // explicit denial → rejected
+  if (stillHiddenPrompt) return false; // re-prompt (prompt did not clear) → rejected
+  return true; // prompt cleared, no denial → accepted
+}
+
+/** Seams the capture-loop wires to the live terminal / pane primitives. */
+export interface LandedDeps {
+  /** Mode A: run the dispatched command under `terminal until:{mode:'exit'}` and return its completion. */
+  runToExit: () => Promise<ExitCompletion>;
+  /**
+   * Mode B: after injection, read the pane's non-secret tail and report whether a hidden-input prompt is
+   * STILL present. Returns `{ tail, stillHiddenPrompt }` observed within the bounded auth window.
+   */
+  readPaneAfterAuth: () => Promise<{ tail: string; stillHiddenPrompt: boolean }>;
+}
+
+/**
+ * The two-mode landed gate. Classifies the command, then applies the matching accept rule over the
+ * injected seam. Never throws for a "not landed" — it returns `accepted:false` so the capture-loop
+ * discards (fail safe).
+ */
+export async function awaitLanded(deps: LandedDeps, command: string): Promise<LandedResult> {
+  const mode = classifyLandedMode(command);
+  if (mode === "one-shot") {
+    const completion = await deps.runToExit();
+    const accepted = isExitAccepted(completion);
+    return { accepted, mode, reason: accepted ? "exit_0" : `not_exit_0:${completion.reason}` };
+  }
+  const { tail, stillHiddenPrompt } = await deps.readPaneAfterAuth();
+  const accepted = isAuthAccepted(tail, stillHiddenPrompt);
+  return { accepted, mode, reason: accepted ? "auth_accepted" : "auth_rejected" };
+}

--- a/src/engine/key-locker/landed-detection.ts
+++ b/src/engine/key-locker/landed-detection.ts
@@ -23,7 +23,7 @@
 // run and the pane read) — no Win32, no direct terminal-tool import — so the capture-loop wires the live
 // primitives and tests drive fakes.
 
-import { tokenizeCommandSegments } from "./command-derivation.js";
+import { tokenizeCommandSegmentsWithOps } from "./command-derivation.js";
 import { ENV_ASSIGN_RE, interactiveSshTarget, programOf } from "./session-tracker.js";
 
 /** Which landed-detection mode a dispatched credential command uses. */
@@ -52,25 +52,59 @@ export interface LandedResult {
 const AUTH_DENIAL_RE =
   /permission denied|authentication failed(?:ure)?|auth(?:entication)? failure|sorry,? try again|access denied|incorrect password|login incorrect|too many authentication failures/i;
 
+/** Shells that, launched with no script argument (or only login/interactive flags), open a shell. */
+const INTERACTIVE_SHELLS = new Set(["su", "bash", "sh", "zsh", "fish", "dash", "ash", "ksh", "pwsh", "powershell"]);
+/** `sudo`/`doas` options that CONSUME the next token as their argument (so it isn't the command). */
+const PRIV_ARG_OPTS = new Set([
+  "-u", "-g", "-p", "-h", "-C", "-r", "-t", "-U", "-R", "-D",
+  "--user", "--group", "--prompt", "--host", "--close-from", "--role", "--type", "--other-user", "--chdir", "--chroot",
+]);
+
+/**
+ * Does a `sudo`/`doas` invocation open an INTERACTIVE shell (so it stays alive → Mode B)? True for the
+ * shell flags (`-i`/`-s`/`--login`/`--shell`) OR when the COMMAND it runs is itself an interactive shell
+ * — `sudo su -`, `sudo -u postgres su`, `sudo bash -l` (Opus #501 P2: the first-program-only check missed
+ * `sudo su`, the commonest root-escalation flow). Skips the privileged tool's OWN options + their args to
+ * find the command token. A bare shell WITH a script argument (`sudo bash deploy.sh`) is one-shot.
+ */
+function privLaunchesInteractiveShell(rest: readonly string[]): boolean {
+  let i = 0;
+  for (; i < rest.length; i++) {
+    const t = rest[i];
+    if (t === "-i" || t === "-s" || t === "--login" || t === "--shell") return true;
+    if (!t.startsWith("-")) break; // first non-option token = the command sudo/doas runs
+    if (PRIV_ARG_OPTS.has(t)) i++; // this option takes the next token as its value — skip it
+  }
+  const command = programOf(rest[i]);
+  if (command === "su") return true; // `su`/`su -`/`su user` always open a shell
+  if (INTERACTIVE_SHELLS.has(command)) {
+    // a login/interactive shell with no script argument stays alive
+    return rest.slice(i + 1).every((a) => a === "-l" || a === "-i" || a === "--login" || a === "--interactive");
+  }
+  return false;
+}
+
 /**
  * Classify which landed-mode a dispatched credential command uses. Interactive = an ssh INTERACTIVE
- * login (reuses the SAME `interactiveSshTarget` that pushes a session frame, so classification and
- * frame-push agree), a `sudo -i`/`-s`/`--login`/`--shell` (starts a shell), or any `su` form (`su`,
- * `su -`, `su user` all open an interactive shell). Everything else — a one-shot `ssh host cmd`, a
- * plain `sudo <cmd>`, `git push`, `ssh-keygen` — is one-shot (Mode A, exit-gated).
+ * login (reuses the SAME `interactiveSshTarget` that pushes a session frame), a `sudo`/`doas` that opens
+ * a shell (`-i`/`-s`/`sudo su`/`sudo bash -l`, see `privLaunchesInteractiveShell`), or a bare `su`.
+ * Everything else — a one-shot `ssh host cmd`, a plain `sudo <cmd>`, `git push`, `ssh-keygen` — is
+ * one-shot (Mode A, exit-gated).
  *
- * The redirect-before-program edge (`>log ssh host`) is intentionally NOT handled here: a mis-classified
- * mode is bounded-safe (a good secret is discarded and re-captured, never mis-filled), so a simple
- * env-assign skip + first-program check suffices.
+ * BACKGROUNDED / piped segments are skipped (they return to the prompt, not an interactive login — the
+ * same guard `recordDispatch` applies before pushing an ssh frame, so the two agree). The
+ * redirect-before-program edge is not handled: a mis-classified mode is bounded-safe (a good secret is
+ * discarded and re-captured, never mis-filled).
  */
 export function classifyLandedMode(command: string): LandedMode {
-  for (const segment of tokenizeCommandSegments(command)) {
+  for (const { tokens, backgrounded, pipedStdin } of tokenizeCommandSegmentsWithOps(command)) {
+    if (backgrounded || pipedStdin) continue; // a backgrounded `ssh host &` / a `… | ssh` opens no interactive login
     let start = 0;
-    while (start < segment.length && ENV_ASSIGN_RE.test(segment[start])) start++;
-    const program = programOf(segment[start]);
-    const rest = segment.slice(start + 1);
+    while (start < tokens.length && ENV_ASSIGN_RE.test(tokens[start])) start++;
+    const program = programOf(tokens[start]);
+    const rest = tokens.slice(start + 1);
     if (program === "ssh" && interactiveSshTarget(rest) !== null) return "interactive";
-    if (program === "sudo" && rest.some((a) => a === "-i" || a === "-s" || a === "--login" || a === "--shell")) return "interactive";
+    if ((program === "sudo" || program === "doas") && privLaunchesInteractiveShell(rest)) return "interactive";
     if (program === "su") return "interactive";
   }
   return "one-shot";
@@ -110,12 +144,18 @@ export interface LandedDeps {
  */
 export async function awaitLanded(deps: LandedDeps, command: string): Promise<LandedResult> {
   const mode = classifyLandedMode(command);
-  if (mode === "one-shot") {
-    const completion = await deps.runToExit();
-    const accepted = isExitAccepted(completion);
-    return { accepted, mode, reason: accepted ? "exit_0" : `not_exit_0:${completion.reason}` };
+  try {
+    if (mode === "one-shot") {
+      const completion = await deps.runToExit();
+      const accepted = isExitAccepted(completion);
+      return { accepted, mode, reason: accepted ? "exit_0" : `not_exit_0:${completion.reason}` };
+    }
+    const { tail, stillHiddenPrompt } = await deps.readPaneAfterAuth();
+    const accepted = isAuthAccepted(tail, stillHiddenPrompt);
+    return { accepted, mode, reason: accepted ? "auth_accepted" : "auth_rejected" };
+  } catch (err) {
+    // A seam failure (terminal read error, etc.) is treated as NOT-landed → the capture-loop discards
+    // the captured secret (fail safe). Never let a probe error crash the loop or trigger a save.
+    return { accepted: false, mode, reason: `probe_error:${err instanceof Error ? err.message : String(err)}` };
   }
-  const { tail, stillHiddenPrompt } = await deps.readPaneAfterAuth();
-  const accepted = isAuthAccepted(tail, stillHiddenPrompt);
-  return { accepted, mode, reason: accepted ? "auth_accepted" : "auth_rejected" };
 }

--- a/src/engine/key-locker/session-tracker.ts
+++ b/src/engine/key-locker/session-tracker.ts
@@ -194,11 +194,13 @@ export class SessionTracker {
   }
 }
 
-/** Leading `FOO=bar` env-assignment (skipped before the program token, mirrors L1). */
-const ENV_ASSIGN_RE = /^[A-Za-z_][A-Za-z0-9_]*=/;
+/** Leading `FOO=bar` env-assignment (skipped before the program token, mirrors L1). Exported for L3
+ *  landed-detection's mode classifier (same env-skip). */
+export const ENV_ASSIGN_RE = /^[A-Za-z_][A-Za-z0-9_]*=/;
 
-/** Program identity of a token: basename-ish, lowercased, `.exe` stripped (mirrors L1). */
-function programOf(token: string | undefined): string {
+/** Program identity of a token: basename-ish, lowercased, `.exe` stripped (mirrors L1). Exported for
+ *  L3 landed-detection. */
+export function programOf(token: string | undefined): string {
   if (token === undefined) return "";
   const base = token.replace(/\\/g, "/").split("/").pop() ?? token;
   return base.toLowerCase().replace(/\.exe$/, "");
@@ -275,7 +277,7 @@ function scanRedirectionsForStdin(tokens: readonly string[]): { touchesStdin: bo
  * `ssh host cmd`, a query mode (`-G`/`-Q`/`-V`), no destination, or a stdin-off-the-tty ssh — none of
  * which open a session.
  */
-function interactiveSshTarget(rawArgs: string[]): string | null {
+export function interactiveSshTarget(rawArgs: string[]): string | null {
   // Redirections are shell I/O plumbing the shell consumes before exec, and they can appear ANYWHERE —
   // before the destination (`ssh 2>&1 host`), after it, or after a remote command. Scan the WHOLE argv:
   // a redirect that TOUCHES fd 0 (`ssh host < in`, `ssh 0>f host`) takes stdin off the tty → the ssh is

--- a/tests/unit/key-locker-landed-detection.test.ts
+++ b/tests/unit/key-locker-landed-detection.test.ts
@@ -24,6 +24,15 @@ describe("classifyLandedMode", () => {
       "su",
       "su -",
       "su postgres",
+      // sudo whose COMMAND is itself an interactive shell (Opus #501 P2 — the commonest root flow)
+      "sudo su",
+      "sudo su -",
+      "sudo su - postgres",
+      "sudo -u postgres su",
+      "sudo bash -l",
+      "sudo bash", // bare shell, no script → interactive
+      "doas -s",
+      "doas su -",
     ]) {
       expect(classifyLandedMode(cmd)).toBe("interactive");
     }
@@ -34,7 +43,10 @@ describe("classifyLandedMode", () => {
       "ssh host uptime", // one-shot remote command
       "ssh -N -L 5432:localhost:5432 host", // port-forward, no shell
       "ssh -f user@host tunnel", // backgrounded
+      "ssh user@host &", // job-control backgrounded → not an interactive login
       "sudo apt update", // plain sudo command
+      "sudo bash deploy.sh", // shell running a SCRIPT → one-shot
+      "sudo -u deploy git pull", // sudo runs a non-shell command
       "git push",
       "ssh-keygen -y -f ~/.ssh/id_ed25519",
       "echo hi",
@@ -105,5 +117,18 @@ describe("awaitLanded", () => {
   it("Mode B (interactive): prompt cleared + no denial → accepted; denial → rejected", async () => {
     expect(await awaitLanded(modeBDeps("user@host:~$ ", false), "ssh user@host")).toMatchObject({ accepted: true, mode: "interactive", reason: "auth_accepted" });
     expect(await awaitLanded(modeBDeps("Permission denied, please try again.", true), "ssh user@host")).toMatchObject({ accepted: false, mode: "interactive", reason: "auth_rejected" });
+  });
+
+  it("a seam failure is treated as not-landed (fail safe, never crashes the loop)", async () => {
+    const throwingDeps: LandedDeps = {
+      runToExit: async () => { throw new Error("terminal read failed"); },
+      readPaneAfterAuth: async () => { throw new Error("pane read failed"); },
+    };
+    const a = await awaitLanded(throwingDeps, "git push"); // Mode A seam throws
+    expect(a.accepted).toBe(false);
+    expect(a.reason).toContain("probe_error");
+    const b = await awaitLanded(throwingDeps, "sudo su -"); // Mode B seam throws
+    expect(b.accepted).toBe(false);
+    expect(b.reason).toContain("probe_error");
   });
 });

--- a/tests/unit/key-locker-landed-detection.test.ts
+++ b/tests/unit/key-locker-landed-detection.test.ts
@@ -1,0 +1,109 @@
+/**
+ * key-locker-landed-detection.test.ts — ADR-014 R3 L3 §2 (the two-mode save-gate).
+ * Pins the mode classifier, the Mode-A exit-0 rule, the Mode-B auth accept/reject rule, and the
+ * awaitLanded orchestration over injected seams.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  awaitLanded,
+  classifyLandedMode,
+  isAuthAccepted,
+  isExitAccepted,
+  type LandedDeps,
+} from "../../src/engine/key-locker/landed-detection.js";
+
+describe("classifyLandedMode", () => {
+  it("interactive logins → interactive (Mode B)", () => {
+    for (const cmd of [
+      "ssh user@host",
+      "ssh -p 2222 deploy@prod.example.com",
+      "LC_ALL=C ssh user@host", // env-assign prefix skipped
+      "sudo -i",
+      "sudo -s",
+      "sudo --login",
+      "su",
+      "su -",
+      "su postgres",
+    ]) {
+      expect(classifyLandedMode(cmd)).toBe("interactive");
+    }
+  });
+
+  it("one-shot commands → one-shot (Mode A)", () => {
+    for (const cmd of [
+      "ssh host uptime", // one-shot remote command
+      "ssh -N -L 5432:localhost:5432 host", // port-forward, no shell
+      "ssh -f user@host tunnel", // backgrounded
+      "sudo apt update", // plain sudo command
+      "git push",
+      "ssh-keygen -y -f ~/.ssh/id_ed25519",
+      "echo hi",
+    ]) {
+      expect(classifyLandedMode(cmd)).toBe("one-shot");
+    }
+  });
+
+  it("a later interactive segment still classifies interactive (`cd x && ssh user@host`)", () => {
+    expect(classifyLandedMode("cd /tmp && ssh user@host")).toBe("interactive");
+  });
+});
+
+describe("isExitAccepted (Mode A)", () => {
+  it("accepts only reason=exited + exitCode 0", () => {
+    expect(isExitAccepted({ reason: "exited", exitCode: 0 })).toBe(true);
+    expect(isExitAccepted({ reason: "exited", exitCode: 1 })).toBe(false);
+    expect(isExitAccepted({ reason: "exited" })).toBe(false); // no code
+    expect(isExitAccepted({ reason: "timeout" })).toBe(false);
+    expect(isExitAccepted({ reason: "quiet" })).toBe(false);
+    expect(isExitAccepted({ reason: "pattern_matched", exitCode: 0 })).toBe(false); // wrong reason
+  });
+});
+
+describe("isAuthAccepted (Mode B)", () => {
+  it("accepts when the prompt cleared and no denial line appeared", () => {
+    expect(isAuthAccepted("deploy@prod:~$ ", false)).toBe(true);
+  });
+  it("rejects on a denial line even if the prompt cleared", () => {
+    for (const tail of [
+      "Permission denied, please try again.",
+      "sudo: 3 incorrect password attempts",
+      "su: Authentication failure",
+      "Access denied",
+      "Received disconnect: Too many authentication failures",
+    ]) {
+      expect(isAuthAccepted(tail, false)).toBe(false);
+    }
+  });
+  it("rejects when a hidden-input prompt is still present (re-prompt)", () => {
+    expect(isAuthAccepted("[sudo] password for user: ", true)).toBe(false);
+  });
+});
+
+describe("awaitLanded", () => {
+  const modeADeps = (completion: { reason: string; exitCode?: number }): LandedDeps => ({
+    runToExit: async () => completion,
+    readPaneAfterAuth: async () => { throw new Error("Mode A must not read the pane"); },
+  });
+  const modeBDeps = (tail: string, stillHiddenPrompt: boolean): LandedDeps => ({
+    runToExit: async () => { throw new Error("Mode B must not run exit mode"); },
+    readPaneAfterAuth: async () => ({ tail, stillHiddenPrompt }),
+  });
+
+  it("Mode A (one-shot): exit 0 → accepted, exit 1 → rejected", async () => {
+    expect(await awaitLanded(modeADeps({ reason: "exited", exitCode: 0 }), "git push")).toMatchObject({ accepted: true, mode: "one-shot", reason: "exit_0" });
+    const r = await awaitLanded(modeADeps({ reason: "exited", exitCode: 1 }), "git push");
+    expect(r.accepted).toBe(false);
+    expect(r.reason).toBe("not_exit_0:exited");
+  });
+
+  it("Mode A: a timeout is not-landed (fail safe, no save)", async () => {
+    const r = await awaitLanded(modeADeps({ reason: "timeout" }), "sudo -v");
+    expect(r.accepted).toBe(false);
+    expect(r.reason).toBe("not_exit_0:timeout");
+  });
+
+  it("Mode B (interactive): prompt cleared + no denial → accepted; denial → rejected", async () => {
+    expect(await awaitLanded(modeBDeps("user@host:~$ ", false), "ssh user@host")).toMatchObject({ accepted: true, mode: "interactive", reason: "auth_accepted" });
+    expect(await awaitLanded(modeBDeps("Permission denied, please try again.", true), "ssh user@host")).toMatchObject({ accepted: false, mode: "interactive", reason: "auth_rejected" });
+  });
+});


### PR DESCRIPTION
## What

The first L3 capture-on-use loop module. After L3 injects a just-captured secret, it must decide whether the credential was **accepted** before persisting the binding (Chrome-model save-gate). A credential command lands in one of two shapes, and BOTH must be handled (Opus L3-R1 P1-1 — exit-0 alone breaks the interactive-login case):

- **Mode A (one-shot)** — `git push`, `sudo -v`, `ssh host cmd`, `ssh-keygen -y`: runs under `terminal until:{mode:'exit'}`; accepted iff it EXITED with code 0. Any other completion (timeout / quiet / pattern / non-exit-able) → not accepted → discard (fail safe).
- **Mode B (interactive login)** — `ssh user@host`, `sudo -i`, `sudo su`, `su -`: opens a shell and never exits, so exit mode would time out and discard a correct secret. The landed signal is **auth-accepted vs auth-rejected** read from the pane: the hidden-input prompt CLEARED and no denial line appeared (accepted) vs a re-prompt / a denial line (rejected). Reads prompt/denial TEXT, never the secret.

Mode B is a **save-gate signal, not a wrong-target defense** (that stays L1 fingerprint + L2 re-verify): a false-accept saves a secret that just fails next use → re-capture; a false-reject re-captures next time. Neither mis-fills — bounded-safe.

## Design

Pure decision logic + async orchestration over **injected seams** — no Win32, no terminal-tool import — so the capture-loop wires the live primitives and tests drive fakes:
- `classifyLandedMode(command)` → `one-shot | interactive`. Interactive reuses the SAME `interactiveSshTarget` that pushes a session frame (classification and frame-push agree) + `sudo -i/-s/--login/--shell` + any `su`.
- `isExitAccepted(completion)` (Mode A) / `isAuthAccepted(paneTail, stillHiddenPrompt)` (Mode B; `AUTH_DENIAL_RE` covers ssh/sudo/su/PAM, a denial rejects even if the prompt cleared).
- `awaitLanded(deps, command)` — never throws for not-landed (returns `accepted:false` → discard).

Exported `interactiveSshTarget` / `programOf` / `ENV_ASSIGN_RE` from session-tracker for reuse.

## Test
+10: classifier (both modes + env-prefix + `cd x && ssh …`), exit-0 rule, auth accept/reject/re-prompt, `awaitLanded` Mode A/B. session-tracker 53 green (exports non-breaking); build + lint clean.

## Not in this PR
The state machine that calls `awaitLanded` (capture-loop, §1) and the live terminal/pane wiring → next PRs; the live run is validated in the L2 §8c dogfood.

Plan: `desktop-touch-mcp-internal:docs/adr-014-v2-r3-l3-capture-plan.md` §2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
