### PR TITLE
ADR-014 v2 R3 L3-4 W-2b: tick argv-classified unregistered-ssh fail-safe

### DIFF
--- a/src/engine/key-locker/ssh-session-watch.ts
+++ b/src/engine/key-locker/ssh-session-watch.ts
@@ -310,8 +310,10 @@ export class SshSessionWatch {
    * `shellPid` and, for each LIVE `ssh`-named DESCENDANT (subtree, not just direct — a `sudo ssh`/wrapper/
    * tmux-reparented login is a grandchild), classify its argv with `interactiveSshTarget` (the SAME rule that
    * decides whether an ssh opens a session). Returns true (⇒ caller `markUnknown`s, decline-not-disclose) iff
-   * any descendant is an interactive in-bound login OR its argv is UNREADABLE (`commandLine` null — an
-   * elevated/cross-user ssh we cannot introspect: fail-safe to "possibly interactive"). A tunnel (`-N`/`-f`/
+   * any LIVE descendant is itself UNREADABLE (identify() name "" — an elevated/cross-user process we cannot
+   * even name, e.g. the ssh in `sudo ssh`; Codex PR#512 P1), OR is an interactive in-bound `ssh` login, OR is
+   * an `ssh` whose argv is UNREADABLE (`commandLine` null — an elevated/cross-user ssh we cannot introspect:
+   * fail-safe to "possibly interactive"). A tunnel (`-N`/`-f`/
    * `-L`), a one-shot (`ssh host cmd`), or scp/sftp/git-over-ssh (whose inner ssh carries a trailing remote
    * command) all classify null ⇒ NOT flagged, so those panes keep autofilling (OQ-W-7 = option B). Short-
    * circuits on the first interactive/unreadable ssh, so the common no-ssh subtree is one adjacency walk.
@@ -331,7 +333,19 @@ export class SshSessionWatch {
         if (seen.has(pid)) continue;
         seen.add(pid);
         frontier.push(pid);
-        if (snap.identify(pid).name !== SSH_PROGRAM) continue; // only ssh descendants can be an in-bound login
+        // Every pid reached here is a KEY in `parentMap` (it came from
+        // buildChildrenMap, which inverts parentMap) ⇒ ALIVE per the module's
+        // liveness contract. So identify()'s "" here is NOT a gone pid — it is a
+        // LIVE-but-UNREADABLE descendant (win32 OpenProcess denied on an elevated
+        // / cross-user process, e.g. `sudo ssh user@host` where the ssh itself
+        // runs as another identity). Fail CLOSED: such a descendant could be an
+        // in-bound ssh login, and the name gate must NOT pre-empt the argv
+        // fail-safe below (Codex PR#512 P1 — otherwise a `sudo ssh` leaves the
+        // depth-0 pane trusted-local and a later fill discloses to the remote).
+        // A READABLE non-ssh descendant genuinely cannot be an in-bound login ⇒ skip.
+        const descName = snap.identify(pid).name;
+        if (descName === "") return true; // unreadable LIVE descendant ⇒ possibly interactive ssh (decline)
+        if (descName !== SSH_PROGRAM) continue; // readable non-ssh ⇒ not an in-bound login
         // Fail-safe on ANY non-classifiable ssh: unreadable (null) OR an EMPTY argv — an ssh we cannot
         // classify must sink the pane, never trust-local (Opus PR#512 P2: `interactiveSshTarget([])` returns
         // null, which without this guard would fall through to "not flagged" = trust local, the opposite of

--- a/src/engine/key-locker/ssh-session-watch.ts
+++ b/src/engine/key-locker/ssh-session-watch.ts
@@ -69,6 +69,22 @@
 //        that pane's frames — never drop the watch while a remote frame stays trusted (Edge 7).
 //   (W3) Derive/mutate atomicity + tick liveness: push-then-`noteSshOpened` in one turn, NO credential derive
 //        interleaved across an un-reconciled turn, and `tick` driven on the timer (Edges 1/2/4/9).
+//
+// W-2b (Opus L3-4 R2 Q1 / R3 Q1a — the UNREGISTERED in-bound ssh fail-safe): the reconcile above only covers
+// sessions the wiring REGISTERED. But in the cooperative model the user can hand-`ssh host` out of the SAME
+// local pane the assistant launched — the wiring never dispatched it, so no frame is pushed and no pid is
+// registered; the tracker stays confidently local and a later assistant `sudo` would fill a LOCAL secret into
+// the REMOTE prompt (disclosure). So at `tick`, for a LOCAL-anchored pane (`session===null` AND
+// `remoteDepth===0`), scan the shell's process SUBTREE for an ssh DESCENDANT (a `sudo ssh`/wrapper/tmux-
+// reparented login is a grandchild) and classify its argv with the SAME `interactiveSshTarget` rule: an
+// interactive in-bound login — OR an ssh whose argv is UNREADABLE (elevated/cross-user: fail-safe) — sinks the
+// pane to `markUnknown`. A tunnel (`-N`/`-f`/`-L`), a one-shot (`ssh host cmd`), scp/sftp/git-over-ssh (their
+// inner ssh carries a trailing remote command) classify non-interactive ⇒ NOT sunk, so those panes keep
+// autofilling (OQ-W-7 = option B). This is a NEW fail-safe (markUnknown on doubt), never a new pop. It is
+// gated on `remoteDepth===0` so a LEGIT assistant-dispatched interactive ssh — whose `recordDispatch` has
+// pushed a frame (depth>0) — is handled by the existing unwatched-frame backstop, not this scan.
+
+import { interactiveSshTarget } from "./session-tracker.js";
 
 /** The tracker surface the watch drives (a subset of `SessionTracker`, so tests inject a fake). */
 export interface SessionTrackerSink {
@@ -108,6 +124,11 @@ export interface ProcessSnapshot {
   /** Identity for a pid (name + creation time). A gone OR present-but-unreadable pid returns
    *  `{ name: "", startTimeMs: 0 }` — use `parentMap` (the liveness authority) to tell the two apart. */
   identify(pid: number): ProcessIdentity;
+  /** A pid's launch argv (`getProcessCommandLineByPid` — W-0), or `null` on ANY read failure
+   *  (dead pid / ACCESS_DENIED on an elevated-or-cross-user target / parse failure). The W-2b scan
+   *  reads it ONLY for `ssh`-named descendants and treats `null` as "possibly interactive" (fail-safe
+   *  markUnknown). `argv[0]` is the ssh image; the classifier takes `argv.slice(1)`. */
+  commandLine(pid: number): string[] | null;
 }
 
 export interface SshWatchDeps {
@@ -226,7 +247,15 @@ export class SshSessionWatch {
       // markUnknown as a systemic backstop (never a stray fire in normal flow — remoteDepth tracks the
       // stack in lockstep with session, so this is >0 only in that genuine unwatched-frame state).
       if (pane.session === null) {
-        if (this.deps.tracker.remoteDepth(paneId) > 0) this.deps.tracker.markUnknown(paneId);
+        // A remote frame with NO live watch (a non-atomic push↔register window, or a registration that
+        // could not confirm a live ssh) — the existing systemic backstop (see block comment above).
+        if (this.deps.tracker.remoteDepth(paneId) > 0) { this.deps.tracker.markUnknown(paneId); continue; }
+        // W-2b: a LOCAL-anchored pane (depth 0) whose shell subtree holds an UNREGISTERED interactive ssh —
+        // the user hand-ssh'd out of a shared L3-launched pane. The tracker is confidently local, so a later
+        // assistant `sudo` would fill a LOCAL secret into the REMOTE prompt. Sink on doubt (decline, never
+        // disclose). Gated on depth 0: a legit assistant-dispatched ssh has pushed a frame (depth>0) and is
+        // handled above, so this scan never fights the normal push→register flow (Opus L3-4 R2 Q1 / R3 Q1a).
+        if (this.hasUnregisteredInteractiveSsh(snap, pane.shellPid)) this.deps.tracker.markUnknown(paneId);
         continue;
       }
       // Liveness is authoritative from the Toolhelp map (a pid present as a KEY is alive); identify() reads
@@ -267,5 +296,43 @@ export class SshSessionWatch {
       this.deps.tracker.noteSessionEnd(paneId);
       pane.session = null; // consumed — do not re-fire until a new session is registered
     }
+  }
+
+  /**
+   * W-2b: does the shell's process SUBTREE hold an UNREGISTERED ssh that would make a LOCAL-anchored pane
+   * actually remote — a user hand-`ssh host` the wiring never dispatched? Walk the `parentMap` subtree from
+   * `shellPid` and, for each LIVE `ssh`-named DESCENDANT (subtree, not just direct — a `sudo ssh`/wrapper/
+   * tmux-reparented login is a grandchild), classify its argv with `interactiveSshTarget` (the SAME rule that
+   * decides whether an ssh opens a session). Returns true (⇒ caller `markUnknown`s, decline-not-disclose) iff
+   * any descendant is an interactive in-bound login OR its argv is UNREADABLE (`commandLine` null — an
+   * elevated/cross-user ssh we cannot introspect: fail-safe to "possibly interactive"). A tunnel (`-N`/`-f`/
+   * `-L`), a one-shot (`ssh host cmd`), or scp/sftp/git-over-ssh (whose inner ssh carries a trailing remote
+   * command) all classify null ⇒ NOT flagged, so those panes keep autofilling (OQ-W-7 = option B). Short-
+   * circuits on the first interactive/unreadable ssh, so the common no-ssh subtree is one adjacency walk.
+   */
+  private hasUnregisteredInteractiveSsh(snap: ProcessSnapshot, shellPid: number): boolean {
+    // Children adjacency (pid → its child pids), built once from the pid→parent map.
+    const children = new Map<number, number[]>();
+    for (const [pid, parentPid] of snap.parentMap) {
+      const arr = children.get(parentPid);
+      if (arr === undefined) children.set(parentPid, [pid]);
+      else arr.push(pid);
+    }
+    // BFS the subtree. `seen` guards against pid-reuse apparent cycles (a child listing an ancestor pid).
+    const seen = new Set<number>([shellPid]);
+    const frontier: number[] = [shellPid];
+    while (frontier.length > 0) {
+      const parent = frontier.pop() as number;
+      for (const pid of children.get(parent) ?? []) {
+        if (seen.has(pid)) continue;
+        seen.add(pid);
+        frontier.push(pid);
+        if (snap.identify(pid).name !== SSH_PROGRAM) continue; // only ssh descendants can be an in-bound login
+        const argv = snap.commandLine(pid);
+        if (argv === null) return true; // unreadable ssh ⇒ fail-safe ("possibly interactive")
+        if (interactiveSshTarget(argv.slice(1)) !== null) return true; // an interactive in-bound login
+      }
+    }
+    return false;
   }
 }

--- a/src/engine/key-locker/ssh-session-watch.ts
+++ b/src/engine/key-locker/ssh-session-watch.ts
@@ -75,9 +75,12 @@
 // local pane the assistant launched — the wiring never dispatched it, so no frame is pushed and no pid is
 // registered; the tracker stays confidently local and a later assistant `sudo` would fill a LOCAL secret into
 // the REMOTE prompt (disclosure). So at `tick`, for a LOCAL-anchored pane (`session===null` AND
-// `remoteDepth===0`), scan the shell's process SUBTREE for an ssh DESCENDANT (a `sudo ssh`/wrapper/tmux-
-// reparented login is a grandchild) and classify its argv with the SAME `interactiveSshTarget` rule: an
-// interactive in-bound login — OR an ssh whose argv is UNREADABLE (elevated/cross-user: fail-safe) — sinks the
+// `remoteDepth===0`), scan the shell's process SUBTREE for an ssh DESCENDANT (an ssh reached through an
+// intermediate — `sudo ssh`, a wrapper, a tmux server that stays UNDER the shell — is a grandchild the walk
+// still finds; an ssh REPARENTED OUT of the shell subtree entirely, e.g. a detached daemon, is out of scope,
+// a low-risk residual on the Windows target where a login pane's ssh normally stays under the shell) and
+// classify its argv with the SAME `interactiveSshTarget` rule: an interactive in-bound login — OR an ssh
+// whose argv is UNREADABLE or EMPTY (elevated/cross-user or a bad read: fail-safe) — sinks the
 // pane to `markUnknown`. A tunnel (`-N`/`-f`/`-L`), a one-shot (`ssh host cmd`), scp/sftp/git-over-ssh (their
 // inner ssh carries a trailing remote command) classify non-interactive ⇒ NOT sunk, so those panes keep
 // autofilling (OQ-W-7 = option B). This is a NEW fail-safe (markUnknown on doubt), never a new pop. It is
@@ -233,6 +236,8 @@ export class SshSessionWatch {
     // A degenerate (empty) snapshot means the native call FAILED, not that every process died — skip the
     // tick rather than markUnknown + unwatch every pane on a transient glitch (Opus R1 P3-A).
     if (snap.parentMap.size === 0) return;
+    // Built lazily ONCE per tick, shared across panes, only if a local pane needs the W-2b subtree scan.
+    let childrenByParent: Map<number, number[]> | null = null;
     for (const [paneId, pane] of this.panes) {
       // (a) Shell gone ⇒ the pane is unobservable ⇒ fail-safe to UNKNOWN and stop watching it. A live
       //     process always appears as a KEY in the Toolhelp map, so absence = dead.
@@ -255,7 +260,8 @@ export class SshSessionWatch {
         // assistant `sudo` would fill a LOCAL secret into the REMOTE prompt. Sink on doubt (decline, never
         // disclose). Gated on depth 0: a legit assistant-dispatched ssh has pushed a frame (depth>0) and is
         // handled above, so this scan never fights the normal push→register flow (Opus L3-4 R2 Q1 / R3 Q1a).
-        if (this.hasUnregisteredInteractiveSsh(snap, pane.shellPid)) this.deps.tracker.markUnknown(paneId);
+        childrenByParent ??= buildChildrenMap(snap.parentMap);
+        if (this.hasUnregisteredInteractiveSsh(snap, childrenByParent, pane.shellPid)) this.deps.tracker.markUnknown(paneId);
         continue;
       }
       // Liveness is authoritative from the Toolhelp map (a pid present as a KEY is alive); identify() reads
@@ -310,15 +316,13 @@ export class SshSessionWatch {
    * command) all classify null ⇒ NOT flagged, so those panes keep autofilling (OQ-W-7 = option B). Short-
    * circuits on the first interactive/unreadable ssh, so the common no-ssh subtree is one adjacency walk.
    */
-  private hasUnregisteredInteractiveSsh(snap: ProcessSnapshot, shellPid: number): boolean {
-    // Children adjacency (pid → its child pids), built once from the pid→parent map.
-    const children = new Map<number, number[]>();
-    for (const [pid, parentPid] of snap.parentMap) {
-      const arr = children.get(parentPid);
-      if (arr === undefined) children.set(parentPid, [pid]);
-      else arr.push(pid);
-    }
-    // BFS the subtree. `seen` guards against pid-reuse apparent cycles (a child listing an ancestor pid).
+  private hasUnregisteredInteractiveSsh(
+    snap: ProcessSnapshot,
+    children: Map<number, number[]>,
+    shellPid: number,
+  ): boolean {
+    // BFS the subtree over the pre-built parent→children map (Opus PR#512 P3: built once per tick, not per
+    // pane). `seen` guards against pid-reuse apparent cycles (a child listing an ancestor pid).
     const seen = new Set<number>([shellPid]);
     const frontier: number[] = [shellPid];
     while (frontier.length > 0) {
@@ -328,11 +332,27 @@ export class SshSessionWatch {
         seen.add(pid);
         frontier.push(pid);
         if (snap.identify(pid).name !== SSH_PROGRAM) continue; // only ssh descendants can be an in-bound login
+        // Fail-safe on ANY non-classifiable ssh: unreadable (null) OR an EMPTY argv — an ssh we cannot
+        // classify must sink the pane, never trust-local (Opus PR#512 P2: `interactiveSshTarget([])` returns
+        // null, which without this guard would fall through to "not flagged" = trust local, the opposite of
+        // the module's "any doubt sinks" invariant).
         const argv = snap.commandLine(pid);
-        if (argv === null) return true; // unreadable ssh ⇒ fail-safe ("possibly interactive")
+        if (argv === null || argv.length === 0) return true; // unreadable / empty ⇒ fail-safe (possibly interactive)
         if (interactiveSshTarget(argv.slice(1)) !== null) return true; // an interactive in-bound login
       }
     }
     return false;
   }
+}
+
+/** Invert a pid→parent map into parent→children. Built ONCE per `tick` and reused across the tick's panes
+ *  (Opus PR#512 P3 — the W-2b subtree scan would otherwise rebuild it per local pane). */
+function buildChildrenMap(parentMap: Map<number, number>): Map<number, number[]> {
+  const children = new Map<number, number[]>();
+  for (const [pid, parentPid] of parentMap) {
+    const arr = children.get(parentPid);
+    if (arr === undefined) children.set(parentPid, [pid]);
+    else arr.push(pid);
+  }
+  return children;
 }

--- a/tests/unit/key-locker-ssh-session-watch.test.ts
+++ b/tests/unit/key-locker-ssh-session-watch.test.ts
@@ -14,7 +14,11 @@ import {
   type SshWatchDeps,
 } from "../../src/engine/key-locker/ssh-session-watch.js";
 
-interface Proc { parent: number; name: string; start: number }
+// `argv` (W-2b): the process's launch argv (as `getProcessCommandLineByPid` would return). Only the
+// W-2b unregistered-ssh scan reads it, and ONLY for `ssh`-named descendants of a LOCAL-anchored pane
+// (session===null AND remoteDepth===0). An ssh proc with no `argv` reads as UNREADABLE (null ⇒ fail-safe
+// "possibly interactive"). Non-ssh procs are never queried, so their `argv` is irrelevant.
+interface Proc { parent: number; name: string; start: number; argv?: string[] }
 
 function snapshotOf(procs: Record<number, Proc>): ProcessSnapshot {
   const parentMap = new Map<number, number>();
@@ -25,6 +29,7 @@ function snapshotOf(procs: Record<number, Proc>): ProcessSnapshot {
       const p = procs[pid];
       return p !== undefined ? { name: p.name, startTimeMs: p.start } : { name: "", startTimeMs: 0 };
     },
+    commandLine: (pid) => procs[pid]?.argv ?? null, // null = unreadable (fail-safe in the W-2b scan)
   };
 }
 
@@ -72,6 +77,7 @@ function unreadableSession(): ProcessSnapshot {
       if (pid === 1000) return { name: "powershell", startTimeMs: 10 };
       return { name: "", startTimeMs: 0 }; // 2000 present but UNREADABLE (and any gone pid also reads "")
     },
+    commandLine: () => null, // not reached: these snapshots drive REGISTERED-session tests (W-2b scan skipped)
   };
 }
 
@@ -87,6 +93,7 @@ function sshWithZeroTime(): ProcessSnapshot {
       if (pid === 1000) return { name: "powershell", startTimeMs: 10 };
       return { name: "ssh", startTimeMs: 0 }; // 2000: live ssh, creation-time read failed
     },
+    commandLine: () => null, // not reached: this snapshot drives a REGISTERED-session test (W-2b scan skipped)
   };
 }
 
@@ -331,10 +338,17 @@ describe("SshSessionWatch — noteSshOpened hygiene", () => {
   });
 
   it("registering a bad pid on a LOCAL pane (depth 0) is ignored (no exit, no spurious sink)", () => {
-    const { watch, sink } = setup(SHELL_WITH_SSH);
+    // The pane's only ssh child (2000) is a background TUNNEL, so the pane is legitimately local — the W-2b
+    // scan classifies it non-interactive and keeps the anchor (the disclosure guard fires only on an
+    // interactive in-bound login, see the W-2b describe block below).
+    const localWithTunnel: Record<number, Proc> = {
+      ...SHELL_WITH_SSH,
+      2000: { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "-N", "-L", "9000:127.0.0.1:9000", "bastion"] },
+    };
+    const { watch, sink } = setup(localWithTunnel);
     watch.watchPane("pane-1", 1000);
     watch.noteSshOpened("pane-1", 9999); // 9999 doesn't exist / isn't ssh; pane still local (remoteDepth 0)
-    watch.tick(); // nothing registered, no remote frame ⇒ nothing fires
+    watch.tick(); // nothing registered, no remote frame, only a tunnel child ⇒ nothing fires
     expect(sink.ends).toEqual([]);
     expect(sink.unknowns).toEqual([]); // must NOT nuke the local anchor
   });
@@ -388,5 +402,109 @@ describe("SshSessionWatch — unwatchable / lifecycle", () => {
     watch.tick();
     expect(sink.ends).toEqual([]);
     expect(sink.unknowns).toEqual([]);
+  });
+});
+
+describe("SshSessionWatch — W-2b: an UNREGISTERED interactive ssh on a LOCAL pane sinks it (shared-terminal disclosure guard)", () => {
+  // The user hand-`ssh host`s out of the SAME local pane the assistant launched. The wiring never
+  // dispatched it (session===null, remoteDepth 0), so the tracker stays confidently local. A tick must
+  // detect the unregistered ssh via its argv and markUnknown, else a later assistant `sudo` fills a LOCAL
+  // secret into the REMOTE prompt (disclosure). Option B (OQ-W-7): decline ONLY an interactive in-bound
+  // login — a tunnel / one-shot / scp keeps the pane local.
+  const localPane = (extra: Record<number, Proc>): Record<number, Proc> => ({ ...SHELL_ONLY, ...extra });
+
+  it("interactive DIRECT-child ssh (`ssh user@host`) ⇒ markUnknown", () => {
+    const { watch, sink } = setup(localPane({ 2000: { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "user@host-a"] } }));
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 0); // local anchor, no session registered
+    watch.tick();
+    expect(sink.unknowns).toEqual(["pane-1"]);
+    expect(sink.ends).toEqual([]);
+  });
+
+  it("interactive GRANDCHILD ssh (`sudo ssh user@host`) ⇒ markUnknown (subtree walk, not just direct children)", () => {
+    const { watch, sink } = setup(localPane({
+      2500: { parent: 1000, name: "sudo", start: 21 },
+      2600: { parent: 2500, name: "ssh", start: 22, argv: ["ssh", "user@host-a"] },
+    }));
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 0);
+    watch.tick();
+    expect(sink.unknowns).toEqual(["pane-1"]);
+  });
+
+  it("a background TUNNEL (`ssh -N -L …`) ⇒ NOT flagged (pane keeps autofilling — option B)", () => {
+    const { watch, sink } = setup(localPane({ 3000: { parent: 1000, name: "ssh", start: 30, argv: ["ssh", "-N", "-L", "9000:127.0.0.1:9000", "bastion"] } }));
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 0);
+    watch.tick();
+    expect(sink.unknowns).toEqual([]);
+  });
+
+  it("a ONE-SHOT (`ssh host cmd`) ⇒ NOT flagged", () => {
+    const { watch, sink } = setup(localPane({ 3100: { parent: 1000, name: "ssh", start: 31, argv: ["ssh", "host-a", "uptime"] } }));
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 0);
+    watch.tick();
+    expect(sink.unknowns).toEqual([]);
+  });
+
+  it("scp's inner ssh (one-shot with a remote command) ⇒ NOT flagged", () => {
+    const { watch, sink } = setup(localPane({
+      3200: { parent: 1000, name: "scp", start: 32 },
+      3201: { parent: 3200, name: "ssh", start: 33, argv: ["ssh", "-x", "host-a", "scp", "-t", "/tmp/f"] },
+    }));
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 0);
+    watch.tick();
+    expect(sink.unknowns).toEqual([]);
+  });
+
+  it("an ssh child with an UNREADABLE argv (null) ⇒ markUnknown (fail-safe: possibly interactive)", () => {
+    // `commandLine` returns null (ACCESS_DENIED on an elevated/cross-user ssh) — the scan cannot classify it,
+    // so it fails safe to decline rather than risk trusting local.
+    const { watch, sink } = setup(localPane({ 4000: { parent: 1000, name: "ssh", start: 40 /* no argv ⇒ null */ } }));
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 0);
+    watch.tick();
+    expect(sink.unknowns).toEqual(["pane-1"]);
+  });
+
+  it("only NON-ssh children ⇒ no scan effect (a plain local pane keeps its anchor)", () => {
+    const { watch, sink } = setup(localPane({
+      5000: { parent: 1000, name: "node", start: 50 },
+      5001: { parent: 5000, name: "esbuild", start: 51 },
+    }));
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 0);
+    watch.tick();
+    expect(sink.unknowns).toEqual([]);
+  });
+
+  it("gating: an interactive ssh at depth>0 (a legit DISPATCHED login mid-registration) is handled by the unwatched-frame backstop, not this scan — still markUnknown once", () => {
+    // recordDispatch pushed the frame (depth 1) but the poller has not registered the pid yet (session null).
+    // The existing depth>0 backstop sinks it; the W-2b scan is depth-0-only, so it never runs here. Either
+    // way the pane declines (bounded-safe), and it does so via ONE markUnknown, not a double-fire.
+    const { watch, sink } = setup(localPane({ 2000: { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "user@host-a"] } }));
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 1); // frame pushed, no session registered
+    watch.tick();
+    expect(sink.unknowns).toEqual(["pane-1"]);
+    expect(sink.ends).toEqual([]);
+  });
+
+  it("a REGISTERED session (session!==null) is NOT re-scanned even with other ssh children present", () => {
+    // Once a session ssh is registered the depth-1 trust logic owns the pane; the W-2b scan (session===null
+    // only) must not run and mistake a sibling for an unregistered login.
+    const { watch, sink } = setup(localPane({
+      2000: { parent: 1000, name: "ssh", start: 20 },                                             // the registered session
+      3000: { parent: 1000, name: "ssh", start: 30, argv: ["ssh", "user@other"] },                 // a sibling that WOULD trip the scan
+    }));
+    watch.watchPane("pane-1", 1000);
+    watch.noteSshOpened("pane-1", 2000);
+    sink.setDepth("pane-1", 1);
+    watch.tick();
+    expect(sink.unknowns).toEqual([]); // trusted depth-1 session; the sibling never triggers the scan
+    expect(sink.ends).toEqual([]);
   });
 });

--- a/tests/unit/key-locker-ssh-session-watch.test.ts
+++ b/tests/unit/key-locker-ssh-session-watch.test.ts
@@ -201,10 +201,14 @@ describe("SshSessionWatch — R3 P2: an unwatchable remote frame must sink, not 
     watch.noteSshOpened("pane-1", 2000); // 2000 is alive but UNREADABLE — cannot confirm a live ssh to watch
     expect(sink.unknowns).toEqual(["pane-1"]); // sink the unwatchable remote frame (stale-remote wrong-target guard)
     expect(sink.ends).toEqual([]); // NEVER a pop-to-local
-    // …no session was registered, and the frame is already sunk (depth 0), so a later tick fires nothing more.
+    // A later tick re-derives from scratch (the module is stateless per tick). No session was registered and
+    // the frame is sunk (depth 0), BUT pid 2000 is STILL a live-but-UNREADABLE descendant of the local shell,
+    // so the depth-0 W-2b scan now correctly re-declines it (Codex PR#512 P1): an unreadable live ssh candidate
+    // must keep the pane sunk, never drift back to trusted-local. markUnknown is the safe idempotent decline
+    // and re-fires each tick the doubt persists (same steady-state as R2's unreadable-session guard).
     watch.tick();
-    expect(sink.ends).toEqual([]);
-    expect(sink.unknowns).toEqual(["pane-1"]);
+    expect(sink.ends).toEqual([]); // NEVER a pop-to-local
+    expect(sink.unknowns).toEqual(["pane-1", "pane-1"]); // registration sink + tick re-decline
     expect(watch.isWatching("pane-1")).toBe(true); // shell alive ⇒ still watched
   });
 
@@ -474,6 +478,32 @@ describe("SshSessionWatch — W-2b: an UNREGISTERED interactive ssh on a LOCAL p
     // Opus PR#512 P2: interactiveSshTarget([]) returns null; without the length===0 guard that would fall
     // through to "not flagged" = trust local (fail-OPEN). Treat an empty argv as unreadable.
     const { watch, sink } = setup(localPane({ 4100: { parent: 1000, name: "ssh", start: 41, argv: [] } }));
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 0);
+    watch.tick();
+    expect(sink.unknowns).toEqual(["pane-1"]);
+  });
+
+  it("a LIVE descendant whose NAME is UNREADABLE (`sudo ssh` with the ssh elevated) ⇒ markUnknown (Codex PR#512 P1)", () => {
+    // The ssh itself runs elevated/cross-user, so win32 identify() returns name "" — and it is a KEY in
+    // parentMap (= ALIVE), NOT a gone pid. The name gate must NOT skip it before the fail-safe: an unreadable
+    // LIVE descendant of a LOCAL shell could be an in-bound ssh login, so decline. Without the fix the pane
+    // stayed trusted-local and a later assistant `sudo` would disclose a LOCAL secret to the REMOTE prompt.
+    const { watch, sink } = setup(localPane({
+      2500: { parent: 1000, name: "sudo", start: 21 },
+      2600: { parent: 2500, name: "", start: 22 }, // the elevated ssh — unreadable name (and argv)
+    }));
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 0);
+    watch.tick();
+    expect(sink.unknowns).toEqual(["pane-1"]);
+    expect(sink.ends).toEqual([]);
+  });
+
+  it("a LIVE DIRECT-child with an UNREADABLE name ⇒ markUnknown (any unreadable live descendant fails closed)", () => {
+    // A readable non-ssh child is skipped (see the plain-local-pane case below); only an UNREADABLE live
+    // child fails closed — we cannot rule out that it is an in-bound ssh.
+    const { watch, sink } = setup(localPane({ 2700: { parent: 1000, name: "", start: 23 } }));
     watch.watchPane("pane-1", 1000);
     sink.setDepth("pane-1", 0);
     watch.tick();

--- a/tests/unit/key-locker-ssh-session-watch.test.ts
+++ b/tests/unit/key-locker-ssh-session-watch.test.ts
@@ -470,6 +470,28 @@ describe("SshSessionWatch — W-2b: an UNREGISTERED interactive ssh on a LOCAL p
     expect(sink.unknowns).toEqual(["pane-1"]);
   });
 
+  it("an ssh child with an EMPTY argv ([]) ⇒ markUnknown (fail-safe — a non-classifiable ssh must not trust-local)", () => {
+    // Opus PR#512 P2: interactiveSshTarget([]) returns null; without the length===0 guard that would fall
+    // through to "not flagged" = trust local (fail-OPEN). Treat an empty argv as unreadable.
+    const { watch, sink } = setup(localPane({ 4100: { parent: 1000, name: "ssh", start: 41, argv: [] } }));
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 0);
+    watch.tick();
+    expect(sink.unknowns).toEqual(["pane-1"]);
+  });
+
+  it("option-bearing interactive logins (`ssh -p 2222 user@host`, `ssh -t user@host`) ⇒ markUnknown", () => {
+    // Lock the classifier over option-bearing interactive forms (Opus PR#512 P3 coverage) — a future
+    // regression that mis-parsed `-p`/`-t` as a one-shot would silently re-open the disclosure.
+    for (const argv of [["ssh", "-p", "2222", "user@host-a"], ["ssh", "-t", "user@host-a"]]) {
+      const { watch, sink } = setup(localPane({ 4200: { parent: 1000, name: "ssh", start: 42, argv } }));
+      watch.watchPane("pane-1", 1000);
+      sink.setDepth("pane-1", 0);
+      watch.tick();
+      expect(sink.unknowns).toEqual(["pane-1"]);
+    }
+  });
+
   it("only NON-ssh children ⇒ no scan effect (a plain local pane keeps its anchor)", () => {
     const { watch, sink } = setup(localPane({
       5000: { parent: 1000, name: "node", start: 50 },


### PR DESCRIPTION
## What

Closes a **credential-disclosure** hole Opus found while reviewing the L3-4 plan (R2 Q1 / R3 Q1a): in the cooperative model a user can hand-`ssh host` out of the SAME local pane the assistant launched. The wiring never dispatched it, so no session frame is pushed and no pid is registered — the tracker stays confidently **local**, and a later assistant `sudo` would fill a **LOCAL secret into the REMOTE prompt**.

## How

`SshSessionWatch.tick()`, for a **LOCAL-anchored** pane (`session===null` AND `remoteDepth===0`), now walks the shell's process **subtree** (`parentMap`) and classifies each live `ssh`-named **descendant**'s argv (new `commandLine(pid)` seam on `ProcessSnapshot`, fed in production by W-0 `getProcessCommandLineByPid`) with the **existing** `interactiveSshTarget` rule:

- interactive in-bound login (`ssh user@host`) → `markUnknown` (decline, never disclose)
- argv **unreadable** (`null` — ACCESS_DENIED on an elevated/cross-user ssh) → `markUnknown` (fail-safe)
- **tunnel** (`-N`/`-f`/`-L`) / one-shot (`ssh host cmd`) / `scp` / `sftp` / git-over-ssh → **NOT** flagged, so those panes keep autofilling (**OQ-W-7 = option B**, the chosen behaviour — decline only real in-bound logins, not every ssh-named descendant)

Design points:
- **Descendant walk** (not direct-children only) closes the `sudo ssh host` grandchild case (Opus R3 Q1a).
- **Gated on `remoteDepth===0`**: a legit assistant-dispatched interactive ssh has already pushed a frame (`depth>0`) and is handled by the existing unwatched-frame backstop — so this scan never fights the normal push→register flow. That's the key correctness point.
- Strictly a **new fail-safe** (`markUnknown` on doubt), never a new pop. Short-circuits on the first interactive/unreadable ssh.

## Tests
35 watch tests (9 new W-2b: interactive direct-child / `sudo ssh` grandchild / tunnel / one-shot / scp-inner-ssh / unreadable-argv / non-ssh-only / depth>0-gating / registered-session-not-rescanned) + full 317 key-locker suite green; `tsc` clean. One existing test (`bad-pid-on-local-pane`) updated to give its incidental ssh child an explicit **tunnel** argv — legitimately local under the new semantics; the assertion is unchanged.

## Review focus
The `remoteDepth===0` gating (does it ever let a legit dispatched ssh get double-markUnknown'd, or let an in-bound ssh through?), the subtree-walk cycle guard, and whether `interactiveSshTarget` over a raw process argv classifies every disclosure case correctly (esp. `scp`/git-over-ssh inner ssh, ProxyJump).

Plan: `desktop-touch-mcp-internal@afcd0bb:docs/adr-014-v2-r3-l3-4-live-wiring-plan.md` (W-2b). Depends conceptually on #510 (W-0) for the production `commandLine` adapter (wired in W-3); this PR uses only the seam interface + fakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)