### PR TITLE
ADR-014 v2 R3 Key Locker — L3-3 PR1: fix inverted confirm-policy default + getPolicy

### DIFF
--- a/src/engine/key-locker/binding-store.ts
+++ b/src/engine/key-locker/binding-store.ts
@@ -40,9 +40,11 @@ export interface BindingMeta {
   /** ISO-8601, stamped by the caller. */
   createdAt: string;
   /**
-   * Per-binding injection policy (L4 §1 `set_policy`): when true, the locker asks the user to confirm
-   * EVERY autofill for this binding (a per-binding opt-in — never a global no-confirm). Absent/false =
-   * the default confirm-every behaviour. The L1 plan §5.1 RESERVED this as "an L3 field, not set in L1";
+   * Per-binding injection confirm policy (L4 §1 `set_policy`). The RESOLVED policy is
+   * `confirmEveryInjection ?? true` (see `getPolicy`): the default (ABSENT field, or `true`) CONFIRMS
+   * every autofill — the D2 safe backstop. `false` is the per-binding opt-OUT ("no-confirm is a
+   * per-binding opt-in", plan §1 — never a global no-confirm). The load-bearing consumer is the
+   * capture-loop's `confirmPolicyFor`. The L1 plan §5.1 RESERVED this as "an L3 field, not set in L1";
    * it is additive-optional, so it does not break the frozen L1 row shape.
    */
   confirmEveryInjection?: boolean;
@@ -172,6 +174,16 @@ export class BindingStore {
     row.confirmEveryInjection = confirmEveryInjection;
     this.save();
     return true;
+  }
+
+  /**
+   * The RESOLVED per-binding confirm policy (the capture-loop's `confirmPolicyFor`, D2). Returns
+   * `confirmEveryInjection ?? true`: an UNKNOWN binding or an UNSET field ⇒ TRUE = confirm (the safe
+   * backstop); only an explicit `confirmEveryInjection: false` opts out. O(1); mirrors `setPolicy`.
+   * Never touches the locker (metadata only).
+   */
+  getPolicy(canonicalKey: string): boolean {
+    return this.data.bindings[canonicalKey]?.confirmEveryInjection ?? true;
   }
 
   /** Enumerate all rows (management / L4). */

--- a/src/tools/key-locker-tool.ts
+++ b/src/tools/key-locker-tool.ts
@@ -36,7 +36,7 @@ import {
   formatBindingUri,
   type BindingUri,
 } from "../engine/key-locker/binding.js";
-import { resolveCanonicalForSshCommand } from "../engine/key-locker/ssh-resolve.js";
+import { resolveCanonicalForSshCommand, type ExecFn } from "../engine/key-locker/ssh-resolve.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Schema — a discriminated union over `action` (Opus R1 P2-6: the FULL 3-layer chain, mirroring excel).
@@ -66,11 +66,14 @@ const forgetSchema = z.object({
 
 const setPolicySchema = z.object({
   action: z.literal("set_policy").describe(
-    "Set the per-binding autofill confirmation policy. confirmEveryInjection=true asks you to approve " +
-      "every autofill for this binding; false restores the default. A per-binding opt-in only.",
+    "Set the per-binding autofill confirmation policy. By DEFAULT every autofill asks you to confirm " +
+      "(the safe backstop). Set confirmEveryInjection=false to OPT OUT of confirmation for this one " +
+      "binding (it will then autofill silently); true restores the confirm-every default.",
   ),
   uri: z.string().min(1).describe(URI_DESC),
-  confirmEveryInjection: z.boolean().describe("true = confirm every autofill for this binding; false = default."),
+  confirmEveryInjection: z.boolean().describe(
+    "true (default) = confirm every autofill for this binding; false = opt out (autofill without asking).",
+  ),
 });
 
 const statusSchema = z.object({
@@ -102,6 +105,16 @@ function manager(): KeyLockerManager {
 /** TEST-ONLY seam: inject a manager (e.g. a fake-host subclass) or reset (null) the singleton. */
 export function __setKeyLockerManagerForTest(mgr: KeyLockerManager | null): void {
   managerSingleton = mgr;
+}
+
+/**
+ * TEST-ONLY seam: inject the `exec` the ssh `save` path passes to `resolveCanonicalForSshCommand`
+ * (a fake `ssh -G` / `ssh-keygen`), so the ssh save→canonical parity is unit-testable without real
+ * ssh binaries / known_hosts. `undefined`/`null` = the real `defaultExec` (production).
+ */
+let sshExecForTest: ExecFn | undefined;
+export function __setSshExecForTest(exec: ExecFn | null): void {
+  sshExecForTest = exec ?? undefined;
 }
 
 /** A management-only store (list/bind/unbind/setPolicy never need the locker's existence check). */
@@ -144,7 +157,10 @@ function handleList(): ToolResult {
     ...(row.user !== undefined ? { user: row.user } : {}),
     ...(row.port !== undefined ? { port: row.port } : {}),
     createdAt: row.createdAt,
-    confirmEveryInjection: row.confirmEveryInjection ?? false,
+    // The RESOLVED policy (matches the capture-loop's `confirmPolicyFor` = `?? true`): an unset binding
+    // CONFIRMS by default (the safe backstop). Reporting `?? false` here would tell the user "won't ask"
+    // while the loop actually asks (#500 vs #502 drift — the confirm default is ON unless opted out).
+    confirmEveryInjection: row.confirmEveryInjection ?? true,
   }));
   return ok({ bindings });
 }
@@ -200,7 +216,7 @@ async function handleSave(uri: string): Promise<ToolResult> {
   if (parsed.scheme === "ssh") {
     const dest = `${parsed.user}@${parsed.host}`;
     const sshArgs = parsed.port === 22 ? [dest] : ["-p", String(parsed.port), dest];
-    const res = await resolveCanonicalForSshCommand(sshArgs);
+    const res = await resolveCanonicalForSshCommand(sshArgs, sshExecForTest);
     if (res.kind === "host-not-known") {
       return fail(
         "KeyLockerSshUnresolved",

--- a/tests/unit/key-locker-binding-store.test.ts
+++ b/tests/unit/key-locker-binding-store.test.ts
@@ -161,3 +161,29 @@ describe("BindingStore — set_policy (L4 §1)", () => {
     expect(store.list()).toHaveLength(0);
   });
 });
+
+describe("BindingStore — getPolicy (resolved confirm policy = `?? true`)", () => {
+  it("defaults an UNSET field to TRUE (confirm — the safe backstop), not false", () => {
+    const dir = freshDir();
+    const store = BindingStore.load(dir, alwaysExists);
+    store.bind("sudo://localhost/root", "aa".repeat(16), meta());
+    // The field is absent, yet the RESOLVED policy is confirm (matches the capture-loop's `?? true`).
+    expect(store.list()[0].confirmEveryInjection).toBeUndefined();
+    expect(store.getPolicy("sudo://localhost/root")).toBe(true);
+  });
+
+  it("returns TRUE for an UNKNOWN binding (fail-safe: confirm when we don't know it)", () => {
+    const store = BindingStore.load(freshDir(), alwaysExists);
+    expect(store.getPolicy("sudo://nope/root")).toBe(true);
+  });
+
+  it("returns the explicit value once set (false = the per-binding opt-OUT)", () => {
+    const dir = freshDir();
+    const store = BindingStore.load(dir, alwaysExists);
+    store.bind("sudo://localhost/root", "aa".repeat(16), meta());
+    store.setPolicy("sudo://localhost/root", false);
+    expect(store.getPolicy("sudo://localhost/root")).toBe(false);
+    store.setPolicy("sudo://localhost/root", true);
+    expect(store.getPolicy("sudo://localhost/root")).toBe(true);
+  });
+});

--- a/tests/unit/key-locker-tool.test.ts
+++ b/tests/unit/key-locker-tool.test.ts
@@ -11,8 +11,9 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { KeyLockerHost } from "../../src/engine/key-locker/key-locker-host.js";
 import { KeyLockerManager } from "../../src/engine/key-locker/key-locker-manager.js";
 import { BindingStore } from "../../src/engine/key-locker/binding-store.js";
-import { keyLockerHandler, __setKeyLockerManagerForTest } from "../../src/tools/key-locker-tool.js";
+import { keyLockerHandler, __setKeyLockerManagerForTest, __setSshExecForTest } from "../../src/tools/key-locker-tool.js";
 import type { KeyLockerArgs } from "../../src/tools/key-locker-tool.js";
+import type { ExecFn } from "../../src/engine/key-locker/ssh-resolve.js";
 
 /** A manager whose host capture/delete + consent dialog are fakes (no exe / GUI / ssh). */
 class FakeManager extends KeyLockerManager {
@@ -59,6 +60,7 @@ beforeEach(() => {
 });
 afterEach(() => {
   __setKeyLockerManagerForTest(null);
+  __setSshExecForTest(null);
   if (savedDisable === undefined) delete process.env.DESKTOP_TOUCH_DISABLE_KEY_LOCKER;
   else process.env.DESKTOP_TOUCH_DISABLE_KEY_LOCKER = savedDisable;
   for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
@@ -96,13 +98,14 @@ describe("key_locker — the consent gate (every action except status)", () => {
 });
 
 describe("key_locker — list", () => {
-  it("returns non-secret metadata (with confirmEveryInjection default false), no opaqueId/secret", async () => {
+  it("returns non-secret metadata (confirmEveryInjection defaults TRUE = confirm), no opaqueId/secret", async () => {
     acceptConsent();
     seed("sudo://host/root", { scheme: "sudo", displayUri: "sudo://host/root", host: "host", targetUser: "root", createdAt: "2026-07-05T00:00:00.000Z" });
     const r = await call({ action: "list" });
     const bindings = r.bindings as Array<Record<string, unknown>>;
     expect(bindings).toHaveLength(1);
-    expect(bindings[0]).toEqual({ displayUri: "sudo://host/root", scheme: "sudo", host: "host", createdAt: "2026-07-05T00:00:00.000Z", confirmEveryInjection: false });
+    // Unset policy ⇒ RESOLVED confirm=true (matches the capture-loop's `?? true` backstop, not `?? false`).
+    expect(bindings[0]).toEqual({ displayUri: "sudo://host/root", scheme: "sudo", host: "host", createdAt: "2026-07-05T00:00:00.000Z", confirmEveryInjection: true });
     // No secret / opaqueId / targetUser leak in the tool output.
     expect(JSON.stringify(r)).not.toContain("aa".repeat(16));
     expect(bindings[0]).not.toHaveProperty("opaqueId");
@@ -136,6 +139,53 @@ describe("key_locker — save (non-ssh, faked capture)", () => {
     mgr.acceptOnConsent = true;
     const r = await call({ action: "save", uri: "not-a-uri" });
     expect(r.ok).toBe(false);
+  });
+});
+
+describe("key_locker — save (ssh, faked ssh -G / ssh-keygen exec) — #500 P3-3 parity lock", () => {
+  it("routes ssh through resolveCanonicalForSshCommand and binds under the RESOLVED canonical (fp tail)", async () => {
+    mgr.acceptOnConsent = true;
+    // A real known_hosts file so the resolver's existsSync() passes; its bytes are irrelevant (the
+    // faked ssh-keygen returns the fingerprint regardless — we are pinning the tool's ROUTING, not ssh).
+    const kh = join(dir, "known_hosts");
+    writeFileSync(kh, "real.example.com ssh-ed25519 AAAAdummy\n", "utf8");
+    const fp = "SHA256:ABCdef0123456789ABCdef0123456789ABCdef01234";
+    const fakeExec: ExecFn = async (file, args) => {
+      if (file === "ssh" && args[0] === "-G") {
+        return { code: 0, stdout: `hostname real.example.com\nuser bob\nport 22\nuserknownhostsfile ${kh}\n`, stderr: "" };
+      }
+      if (file === "ssh-keygen") return { code: 0, stdout: `1 ${fp} real.example.com\n`, stderr: "" };
+      return { code: 1, stdout: "", stderr: "unexpected exec" };
+    };
+    __setSshExecForTest(fakeExec);
+
+    const r = await call({ action: "save", uri: "ssh://bob@real.example.com" });
+    expect(r).toMatchObject({ captured: true });
+    expect(mgr.captureCalls).toHaveLength(1);
+    const rows = BindingStore.load(dir).list();
+    expect(rows).toHaveLength(1);
+    // Bound under the resolver's canonical (the fp-set tail the capture-loop's deriveBinding also
+    // produces — save↔derive key parity), NOT a raw URI; the secret sits under the same opaqueId.
+    expect(rows[0]).toMatchObject({ scheme: "ssh", host: "real.example.com", user: "bob", port: 22, fpSet: [fp], opaqueId: mgr.captureCalls[0] });
+    expect(rows[0].canonicalKey).toContain("|fp=");
+  });
+
+  it("host-not-known (empty fp union) → KeyLockerSshUnresolved, fails closed BEFORE capture", async () => {
+    mgr.acceptOnConsent = true;
+    const fakeExec: ExecFn = async (file, args) => {
+      if (file === "ssh" && args[0] === "-G") {
+        // A known_hosts path that does not exist ⇒ existsSync false ⇒ empty union ⇒ host-not-known.
+        return { code: 0, stdout: `hostname new.example.com\nuser bob\nport 22\nuserknownhostsfile ${join(dir, "absent_known_hosts")}\n`, stderr: "" };
+      }
+      return { code: 1, stdout: "", stderr: "" };
+    };
+    __setSshExecForTest(fakeExec);
+
+    const r = await call({ action: "save", uri: "ssh://bob@new.example.com" });
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe("KeyLockerSshUnresolved");
+    expect(BindingStore.load(dir).list()).toHaveLength(0);
+    expect(mgr.captureCalls).toHaveLength(0); // no dialog opened — resolution fails closed first
   });
 });
 


### PR DESCRIPTION
## What & why

The `key_locker` tool and the credential-autofill loop disagreed on the default of the per-binding **autofill-confirmation** policy — a user-facing safety bug, not cosmetics.

- **The loop (authoritative consumer):** an unset binding **confirms** every autofill (the safe backstop); `confirmEveryInjection: false` is the per-binding **opt-out**.
- **The tool (before this PR):** `list` displayed unset as `false` ("won't ask") while the loop **does** ask, and `set_policy`'s help said `false = default` — so a user setting `false` to "restore the default" would silently **turn the confirmation off**.

This PR makes the tool tell the truth and match the loop.

## Changes
- `BindingStore.getPolicy(key)` — the resolved policy `confirmEveryInjection ?? true` (additive; unknown/unset ⇒ confirm).
- `key_locker` `list` reports the resolved policy; `set_policy` help + the metadata doc state the correct default (unset/`true` = confirm; `false` = opt out).
- Adds tool-level `save` tests for the **ssh** path (a test-only faked `ssh -G`/`ssh-keygen`) that pin the save↔autofill key parity and the "host not in known_hosts ⇒ fail before capture" behavior.

## Verification
- `npm run build` clean; `npm run lint` 0 errors.
- `key-locker-*` unit suite 267 passed; `tools-list-schema` 6 passed.
- No public tool added ⇒ no catalogue change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)