### PR TITLE
ADR-014 v2 R3 Key Locker — L3-3 PR3: ssh session-end watch (OQ-7) + idle-dispose

### DIFF
--- a/src/engine/key-locker/key-locker-manager.ts
+++ b/src/engine/key-locker/key-locker-manager.ts
@@ -74,6 +74,8 @@ export function keyLockerDisabled(): boolean {
 export interface KeyLockerManagerOptions extends KeyLockerStartOptions {
   /** Override the store dir (tests); production uses the locker default. */
   storeDir?: string;
+  /** Injected monotonic-ish clock for idle-dispose dormancy (default `Date.now`); overridden in tests. */
+  now?: () => number;
 }
 
 /**
@@ -86,8 +88,14 @@ export class KeyLockerManager {
   private host: KeyLockerHost | null = null;
   private starting: Promise<KeyLockerHost> | null = null;
   private consenting: Promise<void> | null = null; // in-flight `-Consent` dialog (dedupes concurrent prompts)
+  private inFlight = 0;        // secret ops currently running through withHost (idle-dispose never runs mid-op)
+  private lastActivityMs = 0;  // clock stamp of the last withHost completion (idle-dispose dormancy timer)
 
   constructor(private readonly opts: KeyLockerManagerOptions = {}) {}
+
+  private now(): number {
+    return (this.opts.now ?? Date.now)();
+  }
 
   /** The store dir this manager reads consent + bindings from. */
   get storeDir(): string {
@@ -116,7 +124,30 @@ export class KeyLockerManager {
       throw new KeyLockerConsentRequiredError();
     }
     const host = await this.ensureHost();
-    return fn(host);
+    // Count the op as in-flight so idle-dispose never tears the host down mid-operation (e.g. while a
+    // capture dialog is open for minutes); stamp the activity clock on completion (dormancy timer).
+    this.inFlight++;
+    try {
+      return await fn(host);
+    } finally {
+      this.inFlight--;
+      this.lastActivityMs = this.now();
+    }
+  }
+
+  /**
+   * Idle-dispose (dormancy): tear the live host down if no secret op has run for `idleMs`, so a locker
+   * that spawned once but is no longer in use does not linger for the process lifetime (the long-lived-
+   * resource discipline). The assembly calls this on a timer. Returns whether it disposed. NEVER disposes
+   * while an op is in flight (`inFlight > 0`) or when nothing is live. `dispose()` awaits any in-flight
+   * start, so this is safe to race with a lazy `withHost`.
+   */
+  async disposeIfIdle(idleMs: number): Promise<boolean> {
+    if (this.inFlight > 0) return false;                              // an op is running — not idle
+    if (this.host === null && this.starting === null) return false;   // nothing live to dispose
+    if (this.now() - this.lastActivityMs < idleMs) return false;      // used within the window
+    await this.dispose();
+    return true;
   }
 
   /**

--- a/src/engine/key-locker/key-locker-manager.ts
+++ b/src/engine/key-locker/key-locker-manager.ts
@@ -123,11 +123,13 @@ export class KeyLockerManager {
     if (!this.isConsentAccepted()) {
       throw new KeyLockerConsentRequiredError();
     }
-    const host = await this.ensureHost();
-    // Count the op as in-flight so idle-dispose never tears the host down mid-operation (e.g. while a
-    // capture dialog is open for minutes); stamp the activity clock on completion (dormancy timer).
+    // Count the op as in-flight BEFORE acquiring the host, so idle-dispose never tears the host down
+    // mid-operation NOR during its lazy START (Opus R1 P2-B: `inFlight++` after `ensureHost` left the
+    // start phase — and every post-idle restart — unguarded, so a racing `disposeIfIdle` could dispose
+    // the host `fn` is about to use). Stamp the activity clock on completion (dormancy timer).
     this.inFlight++;
     try {
+      const host = await this.ensureHost();
       return await fn(host);
     } finally {
       this.inFlight--;
@@ -139,12 +141,14 @@ export class KeyLockerManager {
    * Idle-dispose (dormancy): tear the live host down if no secret op has run for `idleMs`, so a locker
    * that spawned once but is no longer in use does not linger for the process lifetime (the long-lived-
    * resource discipline). The assembly calls this on a timer. Returns whether it disposed. NEVER disposes
-   * while an op is in flight (`inFlight > 0`) or when nothing is live. `dispose()` awaits any in-flight
-   * start, so this is safe to race with a lazy `withHost`.
+   * while an op is in flight (`inFlight > 0`, which now spans the lazy start too) or when nothing is
+   * live. `dispose()` awaits any in-flight start, so this is safe to race with a lazy `withHost`.
    */
   async disposeIfIdle(idleMs: number): Promise<boolean> {
-    if (this.inFlight > 0) return false;                              // an op is running — not idle
-    if (this.host === null && this.starting === null) return false;   // nothing live to dispose
+    // `inFlight` now covers the whole withHost body incl. the start, so a start-in-flight is inFlight>0;
+    // the `starting` check is belt-and-braces (no ensureHost path runs outside withHost).
+    if (this.inFlight > 0 || this.starting !== null) return false;    // an op / start is running — not idle
+    if (this.host === null) return false;                            // nothing live to dispose
     if (this.now() - this.lastActivityMs < idleMs) return false;      // used within the window
     await this.dispose();
     return true;

--- a/src/engine/key-locker/session-tracker.ts
+++ b/src/engine/key-locker/session-tracker.ts
@@ -169,6 +169,20 @@ export class SessionTracker {
   }
 
   /**
+   * How many REMOTE frames are stacked above the base local shell (0 = local / unknown / never
+   * anchored). The ssh process-tree watch (SP-L3-OQ-7) reads this to decide, when it observes the
+   * pane's outermost ssh child EXIT, between a lone `noteSessionEnd` (depth ≤ 1 — the one visible ssh
+   * maps 1:1 to the one remote frame) and `markUnknown` (depth ≥ 2 — NESTED ssh the local process tree
+   * cannot see, so a single pop would strand an inner remote frame → a later local command wrong-targets
+   * that inner host; Opus L3-3 PR#495 R4 P3). Never a stale trusted `isRemote:true` on doubt.
+   */
+  remoteDepth(paneId: string): number {
+    const st = this.panes.get(paneId);
+    if (st === undefined || st.stack === null) return 0;
+    return Math.max(0, st.stack.length - 1);
+  }
+
+  /**
    * Pop the top ssh frame — the manager calls this when it observes the pane's `ssh` child process
    * exit (the authoritative session-end signal, §3). Popping the base local frame is a no-op (you
    * can't ssh-out of the local shell). Never sinks to unknown by itself.

--- a/src/engine/key-locker/ssh-session-watch.ts
+++ b/src/engine/key-locker/ssh-session-watch.ts
@@ -6,23 +6,32 @@
 // WHY: an interactive `ssh user@host` runs under Mode B (a pane read), NOT an exit-mode watch — so the
 // SessionTracker frame it pushed has no exit code to pop on. If it is never popped, a later LOCAL command
 // in that pane derives `sudo://<remotehost>` and, on a MATCH, would autofill the REMOTE secret into a
-// LOCAL prompt — a wrong-target fill. The authoritative session-end signal is therefore the pane's `ssh`
-// CHILD PROCESS exiting, observed via the process tree (a process observation, never a screen-scrape).
+// LOCAL prompt — a wrong-target fill. The authoritative session-end signal is the SESSION's `ssh` CHILD
+// PROCESS exiting, observed via the process tree (a process observation, never a screen-scrape).
 //
-// This module is PURE reconciliation logic over an injected process snapshot — no Win32 import — so it
-// unit-tests with a fake tree. The KeyLockerManager (the assembly) owns the live instance: it snapshots
-// via win32 `buildProcessParentMap()` + `getProcessIdentityByPid()`, registers a pane's shell pid on
-// anchor, and drives `tick()` on a timer. That live wiring lands with the terminal-event subscription.
+// WHAT IT WATCHES (Opus L3-3 PR#505 R1 P2-A): the tracker pushes a frame ONLY for an INTERACTIVE ssh —
+// a backgrounded `ssh -f -L`, a one-shot `ssh host cmd`, and a ProxyJump/`-W` child ssh push NO frame yet
+// are ALSO `ssh` processes under the shell. So the watch must NOT react to "any ssh descendant exiting"
+// (a dying tunnel would pop a still-live interactive frame → the pane mislabels remote-as-local → the
+// INVERSE wrong-target). Instead the wiring, which dispatched the interactive ssh and can correlate the
+// child it spawned, REGISTERS that specific pid via `noteSshOpened`; the watch fires only when THAT pid
+// exits. Only the OUTERMOST ssh is locally visible (an inner `ssh b` runs ON host-a), so the watch tracks
+// one session pid per pane and the depth pivot (below) covers nesting.
+//
+// This module is PURE reconciliation over an injected process snapshot — no Win32 import — so it
+// unit-tests with a fake tree. The KeyLockerManager (the live wiring, deferred) owns the instance: it
+// snapshots via win32 `buildProcessParentMap()` + `getProcessIdentityByPid()` (mapping `processName`
+// LOWERCASED into `ProcessIdentity.name`), registers the shell pid + the session ssh pid, and drives
+// `tick()` on a timer. That live wiring lands with the terminal-event subscription.
 //
 // FAIL-SAFE (§3, Opus R2 P2): any doubt sinks the pane to `markUnknown` (decline-to-derive), NEVER a
-// stale trusted `isRemote:true`. Two doubt sources: (a) an unwatchable pane (its shell pid vanished from
-// the snapshot) and (b) NESTED ssh — the local tree shows only the OUTERMOST ssh (an inner `ssh b` runs
-// ON host-a, invisible locally), so when the outer ssh exits while the tracker still holds ≥ 2 remote
-// frames, a single pop would strand the inner frame → markUnknown instead (SP-L3-OQ-7 depth rule).
+// stale trusted `isRemote:true`. Two doubt sources: (a) an unwatchable pane (its shell pid vanished) and
+// (b) NESTED ssh — when the registered outer ssh exits while the tracker still holds ≥ 2 remote frames, a
+// single pop would strand the invisible inner frame → markUnknown instead (SP-L3-OQ-7 depth rule).
 
 /** The tracker surface the watch drives (a subset of `SessionTracker`, so tests inject a fake). */
 export interface SessionTrackerSink {
-  /** Pop one remote frame — the observed outermost ssh child exited and the pane maps 1:1 (depth ≤ 1). */
+  /** Pop one remote frame — the registered session ssh exited and the pane maps 1:1 (depth ≤ 1). */
   noteSessionEnd(paneId: string): void;
   /** Sink the pane to UNKNOWN — an unconfirmable / unobservable session-end (depth ≥ 2, shell gone). */
   markUnknown(paneId: string): void;
@@ -32,7 +41,8 @@ export interface SessionTrackerSink {
 
 /** One process's identity in a snapshot (from win32 `getProcessIdentityByPid`). */
 export interface ProcessIdentity {
-  /** Image name, lowercased, `.exe` stripped (e.g. "ssh", "powershell"). "" when unknown/gone. */
+  /** Image name, LOWERCASED, `.exe` stripped (e.g. "ssh", "powershell"). "" when unknown/gone. The live
+   *  adapter MUST lowercase win32's `processName` (it is not lowercased at source). */
   name: string;
   /** Creation time (ms since the Windows epoch); 0 on failure. Distinguishes a REUSED pid from the same. */
   startTimeMs: number;
@@ -40,7 +50,9 @@ export interface ProcessIdentity {
 
 /** A live process-tree snapshot the watch reconciles against (injected so it unit-tests with a fake). */
 export interface ProcessSnapshot {
-  /** pid → parentPid for every live process (Toolhelp32). A pid present as a KEY means it is alive. */
+  /** pid → parentPid for every live process (Toolhelp32). A pid present as a KEY means it is alive. An
+   *  EMPTY map = a native-snapshot failure (`buildProcessParentMap` swallows errors → {}), NOT "no
+   *  processes" — the watch skips such a tick rather than mis-read every shell as dead. */
   parentMap: Map<number, number>;
   /** Identity for a pid (name + creation time). A gone pid returns `{ name: "", startTimeMs: 0 }`. */
   identify(pid: number): ProcessIdentity;
@@ -53,20 +65,20 @@ export interface SshWatchDeps {
   tracker: SessionTrackerSink;
 }
 
-/** A registered pane: the shell pid to root the descendant search + the ssh children currently watched. */
+/** A registered pane: the shell pid (liveness anchor) + the outermost session ssh currently watched. */
 interface WatchedPane {
   shellPid: number;
-  /** pid → creation-time of every `ssh` descendant seen last tick (identity guards pid reuse). */
-  ssh: Map<number, number>;
+  /** The outermost interactive-session ssh child, or null when the pane holds no live ssh session. */
+  session: { pid: number; startedAt: number } | null;
 }
 
 const SSH_PROGRAM = "ssh";
 
 /**
- * Watches registered panes for their `ssh` child processes exiting, driving the SessionTracker's
- * pop / markUnknown. Pure reconciliation: `tick()` snapshots the tree and diffs each pane's ssh
- * descendants against the previous tick. Register a pane with `watchPane` when its session is anchored
- * on a known shell pid; `unwatchPane` when the window closes.
+ * Watches each registered pane's outermost interactive-session ssh process for exit, driving the
+ * SessionTracker's pop / markUnknown. Pure reconciliation: `tick()` snapshots the tree and checks the
+ * one registered session pid per pane. Register a pane with `watchPane` on anchor; register its session
+ * ssh child with `noteSshOpened` when the wiring pushes an interactive frame; `unwatchPane` on close.
  */
 export class SshSessionWatch {
   private readonly panes = new Map<string, WatchedPane>();
@@ -74,14 +86,12 @@ export class SshSessionWatch {
   constructor(private readonly deps: SshWatchDeps) {}
 
   /**
-   * Start watching `paneId`, rooted at its shell pid (`getWindowProcessId(hwnd)` — the window-owning
-   * pid, value-consistent with L2's re-verify). Seeds the watched-ssh set from a snapshot NOW, so a
-   * `tick` does not mistake an ALREADY-open ssh (present at registration) for a fresh exit later. Re-
-   * registering a pane resets it.
+   * Start watching `paneId`, anchored at its shell pid (`getWindowProcessId(hwnd)` — the window-owning
+   * pid, value-consistent with L2's re-verify). No session ssh is watched until `noteSshOpened`.
+   * Re-registering a pane resets it (drops any tracked session).
    */
   watchPane(paneId: string, shellPid: number): void {
-    const snap = this.deps.snapshot();
-    this.panes.set(paneId, { shellPid, ssh: this.sshDescendants(snap, shellPid) });
+    this.panes.set(paneId, { shellPid, session: null });
   }
 
   /** Stop watching a pane (its window closed / the tracker forgot it). Idempotent. */
@@ -89,18 +99,37 @@ export class SshSessionWatch {
     this.panes.delete(paneId);
   }
 
-  /** Is this pane currently watched? (Lets the assembly avoid double-registration.) */
+  /** Is this pane currently watched? (Lets the wiring avoid double-registration.) */
   isWatching(paneId: string): boolean {
     return this.panes.has(paneId);
   }
 
   /**
-   * One poll tick: snapshot once, then for each watched pane reconcile its `ssh` descendants against the
-   * previous tick and drive the tracker. Cheap: one Toolhelp snapshot + a bounded per-pane walk.
+   * Register the OUTERMOST interactive-session ssh child pid for a pane — the wiring calls this when it
+   * pushes an interactive frame, having correlated the ssh child it just spawned. The watch records that
+   * pid's identity and fires only on ITS exit (never on a sibling tunnel / one-shot ssh — P2-A). A no-op
+   * if the pane isn't watched; a pid that isn't a live `ssh` is ignored (a late/bad pid never seeds a
+   * spurious exit — it would otherwise mismatch identity next tick and fire). Nested logins re-register
+   * the same visible outer pid; the invisible inner frame is covered by the depth pivot in `tick`.
+   */
+  noteSshOpened(paneId: string, sshPid: number): void {
+    const pane = this.panes.get(paneId);
+    if (pane === undefined) return;
+    const id = this.deps.snapshot().identify(sshPid);
+    if (id.name !== SSH_PROGRAM) { pane.session = null; return; } // not a live ssh — ignore
+    pane.session = { pid: sshPid, startedAt: id.startTimeMs };
+  }
+
+  /**
+   * One poll tick: snapshot once, then for each watched pane check its registered session ssh. Cheap:
+   * one Toolhelp snapshot + a bounded per-pane identity read.
    */
   tick(): void {
     if (this.panes.size === 0) return;
     const snap = this.deps.snapshot();
+    // A degenerate (empty) snapshot means the native call FAILED, not that every process died — skip the
+    // tick rather than markUnknown + unwatch every pane on a transient glitch (Opus R1 P3-A).
+    if (snap.parentMap.size === 0) return;
     for (const [paneId, pane] of this.panes) {
       // (a) Shell gone ⇒ the pane is unobservable ⇒ fail-safe to UNKNOWN and stop watching it. A live
       //     process always appears as a KEY in the Toolhelp map, so absence = dead.
@@ -109,55 +138,16 @@ export class SshSessionWatch {
         this.panes.delete(paneId);
         continue;
       }
-      const current = this.sshDescendants(snap, pane.shellPid);
-      // A previously-watched ssh whose pid is gone OR whose creation time changed (pid REUSE) has exited.
-      let anyExited = false;
-      for (const [pid, startedAt] of pane.ssh) {
-        if (current.get(pid) !== startedAt) { anyExited = true; break; }
-      }
-      if (anyExited) {
-        // (b) Depth pivot (SP-L3-OQ-7): the local tree only ever shows the OUTERMOST ssh, so a lone pop is
-        //     safe only when the tracker holds ≤ 1 remote frame. With NESTED frames (≥ 2) the watch cannot
-        //     tell which ended → markUnknown rather than strand an inner remote frame (wrong-target guard).
-        if (this.deps.tracker.remoteDepth(paneId) <= 1) this.deps.tracker.noteSessionEnd(paneId);
-        else this.deps.tracker.markUnknown(paneId);
-      }
-      pane.ssh = current; // adopt the new set (new ssh added, exited ssh dropped)
+      if (pane.session === null) continue; // no interactive ssh registered — nothing to pop
+      // The registered session ssh has EXITED iff its pid is gone OR its creation time changed (pid reuse).
+      const id = snap.identify(pane.session.pid);
+      if (id.name === SSH_PROGRAM && id.startTimeMs === pane.session.startedAt) continue; // still alive
+      // (b) Depth pivot (SP-L3-OQ-7): a lone pop is safe only when the tracker holds ≤ 1 remote frame; with
+      //     NESTED frames (≥ 2) the invisible inner login means a single pop would strand a remote frame →
+      //     markUnknown rather than relabel remote-as-local (wrong-target guard).
+      if (this.deps.tracker.remoteDepth(paneId) <= 1) this.deps.tracker.noteSessionEnd(paneId);
+      else this.deps.tracker.markUnknown(paneId);
+      pane.session = null; // consumed — do not re-fire until a new session is registered
     }
   }
-
-  /** Every `ssh`-named process descended from `rootPid` (walk the parent map), pid → creation time. */
-  private sshDescendants(snap: ProcessSnapshot, rootPid: number): Map<number, number> {
-    const out = new Map<number, number>();
-    for (const pid of descendantsOf(snap.parentMap, rootPid)) {
-      const id = snap.identify(pid);
-      if (id.name === SSH_PROGRAM) out.set(pid, id.startTimeMs);
-    }
-    return out;
-  }
-}
-
-/**
- * All descendant pids of `rootPid` in a pid→parentPid map (excludes `rootPid` itself). Iterative BFS
- * with a visited guard so a cyclic/self-parented snapshot (pid reuse mid-enumeration) cannot loop.
- */
-function descendantsOf(parentMap: Map<number, number>, rootPid: number): number[] {
-  // Invert once to children lists so the walk is O(n) not O(n·depth).
-  const children = new Map<number, number[]>();
-  for (const [pid, parent] of parentMap) {
-    if (pid === parent) continue; // a self-parented root (System/Idle) is not its own child
-    (children.get(parent) ?? children.set(parent, []).get(parent)!).push(pid);
-  }
-  const out: number[] = [];
-  const seen = new Set<number>([rootPid]);
-  const queue = [...(children.get(rootPid) ?? [])];
-  while (queue.length > 0) {
-    const pid = queue.pop()!;
-    if (seen.has(pid)) continue;
-    seen.add(pid);
-    out.push(pid);
-    const kids = children.get(pid);
-    if (kids !== undefined) queue.push(...kids);
-  }
-  return out;
 }

--- a/src/engine/key-locker/ssh-session-watch.ts
+++ b/src/engine/key-locker/ssh-session-watch.ts
@@ -129,6 +129,11 @@ export class SshSessionWatch {
    * Re-registering a pane resets it (drops any tracked session).
    */
   watchPane(paneId: string, shellPid: number): void {
+    // Re-anchoring a pane that STILL holds a live ssh session: silently resetting to a trusted-local slot
+    // (`session = null`) would let the R5 `tick` guard miss it (that guard needs `session !== null` to see
+    // the live-remote-vs-local contradiction), leaving a live remote login derived as local. Decline first,
+    // then reset — a re-anchor over a live session is doubt, so sink it (Opus/Codex R6).
+    if (this.panes.get(paneId)?.session != null) this.deps.tracker.markUnknown(paneId);
     this.panes.set(paneId, { shellPid, session: null });
   }
 
@@ -242,11 +247,10 @@ export class SshSessionWatch {
         this.deps.tracker.markUnknown(paneId); pane.session = null; continue;
       }
       // (d) CONFIRMED exit: pid gone, reused by a readable non-ssh, or reused by a DIFFERENT ssh (a non-zero
-      //     creation time that does not match). `depth` is provably 1 here (the `!== 1` guard declined 0 and
-      //     ≥ 2), so this pops to local; the `else markUnknown` is a defensive assertion — now UNREACHABLE,
-      //     kept as the last line of defense if the depth guard is ever weakened (SP-L3-OQ-7 depth rule).
-      if (depth <= 1) this.deps.tracker.noteSessionEnd(paneId);
-      else this.deps.tracker.markUnknown(paneId);
+      //     creation time that does not match). `depth` is provably 1 here — the `!== 1` guard above already
+      //     declined depth 0 and depth ≥ 2 — so this is always a single-frame pop to local (SP-L3-OQ-7: the
+      //     nested case that would have needed markUnknown is handled by that guard, never reached here).
+      this.deps.tracker.noteSessionEnd(paneId);
       pane.session = null; // consumed — do not re-fire until a new session is registered
     }
   }

--- a/src/engine/key-locker/ssh-session-watch.ts
+++ b/src/engine/key-locker/ssh-session-watch.ts
@@ -41,8 +41,11 @@ export interface SessionTrackerSink {
 
 /** One process's identity in a snapshot (from win32 `getProcessIdentityByPid`). */
 export interface ProcessIdentity {
-  /** Image name, LOWERCASED, `.exe` stripped (e.g. "ssh", "powershell"). "" when unknown/gone. The live
-   *  adapter MUST lowercase win32's `processName` (it is not lowercased at source). */
+  /** Image name, LOWERCASED, `.exe` stripped (e.g. "ssh", "powershell"). "" when the pid is GONE **or**
+   *  present-but-UNREADABLE this tick: win32 `getProcessIdentityByPid` returns empty on an OpenProcess
+   *  failure — including ACCESS_DENIED on a LIVE elevated/other-user process — not only on a dead pid. So a
+   *  caller MUST NOT infer exit from "" alone; cross-check `parentMap` (the liveness authority) first. The
+   *  live adapter MUST lowercase win32's `processName` (it is not lowercased at source). */
   name: string;
   /** Creation time (ms since the Windows epoch); 0 on failure. Distinguishes a REUSED pid from the same. */
   startTimeMs: number;
@@ -54,7 +57,8 @@ export interface ProcessSnapshot {
    *  EMPTY map = a native-snapshot failure (`buildProcessParentMap` swallows errors → {}), NOT "no
    *  processes" — the watch skips such a tick rather than mis-read every shell as dead. */
   parentMap: Map<number, number>;
-  /** Identity for a pid (name + creation time). A gone pid returns `{ name: "", startTimeMs: 0 }`. */
+  /** Identity for a pid (name + creation time). A gone OR present-but-unreadable pid returns
+   *  `{ name: "", startTimeMs: 0 }` — use `parentMap` (the liveness authority) to tell the two apart. */
   identify(pid: number): ProcessIdentity;
 }
 
@@ -139,12 +143,21 @@ export class SshSessionWatch {
         continue;
       }
       if (pane.session === null) continue; // no interactive ssh registered — nothing to pop
-      // The registered session ssh has EXITED iff its pid is gone OR its creation time changed (pid reuse).
+      // Liveness is authoritative from the Toolhelp map (a pid present as a KEY is alive); identify() is a
+      // secondary per-process read that returns "" for BOTH a gone pid AND a LIVE-but-UNREADABLE one
+      // (OpenProcess ACCESS_DENIED on an elevated/other-user ssh). So the session ssh has CONFIRMABLY exited
+      // only when its pid is gone from the map, or present as a DIFFERENT readable process (pid reuse).
+      const alive = snap.parentMap.has(pane.session.pid);
       const id = snap.identify(pane.session.pid);
-      if (id.name === SSH_PROGRAM && id.startTimeMs === pane.session.startedAt) continue; // still alive
-      // (b) Depth pivot (SP-L3-OQ-7): a lone pop is safe only when the tracker holds ≤ 1 remote frame; with
-      //     NESTED frames (≥ 2) the invisible inner login means a single pop would strand a remote frame →
-      //     markUnknown rather than relabel remote-as-local (wrong-target guard).
+      if (alive && id.name === SSH_PROGRAM && id.startTimeMs === pane.session.startedAt) continue; // same ssh
+      // (b) Live but UNREADABLE this tick (present + empty identity): DOUBT, not a confirmed exit. A pop here
+      //     would relabel a still-REMOTE pane as local → a LOCAL secret autofilled into a REMOTE prompt (the
+      //     inverse wrong-target). Fail-safe to markUnknown — never a pop-to-local on a live session, never a
+      //     stale trusted isRemote:true (Codex/Opus L3-3 PR#505 R2 P2).
+      if (alive && id.name === "") { this.deps.tracker.markUnknown(paneId); pane.session = null; continue; }
+      // (c) CONFIRMED exit (pid gone, or reused by another process). Depth pivot (SP-L3-OQ-7): a lone pop is
+      //     safe only when the tracker holds ≤ 1 remote frame; with NESTED frames (≥ 2) the invisible inner
+      //     login means a single pop would strand a remote frame → markUnknown rather than relabel.
       if (this.deps.tracker.remoteDepth(paneId) <= 1) this.deps.tracker.noteSessionEnd(paneId);
       else this.deps.tracker.markUnknown(paneId);
       pane.session = null; // consumed — do not re-fire until a new session is registered

--- a/src/engine/key-locker/ssh-session-watch.ts
+++ b/src/engine/key-locker/ssh-session-watch.ts
@@ -1,0 +1,163 @@
+// ADR-014 v2 R3 Key Locker — L3 §3 / §6: the ssh session-end watch (SP-L3-OQ-7).
+//
+// Plan: desktop-touch-mcp-internal:docs/adr-014-v2-r3-l3-3-manager-watch-plan.md (PR 3) +
+//   adr-014-v2-r3-l3-capture-plan.md §3 (the ssh-out pop signal).
+//
+// WHY: an interactive `ssh user@host` runs under Mode B (a pane read), NOT an exit-mode watch — so the
+// SessionTracker frame it pushed has no exit code to pop on. If it is never popped, a later LOCAL command
+// in that pane derives `sudo://<remotehost>` and, on a MATCH, would autofill the REMOTE secret into a
+// LOCAL prompt — a wrong-target fill. The authoritative session-end signal is therefore the pane's `ssh`
+// CHILD PROCESS exiting, observed via the process tree (a process observation, never a screen-scrape).
+//
+// This module is PURE reconciliation logic over an injected process snapshot — no Win32 import — so it
+// unit-tests with a fake tree. The KeyLockerManager (the assembly) owns the live instance: it snapshots
+// via win32 `buildProcessParentMap()` + `getProcessIdentityByPid()`, registers a pane's shell pid on
+// anchor, and drives `tick()` on a timer. That live wiring lands with the terminal-event subscription.
+//
+// FAIL-SAFE (§3, Opus R2 P2): any doubt sinks the pane to `markUnknown` (decline-to-derive), NEVER a
+// stale trusted `isRemote:true`. Two doubt sources: (a) an unwatchable pane (its shell pid vanished from
+// the snapshot) and (b) NESTED ssh — the local tree shows only the OUTERMOST ssh (an inner `ssh b` runs
+// ON host-a, invisible locally), so when the outer ssh exits while the tracker still holds ≥ 2 remote
+// frames, a single pop would strand the inner frame → markUnknown instead (SP-L3-OQ-7 depth rule).
+
+/** The tracker surface the watch drives (a subset of `SessionTracker`, so tests inject a fake). */
+export interface SessionTrackerSink {
+  /** Pop one remote frame — the observed outermost ssh child exited and the pane maps 1:1 (depth ≤ 1). */
+  noteSessionEnd(paneId: string): void;
+  /** Sink the pane to UNKNOWN — an unconfirmable / unobservable session-end (depth ≥ 2, shell gone). */
+  markUnknown(paneId: string): void;
+  /** Remote-frame depth above the base local shell (0 = local/unknown) — the pop-vs-markUnknown pivot. */
+  remoteDepth(paneId: string): number;
+}
+
+/** One process's identity in a snapshot (from win32 `getProcessIdentityByPid`). */
+export interface ProcessIdentity {
+  /** Image name, lowercased, `.exe` stripped (e.g. "ssh", "powershell"). "" when unknown/gone. */
+  name: string;
+  /** Creation time (ms since the Windows epoch); 0 on failure. Distinguishes a REUSED pid from the same. */
+  startTimeMs: number;
+}
+
+/** A live process-tree snapshot the watch reconciles against (injected so it unit-tests with a fake). */
+export interface ProcessSnapshot {
+  /** pid → parentPid for every live process (Toolhelp32). A pid present as a KEY means it is alive. */
+  parentMap: Map<number, number>;
+  /** Identity for a pid (name + creation time). A gone pid returns `{ name: "", startTimeMs: 0 }`. */
+  identify(pid: number): ProcessIdentity;
+}
+
+export interface SshWatchDeps {
+  /** Snapshot the live process tree (win32 in production; a fake in tests). Called once per `tick`. */
+  snapshot(): ProcessSnapshot;
+  /** The SessionTracker to drive on a session-end / unconfirmable end. */
+  tracker: SessionTrackerSink;
+}
+
+/** A registered pane: the shell pid to root the descendant search + the ssh children currently watched. */
+interface WatchedPane {
+  shellPid: number;
+  /** pid → creation-time of every `ssh` descendant seen last tick (identity guards pid reuse). */
+  ssh: Map<number, number>;
+}
+
+const SSH_PROGRAM = "ssh";
+
+/**
+ * Watches registered panes for their `ssh` child processes exiting, driving the SessionTracker's
+ * pop / markUnknown. Pure reconciliation: `tick()` snapshots the tree and diffs each pane's ssh
+ * descendants against the previous tick. Register a pane with `watchPane` when its session is anchored
+ * on a known shell pid; `unwatchPane` when the window closes.
+ */
+export class SshSessionWatch {
+  private readonly panes = new Map<string, WatchedPane>();
+
+  constructor(private readonly deps: SshWatchDeps) {}
+
+  /**
+   * Start watching `paneId`, rooted at its shell pid (`getWindowProcessId(hwnd)` — the window-owning
+   * pid, value-consistent with L2's re-verify). Seeds the watched-ssh set from a snapshot NOW, so a
+   * `tick` does not mistake an ALREADY-open ssh (present at registration) for a fresh exit later. Re-
+   * registering a pane resets it.
+   */
+  watchPane(paneId: string, shellPid: number): void {
+    const snap = this.deps.snapshot();
+    this.panes.set(paneId, { shellPid, ssh: this.sshDescendants(snap, shellPid) });
+  }
+
+  /** Stop watching a pane (its window closed / the tracker forgot it). Idempotent. */
+  unwatchPane(paneId: string): void {
+    this.panes.delete(paneId);
+  }
+
+  /** Is this pane currently watched? (Lets the assembly avoid double-registration.) */
+  isWatching(paneId: string): boolean {
+    return this.panes.has(paneId);
+  }
+
+  /**
+   * One poll tick: snapshot once, then for each watched pane reconcile its `ssh` descendants against the
+   * previous tick and drive the tracker. Cheap: one Toolhelp snapshot + a bounded per-pane walk.
+   */
+  tick(): void {
+    if (this.panes.size === 0) return;
+    const snap = this.deps.snapshot();
+    for (const [paneId, pane] of this.panes) {
+      // (a) Shell gone ⇒ the pane is unobservable ⇒ fail-safe to UNKNOWN and stop watching it. A live
+      //     process always appears as a KEY in the Toolhelp map, so absence = dead.
+      if (!snap.parentMap.has(pane.shellPid)) {
+        this.deps.tracker.markUnknown(paneId);
+        this.panes.delete(paneId);
+        continue;
+      }
+      const current = this.sshDescendants(snap, pane.shellPid);
+      // A previously-watched ssh whose pid is gone OR whose creation time changed (pid REUSE) has exited.
+      let anyExited = false;
+      for (const [pid, startedAt] of pane.ssh) {
+        if (current.get(pid) !== startedAt) { anyExited = true; break; }
+      }
+      if (anyExited) {
+        // (b) Depth pivot (SP-L3-OQ-7): the local tree only ever shows the OUTERMOST ssh, so a lone pop is
+        //     safe only when the tracker holds ≤ 1 remote frame. With NESTED frames (≥ 2) the watch cannot
+        //     tell which ended → markUnknown rather than strand an inner remote frame (wrong-target guard).
+        if (this.deps.tracker.remoteDepth(paneId) <= 1) this.deps.tracker.noteSessionEnd(paneId);
+        else this.deps.tracker.markUnknown(paneId);
+      }
+      pane.ssh = current; // adopt the new set (new ssh added, exited ssh dropped)
+    }
+  }
+
+  /** Every `ssh`-named process descended from `rootPid` (walk the parent map), pid → creation time. */
+  private sshDescendants(snap: ProcessSnapshot, rootPid: number): Map<number, number> {
+    const out = new Map<number, number>();
+    for (const pid of descendantsOf(snap.parentMap, rootPid)) {
+      const id = snap.identify(pid);
+      if (id.name === SSH_PROGRAM) out.set(pid, id.startTimeMs);
+    }
+    return out;
+  }
+}
+
+/**
+ * All descendant pids of `rootPid` in a pid→parentPid map (excludes `rootPid` itself). Iterative BFS
+ * with a visited guard so a cyclic/self-parented snapshot (pid reuse mid-enumeration) cannot loop.
+ */
+function descendantsOf(parentMap: Map<number, number>, rootPid: number): number[] {
+  // Invert once to children lists so the walk is O(n) not O(n·depth).
+  const children = new Map<number, number[]>();
+  for (const [pid, parent] of parentMap) {
+    if (pid === parent) continue; // a self-parented root (System/Idle) is not its own child
+    (children.get(parent) ?? children.set(parent, []).get(parent)!).push(pid);
+  }
+  const out: number[] = [];
+  const seen = new Set<number>([rootPid]);
+  const queue = [...(children.get(rootPid) ?? [])];
+  while (queue.length > 0) {
+    const pid = queue.pop()!;
+    if (seen.has(pid)) continue;
+    seen.add(pid);
+    out.push(pid);
+    const kids = children.get(pid);
+    if (kids !== undefined) queue.push(...kids);
+  }
+  return out;
+}

--- a/src/engine/key-locker/ssh-session-watch.ts
+++ b/src/engine/key-locker/ssh-session-watch.ts
@@ -24,10 +24,13 @@
 // LOWERCASED into `ProcessIdentity.name`), registers the shell pid + the session ssh pid, and drives
 // `tick()` on a timer. That live wiring lands with the terminal-event subscription.
 //
-// FAIL-SAFE (§3, Opus R2 P2): any doubt sinks the pane to `markUnknown` (decline-to-derive), NEVER a
-// stale trusted `isRemote:true`. Two doubt sources: (a) an unwatchable pane (its shell pid vanished) and
-// (b) NESTED ssh — when the registered outer ssh exits while the tracker still holds ≥ 2 remote frames, a
-// single pop would strand the invisible inner frame → markUnknown instead (SP-L3-OQ-7 depth rule).
+// FAIL-SAFE (§3, Opus/Codex R2+R3 P2): any doubt sinks the pane to `markUnknown` (decline-to-derive),
+// NEVER a stale trusted `isRemote:true` and NEVER a pop-to-local on a live session. Doubt sources: (a) an
+// unwatchable pane (its shell pid vanished); (b) NESTED ssh — the registered outer ssh exits while the
+// tracker still holds ≥ 2 remote frames, so a single pop would strand the invisible inner frame (SP-L3-OQ-7
+// depth rule); (c) a registered session ssh that is PRESENT but UNREADABLE this tick (identify() reads ""
+// for a LIVE pid — R2); (d) a remote frame with NO live watch — a registration that could not confirm a
+// live `ssh`, or the non-atomic push↔register window (R3: `noteSshOpened` sink + the `tick` backstop).
 
 /** The tracker surface the watch drives (a subset of `SessionTracker`, so tests inject a fake). */
 export interface SessionTrackerSink {
@@ -109,19 +112,36 @@ export class SshSessionWatch {
   }
 
   /**
-   * Register the OUTERMOST interactive-session ssh child pid for a pane — the wiring calls this when it
-   * pushes an interactive frame, having correlated the ssh child it just spawned. The watch records that
-   * pid's identity and fires only on ITS exit (never on a sibling tunnel / one-shot ssh — P2-A). A no-op
-   * if the pane isn't watched; a pid that isn't a live `ssh` is ignored (a late/bad pid never seeds a
-   * spurious exit — it would otherwise mismatch identity next tick and fire). Nested logins re-register
-   * the same visible outer pid; the invisible inner frame is covered by the depth pivot in `tick`.
+   * Register the OUTERMOST interactive-session ssh child pid for a pane — the wiring calls this in the SAME
+   * synchronous turn it pushes the interactive frame (push FIRST, then this — no `await`/tick between, so
+   * `remoteDepth` already reflects the push here), having correlated the ssh child it just spawned. The
+   * watch records that pid's identity and fires only on ITS exit (never on a sibling tunnel / one-shot ssh
+   * — P2-A). A no-op if the pane isn't watched. Four registration cases, disambiguated by Toolhelp liveness
+   * (`parentMap.has`) since identify() reads "" for BOTH a gone pid AND a live-but-unreadable one:
+   *   (2) present + a readable `ssh` ⇒ WATCH it (record pid + startTime).
+   *   (1) pid gone/bad, (3) present but a readable NON-ssh (wrong pid), (4) present but UNREADABLE (maybe
+   *       the real elevated/other-user ssh, maybe a bad pid — indistinguishable) ⇒ cannot establish a
+   *       reliable watch: clear the slot, and if a remote frame was ALREADY pushed (`remoteDepth > 0`) sink
+   *       it to `markUnknown` so no unwatched `isRemote:true` is stranded (the stale-remote wrong-target —
+   *       a later LOCAL command would derive-remote into a REMOTE secret; Codex/Opus L3-3 PR#505 R3 P2).
+   *       A speculative call on a still-LOCAL pane (`remoteDepth 0`) just clears the slot — it must NOT
+   *       nuke the local anchor. Nested logins re-register the same visible outer pid; the invisible inner
+   *       frame is covered by the depth pivot in `tick`.
    */
   noteSshOpened(paneId: string, sshPid: number): void {
     const pane = this.panes.get(paneId);
     if (pane === undefined) return;
-    const id = this.deps.snapshot().identify(sshPid);
-    if (id.name !== SSH_PROGRAM) { pane.session = null; return; } // not a live ssh — ignore
-    pane.session = { pid: sshPid, startedAt: id.startTimeMs };
+    const snap = this.deps.snapshot();
+    // (2) Register ONLY a pid we can POSITIVELY confirm is a live `ssh` (present in the Toolhelp map AND a
+    //     readable `ssh` identity). Toolhelp liveness gates identify()'s empty-means-gone-OR-unreadable.
+    if (snap.parentMap.has(sshPid)) {
+      const id = snap.identify(sshPid);
+      if (id.name === SSH_PROGRAM) { pane.session = { pid: sshPid, startedAt: id.startTimeMs }; return; }
+    }
+    // (1)/(3)/(4) No reliable watch. Drop the slot; if a frame was already pushed, sink it rather than
+    // strand an unwatched isRemote:true. On a still-local pane this is a no-op beyond clearing the slot.
+    pane.session = null;
+    if (this.deps.tracker.remoteDepth(paneId) > 0) this.deps.tracker.markUnknown(paneId);
   }
 
   /**
@@ -142,7 +162,15 @@ export class SshSessionWatch {
         this.panes.delete(paneId);
         continue;
       }
-      if (pane.session === null) continue; // no interactive ssh registered — nothing to pop
+      // No interactive ssh registered. Normally nothing to pop — but a pane that holds a remote frame with
+      // NO live watch (a non-atomic push↔register window, or a registration that could not confirm a live
+      // ssh) is unsafe: a later LOCAL command would derive-remote against a stale isRemote:true. Sink it to
+      // markUnknown as a systemic backstop (never a stray fire in normal flow — remoteDepth tracks the
+      // stack in lockstep with session, so this is >0 only in that genuine unwatched-frame state).
+      if (pane.session === null) {
+        if (this.deps.tracker.remoteDepth(paneId) > 0) this.deps.tracker.markUnknown(paneId);
+        continue;
+      }
       // Liveness is authoritative from the Toolhelp map (a pid present as a KEY is alive); identify() is a
       // secondary per-process read that returns "" for BOTH a gone pid AND a LIVE-but-UNREADABLE one
       // (OpenProcess ACCESS_DENIED on an elevated/other-user ssh). So the session ssh has CONFIRMABLY exited

--- a/src/engine/key-locker/ssh-session-watch.ts
+++ b/src/engine/key-locker/ssh-session-watch.ts
@@ -15,8 +15,16 @@
 // (a dying tunnel would pop a still-live interactive frame → the pane mislabels remote-as-local → the
 // INVERSE wrong-target). Instead the wiring, which dispatched the interactive ssh and can correlate the
 // child it spawned, REGISTERS that specific pid via `noteSshOpened`; the watch fires only when THAT pid
-// exits. Only the OUTERMOST ssh is locally visible (an inner `ssh b` runs ON host-a), so the watch tracks
-// one session pid per pane and the depth pivot (below) covers nesting.
+// exits. Only the OUTERMOST ssh is locally visible (an inner `ssh b` runs ON host-a).
+//
+// STRUCTURAL AXIS (Opus/Codex PR#505 R2–R4, folded from four rounds of wrong-target edges): the watch can
+// reliably observe EXACTLY ONE thing — the single depth-1 outer ssh, ALIVE, readable as `ssh`, with a
+// NON-ZERO creation time matching the registered baseline. It TRUSTS only that one state; EVERY other state
+// declines to `markUnknown`. So: trust depth exactly 1 (confirmed-same) → keep; depth-1 confirmed-exit →
+// pop; depth 0 with a live session-slot but a remote frame up → sink; **depth ≥ 2 (nested) → ALWAYS sink**
+// (the inner login runs on the remote host, its end is unobservable locally, so it can never be popped);
+// any unconfirmable identity → sink. Nesting is declined at BOTH registration and `tick` so the watch
+// self-enforces the invariant instead of trusting wiring discipline.
 //
 // This module is PURE reconciliation over an injected process snapshot — no Win32 import — so it
 // unit-tests with a fake tree. The KeyLockerManager (the live wiring, deferred) owns the instance: it
@@ -24,19 +32,33 @@
 // LOWERCASED into `ProcessIdentity.name`), registers the shell pid + the session ssh pid, and drives
 // `tick()` on a timer. That live wiring lands with the terminal-event subscription.
 //
-// FAIL-SAFE (§3, Opus/Codex R2+R3 P2): any doubt sinks the pane to `markUnknown` (decline-to-derive),
-// NEVER a stale trusted `isRemote:true` and NEVER a pop-to-local on a live session. Doubt sources: (a) an
-// unwatchable pane (its shell pid vanished); (b) NESTED ssh — the registered outer ssh exits while the
-// tracker still holds ≥ 2 remote frames, so a single pop would strand the invisible inner frame (SP-L3-OQ-7
-// depth rule); (c) a registered session ssh that is PRESENT but UNREADABLE this tick (identify() reads ""
-// for a LIVE pid — R2); (d) a remote frame with NO live watch — a registration that could not confirm a
-// live `ssh`, or the non-atomic push↔register window (R3: `noteSshOpened` sink + the `tick` backstop).
+// FAIL-SAFE (§3, Opus/Codex R2–R4 P2): any doubt sinks the pane to `markUnknown` (decline-to-derive), NEVER
+// a stale trusted `isRemote:true` and NEVER a pop-to-local on a live session. Doubt sources: (a) an
+// unwatchable pane (its shell pid vanished); (b) NESTED ssh (`remoteDepth ≥ 2`) — the invisible inner login
+// is unobservable, so a nested pane is declined outright (R4); (c) a registered session ssh PRESENT but
+// UNREADABLE this tick — identify() reads "" for a live pid (R2) OR `startTimeMs === 0` for a live ssh whose
+// creation-time read failed (win32 reads name/time independently — R4); (d) a remote frame with NO live
+// watch — a registration that could not confirm a live `ssh`, or the non-atomic push↔register window (R3:
+// `noteSshOpened` sink + the `tick` backstop).
+//
+// INVARIANTS the watch relies on (breaking either breaks the watch): (1) `SessionTracker.recordDispatch`
+// pushes `isRemote:true` ONLY for `program === "ssh"`, so EVERY remote frame is an ssh frame and the
+// `name === "ssh"` trust is sound; (2) `session.startedAt` is never 0 (registration forbids it). RECOVERY:
+// `markUnknown` sets the tracker stack to null and does NOT auto-recover on the session's later exit —
+// `recordDispatch` early-returns on a null stack — so an unknown pane re-anchors only when the wiring calls
+// `beginLocalSession` at a fresh local prompt (SP-L3-OQ-8 territory), not via exit observation. Safe
+// (declines), just degraded longer. RESIDUAL (P3, plan §Risks): the shell anchor is liveness-only
+// (`!parentMap.has(shellPid)`) with no startTime check — a reused shell pid can mask shell death; it
+// self-heals (the dead shell's ssh child dies/reparents ⇒ the session check catches it) and is tracked in
+// the plan, not gated on.
 
 /** The tracker surface the watch drives (a subset of `SessionTracker`, so tests inject a fake). */
 export interface SessionTrackerSink {
   /** Pop one remote frame — the registered session ssh exited and the pane maps 1:1 (depth ≤ 1). */
   noteSessionEnd(paneId: string): void;
-  /** Sink the pane to UNKNOWN — an unconfirmable / unobservable session-end (depth ≥ 2, shell gone). */
+  /** Sink the pane to UNKNOWN (decline-to-derive) — used for EVERY non-trusted state: a nested login
+   *  (depth ≥ 2), an unwatchable pane (shell gone), a live-but-unconfirmable session ssh (unreadable or a
+   *  zero creation time), or a remote frame with no live watch. Never followed by a pop-to-local. */
   markUnknown(paneId: string): void;
   /** Remote-frame depth above the base local shell (0 = local/unknown) — the pop-vs-markUnknown pivot. */
   remoteDepth(paneId: string): number;
@@ -50,7 +72,12 @@ export interface ProcessIdentity {
    *  caller MUST NOT infer exit from "" alone; cross-check `parentMap` (the liveness authority) first. The
    *  live adapter MUST lowercase win32's `processName` (it is not lowercased at source). */
   name: string;
-  /** Creation time (ms since the Windows epoch); 0 on failure. Distinguishes a REUSED pid from the same. */
+  /** Creation time (ms since the Windows epoch). **0 = the creation-time read FAILED, NOT a real time** —
+   *  win32 reads the image name and the creation time INDEPENDENTLY (`process.rs` step A / step B), so a
+   *  LIVE process can return `{ name: "ssh", startTimeMs: 0 }` when only `GetProcessTimes` failed. A real
+   *  running process never has creation time 0 (the Windows epoch is 1601), so 0 is the canonical DOUBT
+   *  sentinel: never treat it as a confirmed exit/reuse, and never store it as a watch baseline
+   *  (`session.startedAt` is always non-zero). A non-zero value distinguishes a REUSED pid from the same. */
   startTimeMs: number;
 }
 
@@ -114,32 +141,40 @@ export class SshSessionWatch {
   /**
    * Register the OUTERMOST interactive-session ssh child pid for a pane — the wiring calls this in the SAME
    * synchronous turn it pushes the interactive frame (push FIRST, then this — no `await`/tick between, so
-   * `remoteDepth` already reflects the push here), having correlated the ssh child it just spawned. The
-   * watch records that pid's identity and fires only on ITS exit (never on a sibling tunnel / one-shot ssh
-   * — P2-A). A no-op if the pane isn't watched. Four registration cases, disambiguated by Toolhelp liveness
-   * (`parentMap.has`) since identify() reads "" for BOTH a gone pid AND a live-but-unreadable one:
-   *   (2) present + a readable `ssh` ⇒ WATCH it (record pid + startTime).
-   *   (1) pid gone/bad, (3) present but a readable NON-ssh (wrong pid), (4) present but UNREADABLE (maybe
-   *       the real elevated/other-user ssh, maybe a bad pid — indistinguishable) ⇒ cannot establish a
-   *       reliable watch: clear the slot, and if a remote frame was ALREADY pushed (`remoteDepth > 0`) sink
-   *       it to `markUnknown` so no unwatched `isRemote:true` is stranded (the stale-remote wrong-target —
-   *       a later LOCAL command would derive-remote into a REMOTE secret; Codex/Opus L3-3 PR#505 R3 P2).
-   *       A speculative call on a still-LOCAL pane (`remoteDepth 0`) just clears the slot — it must NOT
-   *       nuke the local anchor. Nested logins re-register the same visible outer pid; the invisible inner
-   *       frame is covered by the depth pivot in `tick`.
+   * `remoteDepth` already reflects the push here), having correlated the ssh child it just spawned. A no-op
+   * if the pane isn't watched. The watch trusts ONE state (see STRUCTURAL AXIS in the file header); this
+   * establishes it or declines:
+   *   - NESTED (`remoteDepth ≥ 2`): a second remote frame is already up, so this is a nested login. The
+   *     inner ssh runs ON the remote host and is invisible locally ⇒ its end can never be observed ⇒
+   *     decline outright (`markUnknown`) rather than trust an unobservable frame (R4). Both this and the
+   *     `tick` nested guard enforce it, so a missed re-registration still declines within one poll.
+   *   - WATCHABLE: the pid is present in the Toolhelp map, readable as `ssh`, AND has a NON-ZERO creation
+   *     time ⇒ record `{pid, startedAt}` as the single trusted session.
+   *   - Everything else (pid gone/bad, present readable NON-ssh, present but UNREADABLE `""`, or a partial
+   *     `ssh` read with `startTimeMs === 0` — no reliable baseline): clear the slot, and if a remote frame
+   *     was already pushed (`remoteDepth > 0`) sink it to `markUnknown` so no unwatched `isRemote:true` is
+   *     stranded (the stale-remote wrong-target — R3). A speculative call on a still-LOCAL pane
+   *     (`remoteDepth 0`) just clears the slot — it must NOT nuke the local anchor.
    */
   noteSshOpened(paneId: string, sshPid: number): void {
     const pane = this.panes.get(paneId);
     if (pane === undefined) return;
+    // NESTED (depth ≥ 2): decline — the invisible inner login is unobservable, so it could never be popped.
+    if (this.deps.tracker.remoteDepth(paneId) >= 2) {
+      pane.session = null;
+      this.deps.tracker.markUnknown(paneId);
+      return;
+    }
     const snap = this.deps.snapshot();
-    // (2) Register ONLY a pid we can POSITIVELY confirm is a live `ssh` (present in the Toolhelp map AND a
-    //     readable `ssh` identity). Toolhelp liveness gates identify()'s empty-means-gone-OR-unreadable.
+    // WATCHABLE: present in the Toolhelp map (liveness authority), readable as `ssh`, AND a NON-ZERO creation
+    // time (a partial read — name "ssh" but time 0 — is a LIVE process whose time read failed; it gives no
+    // reliable pid-reuse baseline, so it is NOT watchable).
     if (snap.parentMap.has(sshPid)) {
       const id = snap.identify(sshPid);
-      if (id.name === SSH_PROGRAM) { pane.session = { pid: sshPid, startedAt: id.startTimeMs }; return; }
+      if (id.name === SSH_PROGRAM && id.startTimeMs !== 0) { pane.session = { pid: sshPid, startedAt: id.startTimeMs }; return; }
     }
-    // (1)/(3)/(4) No reliable watch. Drop the slot; if a frame was already pushed, sink it rather than
-    // strand an unwatched isRemote:true. On a still-local pane this is a no-op beyond clearing the slot.
+    // No reliable watch (gone/bad, non-ssh, unreadable, or ssh-with-0-time). Drop the slot; if a frame was
+    // already pushed, sink it rather than strand an unwatched isRemote:true. Still-local ⇒ just clear.
     pane.session = null;
     if (this.deps.tracker.remoteDepth(paneId) > 0) this.deps.tracker.markUnknown(paneId);
   }
@@ -171,21 +206,29 @@ export class SshSessionWatch {
         if (this.deps.tracker.remoteDepth(paneId) > 0) this.deps.tracker.markUnknown(paneId);
         continue;
       }
-      // Liveness is authoritative from the Toolhelp map (a pid present as a KEY is alive); identify() is a
-      // secondary per-process read that returns "" for BOTH a gone pid AND a LIVE-but-UNREADABLE one
-      // (OpenProcess ACCESS_DENIED on an elevated/other-user ssh). So the session ssh has CONFIRMABLY exited
-      // only when its pid is gone from the map, or present as a DIFFERENT readable process (pid reuse).
+      // (b) NESTED (`remoteDepth ≥ 2`): a session-bearing pane should never reach here — registration
+      //     declines nesting — but self-enforce the invariant rather than trust the wiring. The inner login
+      //     runs on the remote host and is unobservable, so decline (R4). A missed re-registration is
+      //     caught here within one poll.
+      if (this.deps.tracker.remoteDepth(paneId) >= 2) { this.deps.tracker.markUnknown(paneId); pane.session = null; continue; }
+      // Liveness is authoritative from the Toolhelp map (a pid present as a KEY is alive); identify() reads
+      // "" for a gone-OR-unreadable pid, and `startTimeMs === 0` for a LIVE ssh whose creation-time read
+      // failed (win32 reads name/time independently). The ONE trusted state: alive, readable `ssh`, and a
+      // NON-ZERO creation time matching the registered (non-zero) baseline.
       const alive = snap.parentMap.has(pane.session.pid);
       const id = snap.identify(pane.session.pid);
-      if (alive && id.name === SSH_PROGRAM && id.startTimeMs === pane.session.startedAt) continue; // same ssh
-      // (b) Live but UNREADABLE this tick (present + empty identity): DOUBT, not a confirmed exit. A pop here
-      //     would relabel a still-REMOTE pane as local → a LOCAL secret autofilled into a REMOTE prompt (the
-      //     inverse wrong-target). Fail-safe to markUnknown — never a pop-to-local on a live session, never a
-      //     stale trusted isRemote:true (Codex/Opus L3-3 PR#505 R2 P2).
-      if (alive && id.name === "") { this.deps.tracker.markUnknown(paneId); pane.session = null; continue; }
-      // (c) CONFIRMED exit (pid gone, or reused by another process). Depth pivot (SP-L3-OQ-7): a lone pop is
-      //     safe only when the tracker holds ≤ 1 remote frame; with NESTED frames (≥ 2) the invisible inner
-      //     login means a single pop would strand a remote frame → markUnknown rather than relabel.
+      if (alive && id.name === SSH_PROGRAM && id.startTimeMs !== 0 && id.startTimeMs === pane.session.startedAt) continue;
+      // (c) Live but UNCONFIRMABLE as the SAME ssh: the whole identity read failed (name ""), OR only the
+      //     creation-time read failed (name "ssh" but `startTimeMs === 0`). DOUBT, not a confirmed exit — a
+      //     pop here would relabel a still-REMOTE pane local → a LOCAL secret into a REMOTE prompt (the
+      //     inverse wrong-target). Fail-safe to markUnknown (R2 + R4).
+      if (alive && (id.name === "" || (id.name === SSH_PROGRAM && id.startTimeMs === 0))) {
+        this.deps.tracker.markUnknown(paneId); pane.session = null; continue;
+      }
+      // (d) CONFIRMED exit: pid gone, reused by a readable non-ssh, or reused by a DIFFERENT ssh (a non-zero
+      //     creation time that does not match). Depth is ≤ 1 here (the nested guard above already declined
+      //     ≥ 2), so this pops to local; the `else markUnknown` is a defensive assertion — formally
+      //     unreachable for a session-bearing pane, kept as the last line of defense (SP-L3-OQ-7 depth rule).
       if (this.deps.tracker.remoteDepth(paneId) <= 1) this.deps.tracker.noteSessionEnd(paneId);
       else this.deps.tracker.markUnknown(paneId);
       pane.session = null; // consumed — do not re-fire until a new session is registered

--- a/src/engine/key-locker/ssh-session-watch.ts
+++ b/src/engine/key-locker/ssh-session-watch.ts
@@ -17,14 +17,17 @@
 // child it spawned, REGISTERS that specific pid via `noteSshOpened`; the watch fires only when THAT pid
 // exits. Only the OUTERMOST ssh is locally visible (an inner `ssh b` runs ON host-a).
 //
-// STRUCTURAL AXIS (Opus/Codex PR#505 R2–R4, folded from four rounds of wrong-target edges): the watch can
+// STRUCTURAL AXIS (Opus/Codex PR#505 R2–R5, folded from five rounds of wrong-target edges): the watch can
 // reliably observe EXACTLY ONE thing — the single depth-1 outer ssh, ALIVE, readable as `ssh`, with a
-// NON-ZERO creation time matching the registered baseline. It TRUSTS only that one state; EVERY other state
-// declines to `markUnknown`. So: trust depth exactly 1 (confirmed-same) → keep; depth-1 confirmed-exit →
-// pop; depth 0 with a live session-slot but a remote frame up → sink; **depth ≥ 2 (nested) → ALWAYS sink**
-// (the inner login runs on the remote host, its end is unobservable locally, so it can never be popped);
-// any unconfirmable identity → sink. Nesting is declined at BOTH registration and `tick` so the watch
-// self-enforces the invariant instead of trusting wiring discipline.
+// NON-ZERO creation time matching the registered baseline. It TRUSTS only that one state; a session-bearing
+// pane is observable/trustable ONLY at EXACTLY `remoteDepth === 1`, and EVERY other state declines. So, for
+// a pane with a registered session: depth 1 + confirmed-same → KEEP; depth 1 + confirmed-exit → POP; depth 1
+// + unconfirmable identity (unreadable "" / zero creation time) → SINK; **depth ≥ 2 (nested) → ALWAYS SINK**
+// (the inner login runs on the remote host, unobservable locally, so it can never be popped); **depth 0 +
+// LIVE registered ssh → SINK** (the tracker was re-anchored local while the ssh lives — trusting local would
+// wrong-target); **depth 0 + GONE pid → DROP the stale watch, KEEP local** (a benign re-anchor race, the
+// local anchor is legitimate). Nesting AND the depth invariant are enforced at `tick` (and nesting also at
+// registration) so the watch self-enforces rather than trusting wiring discipline.
 //
 // This module is PURE reconciliation over an injected process snapshot — no Win32 import — so it
 // unit-tests with a fake tree. The KeyLockerManager (the live wiring, deferred) owns the instance: it
@@ -32,14 +35,15 @@
 // LOWERCASED into `ProcessIdentity.name`), registers the shell pid + the session ssh pid, and drives
 // `tick()` on a timer. That live wiring lands with the terminal-event subscription.
 //
-// FAIL-SAFE (§3, Opus/Codex R2–R4 P2): any doubt sinks the pane to `markUnknown` (decline-to-derive), NEVER
+// FAIL-SAFE (§3, Opus/Codex R2–R5 P2): any doubt sinks the pane to `markUnknown` (decline-to-derive), NEVER
 // a stale trusted `isRemote:true` and NEVER a pop-to-local on a live session. Doubt sources: (a) an
 // unwatchable pane (its shell pid vanished); (b) NESTED ssh (`remoteDepth ≥ 2`) — the invisible inner login
 // is unobservable, so a nested pane is declined outright (R4); (c) a registered session ssh PRESENT but
 // UNREADABLE this tick — identify() reads "" for a live pid (R2) OR `startTimeMs === 0` for a live ssh whose
 // creation-time read failed (win32 reads name/time independently — R4); (d) a remote frame with NO live
 // watch — a registration that could not confirm a live `ssh`, or the non-atomic push↔register window (R3:
-// `noteSshOpened` sink + the `tick` backstop).
+// `noteSshOpened` sink + the `tick` backstop); (e) `remoteDepth === 0` with a LIVE registered ssh — the
+// tracker was re-anchored local while the ssh lives, so trusting local would wrong-target (R5).
 //
 // INVARIANTS the watch relies on (breaking either breaks the watch): (1) `SessionTracker.recordDispatch`
 // pushes `isRemote:true` ONLY for `program === "ssh"`, so EVERY remote frame is an ssh frame and the
@@ -206,17 +210,29 @@ export class SshSessionWatch {
         if (this.deps.tracker.remoteDepth(paneId) > 0) this.deps.tracker.markUnknown(paneId);
         continue;
       }
-      // (b) NESTED (`remoteDepth ≥ 2`): a session-bearing pane should never reach here — registration
-      //     declines nesting — but self-enforce the invariant rather than trust the wiring. The inner login
-      //     runs on the remote host and is unobservable, so decline (R4). A missed re-registration is
-      //     caught here within one poll.
-      if (this.deps.tracker.remoteDepth(paneId) >= 2) { this.deps.tracker.markUnknown(paneId); pane.session = null; continue; }
       // Liveness is authoritative from the Toolhelp map (a pid present as a KEY is alive); identify() reads
       // "" for a gone-OR-unreadable pid, and `startTimeMs === 0` for a LIVE ssh whose creation-time read
-      // failed (win32 reads name/time independently). The ONE trusted state: alive, readable `ssh`, and a
-      // NON-ZERO creation time matching the registered (non-zero) baseline.
+      // failed (win32 reads name/time independently). Compute both here — the depth guard below needs
+      // liveness too.
       const alive = snap.parentMap.has(pane.session.pid);
       const id = snap.identify(pane.session.pid);
+      const depth = this.deps.tracker.remoteDepth(paneId);
+      // (b) A session-bearing pane is observable/trustable ONLY at EXACTLY depth 1 (the structural axis).
+      //     Otherwise the trusted region is declined:
+      //       - depth ≥ 2 (NESTED): the inner login runs on the remote host and is unobservable ⇒ sink.
+      //       - depth 0 with a LIVE registered ssh: the tracker reports LOCAL while the ssh is still alive — a
+      //         contradiction (a re-anchor that didn't reset the watch); trusting local would derive a LOCAL
+      //         binding for a live remote ⇒ sink (R5).
+      //       - depth 0 with a GONE pid: a benign re-anchor race (the ssh exited and the tracker re-anchored
+      //         local before this tick cleared the slot). The local anchor is LEGITIMATE, so just DROP the
+      //         stale watch — do NOT markUnknown a correct local pane.
+      if (depth !== 1) {
+        if (depth >= 2 || alive) this.deps.tracker.markUnknown(paneId);
+        pane.session = null;
+        continue;
+      }
+      // At EXACTLY depth 1. The ONE trusted state: alive, readable `ssh`, and a NON-ZERO creation time
+      // matching the registered (non-zero) baseline.
       if (alive && id.name === SSH_PROGRAM && id.startTimeMs !== 0 && id.startTimeMs === pane.session.startedAt) continue;
       // (c) Live but UNCONFIRMABLE as the SAME ssh: the whole identity read failed (name ""), OR only the
       //     creation-time read failed (name "ssh" but `startTimeMs === 0`). DOUBT, not a confirmed exit — a
@@ -226,10 +242,10 @@ export class SshSessionWatch {
         this.deps.tracker.markUnknown(paneId); pane.session = null; continue;
       }
       // (d) CONFIRMED exit: pid gone, reused by a readable non-ssh, or reused by a DIFFERENT ssh (a non-zero
-      //     creation time that does not match). Depth is ≤ 1 here (the nested guard above already declined
-      //     ≥ 2), so this pops to local; the `else markUnknown` is a defensive assertion — formally
-      //     unreachable for a session-bearing pane, kept as the last line of defense (SP-L3-OQ-7 depth rule).
-      if (this.deps.tracker.remoteDepth(paneId) <= 1) this.deps.tracker.noteSessionEnd(paneId);
+      //     creation time that does not match). `depth` is provably 1 here (the `!== 1` guard declined 0 and
+      //     ≥ 2), so this pops to local; the `else markUnknown` is a defensive assertion — now UNREACHABLE,
+      //     kept as the last line of defense if the depth guard is ever weakened (SP-L3-OQ-7 depth rule).
+      if (depth <= 1) this.deps.tracker.noteSessionEnd(paneId);
       else this.deps.tracker.markUnknown(paneId);
       pane.session = null; // consumed — do not re-fire until a new session is registered
     }

--- a/src/engine/key-locker/ssh-session-watch.ts
+++ b/src/engine/key-locker/ssh-session-watch.ts
@@ -55,6 +55,20 @@
 // (`!parentMap.has(shellPid)`) with no startTime check — a reused shell pid can mask shell death; it
 // self-heals (the dead shell's ssh child dies/reparents ⇒ the session check catches it) and is tracked in
 // the plan, not gated on.
+//
+// SCOPE / FIXED POINT (Opus PR#505 closing sweep): this pure module reconciles every STEADY (watch,tracker)
+// state to safety — any desync self-heals within one `tick`, so at rest there is no wrong-target. What a
+// pure module CANNOT close is the INTER-TICK WINDOW: a credential fill derives straight from `tracker.get()`
+// (never through this watch), so a wiring mutation that transiently puts the tracker in a wrong-target state
+// can be read before the next tick reconciles. Closing that window is therefore a WIRING obligation, not a
+// module fix. INVARIANTS THE LIVE WIRING MUST HONOR (deferred to the terminal-subscription PR, plan §Risks):
+//   (W1) Re-anchor atomicity: `tracker.beginLocalSession(paneId)` MUST run in the SAME synchronous turn as
+//        `watchPane(paneId, shellPid)` — never re-anchor the tracker to local while a live watch session
+//        lingers (Edge 3).
+//   (W2) Close atomicity: `unwatchPane(paneId)` MUST be paired same-turn with the tracker forgetting/clearing
+//        that pane's frames — never drop the watch while a remote frame stays trusted (Edge 7).
+//   (W3) Derive/mutate atomicity + tick liveness: push-then-`noteSshOpened` in one turn, NO credential derive
+//        interleaved across an un-reconciled turn, and `tick` driven on the timer (Edges 1/2/4/9).
 
 /** The tracker surface the watch drives (a subset of `SessionTracker`, so tests inject a fake). */
 export interface SessionTrackerSink {

--- a/tests/fixtures/failwith-callsite-shapes.json
+++ b/tests/fixtures/failwith-callsite-shapes.json
@@ -286,7 +286,7 @@
     },
     {
       "file": "src/tools/key-locker-tool.ts",
-      "line": 129,
+      "line": 142,
       "tool": "key_locker",
       "errKind": "identifier",
       "contextShape": "none"

--- a/tests/unit/key-locker-manager.test.ts
+++ b/tests/unit/key-locker-manager.test.ts
@@ -196,3 +196,65 @@ describe("KeyLockerManager.ensureConsent — the acquire path", () => {
     expect(mgr.consentCalls).toBe(0);
   });
 });
+
+describe("KeyLockerManager.disposeIfIdle — dormancy", () => {
+  const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+  it("returns false when nothing is live", async () => {
+    const mgr = new FakeHostManager({ storeDir: freshDir(), now: () => 999_999 });
+    expect(await mgr.disposeIfIdle(0)).toBe(false);
+  });
+
+  it("disposes a live host only after the idle window; a later op lazily re-starts", async () => {
+    const d = freshDir();
+    writeConsent(d, { version: 1, acceptedAt: "2026-07-06T00:00:00.000Z" });
+    let clock = 1_000;
+    const mgr = new FakeHostManager({ storeDir: d, now: () => clock });
+
+    const first = mgr.withHost(async () => "x");
+    mgr.settleStart();
+    expect(await first).toBe("x");
+    expect(mgr.startCalls).toBe(1);
+
+    // Still within the window ⇒ no dispose.
+    expect(await mgr.disposeIfIdle(5_000)).toBe(false);
+    expect(mgr.disposed).toBe(0);
+
+    // Past the idle window ⇒ dispose.
+    clock += 6_000;
+    expect(await mgr.disposeIfIdle(5_000)).toBe(true);
+    expect(mgr.disposed).toBe(1);
+    // Idempotent: nothing live now.
+    expect(await mgr.disposeIfIdle(5_000)).toBe(false);
+
+    // A later secret op re-starts the host (the resolved start promise re-runs).
+    const second = mgr.withHost(async () => "y");
+    expect(await second).toBe("y");
+    expect(mgr.startCalls).toBe(2);
+  });
+
+  it("never disposes while an op is IN FLIGHT, even past the window", async () => {
+    const d = freshDir();
+    writeConsent(d, { version: 1, acceptedAt: "2026-07-06T00:00:00.000Z" });
+    let clock = 1_000;
+    const mgr = new FakeHostManager({ storeDir: d, now: () => clock });
+
+    let release: (() => void) | null = null;
+    const gate = new Promise<void>((r) => { release = r; });
+    const op = mgr.withHost(async () => { await gate; return "done"; });
+    mgr.settleStart();
+    await flush(); // let withHost pass ensureHost + enter the try (inFlight++)
+
+    clock += 100_000; // far past any window
+    expect(await mgr.disposeIfIdle(5_000)).toBe(false); // op in flight ⇒ not idle
+    expect(mgr.disposed).toBe(0);
+
+    release!();
+    expect(await op).toBe("done");
+    // The completed op just refreshed the dormancy timer, so advance past the window again before it
+    // is eligible to dispose.
+    clock += 6_000;
+    expect(await mgr.disposeIfIdle(5_000)).toBe(true);
+    expect(mgr.disposed).toBe(1);
+  });
+});

--- a/tests/unit/key-locker-session-tracker.test.ts
+++ b/tests/unit/key-locker-session-tracker.test.ts
@@ -69,6 +69,21 @@ describe("SessionTracker — ssh in/out (the wrong-target crux)", () => {
     expect(t.get(P)).toEqual({ execHost: "localhost", isRemote: false });
   });
 
+  it("remoteDepth counts pushed remote frames (the ssh-watch pop-vs-markUnknown pivot, SP-L3-OQ-7)", () => {
+    const t = new SessionTracker();
+    expect(t.remoteDepth(P)).toBe(0);           // never anchored
+    t.beginLocalSession(P);
+    expect(t.remoteDepth(P)).toBe(0);           // local base only
+    t.recordDispatch(P, "ssh a@host-a");
+    expect(t.remoteDepth(P)).toBe(1);           // one remote frame → a lone pop is safe
+    t.recordDispatch(P, "ssh b@host-b");
+    expect(t.remoteDepth(P)).toBe(2);           // nested → the watch must markUnknown, not pop
+    t.noteSessionEnd(P);
+    expect(t.remoteDepth(P)).toBe(1);
+    t.markUnknown(P);
+    expect(t.remoteDepth(P)).toBe(0);           // unknown pane has no trusted remote depth
+  });
+
   it("a one-shot `ssh host cmd` does NOT open a session (no push)", () => {
     const t = new SessionTracker();
     t.beginLocalSession(P);

--- a/tests/unit/key-locker-ssh-session-watch.test.ts
+++ b/tests/unit/key-locker-ssh-session-watch.test.ts
@@ -295,6 +295,30 @@ describe("SshSessionWatch — R5: trust ONLY at exactly depth 1 (decline a re-an
   });
 });
 
+describe("SshSessionWatch — R6: re-watching a pane must not silently drop a live ssh session", () => {
+  it("re-watching a pane that holds a LIVE ssh session ⇒ markUnknown before resetting (never trust-local silently)", () => {
+    const { watch, sink } = setup(SHELL_WITH_SSH);
+    watch.watchPane("pane-1", 1000);
+    watch.noteSshOpened("pane-1", 2000); // a live ssh session is registered
+    watch.watchPane("pane-1", 1000); // re-anchor the same shell — must NOT silently reset to a trusted-local slot
+    expect(sink.unknowns).toEqual(["pane-1"]);
+    expect(watch.isWatching("pane-1")).toBe(true); // still watched (session reset to null)
+  });
+
+  it("the FIRST watchPane (no prior session) does not markUnknown", () => {
+    const { watch, sink } = setup(SHELL_WITH_SSH);
+    watch.watchPane("pane-1", 1000); // initial registration — nothing to decline
+    expect(sink.unknowns).toEqual([]);
+  });
+
+  it("re-watching a pane with NO live session (session already null) does not markUnknown", () => {
+    const { watch, sink } = setup(SHELL_WITH_SSH);
+    watch.watchPane("pane-1", 1000);
+    watch.watchPane("pane-1", 1000); // no session was registered ⇒ nothing to decline
+    expect(sink.unknowns).toEqual([]);
+  });
+});
+
 describe("SshSessionWatch — noteSshOpened hygiene", () => {
   it("noteSshOpened on an UNWATCHED pane is a no-op (no throw, no registration)", () => {
     const { watch, sink, set } = setup(SHELL_WITH_SSH);

--- a/tests/unit/key-locker-ssh-session-watch.test.ts
+++ b/tests/unit/key-locker-ssh-session-watch.test.ts
@@ -3,8 +3,9 @@
 // contract (a sibling tunnel/one-shot ssh exiting must NOT fire — Opus R1 P2-A), pid-reuse-is-an-exit,
 // bad/late-pid registration, the degenerate-snapshot skip (P3-A), the live-but-UNREADABLE session ssh
 // never popping-to-local (R2 P2), an unwatchable remote frame sinking to markUnknown rather than stranding
-// isRemote:true (R3 P2), and the R4 fold to depth-1-only trust — nested logins (depth ≥ 2) and zero-
-// creation-time partial reads decline. Pure reconciliation over a fake process snapshot + a fake tracker sink.
+// isRemote:true (R3 P2), the R4 fold to depth-1-only trust — nested logins (depth ≥ 2) and zero-creation-
+// time partial reads decline — and the R5 depth-exactly-1 guard (depth 0 + live ssh ⇒ sink, depth 0 + gone
+// ⇒ drop-keep-local). Pure reconciliation over a fake process snapshot + a fake tracker sink.
 import { describe, expect, it } from "vitest";
 import {
   SshSessionWatch,
@@ -267,6 +268,30 @@ describe("SshSessionWatch — R4: fold to depth-1-only trust (nested + zero crea
     watch.noteSshOpened("pane-1", 2000); // 2000 present + "ssh" but startTimeMs 0 ⇒ no reliable baseline
     expect(sink.unknowns).toEqual(["pane-1"]); // sink the unwatchable frame rather than store a 0 baseline
     expect(sink.ends).toEqual([]);
+  });
+});
+
+describe("SshSessionWatch — R5: trust ONLY at exactly depth 1 (decline a re-anchored live remote)", () => {
+  it("depth 0 with a LIVE registered ssh ⇒ markUnknown (the tracker was re-anchored local while ssh lives)", () => {
+    const { watch, sink } = setup(SHELL_WITH_SSH);
+    watch.watchPane("pane-1", 1000);
+    watch.noteSshOpened("pane-1", 2000); // registers {2000, 20}
+    sink.setDepth("pane-1", 0); // the tracker re-anchored the pane to LOCAL without resetting the watch
+    watch.tick(); // 2000 is still ALIVE — trusting local would derive a local binding for a live remote
+    expect(sink.unknowns).toEqual(["pane-1"]);
+    expect(sink.ends).toEqual([]);
+  });
+
+  it("depth 0 with a GONE pid ⇒ drop the stale watch, do NOT markUnknown (benign re-anchor race)", () => {
+    const { watch, sink, set } = setup(SHELL_WITH_SSH);
+    watch.watchPane("pane-1", 1000);
+    watch.noteSshOpened("pane-1", 2000); // registers {2000, 20}
+    sink.setDepth("pane-1", 0); // re-anchored local…
+    set(SHELL_ONLY); // …and the ssh already exited — the local anchor is LEGITIMATE
+    watch.tick();
+    expect(sink.unknowns).toEqual([]); // must NOT nuke a correct local pane
+    expect(sink.ends).toEqual([]); // and no pop (the tracker is already local)
+    expect(watch.isWatching("pane-1")).toBe(true); // pane still watched; only the stale session slot is dropped
   });
 });
 

--- a/tests/unit/key-locker-ssh-session-watch.test.ts
+++ b/tests/unit/key-locker-ssh-session-watch.test.ts
@@ -1,8 +1,9 @@
 // key-locker-ssh-session-watch.test.ts — ADR-014 R3 L3-3 PR3 (SP-L3-OQ-7, the ssh session-end watch).
 // Pins the depth pivot (≤1 pop / ≥2 markUnknown), shell-gone markUnknown, the REGISTERED-session-pid
 // contract (a sibling tunnel/one-shot ssh exiting must NOT fire — Opus R1 P2-A), pid-reuse-is-an-exit,
-// bad/late-pid registration, the degenerate-snapshot skip (P3-A), and the live-but-UNREADABLE session ssh
-// never popping-to-local (R2 P2). Pure reconciliation over a fake process snapshot + a fake tracker sink.
+// bad/late-pid registration, the degenerate-snapshot skip (P3-A), the live-but-UNREADABLE session ssh
+// never popping-to-local (R2 P2), and an unwatchable remote frame sinking to markUnknown rather than
+// stranding isRemote:true (R3 P2). Pure reconciliation over a fake process snapshot + a fake tracker sink.
 import { describe, expect, it } from "vitest";
 import {
   SshSessionWatch,
@@ -30,8 +31,10 @@ class FakeSink implements SessionTrackerSink {
   unknowns: string[] = [];
   private readonly depth = new Map<string, number>();
   setDepth(paneId: string, d: number): void { this.depth.set(paneId, d); }
-  noteSessionEnd(paneId: string): void { this.ends.push(paneId); }
-  markUnknown(paneId: string): void { this.unknowns.push(paneId); }
+  // Model the REAL SessionTracker's depth side-effects so multi-tick tests (and the session===null
+  // backstop) see faithful `remoteDepth`: a pop removes one remote frame, markUnknown nulls the stack.
+  noteSessionEnd(paneId: string): void { this.ends.push(paneId); this.depth.set(paneId, Math.max(0, (this.depth.get(paneId) ?? 0) - 1)); }
+  markUnknown(paneId: string): void { this.unknowns.push(paneId); this.depth.set(paneId, 0); }
   remoteDepth(paneId: string): number { return this.depth.get(paneId) ?? 0; }
 }
 
@@ -53,6 +56,22 @@ const SHELL_ONLY: Record<number, Proc> = {
   500: { parent: 0, name: "windowsterminal", start: 1 },
   1000: { parent: 500, name: "powershell", start: 10 },
 };
+
+// A snapshot where the session ssh (2000) is STILL ALIVE (present as a parentMap key) but its per-process
+// identity read fails (empty name) — models win32 `getProcessIdentityByPid` returning "" on an OpenProcess
+// ACCESS_DENIED against a LIVE elevated/other-user ssh. The generic `snapshotOf` helper can't express this
+// (it couples parentMap presence to a readable identity), so build the snapshot by hand.
+function unreadableSession(): ProcessSnapshot {
+  const parentMap = new Map<number, number>([[500, 0], [1000, 500], [2000, 1000]]); // 2000 alive
+  return {
+    parentMap,
+    identify: (pid) => {
+      if (pid === 500) return { name: "windowsterminal", startTimeMs: 1 };
+      if (pid === 1000) return { name: "powershell", startTimeMs: 10 };
+      return { name: "", startTimeMs: 0 }; // 2000 present but UNREADABLE (and any gone pid also reads "")
+    },
+  };
+}
 
 describe("SshSessionWatch — the depth pivot on a registered session ssh exit (SP-L3-OQ-7)", () => {
   it("depth ≤ 1: the registered session ssh exits ⇒ noteSessionEnd (pop one frame)", () => {
@@ -134,22 +153,6 @@ describe("SshSessionWatch — P2-A: a NON-session ssh must never pop the frame",
 });
 
 describe("SshSessionWatch — R2 P2: a live-but-UNREADABLE session ssh must not pop-to-local", () => {
-  // A snapshot where the session ssh (2000) is STILL ALIVE (present as a parentMap key) but its per-process
-  // identity read fails this tick (empty name) — models win32 `getProcessIdentityByPid` returning "" on an
-  // OpenProcess ACCESS_DENIED against a LIVE elevated/other-user ssh. The generic `snapshotOf` helper can't
-  // express this (it couples parentMap presence to a readable identity), so build the snapshot by hand.
-  function unreadableSession(): ProcessSnapshot {
-    const parentMap = new Map<number, number>([[500, 0], [1000, 500], [2000, 1000]]); // 2000 alive
-    return {
-      parentMap,
-      identify: (pid) => {
-        if (pid === 500) return { name: "windowsterminal", startTimeMs: 1 };
-        if (pid === 1000) return { name: "powershell", startTimeMs: 10 };
-        return { name: "", startTimeMs: 0 }; // 2000 present but UNREADABLE (and any gone pid also reads "")
-      },
-    };
-  }
-
   it("present in parentMap but identify() empty ⇒ markUnknown, NEVER noteSessionEnd (no pop-to-local)", () => {
     const sink = new FakeSink();
     let snap: ProcessSnapshot = snapshotOf(SHELL_WITH_SSH);
@@ -165,6 +168,44 @@ describe("SshSessionWatch — R2 P2: a live-but-UNREADABLE session ssh must not 
   });
 });
 
+describe("SshSessionWatch — R3 P2: an unwatchable remote frame must sink, not strand isRemote:true", () => {
+  it("registration-time: an unreadable pid while a frame is up (remoteDepth>0) ⇒ markUnknown, no watch", () => {
+    const sink = new FakeSink();
+    const watch = new SshSessionWatch({ snapshot: () => unreadableSession(), tracker: sink });
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 1); // the wiring pushed the interactive frame FIRST (push-then-register contract)
+    watch.noteSshOpened("pane-1", 2000); // 2000 is alive but UNREADABLE — cannot confirm a live ssh to watch
+    expect(sink.unknowns).toEqual(["pane-1"]); // sink the unwatchable remote frame (stale-remote wrong-target guard)
+    expect(sink.ends).toEqual([]); // NEVER a pop-to-local
+    // …no session was registered, and the frame is already sunk (depth 0), so a later tick fires nothing more.
+    watch.tick();
+    expect(sink.ends).toEqual([]);
+    expect(sink.unknowns).toEqual(["pane-1"]);
+    expect(watch.isWatching("pane-1")).toBe(true); // shell alive ⇒ still watched
+  });
+
+  it("registration-time: an unreadable pid on a LOCAL pane (remoteDepth 0) ⇒ no markUnknown (anchor kept)", () => {
+    const sink = new FakeSink();
+    const watch = new SshSessionWatch({ snapshot: () => unreadableSession(), tracker: sink });
+    watch.watchPane("pane-1", 1000);
+    // No frame pushed (remoteDepth 0): a speculative/early bad-or-unreadable register must NOT nuke the local anchor.
+    watch.noteSshOpened("pane-1", 2000);
+    expect(sink.unknowns).toEqual([]);
+    expect(sink.ends).toEqual([]);
+  });
+
+  it("tick backstop: a pushed frame with NO registered session (remoteDepth>0) ⇒ markUnknown", () => {
+    // The non-atomic push↔register window: the wiring pushed the interactive frame but a tick fired before
+    // noteSshOpened ran. A remote frame with no live watch is unsafe ⇒ sink it rather than strand it.
+    const { watch, sink } = setup(SHELL_WITH_SSH);
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 1);
+    watch.tick();
+    expect(sink.unknowns).toEqual(["pane-1"]);
+    expect(sink.ends).toEqual([]);
+  });
+});
+
 describe("SshSessionWatch — noteSshOpened hygiene", () => {
   it("noteSshOpened on an UNWATCHED pane is a no-op (no throw, no registration)", () => {
     const { watch, sink, set } = setup(SHELL_WITH_SSH);
@@ -176,14 +217,13 @@ describe("SshSessionWatch — noteSshOpened hygiene", () => {
     expect(sink.unknowns).toEqual([]);
   });
 
-  it("registering a pid that isn't a live ssh is ignored (no spurious exit next tick)", () => {
+  it("registering a bad pid on a LOCAL pane (depth 0) is ignored (no exit, no spurious sink)", () => {
     const { watch, sink } = setup(SHELL_WITH_SSH);
     watch.watchPane("pane-1", 1000);
-    watch.noteSshOpened("pane-1", 9999); // 9999 doesn't exist / isn't ssh
-    sink.setDepth("pane-1", 1);
-    watch.tick(); // nothing registered ⇒ nothing fires
+    watch.noteSshOpened("pane-1", 9999); // 9999 doesn't exist / isn't ssh; pane still local (remoteDepth 0)
+    watch.tick(); // nothing registered, no remote frame ⇒ nothing fires
     expect(sink.ends).toEqual([]);
-    expect(sink.unknowns).toEqual([]);
+    expect(sink.unknowns).toEqual([]); // must NOT nuke the local anchor
   });
 
   it("pid REUSE (same pid, different creation time) counts as an exit", () => {

--- a/tests/unit/key-locker-ssh-session-watch.test.ts
+++ b/tests/unit/key-locker-ssh-session-watch.test.ts
@@ -1,0 +1,162 @@
+// key-locker-ssh-session-watch.test.ts — ADR-014 R3 L3-3 PR3 (SP-L3-OQ-7, the ssh session-end watch).
+// Pins the depth pivot (≤1 pop / ≥2 markUnknown), shell-gone markUnknown, new-ssh-is-not-an-exit,
+// pid-reuse-is-an-exit, grandchild ssh discovery, and the seed-on-register (no false exit). Pure
+// reconciliation over a fake process snapshot + a fake tracker sink.
+import { describe, expect, it } from "vitest";
+import {
+  SshSessionWatch,
+  type ProcessSnapshot,
+  type SessionTrackerSink,
+  type SshWatchDeps,
+} from "../../src/engine/key-locker/ssh-session-watch.js";
+
+interface Proc { parent: number; name: string; start: number }
+
+function snapshotOf(procs: Record<number, Proc>): ProcessSnapshot {
+  const parentMap = new Map<number, number>();
+  for (const [pid, p] of Object.entries(procs)) parentMap.set(Number(pid), p.parent);
+  return {
+    parentMap,
+    identify: (pid) => {
+      const p = procs[pid];
+      return p !== undefined ? { name: p.name, startTimeMs: p.start } : { name: "", startTimeMs: 0 };
+    },
+  };
+}
+
+class FakeSink implements SessionTrackerSink {
+  ends: string[] = [];
+  unknowns: string[] = [];
+  private readonly depth = new Map<string, number>();
+  setDepth(paneId: string, d: number): void { this.depth.set(paneId, d); }
+  noteSessionEnd(paneId: string): void { this.ends.push(paneId); }
+  markUnknown(paneId: string): void { this.unknowns.push(paneId); }
+  remoteDepth(paneId: string): number { return this.depth.get(paneId) ?? 0; }
+}
+
+/** Build a watch whose snapshot reads a MUTABLE `procs` ref (so a test can change the tree between ticks). */
+function setup(initial: Record<number, Proc>): { watch: SshSessionWatch; sink: FakeSink; set: (p: Record<number, Proc>) => void } {
+  let procs = initial;
+  const sink = new FakeSink();
+  const deps: SshWatchDeps = { snapshot: () => snapshotOf(procs), tracker: sink };
+  return { watch: new SshSessionWatch(deps), sink, set: (p) => { procs = p; } };
+}
+
+// A shell (1000) with a direct ssh child (2000). 500 is the shell's parent (terminal host).
+const SHELL_WITH_SSH: Record<number, Proc> = {
+  500: { parent: 0, name: "windowsterminal", start: 1 },
+  1000: { parent: 500, name: "powershell", start: 10 },
+  2000: { parent: 1000, name: "ssh", start: 20 },
+};
+const SHELL_ONLY: Record<number, Proc> = {
+  500: { parent: 0, name: "windowsterminal", start: 1 },
+  1000: { parent: 500, name: "powershell", start: 10 },
+};
+
+describe("SshSessionWatch — the depth pivot on an ssh exit (SP-L3-OQ-7)", () => {
+  it("depth ≤ 1: the outermost ssh exits ⇒ noteSessionEnd (pop one frame)", () => {
+    const { watch, sink, set } = setup(SHELL_WITH_SSH);
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 1);
+    set(SHELL_ONLY); // the ssh process exited
+    watch.tick();
+    expect(sink.ends).toEqual(["pane-1"]);
+    expect(sink.unknowns).toEqual([]);
+  });
+
+  it("depth ≥ 2 (nested ssh): the visible outer ssh exits ⇒ markUnknown (never strand an inner frame)", () => {
+    const { watch, sink, set } = setup(SHELL_WITH_SSH); // only the OUTER ssh is locally visible
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 2); // tracker holds two remote frames (ssh a → ssh b)
+    set(SHELL_ONLY);
+    watch.tick();
+    expect(sink.unknowns).toEqual(["pane-1"]);
+    expect(sink.ends).toEqual([]);
+  });
+
+  it("no ssh exited ⇒ no signal", () => {
+    const { watch, sink } = setup(SHELL_WITH_SSH);
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 1);
+    watch.tick(); // same tree
+    expect(sink.ends).toEqual([]);
+    expect(sink.unknowns).toEqual([]);
+  });
+});
+
+describe("SshSessionWatch — unwatchable / lifecycle", () => {
+  it("the shell pid vanishing ⇒ markUnknown + stops watching (fail-safe)", () => {
+    const { watch, sink, set } = setup(SHELL_WITH_SSH);
+    watch.watchPane("pane-1", 1000);
+    set({ 500: { parent: 0, name: "windowsterminal", start: 1 } }); // shell 1000 gone
+    watch.tick();
+    expect(sink.unknowns).toEqual(["pane-1"]);
+    expect(watch.isWatching("pane-1")).toBe(false);
+  });
+
+  it("unwatchPane stops all further signalling for that pane", () => {
+    const { watch, sink, set } = setup(SHELL_WITH_SSH);
+    watch.watchPane("pane-1", 1000);
+    watch.unwatchPane("pane-1");
+    set(SHELL_ONLY);
+    watch.tick();
+    expect(sink.ends).toEqual([]);
+    expect(sink.unknowns).toEqual([]);
+  });
+
+  it("tick with no watched panes is a no-op", () => {
+    const { watch, sink } = setup(SHELL_WITH_SSH);
+    watch.tick();
+    expect(sink.ends).toEqual([]);
+    expect(sink.unknowns).toEqual([]);
+  });
+});
+
+describe("SshSessionWatch — reconciliation edge cases", () => {
+  it("seeds from an ALREADY-open ssh ⇒ the first tick does not mistake it for an exit", () => {
+    const { watch, sink } = setup(SHELL_WITH_SSH); // ssh already present at registration
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 1);
+    watch.tick(); // ssh still there — nothing changed
+    expect(sink.ends).toEqual([]);
+    expect(sink.unknowns).toEqual([]);
+  });
+
+  it("a NEW ssh appearing is a session OPENING, not an exit (no signal)", () => {
+    const { watch, sink, set } = setup(SHELL_ONLY); // no ssh at register
+    watch.watchPane("pane-1", 1000);
+    set(SHELL_WITH_SSH); // ssh 2000 now opened
+    sink.setDepth("pane-1", 1);
+    watch.tick();
+    expect(sink.ends).toEqual([]);
+    expect(sink.unknowns).toEqual([]);
+    // …and its LATER exit does fire.
+    set(SHELL_ONLY);
+    watch.tick();
+    expect(sink.ends).toEqual(["pane-1"]);
+  });
+
+  it("pid REUSE (same pid, different creation time) counts as an exit", () => {
+    const { watch, sink, set } = setup(SHELL_WITH_SSH);
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 1);
+    // pid 2000 is now a DIFFERENT process (creation time changed) — the watched ssh really exited.
+    set({ ...SHELL_ONLY, 2000: { parent: 1000, name: "ssh", start: 999 } });
+    watch.tick();
+    expect(sink.ends).toEqual(["pane-1"]);
+  });
+
+  it("discovers an ssh that is a GRANDCHILD of the shell (conhost in between)", () => {
+    const nested: Record<number, Proc> = {
+      1000: { parent: 500, name: "powershell", start: 10 },
+      1500: { parent: 1000, name: "conhost", start: 15 },
+      2000: { parent: 1500, name: "ssh", start: 20 },
+    };
+    const { watch, sink, set } = setup(nested);
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 1);
+    set({ 1000: { parent: 500, name: "powershell", start: 10 }, 1500: { parent: 1000, name: "conhost", start: 15 } }); // ssh gone
+    watch.tick();
+    expect(sink.ends).toEqual(["pane-1"]);
+  });
+});

--- a/tests/unit/key-locker-ssh-session-watch.test.ts
+++ b/tests/unit/key-locker-ssh-session-watch.test.ts
@@ -1,7 +1,8 @@
 // key-locker-ssh-session-watch.test.ts — ADR-014 R3 L3-3 PR3 (SP-L3-OQ-7, the ssh session-end watch).
-// Pins the depth pivot (≤1 pop / ≥2 markUnknown), shell-gone markUnknown, new-ssh-is-not-an-exit,
-// pid-reuse-is-an-exit, grandchild ssh discovery, and the seed-on-register (no false exit). Pure
-// reconciliation over a fake process snapshot + a fake tracker sink.
+// Pins the depth pivot (≤1 pop / ≥2 markUnknown), shell-gone markUnknown, the REGISTERED-session-pid
+// contract (a sibling tunnel/one-shot ssh exiting must NOT fire — Opus R1 P2-A), pid-reuse-is-an-exit,
+// bad/late-pid registration, and the degenerate-snapshot skip (P3-A). Pure reconciliation over a fake
+// process snapshot + a fake tracker sink.
 import { describe, expect, it } from "vitest";
 import {
   SshSessionWatch,
@@ -42,7 +43,7 @@ function setup(initial: Record<number, Proc>): { watch: SshSessionWatch; sink: F
   return { watch: new SshSessionWatch(deps), sink, set: (p) => { procs = p; } };
 }
 
-// A shell (1000) with a direct ssh child (2000). 500 is the shell's parent (terminal host).
+// A shell (1000) with a direct interactive ssh child (2000). 500 is the shell's parent (terminal host).
 const SHELL_WITH_SSH: Record<number, Proc> = {
   500: { parent: 0, name: "windowsterminal", start: 1 },
   1000: { parent: 500, name: "powershell", start: 10 },
@@ -53,20 +54,22 @@ const SHELL_ONLY: Record<number, Proc> = {
   1000: { parent: 500, name: "powershell", start: 10 },
 };
 
-describe("SshSessionWatch — the depth pivot on an ssh exit (SP-L3-OQ-7)", () => {
-  it("depth ≤ 1: the outermost ssh exits ⇒ noteSessionEnd (pop one frame)", () => {
+describe("SshSessionWatch — the depth pivot on a registered session ssh exit (SP-L3-OQ-7)", () => {
+  it("depth ≤ 1: the registered session ssh exits ⇒ noteSessionEnd (pop one frame)", () => {
     const { watch, sink, set } = setup(SHELL_WITH_SSH);
     watch.watchPane("pane-1", 1000);
+    watch.noteSshOpened("pane-1", 2000);
     sink.setDepth("pane-1", 1);
-    set(SHELL_ONLY); // the ssh process exited
+    set(SHELL_ONLY); // the session ssh exited
     watch.tick();
     expect(sink.ends).toEqual(["pane-1"]);
     expect(sink.unknowns).toEqual([]);
   });
 
-  it("depth ≥ 2 (nested ssh): the visible outer ssh exits ⇒ markUnknown (never strand an inner frame)", () => {
+  it("depth ≥ 2 (nested ssh): the visible outer session ssh exits ⇒ markUnknown (never strand an inner frame)", () => {
     const { watch, sink, set } = setup(SHELL_WITH_SSH); // only the OUTER ssh is locally visible
     watch.watchPane("pane-1", 1000);
+    watch.noteSshOpened("pane-1", 2000);
     sink.setDepth("pane-1", 2); // tracker holds two remote frames (ssh a → ssh b)
     set(SHELL_ONLY);
     watch.tick();
@@ -74,13 +77,92 @@ describe("SshSessionWatch — the depth pivot on an ssh exit (SP-L3-OQ-7)", () =
     expect(sink.ends).toEqual([]);
   });
 
-  it("no ssh exited ⇒ no signal", () => {
+  it("the registered session ssh still alive ⇒ no signal", () => {
     const { watch, sink } = setup(SHELL_WITH_SSH);
     watch.watchPane("pane-1", 1000);
+    watch.noteSshOpened("pane-1", 2000);
     sink.setDepth("pane-1", 1);
     watch.tick(); // same tree
     expect(sink.ends).toEqual([]);
     expect(sink.unknowns).toEqual([]);
+  });
+
+  it("consumes the exit (does not re-fire on the next tick until a new session is registered)", () => {
+    const { watch, sink, set } = setup(SHELL_WITH_SSH);
+    watch.watchPane("pane-1", 1000);
+    watch.noteSshOpened("pane-1", 2000);
+    sink.setDepth("pane-1", 1);
+    set(SHELL_ONLY);
+    watch.tick();
+    watch.tick(); // no new session — must not fire again
+    expect(sink.ends).toEqual(["pane-1"]);
+  });
+});
+
+describe("SshSessionWatch — P2-A: a NON-session ssh must never pop the frame", () => {
+  it("a sibling tunnel ssh exiting while the session ssh is alive ⇒ NO signal", () => {
+    // Two ssh under the shell: 2000 is the interactive session (registered); 3000 is a background
+    // tunnel (`ssh -f -L …`, pushes no tracker frame). The tunnel dying must NOT pop the live frame.
+    const withTunnel: Record<number, Proc> = {
+      ...SHELL_WITH_SSH,
+      3000: { parent: 1000, name: "ssh", start: 30 },
+    };
+    const { watch, sink, set } = setup(withTunnel);
+    watch.watchPane("pane-1", 1000);
+    watch.noteSshOpened("pane-1", 2000); // register ONLY the interactive session
+    sink.setDepth("pane-1", 1);
+    set(SHELL_WITH_SSH); // tunnel 3000 gone, session 2000 still alive
+    watch.tick();
+    expect(sink.ends).toEqual([]);
+    expect(sink.unknowns).toEqual([]);
+    // …and the session ssh's OWN later exit still fires.
+    set(SHELL_ONLY);
+    watch.tick();
+    expect(sink.ends).toEqual(["pane-1"]);
+  });
+
+  it("with NO session registered (only a tunnel present), an ssh exit is ignored", () => {
+    const withTunnelOnly: Record<number, Proc> = { ...SHELL_ONLY, 3000: { parent: 1000, name: "ssh", start: 30 } };
+    const { watch, sink, set } = setup(withTunnelOnly);
+    watch.watchPane("pane-1", 1000); // watched, but no interactive session registered
+    sink.setDepth("pane-1", 0);
+    set(SHELL_ONLY); // tunnel gone
+    watch.tick();
+    expect(sink.ends).toEqual([]);
+    expect(sink.unknowns).toEqual([]);
+  });
+});
+
+describe("SshSessionWatch — noteSshOpened hygiene", () => {
+  it("noteSshOpened on an UNWATCHED pane is a no-op (no throw, no registration)", () => {
+    const { watch, sink, set } = setup(SHELL_WITH_SSH);
+    watch.noteSshOpened("ghost", 2000); // never watchPane'd
+    sink.setDepth("ghost", 1);
+    set(SHELL_ONLY);
+    watch.tick();
+    expect(sink.ends).toEqual([]);
+    expect(sink.unknowns).toEqual([]);
+  });
+
+  it("registering a pid that isn't a live ssh is ignored (no spurious exit next tick)", () => {
+    const { watch, sink } = setup(SHELL_WITH_SSH);
+    watch.watchPane("pane-1", 1000);
+    watch.noteSshOpened("pane-1", 9999); // 9999 doesn't exist / isn't ssh
+    sink.setDepth("pane-1", 1);
+    watch.tick(); // nothing registered ⇒ nothing fires
+    expect(sink.ends).toEqual([]);
+    expect(sink.unknowns).toEqual([]);
+  });
+
+  it("pid REUSE (same pid, different creation time) counts as an exit", () => {
+    const { watch, sink, set } = setup(SHELL_WITH_SSH);
+    watch.watchPane("pane-1", 1000);
+    watch.noteSshOpened("pane-1", 2000);
+    sink.setDepth("pane-1", 1);
+    // pid 2000 is now a DIFFERENT process (creation time changed) — the registered ssh really exited.
+    set({ ...SHELL_ONLY, 2000: { parent: 1000, name: "ssh", start: 999 } });
+    watch.tick();
+    expect(sink.ends).toEqual(["pane-1"]);
   });
 });
 
@@ -88,6 +170,7 @@ describe("SshSessionWatch — unwatchable / lifecycle", () => {
   it("the shell pid vanishing ⇒ markUnknown + stops watching (fail-safe)", () => {
     const { watch, sink, set } = setup(SHELL_WITH_SSH);
     watch.watchPane("pane-1", 1000);
+    watch.noteSshOpened("pane-1", 2000);
     set({ 500: { parent: 0, name: "windowsterminal", start: 1 } }); // shell 1000 gone
     watch.tick();
     expect(sink.unknowns).toEqual(["pane-1"]);
@@ -97,6 +180,7 @@ describe("SshSessionWatch — unwatchable / lifecycle", () => {
   it("unwatchPane stops all further signalling for that pane", () => {
     const { watch, sink, set } = setup(SHELL_WITH_SSH);
     watch.watchPane("pane-1", 1000);
+    watch.noteSshOpened("pane-1", 2000);
     watch.unwatchPane("pane-1");
     set(SHELL_ONLY);
     watch.tick();
@@ -104,59 +188,20 @@ describe("SshSessionWatch — unwatchable / lifecycle", () => {
     expect(sink.unknowns).toEqual([]);
   });
 
+  it("a degenerate (empty) snapshot skips the tick — does NOT markUnknown every pane (P3-A)", () => {
+    const { watch, sink, set } = setup(SHELL_WITH_SSH);
+    watch.watchPane("pane-1", 1000);
+    watch.noteSshOpened("pane-1", 2000);
+    set({}); // native snapshot failure ⇒ empty map
+    watch.tick();
+    expect(sink.unknowns).toEqual([]);
+    expect(watch.isWatching("pane-1")).toBe(true); // still watched — a transient glitch is not a death
+  });
+
   it("tick with no watched panes is a no-op", () => {
     const { watch, sink } = setup(SHELL_WITH_SSH);
     watch.tick();
     expect(sink.ends).toEqual([]);
     expect(sink.unknowns).toEqual([]);
-  });
-});
-
-describe("SshSessionWatch — reconciliation edge cases", () => {
-  it("seeds from an ALREADY-open ssh ⇒ the first tick does not mistake it for an exit", () => {
-    const { watch, sink } = setup(SHELL_WITH_SSH); // ssh already present at registration
-    watch.watchPane("pane-1", 1000);
-    sink.setDepth("pane-1", 1);
-    watch.tick(); // ssh still there — nothing changed
-    expect(sink.ends).toEqual([]);
-    expect(sink.unknowns).toEqual([]);
-  });
-
-  it("a NEW ssh appearing is a session OPENING, not an exit (no signal)", () => {
-    const { watch, sink, set } = setup(SHELL_ONLY); // no ssh at register
-    watch.watchPane("pane-1", 1000);
-    set(SHELL_WITH_SSH); // ssh 2000 now opened
-    sink.setDepth("pane-1", 1);
-    watch.tick();
-    expect(sink.ends).toEqual([]);
-    expect(sink.unknowns).toEqual([]);
-    // …and its LATER exit does fire.
-    set(SHELL_ONLY);
-    watch.tick();
-    expect(sink.ends).toEqual(["pane-1"]);
-  });
-
-  it("pid REUSE (same pid, different creation time) counts as an exit", () => {
-    const { watch, sink, set } = setup(SHELL_WITH_SSH);
-    watch.watchPane("pane-1", 1000);
-    sink.setDepth("pane-1", 1);
-    // pid 2000 is now a DIFFERENT process (creation time changed) — the watched ssh really exited.
-    set({ ...SHELL_ONLY, 2000: { parent: 1000, name: "ssh", start: 999 } });
-    watch.tick();
-    expect(sink.ends).toEqual(["pane-1"]);
-  });
-
-  it("discovers an ssh that is a GRANDCHILD of the shell (conhost in between)", () => {
-    const nested: Record<number, Proc> = {
-      1000: { parent: 500, name: "powershell", start: 10 },
-      1500: { parent: 1000, name: "conhost", start: 15 },
-      2000: { parent: 1500, name: "ssh", start: 20 },
-    };
-    const { watch, sink, set } = setup(nested);
-    watch.watchPane("pane-1", 1000);
-    sink.setDepth("pane-1", 1);
-    set({ 1000: { parent: 500, name: "powershell", start: 10 }, 1500: { parent: 1000, name: "conhost", start: 15 } }); // ssh gone
-    watch.tick();
-    expect(sink.ends).toEqual(["pane-1"]);
   });
 });

--- a/tests/unit/key-locker-ssh-session-watch.test.ts
+++ b/tests/unit/key-locker-ssh-session-watch.test.ts
@@ -2,8 +2,9 @@
 // Pins the depth pivot (≤1 pop / ≥2 markUnknown), shell-gone markUnknown, the REGISTERED-session-pid
 // contract (a sibling tunnel/one-shot ssh exiting must NOT fire — Opus R1 P2-A), pid-reuse-is-an-exit,
 // bad/late-pid registration, the degenerate-snapshot skip (P3-A), the live-but-UNREADABLE session ssh
-// never popping-to-local (R2 P2), and an unwatchable remote frame sinking to markUnknown rather than
-// stranding isRemote:true (R3 P2). Pure reconciliation over a fake process snapshot + a fake tracker sink.
+// never popping-to-local (R2 P2), an unwatchable remote frame sinking to markUnknown rather than stranding
+// isRemote:true (R3 P2), and the R4 fold to depth-1-only trust — nested logins (depth ≥ 2) and zero-
+// creation-time partial reads decline. Pure reconciliation over a fake process snapshot + a fake tracker sink.
 import { describe, expect, it } from "vitest";
 import {
   SshSessionWatch,
@@ -73,6 +74,21 @@ function unreadableSession(): ProcessSnapshot {
   };
 }
 
+// A snapshot where the session ssh (2000) is ALIVE and its NAME reads "ssh", but its creation-time read
+// failed (startTimeMs 0) — models the win32 partial read (OpenProcess ok, GetProcessTimes failed; name and
+// time are read INDEPENDENTLY). A real running process never has creation time 0, so 0 is a doubt sentinel.
+function sshWithZeroTime(): ProcessSnapshot {
+  const parentMap = new Map<number, number>([[500, 0], [1000, 500], [2000, 1000]]); // 2000 alive
+  return {
+    parentMap,
+    identify: (pid) => {
+      if (pid === 500) return { name: "windowsterminal", startTimeMs: 1 };
+      if (pid === 1000) return { name: "powershell", startTimeMs: 10 };
+      return { name: "ssh", startTimeMs: 0 }; // 2000: live ssh, creation-time read failed
+    },
+  };
+}
+
 describe("SshSessionWatch — the depth pivot on a registered session ssh exit (SP-L3-OQ-7)", () => {
   it("depth ≤ 1: the registered session ssh exits ⇒ noteSessionEnd (pop one frame)", () => {
     const { watch, sink, set } = setup(SHELL_WITH_SSH);
@@ -91,7 +107,7 @@ describe("SshSessionWatch — the depth pivot on a registered session ssh exit (
     watch.noteSshOpened("pane-1", 2000);
     sink.setDepth("pane-1", 2); // tracker holds two remote frames (ssh a → ssh b)
     set(SHELL_ONLY);
-    watch.tick();
+    watch.tick(); // the nested guard declines at depth ≥ 2 before the exit is even evaluated (R4)
     expect(sink.unknowns).toEqual(["pane-1"]);
     expect(sink.ends).toEqual([]);
   });
@@ -202,6 +218,54 @@ describe("SshSessionWatch — R3 P2: an unwatchable remote frame must sink, not 
     sink.setDepth("pane-1", 1);
     watch.tick();
     expect(sink.unknowns).toEqual(["pane-1"]);
+    expect(sink.ends).toEqual([]);
+  });
+});
+
+describe("SshSessionWatch — R4: fold to depth-1-only trust (nested + zero creation time decline)", () => {
+  it("registration at depth ≥ 2 (nested login) ⇒ markUnknown, no session registered (even for a valid ssh)", () => {
+    const { watch, sink } = setup(SHELL_WITH_SSH);
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 2); // a second interactive frame already pushed (ssh a → ssh b)
+    watch.noteSshOpened("pane-1", 2000); // 2000 is a valid live ssh, but the pane is already nested
+    expect(sink.unknowns).toEqual(["pane-1"]); // decline — the inner login is unobservable, never poppable
+    expect(sink.ends).toEqual([]);
+    watch.tick(); // no session registered (frame sunk to depth 0) ⇒ nothing more fires
+    expect(sink.ends).toEqual([]);
+  });
+
+  it("tick at depth ≥ 2 with the outer ssh still ALIVE ⇒ markUnknown (self-enforced nested guard)", () => {
+    // The user exited only the INNER login (invisible locally) — the outer ssh is still alive. A depth ≥ 2
+    // session-bearing pane must decline rather than keep trusting the now-wrong top frame.
+    const { watch, sink } = setup(SHELL_WITH_SSH);
+    watch.watchPane("pane-1", 1000);
+    watch.noteSshOpened("pane-1", 2000); // registered at depth 0…
+    sink.setDepth("pane-1", 2); // …then the tracker deepened without a re-registration
+    watch.tick();
+    expect(sink.unknowns).toEqual(["pane-1"]);
+    expect(sink.ends).toEqual([]);
+  });
+
+  it("tick: a live registered ssh with a ZERO creation time ⇒ markUnknown, NEVER noteSessionEnd", () => {
+    const sink = new FakeSink();
+    let snap: ProcessSnapshot = snapshotOf(SHELL_WITH_SSH);
+    const watch = new SshSessionWatch({ snapshot: () => snap, tracker: sink });
+    watch.watchPane("pane-1", 1000);
+    watch.noteSshOpened("pane-1", 2000); // registers startedAt=20 from a readable snapshot
+    sink.setDepth("pane-1", 1);
+    snap = sshWithZeroTime(); // 2000 alive, name "ssh", but its creation-time read failed (startTimeMs 0)
+    watch.tick();
+    expect(sink.ends).toEqual([]); // a partial read is NOT a confirmed exit — never pop a live remote
+    expect(sink.unknowns).toEqual(["pane-1"]);
+  });
+
+  it("registration: a live ssh with a ZERO creation time is not watched; an already-pushed frame is sunk", () => {
+    const sink = new FakeSink();
+    const watch = new SshSessionWatch({ snapshot: () => sshWithZeroTime(), tracker: sink });
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 1); // frame pushed
+    watch.noteSshOpened("pane-1", 2000); // 2000 present + "ssh" but startTimeMs 0 ⇒ no reliable baseline
+    expect(sink.unknowns).toEqual(["pane-1"]); // sink the unwatchable frame rather than store a 0 baseline
     expect(sink.ends).toEqual([]);
   });
 });

--- a/tests/unit/key-locker-ssh-session-watch.test.ts
+++ b/tests/unit/key-locker-ssh-session-watch.test.ts
@@ -1,8 +1,8 @@
 // key-locker-ssh-session-watch.test.ts — ADR-014 R3 L3-3 PR3 (SP-L3-OQ-7, the ssh session-end watch).
 // Pins the depth pivot (≤1 pop / ≥2 markUnknown), shell-gone markUnknown, the REGISTERED-session-pid
 // contract (a sibling tunnel/one-shot ssh exiting must NOT fire — Opus R1 P2-A), pid-reuse-is-an-exit,
-// bad/late-pid registration, and the degenerate-snapshot skip (P3-A). Pure reconciliation over a fake
-// process snapshot + a fake tracker sink.
+// bad/late-pid registration, the degenerate-snapshot skip (P3-A), and the live-but-UNREADABLE session ssh
+// never popping-to-local (R2 P2). Pure reconciliation over a fake process snapshot + a fake tracker sink.
 import { describe, expect, it } from "vitest";
 import {
   SshSessionWatch,
@@ -130,6 +130,38 @@ describe("SshSessionWatch — P2-A: a NON-session ssh must never pop the frame",
     watch.tick();
     expect(sink.ends).toEqual([]);
     expect(sink.unknowns).toEqual([]);
+  });
+});
+
+describe("SshSessionWatch — R2 P2: a live-but-UNREADABLE session ssh must not pop-to-local", () => {
+  // A snapshot where the session ssh (2000) is STILL ALIVE (present as a parentMap key) but its per-process
+  // identity read fails this tick (empty name) — models win32 `getProcessIdentityByPid` returning "" on an
+  // OpenProcess ACCESS_DENIED against a LIVE elevated/other-user ssh. The generic `snapshotOf` helper can't
+  // express this (it couples parentMap presence to a readable identity), so build the snapshot by hand.
+  function unreadableSession(): ProcessSnapshot {
+    const parentMap = new Map<number, number>([[500, 0], [1000, 500], [2000, 1000]]); // 2000 alive
+    return {
+      parentMap,
+      identify: (pid) => {
+        if (pid === 500) return { name: "windowsterminal", startTimeMs: 1 };
+        if (pid === 1000) return { name: "powershell", startTimeMs: 10 };
+        return { name: "", startTimeMs: 0 }; // 2000 present but UNREADABLE (and any gone pid also reads "")
+      },
+    };
+  }
+
+  it("present in parentMap but identify() empty ⇒ markUnknown, NEVER noteSessionEnd (no pop-to-local)", () => {
+    const sink = new FakeSink();
+    let snap: ProcessSnapshot = snapshotOf(SHELL_WITH_SSH);
+    const watch = new SshSessionWatch({ snapshot: () => snap, tracker: sink });
+    watch.watchPane("pane-1", 1000);
+    watch.noteSshOpened("pane-1", 2000); // registers start=20 from the readable snapshot
+    sink.setDepth("pane-1", 1); // depth ≤ 1: the OLD code would have popped-to-local here
+    snap = unreadableSession(); // session ssh now alive-but-unreadable
+    watch.tick();
+    expect(sink.ends).toEqual([]); // NOT popped — a live remote session must never be relabelled local
+    expect(sink.unknowns).toEqual(["pane-1"]); // declined to derive instead (fail-safe)
+    expect(watch.isWatching("pane-1")).toBe(true); // shell alive ⇒ still watched (only the session is consumed)
   });
 });
 


### PR DESCRIPTION
## What & why

When you `ssh` into a remote host from a tracked terminal pane, the key locker remembers you're now "on that host" so it fills the right credentials. This PR adds the missing half: noticing when that ssh session **ends**, so the pane goes back to "local" and a later local command doesn't get a remote host's secret (a wrong-target fill).

Because an interactive `ssh user@host` never exits with a code we can watch, the reliable end-of-session signal is the **ssh child process disappearing** — observed from the process tree.

## Changes
- `ssh-session-watch.ts` (new): watches each pane's ssh child process and, when it exits, tells the session tracker. Pure logic over an injected process snapshot (fully unit-tested; the live Win32 snapshot + timer are wired later with the terminal integration).
- **Nested ssh guard:** only the outermost ssh is visible locally, so when the tracker is 2+ hops deep the watch can't tell which hop ended — it conservatively marks the pane "unknown" (declines to autofill) rather than risk targeting the wrong host. Adds `SessionTracker.remoteDepth()`.
- `KeyLockerManager.disposeIfIdle()`: shuts the locker helper down after an idle period, never mid-operation.

## Verification
- `npm run build` clean; lint clean on changed files.
- `key-locker-*` unit suite 276 passed (adds the watch suite + `remoteDepth` + `disposeIfIdle` cases).
- Additive only — no public tool / schema / catalogue change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)