### PR TITLE
ADR-014 v2 R3 Key Locker — L3-4 W-2: capture driver (RECONCILE-then-FREEZE)

### DIFF
--- a/src/engine/key-locker/key-locker-capture-driver.ts
+++ b/src/engine/key-locker/key-locker-capture-driver.ts
@@ -253,12 +253,15 @@ export class KeyLockerCaptureDriver {
     this.tracker.recordDispatch(paneId, command);
     if (this.tracker.remoteDepth(paneId) > depthBefore) rec.pendingSsh = this.snapshotSshBaseline(rec.shellPid);
 
-    // (3) ARM the poller iff this is a credential command in a KNOWN session (OQ-W-3 — don't poll after
-    //     `ls`). The derive is pure/idempotent; the loop re-derives from the SAME frozen frame (a benign
-    //     double-derive). An UNKNOWN pane (reconcile sank it, or a conditional/ambiguous record) stays
-    //     disarmed (rec.armed already null from 0a) — but `pendingSsh` (session tracking) is INDEPENDENT of
-    //     arming, so it stays. Both pre-await returns leave the null from 0a; nothing interleaved (sync).
-    if (!isKnownSession(frozen)) return;
+    // (3) ARM the poller iff this is a credential command in a session that is KNOWN both BEFORE the record
+    //     (the derive-then-record context) AND AFTER it. `recordDispatch` can SINK the pane to UNKNOWN for a
+    //     conditional/ambiguous command — `false && ssh host ; sudo -v`, `cd x && ssh host` — whose effect it
+    //     cannot predict; the pre-record `frozen` still looks local, so without the post-record check the
+    //     trailing `sudo` prompt would fill under the (mis-derived) skipped-ssh binding (Codex L3-4-W2 R5 P1).
+    //     Declining a sunk pane is the fail-safe (never wrong-target). The derive is pure/idempotent; the loop
+    //     re-derives from the SAME frozen frame (a benign double-derive). `pendingSsh` (session tracking) is
+    //     INDEPENDENT of arming, so it stays. Both pre-await returns leave the null from 0a (nothing async yet).
+    if (!isKnownSession(frozen) || !isKnownSession(this.tracker.get(paneId))) return;
     const binding = await this.deps.deriveBinding(command, frozen);
     // Publish ONLY if this dispatch is still the latest for the pane — a newer onDispatch (which bumped
     // `dispatchSeq` and cleared `rec.armed`) owns the arm now; an out-of-order older derive must not clobber

--- a/src/engine/key-locker/key-locker-capture-driver.ts
+++ b/src/engine/key-locker/key-locker-capture-driver.ts
@@ -167,12 +167,11 @@ interface PaneRecord {
   /** A `poll()` is in progress for this pane — serializes polls (a re-entrant poll returns `busy`) so a
    *  slow prompt read cannot let two polls run two capture loops for one dispatch (Codex L3-4-W2 R2 P2). */
   pollBusy: boolean;
-  /** The CAPTURE LOOP (prompt found → fill → landed → save) is running — a SUBSET of `pollBusy`. onDispatch
-   *  drops ONLY a re-dispatch of `loopCommand` (the Mode-A landed re-run, P2-E / W4-O2), not a real dispatch. */
-  loopInFlight: boolean;
-  /** The command the in-flight capture loop is processing (null when no loop) — lets onDispatch tell the
-   *  Mode-A re-run (same command) from a REAL post-auth dispatch (different command) that must be processed. */
-  loopCommand: string | null;
+  /** True ONLY while the Mode-A `runToExit` landed seam is executing — the exact window that seam re-fires
+   *  onDispatch for the same command (W4-O2). onDispatch drops a re-entrant ONLY on this flag (NOT a command
+   *  string, which is fragile to hook-emission normalization — Opus R7 P2). Mode B never enters runToExit, so
+   *  a genuine post-auth dispatch during readPaneAfterAuth/offerSave is admitted (recorded/reconciled). */
+  inRunToExit: boolean;
 }
 
 const SSH_PROGRAM = "ssh";
@@ -199,7 +198,7 @@ export class KeyLockerCaptureDriver {
   onLocalPaneLaunched(paneId: string, shellPid: number, cwd?: string): void {
     this.tracker.beginLocalSession(paneId, cwd);
     this.watch.watchPane(paneId, shellPid);
-    this.panes.set(paneId, { shellPid, armed: null, dispatchSeq: 0, pendingSsh: undefined, pollBusy: false, loopInFlight: false, loopCommand: null });
+    this.panes.set(paneId, { shellPid, armed: null, dispatchSeq: 0, pendingSsh: undefined, pollBusy: false, inRunToExit: false });
   }
 
   /**
@@ -221,13 +220,12 @@ export class KeyLockerCaptureDriver {
   async onDispatch(paneId: string, command: string): Promise<void> {
     const rec = this.panes.get(paneId);
     if (rec === undefined) return;
-    // Drop the Mode-A landed RE-RUN — the `runToExit` seam re-fires onDispatch for the SAME command mid-loop
-    // (W4-O2) — but NOT a REAL new dispatch. A Mode-B interactive login succeeds mid-loop, so a genuine
-    // `ssh host-b` during `readPaneAfterAuth`/`offerSave` must be recorded/reconciled, not dropped (Codex R6
-    // P1). The re-run carries the loop's own command (W4-O1: the hook emits the user input, = `loopCommand`);
-    // a real dispatch is a different command. A same-command real re-dispatch (rare) is bounded-safe to drop
-    // (same session effect: a nested `ssh host-a` from host-a still resolves to host-a).
-    if (rec.loopInFlight && command === rec.loopCommand) return;
+    // Drop the Mode-A landed RE-RUN — the `runToExit` seam re-fires onDispatch mid-loop (W4-O2) — but NOT a
+    // real dispatch. We gate on the `inRunToExit` FLAG (set only around that seam, `runCaptureLoopFor`), NOT a
+    // command-string match (fragile to any hook-emission normalization — Opus R7 P2). A Mode-B interactive
+    // login succeeds mid-loop and never enters runToExit, so a genuine `ssh host-b` during
+    // `readPaneAfterAuth`/`offerSave` is recorded/reconciled, not dropped (Codex R6 P1).
+    if (rec.inRunToExit) return;
 
     // (0a) SUPERSEDE the prior arm. A newer dispatch means the previous command's prompt is stale — clearing
     //      `rec.armed` HERE, before the arm-derive await, stops a poll from filling THIS command's prompt
@@ -292,8 +290,8 @@ export class KeyLockerCaptureDriver {
     // SERIALIZE polls per pane (Codex L3-4-W2 P2). `pollBusy` is set BEFORE the `readPromptTail` await, so a
     // poll-timer re-entry while a prior poll is still awaiting the (slow, UIA) prompt read is dropped —
     // otherwise BOTH would pass the guard, observe the same prompt, and run two capture loops for one armed
-    // dispatch (duplicate capture/inject/save). `loopInFlight` (the capture-loop window) is a SUBSET of
-    // `pollBusy`; onDispatch checks `loopInFlight` to drop the Mode-A re-run (W4-O2), so both are kept.
+    // dispatch (duplicate capture/inject/save). `pollBusy` spans the WHOLE poll incl. the capture loop, so it
+    // is the sole poll-serialization gate (onDispatch's own drop uses the separate `inRunToExit` flag).
     if (rec.pollBusy) return { status: "busy" };
     rec.pollBusy = true;
     try {
@@ -307,29 +305,25 @@ export class KeyLockerCaptureDriver {
       if (this.deps.nowMs() - armed.armedAtMs > this.pollTimeoutMs) { rec.armed = null; return { status: "timed_out" }; }
 
       const verdict = await this.deps.readPromptTail(paneId);
-      // The arm can be OVERWRITTEN during the (slow, UIA) read: onDispatch is gated only by `loopInFlight`
-      // (not `pollBusy`), so a NEWER credential dispatch to this pane replaces `rec.armed` mid-read. Acting on
+      // The arm can be OVERWRITTEN during the (slow, UIA) read: onDispatch is NOT gated by `pollBusy` (only by
+      // `inRunToExit`, false here), so a NEWER credential dispatch to this pane replaces `rec.armed` mid-read. Acting on
       // the STALE `armed` would fill/save the newer prompt under the OLDER binding (e.g. a cached-sudo arm
       // then an ssh-password prompt → sudo secret into the ssh prompt). If the arm changed, abort — the
       // fresh arm is polled next tick (Codex L3-4-W2 R3 P1). Never clear the newer arm.
       if (rec.armed !== armed) return { status: "superseded" };
       if (verdict === null || !verdict.isCredentialPrompt) return { status: "polling" };
 
-      // A credential prompt appeared → run the loop. `loopInFlight` + `loopCommand` are set BEFORE the loop:
-      // onDispatch drops ONLY the Mode-A landed re-run (the SAME command re-fired by `runToExit`, W4-O2), NOT
-      // a REAL post-auth dispatch — a Mode-B login succeeds mid-loop (the shell is back at an interactive
-      // prompt during `readPaneAfterAuth`/`offerSave`), so `ssh host-b` there must still record/reconcile, else
-      // the tracker stays on host-a and a later host-b `sudo` fills the host-a binding (Codex L3-4-W2 R6 P1).
-      rec.loopInFlight = true;
-      rec.loopCommand = armed.command;
+      // A credential prompt appeared → run the loop. `pollBusy` (set above) already blocks a re-entrant poll
+      // for the whole loop; onDispatch is admitted EXCEPT while the Mode-A `runToExit` seam runs (the driver
+      // brackets it with `inRunToExit`, `runCaptureLoopFor`). A Mode-B login succeeds mid-loop, so a real
+      // `ssh host-b` during `readPaneAfterAuth`/`offerSave` records/reconciles rather than being dropped and
+      // leaving the tracker stale on host-a (Codex L3-4-W2 R6 P1).
       try {
-        const outcome = await this.runCaptureLoopFor(paneId, armed);
+        const outcome = await this.runCaptureLoopFor(rec, paneId, armed);
         return { status: "filled", outcome };
       } finally {
-        rec.loopInFlight = false;
-        rec.loopCommand = null;
-        // Disarm ONLY the loop's OWN arm — a real dispatch that ran mid-loop (above) may have replaced
-        // `rec.armed` with a newer arm (via 0a clear + republish), which must survive to be polled next.
+        // Disarm ONLY the loop's OWN arm — a real dispatch that ran mid-loop may have replaced `rec.armed`
+        // with a newer arm (via the onDispatch 0a-clear + republish), which must survive to be polled next.
         if (rec.armed === armed) rec.armed = null;
       }
     } finally {
@@ -427,7 +421,7 @@ export class KeyLockerCaptureDriver {
    * Assemble the per-event `CaptureLoopDeps` bound to the FROZEN session (W3 — `getSession` returns the
    * frozen frame, never a live `tracker.get`) and run the merged capture loop.
    */
-  private runCaptureLoopFor(paneId: string, armed: ArmedDispatch): Promise<CaptureLoopOutcome> {
+  private runCaptureLoopFor(rec: PaneRecord, paneId: string, armed: ArmedDispatch): Promise<CaptureLoopOutcome> {
     const event: CredentialEvent = { paneId, dispatchedCommand: armed.command };
     const loopDeps: CaptureLoopDeps = {
       getSession: () => armed.frozen, // FROZEN pre-effect frame — the W3 closure
@@ -439,7 +433,14 @@ export class KeyLockerCaptureDriver {
       deleteSecret: (id) => this.deps.deleteSecret(id),
       injectPane: (b, id, sub) => this.deps.injectPane(paneId, b, id, sub),
       awaitLanded: (cmd) => awaitLanded({
-        runToExit: () => this.deps.runToExit(paneId, cmd, armed.frozen.isRemote),
+        // BRACKET the Mode-A re-run window: onDispatch drops a re-entrant only while `inRunToExit` is set (the
+        // exact seam that re-fires it, W4-O2) — robust to hook-string normalization (Opus R7 P2). Mode B calls
+        // `readPaneAfterAuth`, never this, so the flag stays false there → real post-auth dispatches admitted.
+        runToExit: async () => {
+          rec.inRunToExit = true;
+          try { return await this.deps.runToExit(paneId, cmd, armed.frozen.isRemote); }
+          finally { rec.inRunToExit = false; }
+        },
         readPaneAfterAuth: () => this.deps.readPaneAfterAuth(paneId),
       }, cmd),
       confirmInjection: (b) => this.deps.confirmInjection(b),

--- a/src/engine/key-locker/key-locker-capture-driver.ts
+++ b/src/engine/key-locker/key-locker-capture-driver.ts
@@ -155,6 +155,9 @@ interface PaneRecord {
   shellPid: number;
   /** The credential dispatch awaiting a prompt, or null. */
   armed: ArmedDispatch | null;
+  /** Monotonic per-pane dispatch counter. Each `onDispatch` bumps it + clears `armed`; the post-derive
+   *  publish is gated on the counter being unchanged, so only the LATEST dispatch arms (Codex L3-4-W2 R4). */
+  dispatchSeq: number;
   /** The pending §3.1 interactive-ssh child correlation, DECOUPLED from `armed` and published the instant
    *  `recordDispatch` pushes the frame — BEFORE the arm-derive await — so `correlateAllPending` can register
    *  the child even while `deriveBinding` (`ssh -G`) is still awaiting (Codex L3-4-W2 R3 P2). Also survives
@@ -193,7 +196,7 @@ export class KeyLockerCaptureDriver {
   onLocalPaneLaunched(paneId: string, shellPid: number, cwd?: string): void {
     this.tracker.beginLocalSession(paneId, cwd);
     this.watch.watchPane(paneId, shellPid);
-    this.panes.set(paneId, { shellPid, armed: null, pendingSsh: undefined, pollBusy: false, loopInFlight: false });
+    this.panes.set(paneId, { shellPid, armed: null, dispatchSeq: 0, pendingSsh: undefined, pollBusy: false, loopInFlight: false });
   }
 
   /**
@@ -216,7 +219,17 @@ export class KeyLockerCaptureDriver {
     const rec = this.panes.get(paneId);
     if (rec === undefined || rec.loopInFlight) return;
 
-    // (0) REGISTER any pending ssh child BEFORE reconciling. `watch.tick()` is driven ONLY from the driver
+    // (0a) SUPERSEDE the prior arm. A newer dispatch means the previous command's prompt is stale — clearing
+    //      `rec.armed` HERE, before the arm-derive await, stops a poll from filling THIS command's prompt
+    //      under the OLD binding while we derive (Codex L3-4-W2 R4 P1: a cached-sudo arm left in place while a
+    //      slow `ssh` derives → the ssh prompt appears → the poll's `rec.armed !== armed` guard sees the
+    //      unchanged sudo arm and fills the ssh prompt under sudo). A per-dispatch sequence token gates the
+    //      post-await publish so only the LATEST dispatch arms — two overlapping derives can resolve out of
+    //      order, and the older must not clobber the newer's arm.
+    const seq = ++rec.dispatchSeq;
+    rec.armed = null;
+
+    // (0b) REGISTER any pending ssh child BEFORE reconciling. `watch.tick()` is driven ONLY from the driver
     //     (here + `tickWatch`), so registering every armed pane's freshly-spawned interactive-ssh child
     //     first makes the push→register window non-observable to this tick: a just-pushed-but-unregistered
     //     remote frame (`session===null && remoteDepth>0`) would otherwise trip the watch's unwatched-frame
@@ -242,11 +255,15 @@ export class KeyLockerCaptureDriver {
 
     // (3) ARM the poller iff this is a credential command in a KNOWN session (OQ-W-3 — don't poll after
     //     `ls`). The derive is pure/idempotent; the loop re-derives from the SAME frozen frame (a benign
-    //     double-derive). An UNKNOWN pane (reconcile sank it, or a conditional/ambiguous record) disarms —
-    //     but `pendingSsh` (session tracking) is INDEPENDENT of arming, so it stays.
-    if (!isKnownSession(frozen)) { rec.armed = null; return; }
+    //     double-derive). An UNKNOWN pane (reconcile sank it, or a conditional/ambiguous record) stays
+    //     disarmed (rec.armed already null from 0a) — but `pendingSsh` (session tracking) is INDEPENDENT of
+    //     arming, so it stays. Both pre-await returns leave the null from 0a; nothing interleaved (sync).
+    if (!isKnownSession(frozen)) return;
     const binding = await this.deps.deriveBinding(command, frozen);
-    if (binding === null) { rec.armed = null; return; }
+    // Publish ONLY if this dispatch is still the latest for the pane — a newer onDispatch (which bumped
+    // `dispatchSeq` and cleared `rec.armed`) owns the arm now; an out-of-order older derive must not clobber
+    // it. `binding === null` (not a credential) leaves the pane disarmed (rec.armed is already null).
+    if (rec.dispatchSeq !== seq || binding === null) return;
     rec.armed = { command, frozen, armedAtMs: this.deps.nowMs() };
   }
 

--- a/src/engine/key-locker/key-locker-capture-driver.ts
+++ b/src/engine/key-locker/key-locker-capture-driver.ts
@@ -155,7 +155,11 @@ interface PaneRecord {
   shellPid: number;
   /** The credential dispatch awaiting a prompt, or null. */
   armed: ArmedDispatch | null;
-  /** A capture loop is running for this pane — single-flight (P2-E) also gates re-entrant onDispatch. */
+  /** A `poll()` is in progress for this pane — serializes polls (a re-entrant poll returns `busy`) so a
+   *  slow prompt read cannot let two polls run two capture loops for one dispatch (Codex L3-4-W2 P2). */
+  pollBusy: boolean;
+  /** The CAPTURE LOOP (prompt found → fill → landed → save) is running — a SUBSET of `pollBusy`. onDispatch
+   *  checks this to drop the re-entrant dispatch the Mode-A landed re-run fires (P2-E / W4-O2). */
   loopInFlight: boolean;
 }
 
@@ -183,7 +187,7 @@ export class KeyLockerCaptureDriver {
   onLocalPaneLaunched(paneId: string, shellPid: number, cwd?: string): void {
     this.tracker.beginLocalSession(paneId, cwd);
     this.watch.watchPane(paneId, shellPid);
-    this.panes.set(paneId, { shellPid, armed: null, loopInFlight: false });
+    this.panes.set(paneId, { shellPid, armed: null, pollBusy: false, loopInFlight: false });
   }
 
   /**
@@ -247,29 +251,38 @@ export class KeyLockerCaptureDriver {
   async poll(paneId: string): Promise<PollResult> {
     const rec = this.panes.get(paneId);
     if (rec === undefined || rec.armed === null) return { status: "idle" };
-    if (rec.loopInFlight) return { status: "busy" };
-    const armed = rec.armed;
-
-    // §3.1: register the newly-appeared interactive-ssh child (the wiring correlates it here, not at
-    // dispatch — the child does not exist yet in that turn). Runs every poll until it resolves.
-    if (armed.ssh !== undefined && !armed.ssh.registered) this.correlateSshChild(paneId, rec.shellPid, armed.ssh);
-
-    // Poller lifetime (OQ-W-2): a key-based ssh / cached sudo prints NO prompt — abandon (safe, no fill).
-    if (this.deps.nowMs() - armed.armedAtMs > this.pollTimeoutMs) { rec.armed = null; return { status: "timed_out" }; }
-
-    const verdict = await this.deps.readPromptTail(paneId);
-    if (verdict === null || !verdict.isCredentialPrompt) return { status: "polling" };
-
-    // A credential prompt appeared → run the loop under single-flight. `loopInFlight` is set BEFORE the loop
-    // so the Mode-A landed re-run's re-entrant onDispatch (W4-O2) is suppressed. Disarm after (one prompt
-    // per dispatch).
-    rec.loopInFlight = true;
+    // SERIALIZE polls per pane (Codex L3-4-W2 P2). `pollBusy` is set BEFORE the `readPromptTail` await, so a
+    // poll-timer re-entry while a prior poll is still awaiting the (slow, UIA) prompt read is dropped —
+    // otherwise BOTH would pass the guard, observe the same prompt, and run two capture loops for one armed
+    // dispatch (duplicate capture/inject/save). `loopInFlight` (the capture-loop window) is a SUBSET of
+    // `pollBusy`; onDispatch checks `loopInFlight` to drop the Mode-A re-run (W4-O2), so both are kept.
+    if (rec.pollBusy) return { status: "busy" };
+    rec.pollBusy = true;
     try {
-      const outcome = await this.runCaptureLoopFor(paneId, armed);
-      return { status: "filled", outcome };
+      const armed = rec.armed;
+
+      // §3.1: register the newly-appeared interactive-ssh child (the wiring correlates it here, not at
+      // dispatch — the child does not exist yet in that turn). Runs every poll until it resolves.
+      if (armed.ssh !== undefined && !armed.ssh.registered) this.correlateSshChild(paneId, rec.shellPid, armed.ssh);
+
+      // Poller lifetime (OQ-W-2): a key-based ssh / cached sudo prints NO prompt — abandon (safe, no fill).
+      if (this.deps.nowMs() - armed.armedAtMs > this.pollTimeoutMs) { rec.armed = null; return { status: "timed_out" }; }
+
+      const verdict = await this.deps.readPromptTail(paneId);
+      if (verdict === null || !verdict.isCredentialPrompt) return { status: "polling" };
+
+      // A credential prompt appeared → run the loop. `loopInFlight` is set BEFORE the loop so the Mode-A
+      // landed re-run's re-entrant onDispatch (W4-O2) is suppressed. Disarm after (one prompt per dispatch).
+      rec.loopInFlight = true;
+      try {
+        const outcome = await this.runCaptureLoopFor(paneId, armed);
+        return { status: "filled", outcome };
+      } finally {
+        rec.loopInFlight = false;
+        rec.armed = null;
+      }
     } finally {
-      rec.loopInFlight = false;
-      rec.armed = null;
+      rec.pollBusy = false;
     }
   }
 

--- a/src/engine/key-locker/key-locker-capture-driver.ts
+++ b/src/engine/key-locker/key-locker-capture-driver.ts
@@ -1,0 +1,369 @@
+// ADR-014 v2 R3 Key Locker — L3-4 W-2: the capture DRIVER (the live-wiring CRUX).
+//
+// Plan: desktop-touch-mcp-internal:docs/adr-014-v2-r3-l3-4-live-wiring-plan.md (§2.2, §3)
+//
+// Every L3 pipeline module is merged, pure, and unit-tested in ISOLATION, but NOTHING wires them into a
+// running loop. This driver is that first production owner — the orchestration that turns the terminal's
+// dispatch/prompt events into "the locker learns and fills credentials", while honoring the three
+// atomicity obligations the pure `ssh-session-watch.ts` header pinned as WIRING responsibilities (W1/W2/W3).
+//
+// It stays ENGINE-PURE over injected seams (no Win32 / host / terminal import) so the whole wrong-target
+// story is unit-testable with a fake process tree; the thin IMPURE composition root (W-4,
+// `key-locker-wiring.ts`) binds these seams to the real terminal hooks + Win32 and drives the timers. It
+// OWNS a live `SessionTracker` + `SshSessionWatch` (constructed by the manager, W-3) — passed in so tests
+// drive the REAL reconciliation against a controllable snapshot.
+//
+// The four events it services (all per-pane, keyed by `paneId = String(hwnd)` decimal — the same key the
+// terminal, inject-target, and ssh-watch all emit, so tracker keys / InjectTarget hwnd / shellPid stay
+// consistent BY CONSTRUCTION):
+//   * onLocalPaneLaunched — W1 anchor: a pane L3 ITSELF launched from a known-local shell is anchored
+//     KNOWN-LOCAL + watched, in ONE synchronous turn. A pre-existing pane is never anchored → stays UNKNOWN
+//     → every fill declines (P1-B: anchoring on "no ssh child seen" would false-anchor a plink/mosh/renamed-
+//     ssh pane local and disclose a LOCAL secret to a REMOTE prompt).
+//   * onDispatch — the S-A dispatch hook. RECONCILE-then-FREEZE (W3): tick the watch FIRST (pop a dead ssh /
+//     markUnknown an ambiguous-or-in-bound-ssh pane) so the tracker is at a correct-or-UNKNOWN steady state,
+//     THEN freeze `tracker.get(paneId)` as the pre-effect frame the capture loop derives from — never a live
+//     read that a later async tick could perturb. Then record the session effect (derive-then-record) and
+//     arm the prompt poller for a credential command.
+//   * poll — the prompt poller (the wiring drives it on a timer). Correlates the newly-spawned ssh child for
+//     the session-end watch (§3.1 before/after DIFF), then, on a credential prompt, runs `runCaptureLoop`
+//     bound to the FROZEN session. Single-flight per pane (P2-E) also suppresses the re-entrant onDispatch
+//     the Mode-A landed re-run fires (W4-O2).
+//   * onPaneClosed — W2 close atomicity: `unwatchPane` paired same-turn with `tracker.forget`.
+
+import type { BindingMeta } from "./binding-store.js";
+import type { BindingUri } from "./binding.js";
+import {
+  runCaptureLoop,
+  type CaptureLoopDeps,
+  type CaptureLoopOutcome,
+  type CredentialEvent,
+  type SaveChoice,
+} from "./capture-loop.js";
+import type { SessionContext } from "./command-derivation.js";
+import { awaitLanded, type ExitCompletion } from "./landed-detection.js";
+import type { InjectResult } from "./injector.js";
+import { interactiveSshTarget, isKnownSession, type SessionFrame, type SessionTracker } from "./session-tracker.js";
+import { type ProcessSnapshot, type SshSessionWatch } from "./ssh-session-watch.js";
+
+/** The prompt-read verdict the S-B seam returns (the tools-layer root runs the detection — §2.2 layer
+ *  rule — so the engine driver never imports `terminal.ts`). `null` = the pane read failed this poll. */
+export interface PromptVerdict {
+  /** The cursor row is an echo-off credential prompt L3 should fill (`isSecretInputPrompt`). */
+  isCredentialPrompt: boolean;
+  /** The non-secret pane tail (Mode-B auth read reuses this shape). */
+  tail: string;
+  /** Whether a hidden-input prompt is STILL on the cursor row (Mode-B re-prompt = rejected). */
+  stillHiddenPrompt: boolean;
+}
+
+/** The result of one `poll(paneId)` — observability for the wiring's timer + the unit tests. */
+export type PollResult =
+  /** The pane is not armed (no credential dispatch pending) — nothing to do. */
+  | { status: "idle" }
+  /** Armed, but no credential prompt has appeared yet — keep polling. */
+  | { status: "polling" }
+  /** A capture loop is already in flight for this pane (single-flight) — the caller should not re-drive. */
+  | { status: "busy" }
+  /** The poller lifetime elapsed with no prompt (a key-based ssh / cached sudo prints none) — disarmed. */
+  | { status: "timed_out" }
+  /** A credential prompt was found and the capture loop ran to a terminal outcome. */
+  | { status: "filled"; outcome: CaptureLoopOutcome };
+
+/**
+ * The injected effects the driver orchestrates. The wiring (W-4) binds these to the real terminal hooks +
+ * Win32 + locker host; tests drive fakes. Most are the merged `CaptureLoopDeps` / `LandedDeps` seams,
+ * pane-parameterized where the driver must bind a specific pane's hwnd/session.
+ */
+export interface CaptureDriverDeps {
+  /** The live per-pane session tracker (owned by the manager; the driver anchors/records/forgets it). */
+  tracker: SessionTracker;
+  /** The live ssh session-end watch (owned by the manager, built with the real/fake snapshot seam). */
+  watch: SshSessionWatch;
+  /** One live process-tree snapshot (win32 `buildProcessParentMap`+`getProcessIdentityByPid`+
+   *  `getProcessCommandLineByPid` in production; a fake in tests). Used ONLY for the §3.1 ssh-child DIFF —
+   *  the watch snapshots independently for its own `tick`. */
+  snapshot(): ProcessSnapshot;
+
+  /** L1 derivation over the dispatched command in the FROZEN session context. null ⇒ not a credential. */
+  deriveBinding(command: string, session: SessionContext): Promise<BindingUri | null>;
+  /** Binding-map lookup, locker-`exists()`-verified. */
+  resolveBinding(canonicalKey: string): Promise<{ opaqueId: string } | undefined>;
+  /** Persist the canonical→opaqueId mapping (the loop calls this ONLY on [Save]). */
+  bindBinding(canonicalKey: string, opaqueId: string, meta: BindingMeta): void;
+  /** The binding's `confirmEveryInjection` policy (default true — the D2 confirm backstop). */
+  confirmPolicyFor(canonicalKey: string): boolean;
+  /** OPTIONAL [Never] tombstone gate (NO-MATCH only) — unwired ⇒ no suppression. */
+  isNever?(canonicalKey: string): boolean;
+  /** OPTIONAL [Never] tombstone writer — unwired ⇒ "never" behaves like "not now". */
+  onNever?(canonicalKey: string): void;
+  /** Open the locker's secure dialog for `opaqueId` (secret stays in the locker). */
+  capture(opaqueId: string): Promise<{ captured: boolean }>;
+  /** Delete the locker entry for `opaqueId` (the reverse-orphan closure). */
+  deleteSecret(opaqueId: string): Promise<void>;
+  /** Assemble the pane InjectTarget for `paneId` (`assembleInjectTarget`) + SendInput (`inject`, "pane"). */
+  injectPane(paneId: string, binding: BindingUri, opaqueId: string, submit: boolean): Promise<InjectResult>;
+  /** The D2 backstop confirm before a MATCH autofill. */
+  confirmInjection(binding: BindingUri): Promise<boolean>;
+  /** The Chrome-model save offer after a landed NO-MATCH fill. */
+  offerSave(binding: BindingUri): Promise<SaveChoice>;
+  /** Mint the opaqueId the loop binds on save. */
+  mintOpaqueId(): string;
+  /** ISO-8601 timestamp for `meta.createdAt`. */
+  now(): string;
+
+  /** Mode A (§2 S-C): run `command` under `terminal until:{mode:'exit'}` (shell from the frozen isRemote,
+   *  OQ-W-4) and return its completion. */
+  runToExit(paneId: string, command: string, isRemote: boolean): Promise<ExitCompletion>;
+  /** Mode B (§2 S-B): read the pane's non-secret tail + still-hidden-prompt after an interactive login. */
+  readPaneAfterAuth(paneId: string): Promise<{ tail: string; stillHiddenPrompt: boolean }>;
+  /** The prompt-read seam (§1 S-B): the credential-prompt verdict for a pane, or null on a read failure. */
+  readPromptTail(paneId: string): Promise<PromptVerdict | null>;
+
+  /** Monotonic-ish ms clock for the poller lifetime (default `Date.now`; injected in tests). */
+  nowMs(): number;
+  /** Abandon a prompt poll after this many ms (a key-based ssh / cached sudo prints no prompt). */
+  pollTimeoutMs?: number;
+}
+
+/** A credential dispatch armed for the prompt poller (the frozen frame is the W3 closure). */
+interface ArmedDispatch {
+  /** The dispatched command — the AUTHORITATIVE binding source (never the prompt text). */
+  command: string;
+  /** The reconciled PRE-effect session the capture loop derives from (never a live tracker.get). */
+  frozen: SessionFrame;
+  /** `nowMs()` when armed (poller lifetime, OQ-W-2). */
+  armedAtMs: number;
+  /** Present only when this dispatch pushed an interactive-ssh frame — the §3.1 child correlation. */
+  ssh?: SshCorrelation;
+}
+
+/** The §3.1 before/after ssh-child DIFF state for one interactive-ssh dispatch. */
+interface SshCorrelation {
+  /** The shell's DIRECT `ssh` children BEFORE the dispatch (the diff baseline — a pre-existing tunnel is
+   *  in here, so it is never mis-registered as this dispatch's login; Opus R2 Q2). */
+  preSsh: Set<number>;
+  /** Whether the pre-dispatch snapshot succeeded (a native failure ⇒ no trustworthy baseline ⇒ fail-safe). */
+  baselineOk: boolean;
+  /** Whether the correlation has resolved (registered the child, or declined) — one-shot per dispatch. */
+  registered: boolean;
+}
+
+/** Per-pane driver state (exists iff the driver ANCHORED the pane — i.e. L3 launched it). */
+interface PaneRecord {
+  /** The window-owning shell pid (`getWindowProcessId(hwnd)`), for the §3.1 subtree root. */
+  shellPid: number;
+  /** The credential dispatch awaiting a prompt, or null. */
+  armed: ArmedDispatch | null;
+  /** A capture loop is running for this pane — single-flight (P2-E) also gates re-entrant onDispatch. */
+  loopInFlight: boolean;
+}
+
+const SSH_PROGRAM = "ssh";
+const DEFAULT_POLL_TIMEOUT_MS = 20_000;
+
+/**
+ * The live capture driver. Constructed once by the manager (W-3) with the shared tracker + watch + the
+ * live seams; the wiring root (W-4) calls its four events from the terminal hooks + a poll/tick timer.
+ */
+export class KeyLockerCaptureDriver {
+  private readonly panes = new Map<string, PaneRecord>();
+  private readonly pollTimeoutMs: number;
+
+  constructor(private readonly deps: CaptureDriverDeps) {
+    this.pollTimeoutMs = deps.pollTimeoutMs ?? DEFAULT_POLL_TIMEOUT_MS;
+  }
+
+  /**
+   * W1 — anchor a pane L3 ITSELF launched from a known-local shell. `beginLocalSession` (tracker known-local)
+   * and `watchPane` (liveness anchor at `shellPid`) run in ONE synchronous turn (Edge 3): never a window
+   * where the tracker trusts local while no watch guards a later ssh-out. Re-launching resets the pane.
+   * ONLY the assistant's own launches call this — a pre-existing pane is never anchored (P1-B, §3 W1).
+   */
+  onLocalPaneLaunched(paneId: string, shellPid: number, cwd?: string): void {
+    this.tracker.beginLocalSession(paneId, cwd);
+    this.watch.watchPane(paneId, shellPid);
+    this.panes.set(paneId, { shellPid, armed: null, loopInFlight: false });
+  }
+
+  /**
+   * The S-A dispatch hook — one credential dispatch's session bookkeeping + poller arm. RECONCILE-then-
+   * FREEZE (W3): the reconcile (tick) and freeze and record run with NO `await` between them, so an
+   * interleaved async tick (an external ssh child exiting) cannot reorder them; only the pure, idempotent
+   * arm-derive is awaited AFTER the tracker is already updated.
+   *
+   * Single-flight (P2-E / W4-O2): while a capture loop is in flight for this pane the shell is blocked on a
+   * prompt, so a re-entrant dispatch — including the one the Mode-A `runToExit` landed-run itself fires —
+   * must NOT advance `recordDispatch` against an un-landed frame. Dropped.
+   *
+   * A pane the driver never anchored (`panes` has no record — a pre-existing user pane, P1-B) is ignored
+   * here; the tracker stays UNKNOWN for it and every fill declines. (W4-O1: this hook may fire for a
+   * command that never actually reaches the shell — a pushed-but-unspawned ssh frame simply never gets an
+   * ssh child to correlate and is markUnknown'd by the watch's unwatched-frame backstop; no prompt ⇒ no
+   * loop. The driver must not assume every fire = a command that ran.)
+   */
+  async onDispatch(paneId: string, command: string): Promise<void> {
+    const rec = this.panes.get(paneId);
+    if (rec === undefined || rec.loopInFlight) return;
+
+    // (1) RECONCILE this pane to a correct-or-UNKNOWN steady state (P1-A: pop a dead ssh so a post-exit
+    //     command doesn't freeze a stale remote; W-2b: markUnknown a user-typed in-bound ssh). Synchronous.
+    this.watch.tick();
+    // (2) FREEZE the reconciled pre-effect frame (the derive-then-record PRE-push context, §3.1 point 1).
+    const frozen = this.tracker.get(paneId);
+    // (4) Apply the session effect for SUBSEQUENT commands. An interactive-ssh frame push (depth delta) arms
+    //     the §3.1 child correlation with the PRE-dispatch direct-ssh-child baseline (the ssh child spawns
+    //     only after the send, so the baseline never contains it — W4-O1).
+    const depthBefore = this.tracker.remoteDepth(paneId);
+    this.tracker.recordDispatch(paneId, command);
+    const ssh = this.tracker.remoteDepth(paneId) > depthBefore
+      ? this.snapshotSshBaseline(rec.shellPid)
+      : undefined;
+
+    // (3) ARM the poller iff this is a credential command in a KNOWN session (OQ-W-3 — don't poll after
+    //     `ls`). The derive is pure/idempotent; the loop re-derives from the SAME frozen frame (a benign
+    //     double-derive). An UNKNOWN pane (reconcile sank it, or a conditional/ambiguous record) disarms.
+    if (!isKnownSession(frozen)) { rec.armed = null; return; }
+    const binding = await this.deps.deriveBinding(command, frozen);
+    if (binding === null) { rec.armed = null; return; }
+    rec.armed = { command, frozen, armedAtMs: this.deps.nowMs(), ssh };
+  }
+
+  /**
+   * One prompt-poll for a pane (the wiring drives this on a timer for every `armedPaneIds()`). Correlates
+   * the freshly-spawned interactive-ssh child for the session-end watch FIRST (§3.1), then runs the capture
+   * loop when a credential prompt appears. Returns a `PollResult` for observability; the loop's own outcome
+   * is the terminal signal.
+   */
+  async poll(paneId: string): Promise<PollResult> {
+    const rec = this.panes.get(paneId);
+    if (rec === undefined || rec.armed === null) return { status: "idle" };
+    if (rec.loopInFlight) return { status: "busy" };
+    const armed = rec.armed;
+
+    // §3.1: register the newly-appeared interactive-ssh child (the wiring correlates it here, not at
+    // dispatch — the child does not exist yet in that turn). Runs every poll until it resolves.
+    if (armed.ssh !== undefined && !armed.ssh.registered) this.correlateSshChild(paneId, rec.shellPid, armed.ssh);
+
+    // Poller lifetime (OQ-W-2): a key-based ssh / cached sudo prints NO prompt — abandon (safe, no fill).
+    if (this.deps.nowMs() - armed.armedAtMs > this.pollTimeoutMs) { rec.armed = null; return { status: "timed_out" }; }
+
+    const verdict = await this.deps.readPromptTail(paneId);
+    if (verdict === null || !verdict.isCredentialPrompt) return { status: "polling" };
+
+    // A credential prompt appeared → run the loop under single-flight. `loopInFlight` is set BEFORE the loop
+    // so the Mode-A landed re-run's re-entrant onDispatch (W4-O2) is suppressed. Disarm after (one prompt
+    // per dispatch).
+    rec.loopInFlight = true;
+    try {
+      const outcome = await this.runCaptureLoopFor(paneId, armed);
+      return { status: "filled", outcome };
+    } finally {
+      rec.loopInFlight = false;
+      rec.armed = null;
+    }
+  }
+
+  /** Panes with a credential dispatch awaiting a prompt (the wiring polls exactly these). */
+  armedPaneIds(): string[] {
+    const out: string[] = [];
+    for (const [paneId, rec] of this.panes) if (rec.armed !== null) out.push(paneId);
+    return out;
+  }
+
+  /**
+   * W2 — a pane's window closed / its hwnd was invalidated (event-bus `window_disappeared` /
+   * identity-tracker reuse). `unwatchPane` is paired SAME-turn with `tracker.forget` (Edge 7): never drop
+   * the watch while a remote frame stays trusted. Idempotent.
+   */
+  onPaneClosed(paneId: string): void {
+    this.watch.unwatchPane(paneId);
+    this.tracker.forget(paneId);
+    this.panes.delete(paneId);
+  }
+
+  /** Drive the watch's periodic reconcile (the wiring's tick timer, §2.1 mechanical half of W3). */
+  tickWatch(): void {
+    this.watch.tick();
+  }
+
+  // ── internals ──────────────────────────────────────────────────────────────────────────────────────
+
+  private get tracker(): SessionTracker { return this.deps.tracker; }
+  private get watch(): SshSessionWatch { return this.deps.watch; }
+
+  /** The shell's DIRECT `ssh` children right now (the §3.1 diff baseline). Called at dispatch, when the
+   *  interactive ssh's own child does NOT yet exist (W4-O1: the hook fires before the send). */
+  private snapshotSshBaseline(shellPid: number): SshCorrelation {
+    const snap = this.deps.snapshot();
+    if (snap.parentMap.size === 0) return { preSsh: new Set(), baselineOk: false, registered: false };
+    return { preSsh: sshDirectChildren(snap, shellPid), baselineOk: true, registered: false };
+  }
+
+  /**
+   * §3.1 before/after DIFF — register the interactive-ssh child THIS dispatch spawned so the session-end
+   * watch can pop it later. Among the shell's DIRECT `ssh` children that are NEW since the baseline (a
+   * pre-existing tunnel/control-master is excluded — Opus R2 Q2), register the one whose argv classifies as
+   * an interactive login. NEVER guess: >1 interactive OR any argv-unreadable NEW ssh child ⇒ `markUnknown`
+   * (Opus R3 Q3, fail-safe — the current fill still uses the frozen frame, only subsequent commands
+   * decline). 0 interactive ⇒ the child has not spawned yet, keep polling.
+   */
+  private correlateSshChild(paneId: string, shellPid: number, ssh: SshCorrelation): void {
+    if (!ssh.baselineOk) { this.tracker.markUnknown(paneId); ssh.registered = true; return; }
+    const snap = this.deps.snapshot();
+    if (snap.parentMap.size === 0) return; // native failure this poll — retry next poll (no baseline change)
+
+    const interactive: number[] = [];
+    let ambiguous = false;
+    for (const pid of sshDirectChildren(snap, shellPid)) {
+      if (ssh.preSsh.has(pid)) continue;                 // pre-existing (tunnel/sibling) — not this dispatch
+      const argv = snap.commandLine(pid);
+      if (argv === null) { ambiguous = true; continue; }  // unreadable elevated/cross-user ssh — fail-safe
+      if (interactiveSshTarget(argv.slice(1)) !== null) interactive.push(pid);
+    }
+
+    if (ambiguous || interactive.length > 1) { this.tracker.markUnknown(paneId); ssh.registered = true; return; }
+    if (interactive.length === 1) { this.watch.noteSshOpened(paneId, interactive[0]); ssh.registered = true; }
+    // 0 interactive ⇒ not spawned yet — leave unresolved so a later poll retries.
+  }
+
+  /**
+   * Assemble the per-event `CaptureLoopDeps` bound to the FROZEN session (W3 — `getSession` returns the
+   * frozen frame, never a live `tracker.get`) and run the merged capture loop.
+   */
+  private runCaptureLoopFor(paneId: string, armed: ArmedDispatch): Promise<CaptureLoopOutcome> {
+    const event: CredentialEvent = { paneId, dispatchedCommand: armed.command };
+    const loopDeps: CaptureLoopDeps = {
+      getSession: () => armed.frozen, // FROZEN pre-effect frame — the W3 closure
+      deriveBinding: (cmd, session) => this.deps.deriveBinding(cmd, session),
+      resolveBinding: (k) => this.deps.resolveBinding(k),
+      bindBinding: (k, id, meta) => this.deps.bindBinding(k, id, meta),
+      confirmPolicyFor: (k) => this.deps.confirmPolicyFor(k),
+      capture: (id) => this.deps.capture(id),
+      deleteSecret: (id) => this.deps.deleteSecret(id),
+      injectPane: (b, id, sub) => this.deps.injectPane(paneId, b, id, sub),
+      awaitLanded: (cmd) => awaitLanded({
+        runToExit: () => this.deps.runToExit(paneId, cmd, armed.frozen.isRemote),
+        readPaneAfterAuth: () => this.deps.readPaneAfterAuth(paneId),
+      }, cmd),
+      confirmInjection: (b) => this.deps.confirmInjection(b),
+      offerSave: (b) => this.deps.offerSave(b),
+      mintOpaqueId: () => this.deps.mintOpaqueId(),
+      now: () => this.deps.now(),
+      ...(this.deps.isNever ? { isNever: (k: string) => this.deps.isNever!(k) } : {}),
+      ...(this.deps.onNever ? { onNever: (k: string) => this.deps.onNever!(k) } : {}),
+    };
+    return runCaptureLoop(loopDeps, event);
+  }
+}
+
+/** The DIRECT `ssh`-named children of `shellPid` in a snapshot (the §3.1 diff works over direct children:
+ *  the outermost session ssh — incl. a ProxyJump `ssh -J bastion host` — is a direct child; only the outer
+ *  ssh is locally visible). */
+function sshDirectChildren(snap: ProcessSnapshot, shellPid: number): Set<number> {
+  const out = new Set<number>();
+  for (const [pid, parentPid] of snap.parentMap) {
+    if (parentPid === shellPid && snap.identify(pid).name === SSH_PROGRAM) out.add(pid);
+  }
+  return out;
+}

--- a/src/engine/key-locker/key-locker-capture-driver.ts
+++ b/src/engine/key-locker/key-locker-capture-driver.ts
@@ -313,6 +313,12 @@ export class KeyLockerCaptureDriver {
     const snap = this.deps.snapshot();
     if (snap.parentMap.size === 0) return; // native failure this poll — retry next poll (no baseline change)
 
+    // `sshDirectChildren` gates on `identify().name === "ssh"`, so a NEW login whose ssh process is
+    // NAME-unreadable (an elevated/cross-user ssh whose OpenProcess is denied) is excluded from this diff
+    // rather than flagged ambiguous. That is still FAIL-SAFE, just via a different path: its pushed remote
+    // frame stays unwatched (`session === null && remoteDepth > 0`), so the watch `tick` backstop
+    // (`ssh-session-watch.ts`) markUnknowns the pane on the next poll. (The argv-unreadable path below flags
+    // immediately; the name-unreadable case is the rarer elevated-ssh variant the backstop covers.)
     const interactive: number[] = [];
     let ambiguous = false;
     for (const pid of sshDirectChildren(snap, shellPid)) {

--- a/src/engine/key-locker/key-locker-capture-driver.ts
+++ b/src/engine/key-locker/key-locker-capture-driver.ts
@@ -63,7 +63,9 @@ export type PollResult =
   | { status: "idle" }
   /** Armed, but no credential prompt has appeared yet — keep polling. */
   | { status: "polling" }
-  /** A capture loop is already in flight for this pane (single-flight) — the caller should not re-drive. */
+  /** A NEWER dispatch replaced the arm during the prompt read — this poll aborts, the fresh arm polls next. */
+  | { status: "superseded" }
+  /** A poll is already in progress for this pane (serialized) — the caller should not re-drive. */
   | { status: "busy" }
   /** The poller lifetime elapsed with no prompt (a key-based ssh / cached sudo prints none) — disarmed. */
   | { status: "timed_out" }
@@ -134,8 +136,6 @@ interface ArmedDispatch {
   frozen: SessionFrame;
   /** `nowMs()` when armed (poller lifetime, OQ-W-2). */
   armedAtMs: number;
-  /** Present only when this dispatch pushed an interactive-ssh frame — the §3.1 child correlation. */
-  ssh?: SshCorrelation;
 }
 
 /** The §3.1 before/after ssh-child DIFF state for one interactive-ssh dispatch. */
@@ -155,8 +155,14 @@ interface PaneRecord {
   shellPid: number;
   /** The credential dispatch awaiting a prompt, or null. */
   armed: ArmedDispatch | null;
+  /** The pending §3.1 interactive-ssh child correlation, DECOUPLED from `armed` and published the instant
+   *  `recordDispatch` pushes the frame — BEFORE the arm-derive await — so `correlateAllPending` can register
+   *  the child even while `deriveBinding` (`ssh -G`) is still awaiting (Codex L3-4-W2 R3 P2). Also survives
+   *  a not-armed ssh (binding null): the session-end watch still needs the child. Overwritten on the next
+   *  ssh push, resolved once `registered`. */
+  pendingSsh: SshCorrelation | undefined;
   /** A `poll()` is in progress for this pane — serializes polls (a re-entrant poll returns `busy`) so a
-   *  slow prompt read cannot let two polls run two capture loops for one dispatch (Codex L3-4-W2 P2). */
+   *  slow prompt read cannot let two polls run two capture loops for one dispatch (Codex L3-4-W2 R2 P2). */
   pollBusy: boolean;
   /** The CAPTURE LOOP (prompt found → fill → landed → save) is running — a SUBSET of `pollBusy`. onDispatch
    *  checks this to drop the re-entrant dispatch the Mode-A landed re-run fires (P2-E / W4-O2). */
@@ -187,7 +193,7 @@ export class KeyLockerCaptureDriver {
   onLocalPaneLaunched(paneId: string, shellPid: number, cwd?: string): void {
     this.tracker.beginLocalSession(paneId, cwd);
     this.watch.watchPane(paneId, shellPid);
-    this.panes.set(paneId, { shellPid, armed: null, pollBusy: false, loopInFlight: false });
+    this.panes.set(paneId, { shellPid, armed: null, pendingSsh: undefined, pollBusy: false, loopInFlight: false });
   }
 
   /**
@@ -224,22 +230,24 @@ export class KeyLockerCaptureDriver {
     this.watch.tick();
     // (2) FREEZE the reconciled pre-effect frame (the derive-then-record PRE-push context, §3.1 point 1).
     const frozen = this.tracker.get(paneId);
-    // (4) Apply the session effect for SUBSEQUENT commands. An interactive-ssh frame push (depth delta) arms
-    //     the §3.1 child correlation with the PRE-dispatch direct-ssh-child baseline (the ssh child spawns
-    //     only after the send, so the baseline never contains it — W4-O1).
+    // (4) Apply the session effect for SUBSEQUENT commands. An interactive-ssh frame push (depth delta)
+    //     PUBLISHES the §3.1 child correlation onto `rec.pendingSsh` — the PRE-dispatch direct-ssh-child
+    //     baseline (the ssh child spawns only after the send, so the baseline never contains it — W4-O1).
+    //     Publishing it HERE (before the arm-derive await, decoupled from `armed`) is load-bearing: a
+    //     `tickWatch` during a slow `deriveBinding` (`ssh -G`) must be able to see the pending correlation via
+    //     `correlateAllPending`, else it markUnknowns the just-pushed unwatched frame (Codex L3-4-W2 R3 P2).
     const depthBefore = this.tracker.remoteDepth(paneId);
     this.tracker.recordDispatch(paneId, command);
-    const ssh = this.tracker.remoteDepth(paneId) > depthBefore
-      ? this.snapshotSshBaseline(rec.shellPid)
-      : undefined;
+    if (this.tracker.remoteDepth(paneId) > depthBefore) rec.pendingSsh = this.snapshotSshBaseline(rec.shellPid);
 
     // (3) ARM the poller iff this is a credential command in a KNOWN session (OQ-W-3 — don't poll after
     //     `ls`). The derive is pure/idempotent; the loop re-derives from the SAME frozen frame (a benign
-    //     double-derive). An UNKNOWN pane (reconcile sank it, or a conditional/ambiguous record) disarms.
+    //     double-derive). An UNKNOWN pane (reconcile sank it, or a conditional/ambiguous record) disarms —
+    //     but `pendingSsh` (session tracking) is INDEPENDENT of arming, so it stays.
     if (!isKnownSession(frozen)) { rec.armed = null; return; }
     const binding = await this.deps.deriveBinding(command, frozen);
     if (binding === null) { rec.armed = null; return; }
-    rec.armed = { command, frozen, armedAtMs: this.deps.nowMs(), ssh };
+    rec.armed = { command, frozen, armedAtMs: this.deps.nowMs() };
   }
 
   /**
@@ -263,12 +271,18 @@ export class KeyLockerCaptureDriver {
 
       // §3.1: register the newly-appeared interactive-ssh child (the wiring correlates it here, not at
       // dispatch — the child does not exist yet in that turn). Runs every poll until it resolves.
-      if (armed.ssh !== undefined && !armed.ssh.registered) this.correlateSshChild(paneId, rec.shellPid, armed.ssh);
+      if (rec.pendingSsh !== undefined && !rec.pendingSsh.registered) this.correlateSshChild(paneId, rec.shellPid, rec.pendingSsh);
 
       // Poller lifetime (OQ-W-2): a key-based ssh / cached sudo prints NO prompt — abandon (safe, no fill).
       if (this.deps.nowMs() - armed.armedAtMs > this.pollTimeoutMs) { rec.armed = null; return { status: "timed_out" }; }
 
       const verdict = await this.deps.readPromptTail(paneId);
+      // The arm can be OVERWRITTEN during the (slow, UIA) read: onDispatch is gated only by `loopInFlight`
+      // (not `pollBusy`), so a NEWER credential dispatch to this pane replaces `rec.armed` mid-read. Acting on
+      // the STALE `armed` would fill/save the newer prompt under the OLDER binding (e.g. a cached-sudo arm
+      // then an ssh-password prompt → sudo secret into the ssh prompt). If the arm changed, abort — the
+      // fresh arm is polled next tick (Codex L3-4-W2 R3 P1). Never clear the newer arm.
+      if (rec.armed !== armed) return { status: "superseded" };
       if (verdict === null || !verdict.isCredentialPrompt) return { status: "polling" };
 
       // A credential prompt appeared → run the loop. `loopInFlight` is set BEFORE the loop so the Mode-A
@@ -334,7 +348,7 @@ export class KeyLockerCaptureDriver {
    */
   private correlateAllPending(): void {
     for (const [paneId, rec] of this.panes) {
-      const ssh = rec.armed?.ssh;
+      const ssh = rec.pendingSsh;
       if (ssh !== undefined && !ssh.registered) this.correlateSshChild(paneId, rec.shellPid, ssh);
     }
   }

--- a/src/engine/key-locker/key-locker-capture-driver.ts
+++ b/src/engine/key-locker/key-locker-capture-driver.ts
@@ -206,6 +206,15 @@ export class KeyLockerCaptureDriver {
     const rec = this.panes.get(paneId);
     if (rec === undefined || rec.loopInFlight) return;
 
+    // (0) REGISTER any pending ssh child BEFORE reconciling. `watch.tick()` is driven ONLY from the driver
+    //     (here + `tickWatch`), so registering every armed pane's freshly-spawned interactive-ssh child
+    //     first makes the push→register window non-observable to this tick: a just-pushed-but-unregistered
+    //     remote frame (`session===null && remoteDepth>0`) would otherwise trip the watch's unwatched-frame
+    //     backstop → markUnknown, losing a NORMAL ssh login's tracking (Codex L3-4-W2 P1; the residual is
+    //     only the sub-ms gap before the child appears in Toolhelp = OQ-W-9). Fail-safe either way — the
+    //     push stays at dispatch (an unwatched frame declines, never wrong-targets; DEFERRING the push
+    //     would under-report remote and DISCLOSE a local secret to a remote prompt, so it is NOT done).
+    this.correlateAllPending();
     // (1) RECONCILE this pane to a correct-or-UNKNOWN steady state (P1-A: pop a dead ssh so a post-exit
     //     command doesn't freeze a stale remote; W-2b: markUnknown a user-typed in-bound ssh). Synchronous.
     this.watch.tick();
@@ -282,8 +291,11 @@ export class KeyLockerCaptureDriver {
     this.panes.delete(paneId);
   }
 
-  /** Drive the watch's periodic reconcile (the wiring's tick timer, §2.1 mechanical half of W3). */
+  /** Drive the watch's periodic reconcile (the wiring's tick timer, §2.1 mechanical half of W3). Registers
+   *  any pending ssh child FIRST so the periodic tick cannot markUnknown a just-pushed-but-unregistered
+   *  interactive-ssh frame (the push→register window — see `onDispatch` step 0). */
   tickWatch(): void {
+    this.correlateAllPending();
     this.watch.tick();
   }
 
@@ -298,6 +310,20 @@ export class KeyLockerCaptureDriver {
     const snap = this.deps.snapshot();
     if (snap.parentMap.size === 0) return { preSsh: new Set(), baselineOk: false, registered: false };
     return { preSsh: sshDirectChildren(snap, shellPid), baselineOk: true, registered: false };
+  }
+
+  /**
+   * Register the freshly-spawned interactive-ssh child of EVERY armed pane whose correlation is still
+   * pending. Called before every `watch.tick()` the driver issues (`onDispatch` step 0 + `tickWatch`) so a
+   * just-pushed remote frame is registered before the tick's unwatched-frame backstop can see it. A pane
+   * whose child is not visible yet stays pending and is retried on the next tick/poll; correlation is a
+   * no-op once resolved (`registered`), so this is idempotent and O(pending panes) — usually 0–1.
+   */
+  private correlateAllPending(): void {
+    for (const [paneId, rec] of this.panes) {
+      const ssh = rec.armed?.ssh;
+      if (ssh !== undefined && !ssh.registered) this.correlateSshChild(paneId, rec.shellPid, ssh);
+    }
   }
 
   /**

--- a/src/engine/key-locker/key-locker-capture-driver.ts
+++ b/src/engine/key-locker/key-locker-capture-driver.ts
@@ -168,8 +168,11 @@ interface PaneRecord {
    *  slow prompt read cannot let two polls run two capture loops for one dispatch (Codex L3-4-W2 R2 P2). */
   pollBusy: boolean;
   /** The CAPTURE LOOP (prompt found → fill → landed → save) is running — a SUBSET of `pollBusy`. onDispatch
-   *  checks this to drop the re-entrant dispatch the Mode-A landed re-run fires (P2-E / W4-O2). */
+   *  drops ONLY a re-dispatch of `loopCommand` (the Mode-A landed re-run, P2-E / W4-O2), not a real dispatch. */
   loopInFlight: boolean;
+  /** The command the in-flight capture loop is processing (null when no loop) — lets onDispatch tell the
+   *  Mode-A re-run (same command) from a REAL post-auth dispatch (different command) that must be processed. */
+  loopCommand: string | null;
 }
 
 const SSH_PROGRAM = "ssh";
@@ -196,7 +199,7 @@ export class KeyLockerCaptureDriver {
   onLocalPaneLaunched(paneId: string, shellPid: number, cwd?: string): void {
     this.tracker.beginLocalSession(paneId, cwd);
     this.watch.watchPane(paneId, shellPid);
-    this.panes.set(paneId, { shellPid, armed: null, dispatchSeq: 0, pendingSsh: undefined, pollBusy: false, loopInFlight: false });
+    this.panes.set(paneId, { shellPid, armed: null, dispatchSeq: 0, pendingSsh: undefined, pollBusy: false, loopInFlight: false, loopCommand: null });
   }
 
   /**
@@ -217,7 +220,14 @@ export class KeyLockerCaptureDriver {
    */
   async onDispatch(paneId: string, command: string): Promise<void> {
     const rec = this.panes.get(paneId);
-    if (rec === undefined || rec.loopInFlight) return;
+    if (rec === undefined) return;
+    // Drop the Mode-A landed RE-RUN — the `runToExit` seam re-fires onDispatch for the SAME command mid-loop
+    // (W4-O2) — but NOT a REAL new dispatch. A Mode-B interactive login succeeds mid-loop, so a genuine
+    // `ssh host-b` during `readPaneAfterAuth`/`offerSave` must be recorded/reconciled, not dropped (Codex R6
+    // P1). The re-run carries the loop's own command (W4-O1: the hook emits the user input, = `loopCommand`);
+    // a real dispatch is a different command. A same-command real re-dispatch (rare) is bounded-safe to drop
+    // (same session effect: a nested `ssh host-a` from host-a still resolves to host-a).
+    if (rec.loopInFlight && command === rec.loopCommand) return;
 
     // (0a) SUPERSEDE the prior arm. A newer dispatch means the previous command's prompt is stale — clearing
     //      `rec.armed` HERE, before the arm-derive await, stops a poll from filling THIS command's prompt
@@ -305,15 +315,22 @@ export class KeyLockerCaptureDriver {
       if (rec.armed !== armed) return { status: "superseded" };
       if (verdict === null || !verdict.isCredentialPrompt) return { status: "polling" };
 
-      // A credential prompt appeared → run the loop. `loopInFlight` is set BEFORE the loop so the Mode-A
-      // landed re-run's re-entrant onDispatch (W4-O2) is suppressed. Disarm after (one prompt per dispatch).
+      // A credential prompt appeared → run the loop. `loopInFlight` + `loopCommand` are set BEFORE the loop:
+      // onDispatch drops ONLY the Mode-A landed re-run (the SAME command re-fired by `runToExit`, W4-O2), NOT
+      // a REAL post-auth dispatch — a Mode-B login succeeds mid-loop (the shell is back at an interactive
+      // prompt during `readPaneAfterAuth`/`offerSave`), so `ssh host-b` there must still record/reconcile, else
+      // the tracker stays on host-a and a later host-b `sudo` fills the host-a binding (Codex L3-4-W2 R6 P1).
       rec.loopInFlight = true;
+      rec.loopCommand = armed.command;
       try {
         const outcome = await this.runCaptureLoopFor(paneId, armed);
         return { status: "filled", outcome };
       } finally {
         rec.loopInFlight = false;
-        rec.armed = null;
+        rec.loopCommand = null;
+        // Disarm ONLY the loop's OWN arm — a real dispatch that ran mid-loop (above) may have replaced
+        // `rec.armed` with a newer arm (via 0a clear + republish), which must survive to be polled next.
+        if (rec.armed === armed) rec.armed = null;
       }
     } finally {
       rec.pollBusy = false;

--- a/tests/unit/key-locker-capture-driver.test.ts
+++ b/tests/unit/key-locker-capture-driver.test.ts
@@ -21,7 +21,8 @@ import { SessionTracker, type SessionFrame } from "../../src/engine/key-locker/s
 import { SshSessionWatch, type ProcessSnapshot } from "../../src/engine/key-locker/ssh-session-watch.js";
 import type { BindingUri } from "../../src/engine/key-locker/binding.js";
 import type { InjectResult } from "../../src/engine/key-locker/injector.js";
-import type { CaptureLoopOutcome } from "../../src/engine/key-locker/capture-loop.js";
+import type { CaptureLoopOutcome, SaveChoice } from "../../src/engine/key-locker/capture-loop.js";
+import type { ExitCompletion } from "../../src/engine/key-locker/landed-detection.js";
 
 interface Proc { parent: number; name: string; start: number; argv?: string[] }
 
@@ -221,24 +222,24 @@ describe("KeyLockerCaptureDriver — RECONCILE-then-FREEZE (W3, P1-A)", () => {
 });
 
 describe("KeyLockerCaptureDriver — single-flight (P2-E / W4-O2)", () => {
-  it("a re-entrant onDispatch while a loop is in flight does NOT record (no frame push, no derive)", async () => {
+  it("the SAME-command re-entrant onDispatch (the Mode-A re-run) is dropped while a loop is in flight", async () => {
     let releaseCapture!: () => void;
     const capture = vi.fn(() => new Promise<{ captured: boolean }>((res) => { releaseCapture = () => res({ captured: true }); }));
     const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)), capture }, shellTree());
     h.driver.onLocalPaneLaunched("pane-1", 1000);
     await h.driver.onDispatch("pane-1", "sudo x"); // arm
 
-    // start the loop; it BLOCKS in capture() → loopInFlight stays true
+    // start the loop; it BLOCKS in capture() → loopInFlight stays true, loopCommand = "sudo x"
     const loopP = h.driver.poll("pane-1");
     await new Promise((r) => setTimeout(r, 0)); // flush microtasks until poll reaches capture()
     expect(capture).toHaveBeenCalledTimes(1);
 
     const derivesBefore = h.deriveCalls.length;
-    const depthBefore = h.tracker.remoteDepth("pane-1");
-    // the Mode-A re-run (W4-O2) or a buffered dispatch re-enters — must be dropped
-    await h.driver.onDispatch("pane-1", "ssh evil@attacker");
-    expect(h.deriveCalls.length).toBe(derivesBefore);       // no arm-derive
-    expect(h.tracker.remoteDepth("pane-1")).toBe(depthBefore); // no frame push
+    // the Mode-A landed re-run re-fires onDispatch with the SAME command (W4-O2) — must be dropped (no
+    // second arm-derive). A DIFFERENT command would be a real dispatch and IS processed (Codex R6 P1, tested
+    // separately) — so this pins specifically the same-command re-run.
+    await h.driver.onDispatch("pane-1", "sudo x");
+    expect(h.deriveCalls.length).toBe(derivesBefore); // dropped — no arm-derive
 
     releaseCapture();
     await loopP;
@@ -532,6 +533,47 @@ describe("KeyLockerCaptureDriver — poll lifecycle + outcome pass-through", () 
     h.driver.onLocalPaneLaunched("pane-1", 1000);
     expect((await h.driver.poll("pane-1")).status).toBe("idle");
     expect((await h.driver.poll("never-launched")).status).toBe("idle");
+  });
+});
+
+describe("KeyLockerCaptureDriver — the loop drops the Mode-A re-run but NOT real dispatches (Codex R6 P1)", () => {
+  it("a REAL nested dispatch during a Mode-B loop's post-auth window is recorded, not dropped", async () => {
+    let releaseOffer!: (c: SaveChoice) => void;
+    const offerSave = vi.fn(() => new Promise<SaveChoice>((res) => { releaseOffer = res; }));
+    const sshA: Proc = { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "deploy@host-a"] };
+    const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)), offerSave }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    await h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // Mode-B login, arms host-a
+    h.setTree(shellTree({ 2000: sshA }));
+    const pLoop = h.driver.poll("pane-1");                     // runs the loop; blocks in offerSave (post-auth)
+    await new Promise((r) => setTimeout(r, 0));
+    expect(offerSave).toHaveBeenCalledTimes(1);
+    expect(h.tracker.get("pane-1")).toEqual({ execHost: "host-a", isRemote: true }); // logged into host-a
+
+    // the login SUCCEEDED — a genuine nested `ssh host-b` now arrives while the loop is still in offerSave.
+    // It must be RECORDED (tracker → host-b), not dropped (which would leave it stale on host-a).
+    await h.driver.onDispatch("pane-1", "ssh admin@host-b");
+    expect(h.tracker.get("pane-1")).toEqual({ execHost: "host-b", isRemote: true }); // processed, NOT stale host-a
+
+    releaseOffer("save");
+    await pLoop;
+    // the loop's finally did NOT clobber the newer host-b arm
+    expect(h.driver.armedPaneIds()).toEqual(["pane-1"]);
+  });
+
+  it("the Mode-A landed re-run (SAME command) is still dropped mid-loop (W4-O2)", async () => {
+    let releaseRun!: () => void;
+    const runToExit = vi.fn((): Promise<ExitCompletion> => new Promise((res) => { releaseRun = () => res({ reason: "exited", exitCode: 0 }); }));
+    const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)), runToExit }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    await h.driver.onDispatch("pane-1", "sudo x"); // Mode-A one-shot, arms
+    const pLoop = h.driver.poll("pane-1");          // loop blocks in runToExit (awaitLanded Mode A)
+    await new Promise((r) => setTimeout(r, 0));
+    const derivesBefore = h.deriveCalls.length;
+    await h.driver.onDispatch("pane-1", "sudo x");  // the SAME-command Mode-A re-run → must be dropped
+    expect(h.deriveCalls.length).toBe(derivesBefore); // no arm-derive ran (dropped, not processed)
+    releaseRun();
+    await pLoop;
   });
 });
 

--- a/tests/unit/key-locker-capture-driver.test.ts
+++ b/tests/unit/key-locker-capture-driver.test.ts
@@ -147,6 +147,18 @@ describe("KeyLockerCaptureDriver — poller arm filter (OQ-W-3)", () => {
     // the derive is skipped for an unknown session (never guess localhost)
     expect(h.deriveCalls).toEqual([]);
   });
+
+  it("a conditional ssh that recordDispatch SINKS to UNKNOWN ⇒ decline — never fill the trailing sudo prompt under the skipped-ssh binding (Codex R5 P1)", async () => {
+    const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)) }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    // `false && ssh host` is a conditional (skipped) ssh → recordDispatch markUnknowns the pane; the pre-record
+    // frozen still looks local, so the post-record gate must decline rather than arm the skipped ssh binding.
+    await h.driver.onDispatch("pane-1", "false && ssh deploy@host-a ; sudo -v");
+    expect(h.tracker.get("pane-1")).toEqual({ unknown: true }); // recordDispatch sank it
+    expect(h.driver.armedPaneIds()).toEqual([]);                 // declined — not armed
+    expect((await h.driver.poll("pane-1")).status).toBe("idle");
+    expect(h.deps.capture).not.toHaveBeenCalled();               // the sudo prompt is left for the human
+  });
 });
 
 describe("KeyLockerCaptureDriver — derive-then-record ordering (§3.1 point 1)", () => {

--- a/tests/unit/key-locker-capture-driver.test.ts
+++ b/tests/unit/key-locker-capture-driver.test.ts
@@ -255,6 +255,19 @@ describe("KeyLockerCaptureDriver — §3.1 before/after ssh-child DIFF (Q2)", ()
     expect(h.tracker.get("pane-1")).toEqual({ execHost: "localhost", isRemote: false });
   });
 
+  it("W-2b: an anchored pane the USER hand-ssh'd out of ⇒ onDispatch(sudo) declines (no arm, unknown)", async () => {
+    // THE security crux: reconcile-at-dispatch runs the W-2b subtree scan, so a LOCAL secret never reaches
+    // a remote prompt in a shared L3-launched pane the user drove an in-bound ssh into.
+    const h = makeHarness({}, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000); // anchored KNOWN-LOCAL
+    // the USER hand-ssh's out of the shared pane — the driver never dispatched it (no frame, no register)
+    h.setTree(shellTree({ 2000: { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "admin@secret-host"] } }));
+    await h.driver.onDispatch("pane-1", "sudo x"); // tick's W-2b scan must sink the pane BEFORE the freeze
+    expect(h.tracker.get("pane-1")).toEqual({ unknown: true }); // sunk — LOCAL secret must not reach remote
+    expect(h.driver.armedPaneIds()).toEqual([]);                // declined, never armed
+    expect(h.deriveCalls).toEqual([]);                          // never derived a localhost binding
+  });
+
   it("an argv-UNREADABLE new ssh child ⇒ markUnknown (fail-safe, never guess)", async () => {
     const h = makeHarness({}, shellTree());
     h.driver.onLocalPaneLaunched("pane-1", 1000);
@@ -303,6 +316,20 @@ describe("KeyLockerCaptureDriver — poll lifecycle + outcome pass-through", () 
     await h.driver.onDispatch("pane-1", "sudo x");
     const r = await h.driver.poll("pane-1");
     expect(r).toEqual({ status: "filled", outcome: { kind: "filled_from_store", verified: true } satisfies CaptureLoopOutcome });
+  });
+
+  it("a rejected D2 confirm on a MATCH flows through as { status: 'filled', outcome: confirm_rejected }", async () => {
+    const h = makeHarness({
+      readPromptTail: vi.fn(async () => PROMPT(true)),
+      resolveBinding: vi.fn(async () => ({ opaqueId: "stored-1" })), // MATCH
+      confirmPolicyFor: vi.fn(() => true),          // backstop on
+      confirmInjection: vi.fn(async () => false),   // user rejects it
+    }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    await h.driver.onDispatch("pane-1", "sudo x");
+    const r = await h.driver.poll("pane-1");
+    expect(r).toEqual({ status: "filled", outcome: { kind: "confirm_rejected" } satisfies CaptureLoopOutcome });
+    expect(h.deps.injectPane).not.toHaveBeenCalled();
   });
 
   it("a NO-MATCH capture→inject→landed→[Save] flows through as { status: 'filled', outcome: saved }", async () => {

--- a/tests/unit/key-locker-capture-driver.test.ts
+++ b/tests/unit/key-locker-capture-driver.test.ts
@@ -40,6 +40,7 @@ function snapshotOf(procs: Record<number, Proc>): ProcessSnapshot {
 
 const SENDINPUT_OK = (verified = true): InjectResult => ({ ok: true, injector: "sendinput", verified });
 const PROMPT = (isCredentialPrompt: boolean): PromptVerdict => ({ isCredentialPrompt, tail: "", stillHiddenPrompt: false });
+const SSH_A_BINDING: BindingUri = { scheme: "ssh", user: "deploy", host: "host-a", port: 22, fpSet: ["SHA256:host-a"] };
 
 /** Records the (command, session) passed to every deriveBinding call (arm + loop). */
 interface Harness {
@@ -326,6 +327,42 @@ describe("KeyLockerCaptureDriver — push→register window closed by correlate-
     await h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // push, but the child has NOT spawned yet
     h.driver.tickWatch(); // child invisible ⇒ nothing to register ⇒ backstop markUnknowns (safe decline)
     expect(h.tracker.get("pane-1")).toEqual({ unknown: true }); // declines, NEVER wrong-targets
+  });
+
+  it("pendingSsh is published BEFORE the arm-derive await, so a tickWatch during a slow deriveBinding still correlates (Codex R3 P2)", async () => {
+    let releaseDerive!: () => void;
+    const deriveBinding = vi.fn((): Promise<BindingUri> =>
+      new Promise((res) => { releaseDerive = () => res(SSH_A_BINDING); }));
+    const h = makeHarness({ deriveBinding }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    const pDispatch = h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // pushes frame + pendingSsh, then BLOCKS on deriveBinding
+    await new Promise((r) => setTimeout(r, 0));                            // let onDispatch reach the deriveBinding await
+    h.setTree(shellTree({ 2000: sshA }));                                  // the ssh child appears while derive is blocked
+    h.driver.tickWatch(); // correlateAllPending must see rec.pendingSsh (published pre-await) → register 2000
+    expect(h.tracker.get("pane-1")).toEqual({ execHost: "host-a", isRemote: true }); // NOT markUnknown'd
+    expect(h.tracker.remoteDepth("pane-1")).toBe(1);
+    releaseDerive();
+    await pDispatch;
+  });
+});
+
+describe("KeyLockerCaptureDriver — stale-arm guard: a newer dispatch during a slow prompt read (Codex R3 P1)", () => {
+  it("a poll whose arm was overwritten mid-read aborts (superseded) — never fills the newer prompt under the older binding", async () => {
+    let releasePrompt!: (v: PromptVerdict) => void;
+    const readPromptTail = vi.fn(() => new Promise<PromptVerdict>((res) => { releasePrompt = res; }));
+    const h = makeHarness({ readPromptTail }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    await h.driver.onDispatch("pane-1", "sudo x"); // arm A (sudo, cached — no prompt of its own)
+
+    const pA = h.driver.poll("pane-1");            // captures armed=A(sudo), awaits the blocked prompt read
+    await new Promise((r) => setTimeout(r, 0));
+    // a NEWER credential command lands while the read is pending — onDispatch is not gated by pollBusy
+    await h.driver.onDispatch("pane-1", "ssh admin@host-b"); // overwrites rec.armed = B(ssh)
+    releasePrompt(PROMPT(true));                    // now a credential prompt (the ssh one) is visible
+
+    expect((await pA).status).toBe("superseded");   // aborts — does NOT fill the ssh prompt under sudo
+    expect(h.deps.capture).not.toHaveBeenCalled();  // no capture loop ran for the stale arm
+    expect(h.driver.armedPaneIds()).toEqual(["pane-1"]); // the newer arm B survives to be polled next
   });
 });
 

--- a/tests/unit/key-locker-capture-driver.test.ts
+++ b/tests/unit/key-locker-capture-driver.test.ts
@@ -413,6 +413,24 @@ describe("KeyLockerCaptureDriver — poll lifecycle + outcome pass-through", () 
     expect(h.driver.armedPaneIds()).toEqual([]);
   });
 
+  it("concurrent polls for one pane run only ONE capture loop (Codex W2-P2 serialize)", async () => {
+    let releasePrompt!: (v: PromptVerdict) => void;
+    const readPromptTail = vi.fn(() => new Promise<PromptVerdict>((res) => { releasePrompt = res; }));
+    const h = makeHarness({ readPromptTail }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    await h.driver.onDispatch("pane-1", "sudo x");
+
+    const p1 = h.driver.poll("pane-1");             // sets pollBusy, awaits the (blocked) prompt read
+    await new Promise((r) => setTimeout(r, 0));      // let p1 reach the readPromptTail await
+    const p2 = await h.driver.poll("pane-1");        // re-entrant while p1 pends → must be dropped
+    expect(p2.status).toBe("busy");
+    expect(readPromptTail).toHaveBeenCalledTimes(1); // only p1 read the pane
+
+    releasePrompt(PROMPT(true));
+    expect((await p1).status).toBe("filled");
+    expect(h.deps.capture).toHaveBeenCalledTimes(1); // exactly ONE capture loop for the one dispatch
+  });
+
   it("poll on an idle / unarmed pane ⇒ idle", async () => {
     const h = makeHarness({}, shellTree());
     h.driver.onLocalPaneLaunched("pane-1", 1000);

--- a/tests/unit/key-locker-capture-driver.test.ts
+++ b/tests/unit/key-locker-capture-driver.test.ts
@@ -291,6 +291,44 @@ describe("KeyLockerCaptureDriver — §3.1 before/after ssh-child DIFF (Q2)", ()
   });
 });
 
+describe("KeyLockerCaptureDriver — push→register window closed by correlate-before-tick (Codex W2-P1)", () => {
+  const sshA: Proc = { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "deploy@host-a"] };
+
+  it("a periodic tickWatch after an ssh dispatch registers the child FIRST, so the frame is NOT markUnknown'd", async () => {
+    const h = makeHarness({}, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    await h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // push host-a, correlation pending (no poll yet)
+    h.setTree(shellTree({ 2000: sshA }));                     // the ssh child is now visible in Toolhelp
+    h.driver.tickWatch(); // must correlate-register 2000 BEFORE the backstop sees the unwatched frame
+    expect(h.tracker.get("pane-1")).toEqual({ execHost: "host-a", isRemote: true }); // survives — tracked
+    expect(h.tracker.remoteDepth("pane-1")).toBe(1);
+  });
+
+  it("another pane's onDispatch does NOT markUnknown pane-1's pending ssh frame (correlated-first)", async () => {
+    const twoShells = (extra: Record<number, Proc> = {}): Record<number, Proc> => ({
+      500: { parent: 0, name: "windowsterminal", start: 1 },
+      1000: { parent: 500, name: "powershell", start: 10 },
+      1100: { parent: 500, name: "powershell", start: 11 },
+      ...extra,
+    });
+    const h = makeHarness({}, twoShells());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-2", 1100);
+    await h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // pane-1 pushes host-a, pending
+    h.setTree(twoShells({ 2000: sshA }));                     // ssh child visible
+    await h.driver.onDispatch("pane-2", "ls");               // pane-2's tick reconciles ALL panes
+    expect(h.tracker.get("pane-1")).toEqual({ execHost: "host-a", isRemote: true }); // pane-1 survives
+  });
+
+  it("if the child is not yet visible when a tick fires, the unwatched frame markUnknowns (fail-safe OQ-W-9 residual)", async () => {
+    const h = makeHarness({}, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    await h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // push, but the child has NOT spawned yet
+    h.driver.tickWatch(); // child invisible ⇒ nothing to register ⇒ backstop markUnknowns (safe decline)
+    expect(h.tracker.get("pane-1")).toEqual({ unknown: true }); // declines, NEVER wrong-targets
+  });
+});
+
 describe("KeyLockerCaptureDriver — poll lifecycle + outcome pass-through", () => {
   it("polls until a credential prompt appears, then runs the loop and disarms", async () => {
     const verdicts = [PROMPT(false), PROMPT(false), PROMPT(true)];

--- a/tests/unit/key-locker-capture-driver.test.ts
+++ b/tests/unit/key-locker-capture-driver.test.ts
@@ -346,6 +346,53 @@ describe("KeyLockerCaptureDriver — push→register window closed by correlate-
   });
 });
 
+describe("KeyLockerCaptureDriver — stale-arm cleared before deriving a newer command (Codex R4 P1)", () => {
+  it("a cached-sudo arm is cleared the instant a newer ssh dispatches, so a poll during the slow ssh derive does not fill the ssh prompt under sudo", async () => {
+    let sshBlocked = true;
+    let releaseDerive!: () => void;
+    const deriveBinding = vi.fn((command: string, session: SessionFrame): Promise<BindingUri | null> => {
+      if (command.startsWith("sudo")) return Promise.resolve({ scheme: "sudo", host: session.execHost, targetUser: "root" });
+      if (sshBlocked) return new Promise((res) => { releaseDerive = () => { sshBlocked = false; res(SSH_A_BINDING); }; });
+      return Promise.resolve(SSH_A_BINDING);
+    });
+    const h = makeHarness({ deriveBinding, readPromptTail: vi.fn(async () => PROMPT(true)) }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    await h.driver.onDispatch("pane-1", "sudo cached"); // arm A (sudo, fast derive, no prompt of its own)
+    expect(h.driver.armedPaneIds()).toEqual(["pane-1"]);
+
+    const pB = h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // newer dispatch — its derive BLOCKS
+    await new Promise((r) => setTimeout(r, 0));                     // let B reach the blocked derive
+    // the ssh password prompt is on screen now; a poll must find NOTHING to fill (A cleared, B not armed yet)
+    expect((await h.driver.poll("pane-1")).status).toBe("idle");
+    expect(h.deps.capture).not.toHaveBeenCalled(); // never filled the ssh prompt under the stale sudo binding
+
+    releaseDerive();
+    await pB; // B publishes its ssh arm
+    expect((await h.driver.poll("pane-1")).status).toBe("filled"); // now the ssh prompt fills under the ssh arm
+    expect(h.deps.capture).toHaveBeenCalledTimes(1);
+  });
+
+  it("an out-of-order older derive does not clobber the newer arm (dispatchSeq token)", async () => {
+    const derived: string[] = [];
+    let releaseA!: () => void;
+    const deriveBinding = vi.fn((command: string): Promise<BindingUri | null> => {
+      derived.push(command);
+      if (command.includes("first")) return new Promise((res) => { releaseA = () => res({ scheme: "sudo", host: "localhost", targetUser: "root" }); });
+      return Promise.resolve({ scheme: "sudo", host: "localhost", targetUser: "alice" }); // "second" resolves fast
+    });
+    const h = makeHarness({ deriveBinding, readPromptTail: vi.fn(async () => PROMPT(true)) }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    const pA = h.driver.onDispatch("pane-1", "sudo -u root first"); // arm-derive BLOCKS (older)
+    await new Promise((r) => setTimeout(r, 0));
+    await h.driver.onDispatch("pane-1", "sudo -u alice second");     // newer, derives fast → arms "second"
+    releaseA(); await pA;                                            // older derive resolves — must be token-gated out
+
+    // fill: the loop derives the ARMED command; it must be the NEWER "second", proving the older didn't clobber it
+    await h.driver.poll("pane-1");
+    expect(derived.at(-1)).toBe("sudo -u alice second");
+  });
+});
+
 describe("KeyLockerCaptureDriver — stale-arm guard: a newer dispatch during a slow prompt read (Codex R3 P1)", () => {
   it("a poll whose arm was overwritten mid-read aborts (superseded) — never fills the newer prompt under the older binding", async () => {
     let releasePrompt!: (v: PromptVerdict) => void;

--- a/tests/unit/key-locker-capture-driver.test.ts
+++ b/tests/unit/key-locker-capture-driver.test.ts
@@ -1,0 +1,368 @@
+// key-locker-capture-driver.test.ts — ADR-014 R3 L3-4 W-2 (the live-wiring CRUX).
+//
+// The driver wires the merged pure pipeline into a running loop while honoring W1/W2/W3. These tests drive
+// the REAL SessionTracker + REAL SshSessionWatch against a mutable fake process tree (so the reconcile
+// behavior is exercised end-to-end), faking only the capture/inject/prompt seams. Pins:
+//   * W1 anchor: only a LAUNCHED pane derives; a pre-existing pane stays UNKNOWN → declines (P1-B).
+//   * RECONCILE-then-FREEZE (W3): reconcile-at-dispatch pops a dead ssh so a post-exit `sudo x` freezes
+//     localhost, NOT stale host-a (P1-A); the frozen frame survives an interleaved tick.
+//   * derive-then-record: `ssh b@host-b` derives from the host-a frame (pre-push).
+//   * single-flight (P2-E / W4-O2): a re-entrant onDispatch during an in-flight loop does not record.
+//   * §3.1 before/after ssh-child DIFF: register the NEW interactive child, not a pre-existing tunnel (Q2).
+//   * every CaptureLoopOutcome flows through as { status: "filled", outcome }.
+//   * W2 close: unwatchPane + forget same-turn.
+import { describe, expect, it, vi } from "vitest";
+import {
+  KeyLockerCaptureDriver,
+  type CaptureDriverDeps,
+  type PromptVerdict,
+} from "../../src/engine/key-locker/key-locker-capture-driver.js";
+import { SessionTracker, type SessionFrame } from "../../src/engine/key-locker/session-tracker.js";
+import { SshSessionWatch, type ProcessSnapshot } from "../../src/engine/key-locker/ssh-session-watch.js";
+import type { BindingUri } from "../../src/engine/key-locker/binding.js";
+import type { InjectResult } from "../../src/engine/key-locker/injector.js";
+import type { CaptureLoopOutcome } from "../../src/engine/key-locker/capture-loop.js";
+
+interface Proc { parent: number; name: string; start: number; argv?: string[] }
+
+function snapshotOf(procs: Record<number, Proc>): ProcessSnapshot {
+  const parentMap = new Map<number, number>();
+  for (const [pid, p] of Object.entries(procs)) parentMap.set(Number(pid), p.parent);
+  return {
+    parentMap,
+    identify: (pid) => {
+      const p = procs[pid];
+      return p !== undefined ? { name: p.name, startTimeMs: p.start } : { name: "", startTimeMs: 0 };
+    },
+    commandLine: (pid) => procs[pid]?.argv ?? null,
+  };
+}
+
+const SENDINPUT_OK = (verified = true): InjectResult => ({ ok: true, injector: "sendinput", verified });
+const PROMPT = (isCredentialPrompt: boolean): PromptVerdict => ({ isCredentialPrompt, tail: "", stillHiddenPrompt: false });
+
+/** Records the (command, session) passed to every deriveBinding call (arm + loop). */
+interface Harness {
+  driver: KeyLockerCaptureDriver;
+  tracker: SessionTracker;
+  watch: SshSessionWatch;
+  setTree(procs: Record<number, Proc>): void;
+  deriveCalls: { command: string; session: SessionFrame }[];
+  deps: CaptureDriverDeps;
+  clock: { ms: number };
+}
+
+function makeHarness(o: Partial<CaptureDriverDeps> = {}, initialTree: Record<number, Proc> = {}): Harness {
+  let procs = initialTree;
+  const snapshot = (): ProcessSnapshot => snapshotOf(procs);
+  const tracker = new SessionTracker();
+  const watch = new SshSessionWatch({ snapshot, tracker });
+  const deriveCalls: { command: string; session: SessionFrame }[] = [];
+  const clock = { ms: 1000 };
+
+  // Default derive: sudo → sudo binding bound to the session host; ssh user@host → ssh binding for host;
+  // anything else → null (not a credential). Records the session it was handed (the frozen frame).
+  const deriveBinding = vi.fn(async (command: string, session: SessionFrame): Promise<BindingUri | null> => {
+    deriveCalls.push({ command, session: { ...session } });
+    if (command.startsWith("sudo")) return { scheme: "sudo", host: session.execHost, targetUser: "root" };
+    const m = /^ssh\s+(?:\S+@)?(\S+)/.exec(command);
+    if (m) return { scheme: "ssh", user: "u", host: m[1].replace(/^\S+@/, ""), port: 22, fpSet: [`SHA256:${m[1]}`] };
+    return null;
+  });
+
+  const deps: CaptureDriverDeps = {
+    tracker,
+    watch,
+    snapshot,
+    deriveBinding,
+    resolveBinding: vi.fn(async () => undefined), // NO MATCH by default (capture path)
+    bindBinding: vi.fn(),
+    confirmPolicyFor: vi.fn(() => false),
+    capture: vi.fn(async () => ({ captured: true })),
+    deleteSecret: vi.fn(async () => {}),
+    injectPane: vi.fn(async () => SENDINPUT_OK()),
+    confirmInjection: vi.fn(async () => true),
+    offerSave: vi.fn(async () => "save"),
+    mintOpaqueId: vi.fn(() => "opaque-1"),
+    now: vi.fn(() => "2026-07-07T00:00:00.000Z"),
+    runToExit: vi.fn(async () => ({ reason: "exited", exitCode: 0 })),
+    readPaneAfterAuth: vi.fn(async () => ({ tail: "", stillHiddenPrompt: false })),
+    readPromptTail: vi.fn(async () => PROMPT(false)), // no prompt by default
+    nowMs: vi.fn(() => clock.ms),
+    ...o,
+  };
+  const driver = new KeyLockerCaptureDriver(deps);
+  return { driver, tracker, watch, setTree: (p) => { procs = p; }, deriveCalls, deps, clock };
+}
+
+// A shell (1000) under a terminal host (500), with configurable ssh children.
+const shellTree = (extra: Record<number, Proc> = {}): Record<number, Proc> => ({
+  500: { parent: 0, name: "windowsterminal", start: 1 },
+  1000: { parent: 500, name: "powershell", start: 10 },
+  ...extra,
+});
+
+describe("KeyLockerCaptureDriver — W1 anchoring (launched panes only, P1-B)", () => {
+  it("a LAUNCHED pane is anchored known-local + watched; a credential dispatch arms + derives localhost", async () => {
+    const h = makeHarness({}, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    expect(h.tracker.get("pane-1")).toEqual({ execHost: "localhost", isRemote: false });
+    expect(h.watch.isWatching("pane-1")).toBe(true);
+
+    await h.driver.onDispatch("pane-1", "sudo apt update");
+    expect(h.driver.armedPaneIds()).toEqual(["pane-1"]);
+    expect(h.deriveCalls.at(-1)?.session).toEqual({ execHost: "localhost", isRemote: false });
+  });
+
+  it("a PRE-EXISTING pane (never launched) is NOT anchored: onDispatch is a no-op, no derive, no arm", async () => {
+    const h = makeHarness({}, shellTree());
+    await h.driver.onDispatch("pane-x", "sudo apt update"); // never launched
+    expect(h.deriveCalls).toEqual([]);
+    expect(h.driver.armedPaneIds()).toEqual([]);
+    expect(h.tracker.get("pane-x")).toEqual({ unknown: true });
+  });
+
+  it("cwd from launch is anchored (for L1's configured-git-remote resolution)", () => {
+    const h = makeHarness({}, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000, "C:/work");
+    expect(h.tracker.get("pane-1")).toEqual({ execHost: "localhost", isRemote: false, cwd: "C:/work" });
+  });
+});
+
+describe("KeyLockerCaptureDriver — poller arm filter (OQ-W-3)", () => {
+  it("a non-credential command (`ls`) does NOT arm", async () => {
+    const h = makeHarness({}, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    await h.driver.onDispatch("pane-1", "ls -la");
+    expect(h.driver.armedPaneIds()).toEqual([]);
+  });
+
+  it("an UNKNOWN pane (sunk by reconcile) does not arm even for a credential command", async () => {
+    const h = makeHarness({}, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.tracker.markUnknown("pane-1"); // simulate a prior sink
+    await h.driver.onDispatch("pane-1", "sudo apt update");
+    expect(h.driver.armedPaneIds()).toEqual([]);
+    // the derive is skipped for an unknown session (never guess localhost)
+    expect(h.deriveCalls).toEqual([]);
+  });
+});
+
+describe("KeyLockerCaptureDriver — derive-then-record ordering (§3.1 point 1)", () => {
+  it("`ssh b@host-b` from a host-a session derives from the host-a frame (PRE-push), not host-b", async () => {
+    // W4-O1: the ssh child does NOT exist at dispatch (the hook fires before the send) — it appears later.
+    const sshA: Proc = { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "deploy@host-a"] };
+    const h = makeHarness({}, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    await h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // pushes host-a, arms
+    h.setTree(shellTree({ 2000: sshA }));                     // the interactive login now spawns
+    await h.driver.poll("pane-1");                            // correlates + registers ssh 2000
+    expect(h.tracker.get("pane-1")).toEqual({ execHost: "host-a", isRemote: true });
+
+    // now a nested login — its OWN binding must derive from the host-a frame it launches from
+    await h.driver.onDispatch("pane-1", "ssh admin@host-b");
+    expect(h.deriveCalls.at(-1)?.command).toBe("ssh admin@host-b");
+    expect(h.deriveCalls.at(-1)?.session).toEqual({ execHost: "host-a", isRemote: true });
+  });
+});
+
+describe("KeyLockerCaptureDriver — RECONCILE-then-FREEZE (W3, P1-A)", () => {
+  it("reconcile-at-dispatch pops a dead ssh so a post-exit `sudo x` freezes localhost, NOT stale host-a", async () => {
+    const sshA: Proc = { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "deploy@host-a"] };
+    const h = makeHarness({}, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    await h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // push host-a (depth 1)
+    h.setTree(shellTree({ 2000: sshA }));                     // the ssh child now appears (W4-O1)
+    await h.driver.poll("pane-1");                             // register ssh 2000 with the watch
+    expect(h.tracker.remoteDepth("pane-1")).toBe(1);
+
+    // the ssh session ended (2000 gone) — but the tracker STILL holds the stale host-a frame
+    h.setTree(shellTree());
+    // a later credential dispatch: reconcile-at-dispatch (tick) must pop host-a BEFORE the freeze
+    await h.driver.onDispatch("pane-1", "sudo x");
+    expect(h.deriveCalls.at(-1)?.command).toBe("sudo x");
+    expect(h.deriveCalls.at(-1)?.session).toEqual({ execHost: "localhost", isRemote: false });
+  });
+
+  it("the FROZEN frame survives an interleaved tick that pops the session before the prompt loop runs", async () => {
+    const sshA: Proc = { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "deploy@host-a"] };
+    const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)) }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    await h.driver.onDispatch("pane-1", "ssh deploy@host-a");
+    h.setTree(shellTree({ 2000: sshA }));                     // ssh child appears (W4-O1)
+    await h.driver.poll("pane-1"); // this poll's prompt fires a loop for the ssh; ignore its outcome
+
+    // dispatch a REMOTE `sudo x` (frozen = host-a)
+    await h.driver.onDispatch("pane-1", "sudo x");
+    // an EXTERNAL event pops the ssh: 2000 exits + a tick reconciles → tracker now local
+    h.setTree(shellTree());
+    h.driver.tickWatch();
+    expect(h.tracker.get("pane-1")).toEqual({ execHost: "localhost", isRemote: false });
+
+    // the prompt loop for `sudo x` must still use the FROZEN host-a frame, not the now-local live value
+    h.deriveCalls.length = 0;
+    await h.driver.poll("pane-1");
+    const loopDerive = h.deriveCalls.find((c) => c.command === "sudo x");
+    expect(loopDerive?.session).toEqual({ execHost: "host-a", isRemote: true });
+  });
+});
+
+describe("KeyLockerCaptureDriver — single-flight (P2-E / W4-O2)", () => {
+  it("a re-entrant onDispatch while a loop is in flight does NOT record (no frame push, no derive)", async () => {
+    let releaseCapture!: () => void;
+    const capture = vi.fn(() => new Promise<{ captured: boolean }>((res) => { releaseCapture = () => res({ captured: true }); }));
+    const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)), capture }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    await h.driver.onDispatch("pane-1", "sudo x"); // arm
+
+    // start the loop; it BLOCKS in capture() → loopInFlight stays true
+    const loopP = h.driver.poll("pane-1");
+    await new Promise((r) => setTimeout(r, 0)); // flush microtasks until poll reaches capture()
+    expect(capture).toHaveBeenCalledTimes(1);
+
+    const derivesBefore = h.deriveCalls.length;
+    const depthBefore = h.tracker.remoteDepth("pane-1");
+    // the Mode-A re-run (W4-O2) or a buffered dispatch re-enters — must be dropped
+    await h.driver.onDispatch("pane-1", "ssh evil@attacker");
+    expect(h.deriveCalls.length).toBe(derivesBefore);       // no arm-derive
+    expect(h.tracker.remoteDepth("pane-1")).toBe(depthBefore); // no frame push
+
+    releaseCapture();
+    await loopP;
+  });
+});
+
+describe("KeyLockerCaptureDriver — §3.1 before/after ssh-child DIFF (Q2)", () => {
+  it("registers the NEW interactive child, NOT a pre-existing background tunnel", async () => {
+    // pre-existing tunnel 1500 (ssh -fNL, non-interactive) is a SIBLING of the future login
+    const tunnel: Proc = { parent: 1000, name: "ssh", start: 15, argv: ["ssh", "-fNL", "9000", "host-t"] };
+    const h = makeHarness({}, shellTree({ 1500: tunnel }));
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    await h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // baseline = {1500 tunnel}
+
+    // the interactive login 2000 now spawns (tunnel 1500 still present)
+    h.setTree(shellTree({ 1500: tunnel, 2000: { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "deploy@host-a"] } }));
+    await h.driver.poll("pane-1"); // correlate → register 2000 (NOT 1500)
+
+    // PROOF: kill the TUNNEL 1500, keep the login 2000 → the frame must NOT pop (2000 was registered)
+    h.setTree(shellTree({ 2000: { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "deploy@host-a"] } }));
+    h.driver.tickWatch();
+    expect(h.tracker.remoteDepth("pane-1")).toBe(1); // still remote — the registered login lives
+
+    // now kill the LOGIN 2000 → the frame pops to local (proves 2000 was the registered pid)
+    h.setTree(shellTree());
+    h.driver.tickWatch();
+    expect(h.tracker.get("pane-1")).toEqual({ execHost: "localhost", isRemote: false });
+  });
+
+  it("an argv-UNREADABLE new ssh child ⇒ markUnknown (fail-safe, never guess)", async () => {
+    const h = makeHarness({}, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    await h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // baseline = {} (no ssh yet)
+    // the new ssh child is present but its argv is unreadable (elevated/cross-user)
+    h.setTree(shellTree({ 2000: { parent: 1000, name: "ssh", start: 20 /* no argv → null */ } }));
+    await h.driver.poll("pane-1");
+    expect(h.tracker.get("pane-1")).toEqual({ unknown: true }); // sunk, not guessed
+  });
+
+  it(">1 new interactive ssh child ⇒ markUnknown (ambiguous, never guess)", async () => {
+    const h = makeHarness({}, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    await h.driver.onDispatch("pane-1", "ssh deploy@host-a");
+    h.setTree(shellTree({
+      2000: { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "deploy@host-a"] },
+      2001: { parent: 1000, name: "ssh", start: 21, argv: ["ssh", "admin@host-b"] },
+    }));
+    await h.driver.poll("pane-1");
+    expect(h.tracker.get("pane-1")).toEqual({ unknown: true });
+  });
+});
+
+describe("KeyLockerCaptureDriver — poll lifecycle + outcome pass-through", () => {
+  it("polls until a credential prompt appears, then runs the loop and disarms", async () => {
+    const verdicts = [PROMPT(false), PROMPT(false), PROMPT(true)];
+    let i = 0;
+    const h = makeHarness({ readPromptTail: vi.fn(async () => verdicts[Math.min(i++, verdicts.length - 1)]) }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    await h.driver.onDispatch("pane-1", "sudo x");
+
+    expect((await h.driver.poll("pane-1")).status).toBe("polling");
+    expect((await h.driver.poll("pane-1")).status).toBe("polling");
+    const filled = await h.driver.poll("pane-1");
+    expect(filled.status).toBe("filled");
+    expect(h.driver.armedPaneIds()).toEqual([]); // disarmed after the loop
+  });
+
+  it("a MATCH autofill flows through as { status: 'filled', outcome: filled_from_store }", async () => {
+    const h = makeHarness({
+      readPromptTail: vi.fn(async () => PROMPT(true)),
+      resolveBinding: vi.fn(async () => ({ opaqueId: "stored-1" })), // MATCH
+      confirmPolicyFor: vi.fn(() => false),
+    }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    await h.driver.onDispatch("pane-1", "sudo x");
+    const r = await h.driver.poll("pane-1");
+    expect(r).toEqual({ status: "filled", outcome: { kind: "filled_from_store", verified: true } satisfies CaptureLoopOutcome });
+  });
+
+  it("a NO-MATCH capture→inject→landed→[Save] flows through as { status: 'filled', outcome: saved }", async () => {
+    const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)) }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    await h.driver.onDispatch("pane-1", "sudo x");
+    const r = await h.driver.poll("pane-1");
+    expect(r).toEqual({ status: "filled", outcome: { kind: "saved", verified: true } satisfies CaptureLoopOutcome });
+    expect(h.deps.bindBinding).toHaveBeenCalledOnce();
+  });
+
+  it("a cancelled capture flows through as { status: 'filled', outcome: capture_cancelled }", async () => {
+    const h = makeHarness({
+      readPromptTail: vi.fn(async () => PROMPT(true)),
+      capture: vi.fn(async () => ({ captured: false })),
+    }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    await h.driver.onDispatch("pane-1", "sudo x");
+    const r = await h.driver.poll("pane-1");
+    expect(r).toEqual({ status: "filled", outcome: { kind: "capture_cancelled" } satisfies CaptureLoopOutcome });
+  });
+
+  it("a not-landed credential flows through as { status: 'filled', outcome: discarded/not_landed }", async () => {
+    const h = makeHarness({
+      readPromptTail: vi.fn(async () => PROMPT(true)),
+      runToExit: vi.fn(async () => ({ reason: "timeout" })), // Mode A not exit-0
+    }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    await h.driver.onDispatch("pane-1", "sudo x");
+    const r = await h.driver.poll("pane-1");
+    expect(r.status).toBe("filled");
+    expect((r as { outcome: CaptureLoopOutcome }).outcome).toMatchObject({ kind: "discarded", reason: "not_landed" });
+    expect(h.deps.deleteSecret).toHaveBeenCalledOnce(); // reverse-orphan delete
+  });
+
+  it("poller lifetime elapses with no prompt ⇒ timed_out + disarm (OQ-W-2)", async () => {
+    const h = makeHarness({ pollTimeoutMs: 5000 }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.clock.ms = 1000;
+    await h.driver.onDispatch("pane-1", "sudo x"); // armedAt = 1000
+    h.clock.ms = 7000; // > 1000 + 5000
+    expect((await h.driver.poll("pane-1")).status).toBe("timed_out");
+    expect(h.driver.armedPaneIds()).toEqual([]);
+  });
+
+  it("poll on an idle / unarmed pane ⇒ idle", async () => {
+    const h = makeHarness({}, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    expect((await h.driver.poll("pane-1")).status).toBe("idle");
+    expect((await h.driver.poll("never-launched")).status).toBe("idle");
+  });
+});
+
+describe("KeyLockerCaptureDriver — W2 close atomicity", () => {
+  it("onPaneClosed unwatches + forgets the pane (same turn)", () => {
+    const h = makeHarness({}, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    expect(h.watch.isWatching("pane-1")).toBe(true);
+    h.driver.onPaneClosed("pane-1");
+    expect(h.watch.isWatching("pane-1")).toBe(false);
+    expect(h.tracker.get("pane-1")).toEqual({ unknown: true });
+  });
+});

--- a/tests/unit/key-locker-capture-driver.test.ts
+++ b/tests/unit/key-locker-capture-driver.test.ts
@@ -221,28 +221,25 @@ describe("KeyLockerCaptureDriver — RECONCILE-then-FREEZE (W3, P1-A)", () => {
   });
 });
 
-describe("KeyLockerCaptureDriver — single-flight (P2-E / W4-O2)", () => {
-  it("the SAME-command re-entrant onDispatch (the Mode-A re-run) is dropped while a loop is in flight", async () => {
+describe("KeyLockerCaptureDriver — a re-entrant dispatch does not corrupt the running loop (P2-E)", () => {
+  it("a re-entrant onDispatch during the capture window (outside runToExit) does not corrupt the loop's own outcome", async () => {
     let releaseCapture!: () => void;
     const capture = vi.fn(() => new Promise<{ captured: boolean }>((res) => { releaseCapture = () => res({ captured: true }); }));
     const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)), capture }, shellTree());
     h.driver.onLocalPaneLaunched("pane-1", 1000);
     await h.driver.onDispatch("pane-1", "sudo x"); // arm
 
-    // start the loop; it BLOCKS in capture() → loopInFlight stays true, loopCommand = "sudo x"
+    // start the loop; it BLOCKS in capture() → pollBusy stays true (a re-entrant POLL would return busy)
     const loopP = h.driver.poll("pane-1");
     await new Promise((r) => setTimeout(r, 0)); // flush microtasks until poll reaches capture()
     expect(capture).toHaveBeenCalledTimes(1);
 
-    const derivesBefore = h.deriveCalls.length;
-    // the Mode-A landed re-run re-fires onDispatch with the SAME command (W4-O2) — must be dropped (no
-    // second arm-derive). A DIFFERENT command would be a real dispatch and IS processed (Codex R6 P1, tested
-    // separately) — so this pins specifically the same-command re-run.
+    // a re-entrant onDispatch during capture is ADMITTED (only the runToExit window drops — inRunToExit),
+    // but the loop reads only the LOCAL captured arm + immutable frozen, so its own outcome is unaffected.
     await h.driver.onDispatch("pane-1", "sudo x");
-    expect(h.deriveCalls.length).toBe(derivesBefore); // dropped — no arm-derive
 
     releaseCapture();
-    await loopP;
+    expect((await loopP).status).toBe("filled"); // the original loop still completes correctly
   });
 });
 


### PR DESCRIPTION
## What this is

The **live-wiring capture driver** (L3-4 slice W-2, THE CRUX) — the first production owner that turns the merged, unit-tested, *pure* L3 pipeline into a running "the locker learns and fills credentials" loop, while honoring the three atomicity obligations (`W1`/`W2`/`W3`) the `ssh-session-watch.ts` header pinned as **wiring** responsibilities that a pure module cannot self-close.

No public tool change — the autofill loop is internal (`key_locker` management surface already shipped in L4).

## Files

- `src/engine/key-locker/key-locker-capture-driver.ts` — engine, **pure over injected seams** (no Win32 / host / terminal import). Owns the live `SessionTracker` + `SshSessionWatch` (constructed by the manager, W-3) so tests drive the REAL reconciliation against a fake process tree.
- `tests/unit/key-locker-capture-driver.test.ts` — 20 tests.

## The four events

| Event | Contract |
|---|---|
| `onLocalPaneLaunched` | **W1**: `beginLocalSession` + `watchPane` in ONE turn — **LAUNCHED panes only**, so a pre-existing pane stays UNKNOWN → declines (**P1-B**; anchoring on "no ssh child seen" would false-anchor a plink/mosh/renamed-ssh pane local → disclose a LOCAL secret to a REMOTE prompt). |
| `onDispatch` | **S-A / W3 RECONCILE-then-FREEZE**: `watch.tick()` reconcile → freeze `tracker.get` → `recordDispatch` (derive-then-record) → arm the poller for a credential command in a known session (OQ-W-3). Reconcile + freeze + record are **synchronous** (no `await` between) so an interleaved async tick can't reorder them; only the pure, idempotent arm-derive is awaited AFTER. **Single-flight (P2-E)** also drops the re-entrant onDispatch the Mode-A landed re-run fires (**W4-O2**). |
| `poll` | **§3.1 before/after ssh-child DIFF**: register the NEW interactive child, not a pre-existing tunnel (**Q2**); `>1` interactive OR argv-unreadable ⇒ `markUnknown`, never guess (**R3 Q3**). Then `runCaptureLoop` bound to the **FROZEN** session on a credential prompt. |
| `onPaneClosed` | **W2**: `unwatchPane` + `tracker.forget` same-turn. |

## Why RECONCILE-then-FREEZE (not freeze alone)

The tracker is mutated not only by dispatches but by `tick()` reacting to an EXTERNAL ssh child exiting. Counterexample freeze-alone misses: `ssh host-a` → the ssh exits (pane now LOCAL) → before the next tick, `sudo x` dispatched → a freeze of `tracker.get()` captures the stale `{host-a, remote}` → autofills host-a's secret into a LOCAL prompt (L2 re-verify can't catch it — window/title unchanged). So `onDispatch` reconciles FIRST (pops the dead ssh), then freezes → correct-or-UNKNOWN.

## Tests (20, real tracker + watch, fake tree)

W1 anchor / P1-B decline / OQ-W-3 arm filter / derive-then-record (`ssh b@host-b` derives host-a) / **P1-A** reconcile-pops-dead-ssh-so-`sudo x`-freezes-localhost / frozen-survives-interleaved-tick / **single-flight** / **§3.1 DIFF** (tunnel-sibling registered-correctly, argv-unreadable ⇒ sink, >1 ⇒ sink) / every `CaptureLoopOutcome` pass-through / poller timeout / **W2** close.

## Verification

```
npm run build && npm run lint            # clean
npx vitest run --project unit tests/unit/key-locker-*.test.ts   # 341 passed
npm run check:stub-catalog               # unchanged (no public tool)
npm run check:failwith-fixtures          # unchanged
```

Next: **W-3** (manager Win32 snapshot adapter + tick timer) → **W-4** (impure wiring root binding the terminal hooks) → live dogfood → R3 release.

Plan: `desktop-touch-mcp-internal@b69c582:docs/adr-014-v2-r3-l3-4-live-wiring-plan.md` (§2.2, §3, §4 W-2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
