### PR TITLE
ADR-014 v2 R3 Key Locker — L3-3 PR2: [Never] tombstone store + capture-loop suppression

### DIFF
--- a/src/engine/key-locker/capture-loop.ts
+++ b/src/engine/key-locker/capture-loop.ts
@@ -65,8 +65,10 @@ export interface CredentialEvent {
  */
 export type CaptureLoopOutcome =
   /** Nothing touched the locker: the pane session is UNKNOWN (§3 fail-safe), the command carries no
-   *  credential L1 attributes, or the binding is not pane-injectable (askpass/git-credential forward flow). */
-  | { kind: "declined"; reason: "unknown_session" | "not_a_credential" | "not_pane_channel" }
+   *  credential L1 attributes, the binding is not pane-injectable (askpass/git-credential forward flow),
+   *  or the user previously chose [Never] for this binding (`never_suppressed` — the save is not
+   *  re-offered, and with no stored secret there is nothing to autofill either). */
+  | { kind: "declined"; reason: "unknown_session" | "not_a_credential" | "not_pane_channel" | "never_suppressed" }
   /** MATCH path: the per-binding confirm backstop (D2) was declined — no injection. */
   | { kind: "confirm_rejected" }
   /** MATCH path: a stored secret was autofilled. `verified` = the locker's injection-instant re-verify. */
@@ -117,6 +119,14 @@ export interface CaptureLoopDeps {
    * next prompt). The seam EXPRESSES the §1 contract point here rather than silently dropping it (強制命令 9).
    */
   onNever?(canonicalKey: string): void;
+  /**
+   * OPTIONAL negative-binding gate — the `[Never]` tombstone the `onNever` seam persists (`NeverStore`).
+   * Consulted in the NO-MATCH branch AFTER canonical is derived and BEFORE `capture` (P3-1): a tombstoned
+   * binding declines with `never_suppressed` (no re-offer, no capture dialog). A resolved MATCH BYPASSES
+   * this entirely — a manually re-saved binding still autofills; the tombstone only suppresses the
+   * capture-and-save OFFER, never a stored secret. Unwired ⇒ no suppression (behaves exactly as before).
+   */
+  isNever?(canonicalKey: string): boolean;
   /** Mint the opaqueId the loop will bind on save (`randomBytes(16).toString("hex")`; a fake in tests). */
   mintOpaqueId(): string;
   /** ISO-8601 timestamp for `meta.createdAt` (injected so tests are deterministic). */
@@ -173,6 +183,11 @@ export async function runCaptureLoop(deps: CaptureLoopDeps, event: CredentialEve
   }
 
   // ── NO MATCH: capture → inject → landed → OFFER → persist only on [Save] (P1-2). ───────────────────
+  // A binding the user tombstoned via [Never] is not re-offered — decline BEFORE opening the capture
+  // dialog (P3-1: NO-MATCH-ONLY — the MATCH path above already autofilled a stored secret regardless, so
+  // a manually re-saved binding is unaffected by a lingering tombstone). Unwired `isNever` ⇒ no change.
+  if (deps.isNever?.(canonical) === true) return { kind: "declined", reason: "never_suppressed" };
+
   const opaqueId = deps.mintOpaqueId(); // minted before capture; bound on save, deleted otherwise
   let captured = false;                 // did a secret actually get stored under opaqueId?
   let committed = false;                // did the user [Save] it? (retain the locker entry)

--- a/src/engine/key-locker/never-store.ts
+++ b/src/engine/key-locker/never-store.ts
@@ -1,0 +1,105 @@
+// ADR-014 v2 R3 Key Locker — L3 §1: the negative-binding ("[Never]") store.
+//
+// Plan: desktop-touch-mcp-internal:docs/adr-014-v2-r3-l3-3-manager-watch-plan.md (PR 2) +
+//   adr-014-v2-r3-l3-capture-plan.md §1 (`policyStore.setNever`).
+//
+// When the user answers [Never] to a post-landing "save this credential?" offer, the capture-loop must
+// not re-offer to save that binding again. This tombstone is a NEGATIVE-binding record — DISTINCT from
+// the saved-row `confirmEveryInjection` policy (which only exists on rows that WERE saved). It holds NO
+// secret (canonical keys only = URIs + public fingerprints), so like `BindingStore` it is plain JSON
+// co-located with the locker store dir (a same-user process editing it is parent §8 out of scope — it
+// could read the DPAPI store directly, same-user).
+//
+// SCOPE: the loop's NO-MATCH branch consults `has()` BEFORE the capture dialog and declines a tombstoned
+// binding; the `onNever` seam calls `add()`. A resolved MATCH bypasses the store entirely (a manually
+// re-saved binding still autofills — the tombstone only suppresses the capture-and-save OFFER, never a
+// stored secret). Clearing a tombstone (e.g. when the user later manually `save`s the same binding) is a
+// future L4-management nicety — not needed for correctness, since MATCH already bypasses this store.
+
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** Mirrors the locker's default store dir (Program.cs: %LOCALAPPDATA%\desktop-touch-mcp\locker). */
+function defaultStoreDir(): string {
+  const localAppData = process.env.LOCALAPPDATA ?? join(homedir(), "AppData", "Local");
+  return join(localAppData, "desktop-touch-mcp", "locker");
+}
+
+const FILE_NAME = "never.json";
+
+interface NeverFile {
+  version: 1;
+  /** Canonical keys the user chose [Never] for. Sorted on write (determinism). */
+  entries: string[];
+}
+
+/**
+ * The set of canonical keys the user tombstoned via [Never], with atomic persistence. Create with
+ * `NeverStore.load()`; `add` saves atomically (tmp write + rename, mirroring `BindingStore.save()`).
+ * In-memory `Set` backs an O(1) `has`.
+ */
+export class NeverStore {
+  private constructor(
+    private readonly filePath: string,
+    private readonly entries: Set<string>,
+  ) {}
+
+  /**
+   * Load (or start) the store under `storeDir` (default: the locker's own store dir, so tests override
+   * with the same `storeDir` the locker accepts). Tolerant of a corrupt / missing / wrong-shape file:
+   * starts empty, preserving the corrupt original as `.corrupt` (a lost tombstone only re-offers a save
+   * — a UX nuisance, never a security or wrong-target issue, so fail-safe to empty).
+   */
+  static load(storeDir?: string): NeverStore {
+    const dir = storeDir ?? defaultStoreDir();
+    mkdirSync(dir, { recursive: true });
+    const filePath = join(dir, FILE_NAME);
+    const entries = new Set<string>();
+    if (existsSync(filePath)) {
+      try {
+        const raw = JSON.parse(readFileSync(filePath, "utf8")) as unknown;
+        if (
+          typeof raw === "object" && raw !== null &&
+          (raw as NeverFile).version === 1 &&
+          Array.isArray((raw as NeverFile).entries) &&
+          (raw as NeverFile).entries.every((e) => typeof e === "string")
+        ) {
+          for (const e of (raw as NeverFile).entries) entries.add(e);
+        } else {
+          preserveCorrupt(filePath);
+        }
+      } catch {
+        preserveCorrupt(filePath);
+      }
+    }
+    return new NeverStore(filePath, entries);
+  }
+
+  /** True if the user chose [Never] for this canonical binding — the loop then skips the save offer. */
+  has(canonicalKey: string): boolean {
+    return this.entries.has(canonicalKey);
+  }
+
+  /** Record a [Never] tombstone (idempotent — a no-op + no write if already present). Atomic persist. */
+  add(canonicalKey: string): void {
+    if (this.entries.has(canonicalKey)) return;
+    this.entries.add(canonicalKey);
+    this.save();
+  }
+
+  /** Atomic persistence: write `<file>.tmp`, then rename over the real file (mirrors L0 Save()). */
+  private save(): void {
+    const tmp = `${this.filePath}.tmp`;
+    const data: NeverFile = { version: 1, entries: [...this.entries].sort() };
+    writeFileSync(tmp, JSON.stringify(data, null, 2), "utf8");
+    renameSync(tmp, this.filePath); // libuv rename uses MOVEFILE_REPLACE_EXISTING on Windows
+  }
+}
+
+/** Keep forensic evidence of an unparseable file instead of silently overwriting it. */
+function preserveCorrupt(filePath: string): void {
+  try {
+    renameSync(filePath, `${filePath}.corrupt`);
+  } catch { /* best-effort */ }
+}

--- a/tests/unit/key-locker-capture-loop.test.ts
+++ b/tests/unit/key-locker-capture-loop.test.ts
@@ -82,6 +82,39 @@ describe("runCaptureLoop — declines (never touch the locker)", () => {
   });
 });
 
+describe("runCaptureLoop — [Never] tombstone suppression (isNever, NO-MATCH only, P3-1)", () => {
+  it("a tombstoned NO-MATCH binding ⇒ decline BEFORE capture, no dialog", async () => {
+    const deps = makeDeps({ isNever: vi.fn(() => true) });
+    expect(await runCaptureLoop(deps, EVENT)).toEqual({ kind: "declined", reason: "never_suppressed" });
+    expect(deps.isNever).toHaveBeenCalledWith("sudo://localhost/root");
+    expect(deps.capture).not.toHaveBeenCalled();
+    expect(deps.mintOpaqueId).not.toHaveBeenCalled();
+  });
+
+  it("a tombstone does NOT block a resolved MATCH (a manually re-saved binding still autofills)", async () => {
+    const deps = makeDeps({
+      isNever: vi.fn(() => true),
+      resolveBinding: vi.fn(async () => ({ opaqueId: "stored-1" })),
+    });
+    expect(await runCaptureLoop(deps, EVENT)).toEqual({ kind: "filled_from_store", verified: true });
+    // MATCH path returns before the NO-MATCH never-check is ever consulted.
+    expect(deps.isNever).not.toHaveBeenCalled();
+    expect(deps.injectPane).toHaveBeenCalledWith(SUDO, "stored-1", true);
+  });
+
+  it("isNever UNWIRED ⇒ no suppression (captures + saves as before)", async () => {
+    const deps = makeDeps({ isNever: undefined });
+    expect(await runCaptureLoop(deps, EVENT)).toEqual({ kind: "saved", verified: true });
+    expect(deps.capture).toHaveBeenCalledOnce();
+  });
+
+  it("isNever returns false ⇒ not suppressed (captures)", async () => {
+    const deps = makeDeps({ isNever: vi.fn(() => false) });
+    expect(await runCaptureLoop(deps, EVENT)).toEqual({ kind: "saved", verified: true });
+    expect(deps.capture).toHaveBeenCalledOnce();
+  });
+});
+
 describe("runCaptureLoop — Mode-B interactive login (mode-agnostic landed, P1-1)", () => {
   it("interactive auth-accepted ⇒ saved (NOT gated on an exit code)", async () => {
     const deps = makeDeps({

--- a/tests/unit/key-locker-never-store.test.ts
+++ b/tests/unit/key-locker-never-store.test.ts
@@ -65,10 +65,11 @@ describe("NeverStore — tolerant load (fail-safe to empty)", () => {
     expect(existsSync(join(dir, "never.json.corrupt"))).toBe(true);
   });
 
-  it("a non-string entry makes the whole file corrupt (fail-safe empty)", () => {
+  it("a non-string entry makes the whole file corrupt (fail-safe empty, preserved as .corrupt)", () => {
     const dir = freshDir();
     writeFileSync(join(dir, "never.json"), JSON.stringify({ version: 1, entries: ["ok", 42] }), "utf8");
     expect(NeverStore.load(dir).has("ok")).toBe(false);
+    expect(existsSync(join(dir, "never.json.corrupt"))).toBe(true);
   });
 
   it("a missing file starts empty without creating a .corrupt", () => {

--- a/tests/unit/key-locker-never-store.test.ts
+++ b/tests/unit/key-locker-never-store.test.ts
@@ -1,0 +1,79 @@
+// key-locker-never-store.test.ts — ADR-014 R3 L3-3 PR2 (the negative-binding "[Never]" tombstone store).
+// Pins has/add, atomic persistence across a reload, idempotent add, and fail-safe tolerant load.
+import { mkdtempSync, existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { NeverStore } from "../../src/engine/key-locker/never-store.js";
+
+const dirs: string[] = [];
+const freshDir = (): string => {
+  const d = mkdtempSync(join(tmpdir(), "dtm-l3-never-"));
+  dirs.push(d);
+  return d;
+};
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+describe("NeverStore — add / has round-trip", () => {
+  it("has is false until added, true after; survives a reload (atomic save)", () => {
+    const dir = freshDir();
+    const store = NeverStore.load(dir);
+    expect(store.has("sudo://localhost/root")).toBe(false);
+    store.add("sudo://localhost/root");
+    expect(store.has("sudo://localhost/root")).toBe(true);
+    // Another key is unaffected.
+    expect(store.has("ssh://deploy@prod:22|fp=SHA256:aaa")).toBe(false);
+    // Reload from disk — the tombstone persisted.
+    expect(NeverStore.load(dir).has("sudo://localhost/root")).toBe(true);
+  });
+
+  it("add is idempotent — re-adding writes nothing new / does not duplicate", () => {
+    const dir = freshDir();
+    const store = NeverStore.load(dir);
+    store.add("sudo://localhost/root");
+    store.add("sudo://localhost/root");
+    store.add("ssh://deploy@prod:22|fp=SHA256:aaa");
+    const parsed = JSON.parse(readFileSync(join(dir, "never.json"), "utf8")) as { version: number; entries: string[] };
+    expect(parsed.version).toBe(1);
+    expect(parsed.entries).toEqual(["ssh://deploy@prod:22|fp=SHA256:aaa", "sudo://localhost/root"]); // sorted, deduped
+  });
+
+  it("no secret-shaped field is ever written — canonical keys only", () => {
+    const dir = freshDir();
+    NeverStore.load(dir).add("sudo://localhost/root");
+    const raw = readFileSync(join(dir, "never.json"), "utf8");
+    expect(Object.keys(JSON.parse(raw)).sort()).toEqual(["entries", "version"]);
+  });
+});
+
+describe("NeverStore — tolerant load (fail-safe to empty)", () => {
+  it("corrupt never.json ⇒ starts empty, preserving the original as .corrupt", () => {
+    const dir = freshDir();
+    writeFileSync(join(dir, "never.json"), "{not json!!", "utf8");
+    const store = NeverStore.load(dir);
+    expect(store.has("sudo://localhost/root")).toBe(false);
+    expect(existsSync(join(dir, "never.json.corrupt"))).toBe(true);
+  });
+
+  it("wrong-shape file (valid JSON, not our schema) is treated as corrupt", () => {
+    const dir = freshDir();
+    writeFileSync(join(dir, "never.json"), JSON.stringify({ version: 99, entries: "nope" }), "utf8");
+    const store = NeverStore.load(dir);
+    expect(store.has("x")).toBe(false);
+    expect(existsSync(join(dir, "never.json.corrupt"))).toBe(true);
+  });
+
+  it("a non-string entry makes the whole file corrupt (fail-safe empty)", () => {
+    const dir = freshDir();
+    writeFileSync(join(dir, "never.json"), JSON.stringify({ version: 1, entries: ["ok", 42] }), "utf8");
+    expect(NeverStore.load(dir).has("ok")).toBe(false);
+  });
+
+  it("a missing file starts empty without creating a .corrupt", () => {
+    const dir = freshDir();
+    expect(NeverStore.load(dir).has("x")).toBe(false);
+    expect(existsSync(join(dir, "never.json.corrupt"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## What & why

When the credential-autofill loop offers to save a newly-captured secret, the user can answer **[Never]**. Until now that answer was honored for the current prompt but not remembered, so the same "save this?" offer would reappear next time. This adds the persistent tombstone that makes **[Never]** stick.

## Changes
- `never-store.ts` (new): a small `never.json` sidecar next to the locker's data — `has`/`add`, atomic writes, tolerant load (a corrupt/missing file just starts empty). Stores only binding identifiers, never a secret.
- `capture-loop.ts`: a `[Never]`'d binding is now skipped **before** the secure-entry dialog even opens, returning a `never_suppressed` decline. This only affects the *save offer* for a binding with no stored secret — a binding that already has a saved secret still autofills normally (so manually re-saving a previously-declined binding works).

## Verification
- `npm run build` clean; lint clean on the changed files.
- `key-locker-*` unit suite 273 passed (adds the `never-store` suite + loop-suppression cases).
- Additive only — no public tool / schema / catalogue change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)