### PR TITLE
ADR-014 v2 R3 L3-4 W-0: getProcessCommandLineByPid native binding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,10 @@ windows = { version = "0.62", features = [
     # Visual GPU Phase 4 capability detection (ADR-005)
     "Win32_System_SystemInformation",
     "Wdk_System_SystemServices",
+    # ADR-014 v2 R3 L3-4 W-0: NtQueryInformationProcess(ProcessCommandLineInformation)
+    # for getProcessCommandLineByPid (read an ssh child's argv to classify
+    # interactive-login vs tunnel/one-shot in the key-locker wrong-target fail-safe).
+    "Wdk_System_Threading",
     # ADR-007 P1: hot-path window APIs (koffi → windows-rs).
     # EnumWindows / GetWindowText / GetWindowRect / GetForegroundWindow /
     # IsWindowVisible / IsIconic / IsZoomed / GetClassNameW /

--- a/index.d.ts
+++ b/index.d.ts
@@ -369,6 +369,7 @@ export declare function win32ForegroundFlashInject(targetHwnd: bigint, targetPid
 export declare function win32GetFocusedChildHwnd(targetHwnd: bigint): bigint | null
 export declare function win32BuildProcessParentMap(): NativeProcessParentEntry[]
 export declare function win32GetProcessIdentity(pid: number): NativeProcessIdentity
+export declare function win32GetProcessCommandLine(pid: number): string[] | null
 export declare function win32GetScrollInfo(hwnd: bigint, axis: string): NativeScrollInfo | null
 export declare function win32PostMessage(hwnd: bigint, msg: number, wParam: bigint, lParam: bigint): boolean
 export declare function win32ConsolePasteNoFocus(hwnd: bigint, text: string): NativeConsolePasteResult

--- a/index.js
+++ b/index.js
@@ -104,6 +104,7 @@ export const win32ForceSetForegroundWindow    = nativeBinding.win32ForceSetForeg
 export const win32GetFocusedChildHwnd         = nativeBinding.win32GetFocusedChildHwnd;
 export const win32BuildProcessParentMap       = nativeBinding.win32BuildProcessParentMap;
 export const win32GetProcessIdentity          = nativeBinding.win32GetProcessIdentity;
+export const win32GetProcessCommandLine       = nativeBinding.win32GetProcessCommandLine;
 export const win32GetScrollInfo               = nativeBinding.win32GetScrollInfo;
 export const win32PostMessage                 = nativeBinding.win32PostMessage;
 export const win32GetFocus                    = nativeBinding.win32GetFocus;

--- a/src/engine/native-engine.ts
+++ b/src/engine/native-engine.ts
@@ -162,6 +162,9 @@ export interface NativeWin32 {
   win32GetFocusedChildHwnd?(targetHwnd: bigint): bigint | null;
   win32BuildProcessParentMap?(): NativeProcessParentEntry[];
   win32GetProcessIdentity?(pid: number): NativeProcessIdentity;
+  /** ADR-014 v2 R3 L3-4 W-0: a process's launch argv (CommandLineToArgvW), or
+   *  null on any failure/ACCESS_DENIED (fail-safe "unreadable" for the caller). */
+  win32GetProcessCommandLine?(pid: number): string[] | null;
   win32GetScrollInfo?(hwnd: bigint, axis: string): NativeScrollInfo | null;
   win32PostMessage?(hwnd: bigint, msg: number, wParam: bigint, lParam: bigint): boolean;
   win32GetFocus?(): bigint | null;

--- a/src/engine/win32.ts
+++ b/src/engine/win32.ts
@@ -402,6 +402,29 @@ export function getWindowIdentity(hwnd: unknown): ProcessIdentity {
 }
 
 /**
+ * A process's launch command line, split into argv exactly as the OS launched it
+ * (`CommandLineToArgvW` parity). Returns `null` on ANY failure — a non-number /
+ * zero pid, a dead process, ACCESS_DENIED on an elevated / cross-user target, or
+ * a query/parse failure — so callers fail SAFE (ADR-014 v2 R3 L3-4 W-2b treats a
+ * null read as "possibly an interactive in-bound ssh" and declines).
+ *
+ * argv[0] is the image (ssh path); pass `argv.slice(1)` to `interactiveSshTarget`.
+ * Uses `NtQueryInformationProcess(ProcessCommandLineInformation)` under the same
+ * `PROCESS_QUERY_LIMITED_INFORMATION` right as the identity query (no cross-process
+ * memory read).
+ */
+export function getProcessCommandLineByPid(pid: number): string[] | null {
+  if (typeof pid !== "number" || pid === 0) {
+    return null;
+  }
+  try {
+    return requireNativeWin32().win32GetProcessCommandLine!(pid >>> 0) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Build a Map of pid → parentPid by snapshotting all processes via Toolhelp32.
  * Returns an empty map on failure. The native binding owns the snapshot
  * handle lifetime via RAII (no JS-side leak risk).

--- a/src/win32/process.rs
+++ b/src/win32/process.rs
@@ -263,9 +263,10 @@ pub fn win32_get_process_command_line(pid: u32) -> napi::Result<Option<Vec<Strin
         // Fail-safe bounds validation (Codex PR#510 P2): before forming the wide
         // slice, prove the whole [Buffer, Buffer+Length) span lies within the
         // bytes the kernel ACTUALLY returned. `Buffer` must sit past the header
-        // and inside `buf`, and `Length` (a BYTE count) must be even for UTF-16.
-        // Any inconsistency (e.g. an OS behavior change or a capped retry) fails
-        // safe to None rather than reading outside the local query buffer.
+        // and inside `buf`, be 2-byte aligned, and `Length` (a BYTE count) must be
+        // even for UTF-16. Any inconsistency (e.g. an OS behavior change or a
+        // capped retry) fails safe to None rather than reading outside the local
+        // query buffer.
         let len_bytes = us.Length as usize;
         let returned = (ret_len as usize).min(buf.len());
         let buf_start = buf.as_ptr() as usize;
@@ -274,6 +275,10 @@ pub fn win32_get_process_command_line(pid: u32) -> napi::Result<Option<Vec<Strin
         let str_start = us.Buffer.0 as usize;
         if us.Buffer.is_null()
             || (len_bytes & 1) != 0
+            // `from_raw_parts::<u16>` below requires 2-byte alignment; `buf` is a
+            // Vec<u8> (byte-aligned only), so an odd `Buffer` would be UB — the same
+            // rationale that made the header use read_unaligned (Opus PR#510 R4 P3).
+            || (str_start & 1) != 0
             || str_start < buf_body
             || str_start > buf_limit
             || len_bytes > buf_limit - str_start

--- a/src/win32/process.rs
+++ b/src/win32/process.rs
@@ -12,7 +12,12 @@
 use std::sync::atomic::Ordering;
 
 use napi_derive::napi;
-use windows::Win32::Foundation::{CloseHandle, FILETIME, HANDLE};
+use windows::core::{PCWSTR, PWSTR};
+use windows::Wdk::System::Threading::{NtQueryInformationProcess, ProcessCommandLineInformation};
+use windows::Win32::Foundation::{
+    CloseHandle, LocalFree, FILETIME, HANDLE, HLOCAL, STATUS_INFO_LENGTH_MISMATCH, STATUS_SUCCESS,
+    UNICODE_STRING,
+};
 use windows::Win32::System::Diagnostics::ToolHelp::{
     CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
     TH32CS_SNAPPROCESS,
@@ -21,6 +26,7 @@ use windows::Win32::System::Threading::{
     GetProcessTimes, OpenProcess, QueryFullProcessImageNameW, PROCESS_NAME_FORMAT,
     PROCESS_QUERY_LIMITED_INFORMATION,
 };
+use windows::Win32::UI::Shell::CommandLineToArgvW;
 
 use super::safety::{napi_safe_call, PANIC_COUNTER};
 use super::types::{NativeProcessIdentity, NativeProcessParentEntry};
@@ -176,4 +182,132 @@ pub fn win32_get_process_identity(pid: u32) -> napi::Result<NativeProcessIdentit
 
         Ok(out)
     })
+}
+
+// ── pid → command-line argv (ADR-014 v2 R3 L3-4 W-0) ────────────────────────
+
+/// Read a process's command line as argv via `NtQueryInformationProcess(
+/// ProcessCommandLineInformation)` (Windows 8.1+). This needs only
+/// `PROCESS_QUERY_LIMITED_INFORMATION` — the SAME right the identity query uses
+/// — and does NO cross-process memory read (the OS copies the string into OUR
+/// buffer). Split with `CommandLineToArgvW` for byte-exact parity with how the
+/// process was actually launched (quote/backslash rules), so the L3-4 caller can
+/// reuse `interactiveSshTarget` to tell an interactive in-bound `ssh host` from a
+/// tunnel (`-N`/`-f`/`-L`) or one-shot (`ssh host cmd`).
+///
+/// Returns `None` on ANY failure — a dead pid, ACCESS_DENIED on an elevated /
+/// cross-user target, a non-success NTSTATUS, an empty line, or a split failure —
+/// so the W-2b fail-safe treats "unreadable" as "possibly interactive" (decline,
+/// never disclose). Never throws (RAII handle guard + panic guard mirror the
+/// identity path). `LocalFree` releases the `CommandLineToArgvW` allocation.
+#[napi]
+pub fn win32_get_process_command_line(pid: u32) -> napi::Result<Option<Vec<String>>> {
+    napi_safe_call("win32_get_process_command_line", || {
+        if pid == 0 {
+            return Ok(None);
+        }
+
+        let handle = match unsafe {
+            OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid)
+        } {
+            Ok(h) if !h.is_invalid() => h,
+            _ => return Ok(None),
+        };
+        let _handle_guard = ProcessHandleGuard(handle);
+
+        // Query ProcessCommandLineInformation. Start with a 4 KiB buffer and grow
+        // once to the reported length if the OS signals a mismatch. Command lines
+        // are bounded; cap the grow so a bogus length can't drive a huge alloc.
+        let mut buf = vec![0u8; 4096];
+        let mut ret_len: u32 = 0;
+        let mut status = unsafe {
+            NtQueryInformationProcess(
+                handle,
+                ProcessCommandLineInformation,
+                buf.as_mut_ptr() as *mut core::ffi::c_void,
+                buf.len() as u32,
+                &mut ret_len,
+            )
+        };
+        if status == STATUS_INFO_LENGTH_MISMATCH && (ret_len as usize) > buf.len() {
+            let cap = (ret_len as usize).min(128 * 1024);
+            buf = vec![0u8; cap];
+            status = unsafe {
+                NtQueryInformationProcess(
+                    handle,
+                    ProcessCommandLineInformation,
+                    buf.as_mut_ptr() as *mut core::ffi::c_void,
+                    buf.len() as u32,
+                    &mut ret_len,
+                )
+            };
+        }
+        if status != STATUS_SUCCESS {
+            return Ok(None);
+        }
+
+        // The buffer begins with a UNICODE_STRING whose `Buffer` points just past
+        // the header, INSIDE `buf` (a local query — not the target's memory).
+        if (ret_len as usize) < std::mem::size_of::<UNICODE_STRING>() {
+            return Ok(None);
+        }
+        let us = unsafe { &*(buf.as_ptr() as *const UNICODE_STRING) };
+        let wlen = (us.Length as usize) / 2; // Length is a BYTE count
+        if wlen == 0 || us.Buffer.is_null() {
+            return Ok(None);
+        }
+
+        // Copy the wide string + NUL-terminate for CommandLineToArgvW.
+        let wide = unsafe { std::slice::from_raw_parts(us.Buffer.0 as *const u16, wlen) };
+        let mut wz: Vec<u16> = Vec::with_capacity(wlen + 1);
+        wz.extend_from_slice(wide);
+        wz.push(0);
+
+        let mut argc: i32 = 0;
+        let argv = unsafe { CommandLineToArgvW(PCWSTR(wz.as_ptr()), &mut argc) };
+        if argv.is_null() || argc <= 0 {
+            return Ok(None);
+        }
+        let mut out: Vec<String> = Vec::with_capacity(argc as usize);
+        for i in 0..argc as isize {
+            let p: PWSTR = unsafe { *argv.offset(i) };
+            let s = unsafe { p.to_string() }.unwrap_or_default();
+            out.push(s);
+        }
+        // Release the single allocation CommandLineToArgvW returned.
+        unsafe {
+            let _ = LocalFree(Some(HLOCAL(argv as *mut core::ffi::c_void)));
+        }
+
+        Ok(Some(out))
+    })
+}
+
+#[cfg(test)]
+mod cmdline_tests {
+    use super::*;
+
+    #[test]
+    fn reads_current_process_command_line() {
+        // The test-runner process always has a readable command line with argv[0].
+        let pid = std::process::id();
+        let argv = win32_get_process_command_line(pid)
+            .expect("must not throw")
+            .expect("the current process command line should be readable");
+        assert!(!argv.is_empty(), "argv must contain at least argv[0]");
+        assert!(!argv[0].is_empty(), "argv[0] (image path) must be non-empty");
+    }
+
+    #[test]
+    fn zero_pid_returns_none() {
+        assert!(win32_get_process_command_line(0).expect("no throw").is_none());
+    }
+
+    #[test]
+    fn nonexistent_pid_fails_safe_to_none() {
+        // A pid extremely unlikely to exist must fail SAFE to None, never panic —
+        // the W-2b caller treats None as "possibly interactive" (decline).
+        let r = win32_get_process_command_line(0xFFFF_FFF0).expect("no throw");
+        assert!(r.is_none());
+    }
 }

--- a/src/win32/process.rs
+++ b/src/win32/process.rs
@@ -251,14 +251,37 @@ pub fn win32_get_process_command_line(pid: u32) -> napi::Result<Option<Vec<Strin
         if (ret_len as usize) < std::mem::size_of::<UNICODE_STRING>() {
             return Ok(None);
         }
-        let us = unsafe { &*(buf.as_ptr() as *const UNICODE_STRING) };
-        // Defense-in-depth (Opus PR#510 P3): bound the wide length by the bytes the
-        // kernel ACTUALLY returned, not just the self-reported UNICODE_STRING.Length,
-        // so a corrupt Length can never drive an over-read past `buf`.
+        // Read the UNICODE_STRING header via read_unaligned: `buf` is a Vec<u8>
+        // (Rust guarantees only byte alignment), so forming `&UNICODE_STRING`
+        // directly would be UB regardless of the later checks. Copy the header
+        // fields into a properly aligned local — UNICODE_STRING is Copy — before
+        // inspecting them (Codex PR#510 P2).
         let header = std::mem::size_of::<UNICODE_STRING>();
-        let avail_wchars = (ret_len as usize).saturating_sub(header) / 2;
-        let wlen = ((us.Length as usize) / 2).min(avail_wchars); // Length is a BYTE count
-        if wlen == 0 || us.Buffer.is_null() {
+        let us: UNICODE_STRING =
+            unsafe { std::ptr::read_unaligned(buf.as_ptr() as *const UNICODE_STRING) };
+
+        // Fail-safe bounds validation (Codex PR#510 P2): before forming the wide
+        // slice, prove the whole [Buffer, Buffer+Length) span lies within the
+        // bytes the kernel ACTUALLY returned. `Buffer` must sit past the header
+        // and inside `buf`, and `Length` (a BYTE count) must be even for UTF-16.
+        // Any inconsistency (e.g. an OS behavior change or a capped retry) fails
+        // safe to None rather than reading outside the local query buffer.
+        let len_bytes = us.Length as usize;
+        let returned = (ret_len as usize).min(buf.len());
+        let buf_start = buf.as_ptr() as usize;
+        let buf_body = buf_start + header;
+        let buf_limit = buf_start + returned;
+        let str_start = us.Buffer.0 as usize;
+        if us.Buffer.is_null()
+            || (len_bytes & 1) != 0
+            || str_start < buf_body
+            || str_start > buf_limit
+            || len_bytes > buf_limit - str_start
+        {
+            return Ok(None);
+        }
+        let wlen = len_bytes / 2;
+        if wlen == 0 {
             return Ok(None);
         }
 
@@ -282,8 +305,20 @@ pub fn win32_get_process_command_line(pid: u32) -> napi::Result<Option<Vec<Strin
         let mut out: Vec<String> = Vec::with_capacity(argc as usize);
         for i in 0..argc as isize {
             let p: PWSTR = unsafe { *argv.offset(i) };
-            let s = unsafe { p.to_string() }.unwrap_or_default();
-            out.push(s);
+            match unsafe { p.to_string() } {
+                Ok(s) => out.push(s),
+                Err(_) => {
+                    // Fail-safe (Codex PR#510 P2): an argv element with invalid
+                    // UTF-16 must NOT be silently coerced to "" — that could let a
+                    // malformed ssh line be misclassified as a safe one-shot and
+                    // disclose. Free the CommandLineToArgvW allocation and decline
+                    // per the fail-safe-to-None contract.
+                    unsafe {
+                        let _ = LocalFree(Some(HLOCAL(argv as *mut core::ffi::c_void)));
+                    }
+                    return Ok(None);
+                }
+            }
         }
         // Release the single allocation CommandLineToArgvW returned.
         unsafe {

--- a/src/win32/process.rs
+++ b/src/win32/process.rs
@@ -252,7 +252,12 @@ pub fn win32_get_process_command_line(pid: u32) -> napi::Result<Option<Vec<Strin
             return Ok(None);
         }
         let us = unsafe { &*(buf.as_ptr() as *const UNICODE_STRING) };
-        let wlen = (us.Length as usize) / 2; // Length is a BYTE count
+        // Defense-in-depth (Opus PR#510 P3): bound the wide length by the bytes the
+        // kernel ACTUALLY returned, not just the self-reported UNICODE_STRING.Length,
+        // so a corrupt Length can never drive an over-read past `buf`.
+        let header = std::mem::size_of::<UNICODE_STRING>();
+        let avail_wchars = (ret_len as usize).saturating_sub(header) / 2;
+        let wlen = ((us.Length as usize) / 2).min(avail_wchars); // Length is a BYTE count
         if wlen == 0 || us.Buffer.is_null() {
             return Ok(None);
         }
@@ -266,6 +271,12 @@ pub fn win32_get_process_command_line(pid: u32) -> napi::Result<Option<Vec<Strin
         let mut argc: i32 = 0;
         let argv = unsafe { CommandLineToArgvW(PCWSTR(wz.as_ptr()), &mut argc) };
         if argv.is_null() || argc <= 0 {
+            // CommandLineToArgvW success always yields argc >= 1, so a non-null argv
+            // with argc <= 0 is unreachable — but free it if it ever occurs (Opus
+            // PR#510 P3: no leak on the edge) rather than dropping the LocalAlloc block.
+            if !argv.is_null() {
+                unsafe { let _ = LocalFree(Some(HLOCAL(argv as *mut core::ffi::c_void))); }
+            }
             return Ok(None);
         }
         let mut out: Vec<String> = Vec::with_capacity(argc as usize);

--- a/src/win32/process.rs
+++ b/src/win32/process.rs
@@ -15,8 +15,8 @@ use napi_derive::napi;
 use windows::core::{PCWSTR, PWSTR};
 use windows::Wdk::System::Threading::{NtQueryInformationProcess, ProcessCommandLineInformation};
 use windows::Win32::Foundation::{
-    CloseHandle, LocalFree, FILETIME, HANDLE, HLOCAL, STATUS_INFO_LENGTH_MISMATCH, STATUS_SUCCESS,
-    UNICODE_STRING,
+    CloseHandle, LocalFree, FILETIME, HANDLE, HLOCAL, STATUS_BUFFER_OVERFLOW,
+    STATUS_BUFFER_TOO_SMALL, STATUS_INFO_LENGTH_MISMATCH, STATUS_SUCCESS, UNICODE_STRING,
 };
 use windows::Win32::System::Diagnostics::ToolHelp::{
     CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
@@ -229,7 +229,18 @@ pub fn win32_get_process_command_line(pid: u32) -> napi::Result<Option<Vec<Strin
                 &mut ret_len,
             )
         };
-        if status == STATUS_INFO_LENGTH_MISMATCH && (ret_len as usize) > buf.len() {
+        // A command line that overflows the initial 4 KiB buffer is reported for
+        // this info class as STATUS_INFO_LENGTH_MISMATCH, but defensively treat the
+        // generic short-buffer codes the same way (an OS/version could report
+        // STATUS_BUFFER_OVERFLOW / STATUS_BUFFER_TOO_SMALL): grow once to the
+        // reported length (capped) and retry, so a long-but-readable ssh command
+        // line isn't misread as "unreadable" and force-declined. A still-short or
+        // otherwise non-success second status falls through to the fail-safe None
+        // below. (Codex PR#510 R6 P2.)
+        let short_buffer = status == STATUS_INFO_LENGTH_MISMATCH
+            || status == STATUS_BUFFER_OVERFLOW
+            || status == STATUS_BUFFER_TOO_SMALL;
+        if short_buffer && (ret_len as usize) > buf.len() {
             let cap = (ret_len as usize).min(128 * 1024);
             buf = vec![0u8; cap];
             status = unsafe {


### PR DESCRIPTION
## What

New win32 native binding `getProcessCommandLineByPid(pid): string[] | null` — reads a process's launch argv.

This is **W-0** of the ADR-014 v2 R3 Key Locker **L3-4 live-wiring** slice set (the last-mile before the R3 release dogfood). It unblocks the OQ-W-7 = **option B** decision: the wrong-target fail-safe reads an unregistered ssh child's argv to decline ONLY an actual interactive in-bound login (not a tunnel / one-shot / scp / git-over-ssh), so those panes keep autofilling.

## How

- `NtQueryInformationProcess(ProcessCommandLineInformation)` (Win 8.1+) — needs only `PROCESS_QUERY_LIMITED_INFORMATION` (the SAME right the identity query already uses; **no** cross-process memory read — the OS copies the string into our buffer).
- `CommandLineToArgvW` splits it for **byte-exact parity** with how the process was actually launched (quote/backslash rules), so the caller can reuse the merged `interactiveSshTarget` classifier.
- Returns `null` on **any** failure (dead pid / ACCESS_DENIED on an elevated-or-cross-user target / non-success NTSTATUS / parse failure) → the caller **fails safe** (a null read = "possibly interactive" ⇒ decline, never disclose).
- RAII handle guard + `napi_safe_call` panic guard mirror the existing identity path; `LocalFree` releases the argv allocation.

## Tests / verification

- `cargo test -p desktop-touch-engine cmdline_tests` → **3/3 on real Windows** (reads the test runner's own argv; zero-pid ⇒ None; nonexistent-pid ⇒ None fail-safe, no panic).
- `tsc` + `check:napi-safe` clean.
- Native compiles (`cargo check --workspace`, `build:rs` compile step). Local `.node` artifact-copy is skipped only because the running MCP server holds the addon lock; CI builds it clean.

## Review focus (native axis)
`unsafe` correctness (UNICODE_STRING buffer bounds, `CommandLineToArgvW`/`LocalFree` lifetime), the ACCESS_DENIED / partial-read fail-safe-to-null contract, and the alloc cap on a bogus returned length.

Plan: `desktop-touch-mcp-internal@afcd0bb:docs/adr-014-v2-r3-l3-4-live-wiring-plan.md` (W-0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)