### PR TITLE
ADR-014 v2 R3 Key Locker — L3-4 W-0.5: SshSessionWatch surgical W-2b exempt (fire-after-delivery prep)

### DIFF
--- a/src/engine/key-locker/ssh-session-watch.ts
+++ b/src/engine/key-locker/ssh-session-watch.ts
@@ -233,13 +233,16 @@ export class SshSessionWatch {
    * `exempt` (L3-4 §0-CORR.2 — the fire-AFTER-delivery correction): when the driver drives this tick from
    * `onDispatch` for a command that ITSELF opens an interactive ssh, that ssh child is ALREADY in the tree
    * (the S-A hook fires post-delivery), so the W-2b unregistered-ssh scan would mis-flag the assistant's OWN
-   * just-dispatched login as a lurking USER ssh and `markUnknown` the pane. `exempt = { paneId, host }`
-   * SURGICALLY removes ONLY the `host`-matching interactive descendant of `exempt.paneId` from the W-2b scan —
-   * every OTHER unregistered interactive ssh (a real user `ssh host-evil` on the same shared pane), and every
-   * other pane, is scanned in full. Omit `exempt` (a `sudo`/non-ssh dispatch, or the periodic timer) ⇒ the
-   * full scan runs everywhere. The exempt NEVER touches the wrong-target pop/markUnknown core.
+   * just-dispatched login as a lurking USER ssh and `markUnknown` the pane. `exempt = { paneId, pid }` skips
+   * EXACTLY that one process pid in the W-2b scan for `exempt.paneId` — the driver PROVED (via a before/after
+   * ssh-descendant delta) it is the child THIS dispatch spawned. Every OTHER interactive-ssh descendant — a
+   * user's ssh to the SAME host is a DIFFERENT pid — STILL flags; every other pane scans in full. A PID (not a
+   * host) is REQUIRED: a host match cannot prove the skipped process is the newly-dispatched one, so a user's
+   * pre-existing `ssh host-a` would be wrongly skipped and leak local→remote (Codex L3-4 W-0.5 P1). Omit
+   * `exempt` (a `sudo`/non-ssh dispatch, the periodic timer, or an ambiguous/unproven delta) ⇒ the full scan
+   * runs everywhere. The exempt NEVER touches the wrong-target pop/markUnknown core.
    */
-  tick(exempt?: { paneId: string; host: string }): void {
+  tick(exempt?: { paneId: string; pid: number }): void {
     if (this.panes.size === 0) return;
     const snap = this.deps.snapshot();
     // A degenerate (empty) snapshot means the native call FAILED, not that every process died — skip the
@@ -270,9 +273,9 @@ export class SshSessionWatch {
         // disclose). Gated on depth 0: a legit assistant-dispatched ssh has pushed a frame (depth>0) and is
         // handled above, so this scan never fights the normal push→register flow (Opus L3-4 R2 Q1 / R3 Q1a).
         childrenByParent ??= buildChildrenMap(snap.parentMap);
-        // §0-CORR.2: exempt the assistant's OWN just-dispatched login (host-matched) for THIS pane only.
-        const exemptHost = exempt?.paneId === paneId ? exempt.host : undefined;
-        if (this.hasUnregisteredInteractiveSsh(snap, childrenByParent, pane.shellPid, exemptHost)) this.deps.tracker.markUnknown(paneId);
+        // §0-CORR.2: exempt the assistant's OWN just-dispatched login (a proven pid) for THIS pane only.
+        const exemptPid = exempt?.paneId === paneId ? exempt.pid : undefined;
+        if (this.hasUnregisteredInteractiveSsh(snap, childrenByParent, pane.shellPid, exemptPid)) this.deps.tracker.markUnknown(paneId);
         continue;
       }
       // Liveness is authoritative from the Toolhelp map (a pid present as a KEY is alive); identify() reads
@@ -329,18 +332,18 @@ export class SshSessionWatch {
    * command) all classify null ⇒ NOT flagged, so those panes keep autofilling (OQ-W-7 = option B). Short-
    * circuits on the first interactive/unreadable ssh, so the common no-ssh subtree is one adjacency walk.
    *
-   * `exemptHost` (§0-CORR.2): when the driver dispatched an interactive `ssh <exemptHost>` for THIS pane, that
-   * login is the assistant's OWN (already in the tree post-delivery), so an interactive descendant whose argv
-   * host === `exemptHost` is NOT flagged. This is SURGICAL: any OTHER interactive ssh descendant (a real user
-   * `ssh host-evil` to a different host) STILL flags, and an UNREADABLE descendant (name "" / argv null) STILL
-   * flags regardless (can't confirm it is the exempt one — fail-safe). Omit `exemptHost` ⇒ every interactive
-   * ssh flags (the pre-correction behavior, used for a non-ssh dispatch and the periodic timer).
+   * `exemptPid` (§0-CORR.2): the ONE process pid the driver proved is the ssh child THIS dispatch spawned
+   * (via a before/after ssh-descendant delta) — it is NOT flagged (its own subtree is still scanned). This is
+   * a PID, not a host, on purpose: a user's ssh to the SAME host is a DIFFERENT pid and STILL flags, and an
+   * UNREADABLE descendant (name "" / argv null) STILL flags (can't confirm it is the exempt one — fail-safe).
+   * Omit `exemptPid` ⇒ every interactive ssh flags (the pre-correction behavior — a non-ssh dispatch, the
+   * periodic timer, or an ambiguous/unproven delta).
    */
   private hasUnregisteredInteractiveSsh(
     snap: ProcessSnapshot,
     children: Map<number, number[]>,
     shellPid: number,
-    exemptHost?: string,
+    exemptPid?: number,
   ): boolean {
     // BFS the subtree over the pre-built parent→children map (Opus PR#512 P3: built once per tick, not per
     // pane). `seen` guards against pid-reuse apparent cycles (a child listing an ancestor pid).
@@ -352,6 +355,9 @@ export class SshSessionWatch {
         if (seen.has(pid)) continue;
         seen.add(pid);
         frontier.push(pid);
+        // §0-CORR.2: the assistant's OWN just-dispatched ssh (a driver-proven pid) — do not flag it; its
+        // subtree is still walked (it was pushed to the frontier above) in case it holds a lurking child.
+        if (pid === exemptPid) continue;
         // Every pid reached here is a KEY in `parentMap` (it came from
         // buildChildrenMap, which inverts parentMap) ⇒ ALIVE per the module's
         // liveness contract. So identify()'s "" here is NOT a gone pid — it is a
@@ -371,10 +377,7 @@ export class SshSessionWatch {
         // the module's "any doubt sinks" invariant).
         const argv = snap.commandLine(pid);
         if (argv === null || argv.length === 0) return true; // unreadable / empty ⇒ fail-safe (possibly interactive)
-        const host = interactiveSshTarget(argv.slice(1));
-        // an interactive in-bound login — flagged UNLESS it is the assistant's own host-matched dispatch
-        // (§0-CORR.2 surgical exempt); a DIFFERENT host (a lurking user ssh) still flags.
-        if (host !== null && host !== exemptHost) return true;
+        if (interactiveSshTarget(argv.slice(1)) !== null) return true; // an interactive in-bound login (exempt pid already skipped)
       }
     }
     return false;

--- a/src/engine/key-locker/ssh-session-watch.ts
+++ b/src/engine/key-locker/ssh-session-watch.ts
@@ -229,8 +229,17 @@ export class SshSessionWatch {
   /**
    * One poll tick: snapshot once, then for each watched pane check its registered session ssh. Cheap:
    * one Toolhelp snapshot + a bounded per-pane identity read.
+   *
+   * `exempt` (L3-4 §0-CORR.2 — the fire-AFTER-delivery correction): when the driver drives this tick from
+   * `onDispatch` for a command that ITSELF opens an interactive ssh, that ssh child is ALREADY in the tree
+   * (the S-A hook fires post-delivery), so the W-2b unregistered-ssh scan would mis-flag the assistant's OWN
+   * just-dispatched login as a lurking USER ssh and `markUnknown` the pane. `exempt = { paneId, host }`
+   * SURGICALLY removes ONLY the `host`-matching interactive descendant of `exempt.paneId` from the W-2b scan —
+   * every OTHER unregistered interactive ssh (a real user `ssh host-evil` on the same shared pane), and every
+   * other pane, is scanned in full. Omit `exempt` (a `sudo`/non-ssh dispatch, or the periodic timer) ⇒ the
+   * full scan runs everywhere. The exempt NEVER touches the wrong-target pop/markUnknown core.
    */
-  tick(): void {
+  tick(exempt?: { paneId: string; host: string }): void {
     if (this.panes.size === 0) return;
     const snap = this.deps.snapshot();
     // A degenerate (empty) snapshot means the native call FAILED, not that every process died — skip the
@@ -261,7 +270,9 @@ export class SshSessionWatch {
         // disclose). Gated on depth 0: a legit assistant-dispatched ssh has pushed a frame (depth>0) and is
         // handled above, so this scan never fights the normal push→register flow (Opus L3-4 R2 Q1 / R3 Q1a).
         childrenByParent ??= buildChildrenMap(snap.parentMap);
-        if (this.hasUnregisteredInteractiveSsh(snap, childrenByParent, pane.shellPid)) this.deps.tracker.markUnknown(paneId);
+        // §0-CORR.2: exempt the assistant's OWN just-dispatched login (host-matched) for THIS pane only.
+        const exemptHost = exempt?.paneId === paneId ? exempt.host : undefined;
+        if (this.hasUnregisteredInteractiveSsh(snap, childrenByParent, pane.shellPid, exemptHost)) this.deps.tracker.markUnknown(paneId);
         continue;
       }
       // Liveness is authoritative from the Toolhelp map (a pid present as a KEY is alive); identify() reads
@@ -317,11 +328,19 @@ export class SshSessionWatch {
    * `-L`), a one-shot (`ssh host cmd`), or scp/sftp/git-over-ssh (whose inner ssh carries a trailing remote
    * command) all classify null ⇒ NOT flagged, so those panes keep autofilling (OQ-W-7 = option B). Short-
    * circuits on the first interactive/unreadable ssh, so the common no-ssh subtree is one adjacency walk.
+   *
+   * `exemptHost` (§0-CORR.2): when the driver dispatched an interactive `ssh <exemptHost>` for THIS pane, that
+   * login is the assistant's OWN (already in the tree post-delivery), so an interactive descendant whose argv
+   * host === `exemptHost` is NOT flagged. This is SURGICAL: any OTHER interactive ssh descendant (a real user
+   * `ssh host-evil` to a different host) STILL flags, and an UNREADABLE descendant (name "" / argv null) STILL
+   * flags regardless (can't confirm it is the exempt one — fail-safe). Omit `exemptHost` ⇒ every interactive
+   * ssh flags (the pre-correction behavior, used for a non-ssh dispatch and the periodic timer).
    */
   private hasUnregisteredInteractiveSsh(
     snap: ProcessSnapshot,
     children: Map<number, number[]>,
     shellPid: number,
+    exemptHost?: string,
   ): boolean {
     // BFS the subtree over the pre-built parent→children map (Opus PR#512 P3: built once per tick, not per
     // pane). `seen` guards against pid-reuse apparent cycles (a child listing an ancestor pid).
@@ -352,7 +371,10 @@ export class SshSessionWatch {
         // the module's "any doubt sinks" invariant).
         const argv = snap.commandLine(pid);
         if (argv === null || argv.length === 0) return true; // unreadable / empty ⇒ fail-safe (possibly interactive)
-        if (interactiveSshTarget(argv.slice(1)) !== null) return true; // an interactive in-bound login
+        const host = interactiveSshTarget(argv.slice(1));
+        // an interactive in-bound login — flagged UNLESS it is the assistant's own host-matched dispatch
+        // (§0-CORR.2 surgical exempt); a DIFFERENT host (a lurking user ssh) still flags.
+        if (host !== null && host !== exemptHost) return true;
       }
     }
     return false;

--- a/src/engine/key-locker/ssh-session-watch.ts
+++ b/src/engine/key-locker/ssh-session-watch.ts
@@ -233,16 +233,18 @@ export class SshSessionWatch {
    * `exempt` (L3-4 §0-CORR.2 — the fire-AFTER-delivery correction): when the driver drives this tick from
    * `onDispatch` for a command that ITSELF opens an interactive ssh, that ssh child is ALREADY in the tree
    * (the S-A hook fires post-delivery), so the W-2b unregistered-ssh scan would mis-flag the assistant's OWN
-   * just-dispatched login as a lurking USER ssh and `markUnknown` the pane. `exempt = { paneId, pid }` skips
-   * EXACTLY that one process pid in the W-2b scan for `exempt.paneId` — the driver PROVED (via a before/after
-   * ssh-descendant delta) it is the child THIS dispatch spawned. Every OTHER interactive-ssh descendant — a
-   * user's ssh to the SAME host is a DIFFERENT pid — STILL flags; every other pane scans in full. A PID (not a
-   * host) is REQUIRED: a host match cannot prove the skipped process is the newly-dispatched one, so a user's
-   * pre-existing `ssh host-a` would be wrongly skipped and leak local→remote (Codex L3-4 W-0.5 P1). Omit
-   * `exempt` (a `sudo`/non-ssh dispatch, the periodic timer, or an ambiguous/unproven delta) ⇒ the full scan
-   * runs everywhere. The exempt NEVER touches the wrong-target pop/markUnknown core.
+   * just-dispatched login as a lurking USER ssh and `markUnknown` the pane. `exempt = { paneId, pid, startTimeMs }`
+   * skips EXACTLY that one process — matched on BOTH pid AND creation time — in the W-2b scan for
+   * `exempt.paneId`. The driver PROVED (via a before/after ssh-descendant delta) it is the child THIS dispatch
+   * spawned. Every OTHER interactive-ssh descendant — a user's ssh to the SAME host is a DIFFERENT pid — STILL
+   * flags; every other pane scans in full. A PID (not a host) is REQUIRED, and the CREATION TIME closes PID
+   * REUSE: if the dispatched ssh exits and Windows reassigns its pid to a user's ssh before this snapshot, the
+   * reused process has a different creation time ⇒ NOT skipped ⇒ still flags (Codex L3-4 W-0.5 P1 host-identity
+   * + P2 pid-reuse; mirrors the module's `session.startedAt` reuse discipline). A zero creation time never
+   * matches (doubt sentinel). Omit `exempt` (a `sudo`/non-ssh dispatch, the periodic timer, or an
+   * ambiguous/unproven delta) ⇒ the full scan runs everywhere. The exempt NEVER touches the pop/markUnknown core.
    */
-  tick(exempt?: { paneId: string; pid: number }): void {
+  tick(exempt?: { paneId: string; pid: number; startTimeMs: number }): void {
     if (this.panes.size === 0) return;
     const snap = this.deps.snapshot();
     // A degenerate (empty) snapshot means the native call FAILED, not that every process died — skip the
@@ -273,9 +275,10 @@ export class SshSessionWatch {
         // disclose). Gated on depth 0: a legit assistant-dispatched ssh has pushed a frame (depth>0) and is
         // handled above, so this scan never fights the normal push→register flow (Opus L3-4 R2 Q1 / R3 Q1a).
         childrenByParent ??= buildChildrenMap(snap.parentMap);
-        // §0-CORR.2: exempt the assistant's OWN just-dispatched login (a proven pid) for THIS pane only.
-        const exemptPid = exempt?.paneId === paneId ? exempt.pid : undefined;
-        if (this.hasUnregisteredInteractiveSsh(snap, childrenByParent, pane.shellPid, exemptPid)) this.deps.tracker.markUnknown(paneId);
+        // §0-CORR.2: exempt the assistant's OWN just-dispatched login (a proven pid+creation-time) for THIS
+        // pane only — the creation time closes pid reuse (a reassigned pid is a different process).
+        const exemptId = exempt?.paneId === paneId ? { pid: exempt.pid, startTimeMs: exempt.startTimeMs } : undefined;
+        if (this.hasUnregisteredInteractiveSsh(snap, childrenByParent, pane.shellPid, exemptId)) this.deps.tracker.markUnknown(paneId);
         continue;
       }
       // Liveness is authoritative from the Toolhelp map (a pid present as a KEY is alive); identify() reads
@@ -332,18 +335,19 @@ export class SshSessionWatch {
    * command) all classify null ⇒ NOT flagged, so those panes keep autofilling (OQ-W-7 = option B). Short-
    * circuits on the first interactive/unreadable ssh, so the common no-ssh subtree is one adjacency walk.
    *
-   * `exemptPid` (§0-CORR.2): the ONE process pid the driver proved is the ssh child THIS dispatch spawned
-   * (via a before/after ssh-descendant delta) — it is NOT flagged (its own subtree is still scanned). This is
-   * a PID, not a host, on purpose: a user's ssh to the SAME host is a DIFFERENT pid and STILL flags, and an
-   * UNREADABLE descendant (name "" / argv null) STILL flags (can't confirm it is the exempt one — fail-safe).
-   * Omit `exemptPid` ⇒ every interactive ssh flags (the pre-correction behavior — a non-ssh dispatch, the
-   * periodic timer, or an ambiguous/unproven delta).
+   * `exempt` (§0-CORR.2): the ONE process the driver proved is the ssh child THIS dispatch spawned (via a
+   * before/after ssh-descendant delta) — matched on BOTH pid AND creation time, so a REUSED pid (a different
+   * process) does not inherit the exemption. It is NOT flagged (its own subtree is still scanned). Pid+time,
+   * not host, on purpose: a user's ssh to the SAME host is a DIFFERENT pid and STILL flags, and an UNREADABLE
+   * descendant (name "" / argv null) STILL flags (can't confirm it is the exempt one — fail-safe). A zero
+   * creation time never matches (doubt sentinel). Omit `exempt` ⇒ every interactive ssh flags (the
+   * pre-correction behavior — a non-ssh dispatch, the periodic timer, or an ambiguous/unproven delta).
    */
   private hasUnregisteredInteractiveSsh(
     snap: ProcessSnapshot,
     children: Map<number, number[]>,
     shellPid: number,
-    exemptPid?: number,
+    exempt?: { pid: number; startTimeMs: number },
   ): boolean {
     // BFS the subtree over the pre-built parent→children map (Opus PR#512 P3: built once per tick, not per
     // pane). `seen` guards against pid-reuse apparent cycles (a child listing an ancestor pid).
@@ -355,9 +359,12 @@ export class SshSessionWatch {
         if (seen.has(pid)) continue;
         seen.add(pid);
         frontier.push(pid);
-        // §0-CORR.2: the assistant's OWN just-dispatched ssh (a driver-proven pid) — do not flag it; its
-        // subtree is still walked (it was pushed to the frontier above) in case it holds a lurking child.
-        if (pid === exemptPid) continue;
+        const id = snap.identify(pid);
+        // §0-CORR.2: the assistant's OWN just-dispatched ssh — matched on pid AND creation time, so a REUSED
+        // pid (a different process; zero creation time never matches) does NOT inherit the exemption (Codex
+        // W-0.5 P2, mirrors `session.startedAt` reuse discipline). Do not flag it; its subtree is still walked
+        // (it was pushed to the frontier above) in case it holds a lurking child.
+        if (exempt !== undefined && pid === exempt.pid && id.startTimeMs !== 0 && id.startTimeMs === exempt.startTimeMs) continue;
         // Every pid reached here is a KEY in `parentMap` (it came from
         // buildChildrenMap, which inverts parentMap) ⇒ ALIVE per the module's
         // liveness contract. So identify()'s "" here is NOT a gone pid — it is a
@@ -368,7 +375,7 @@ export class SshSessionWatch {
         // fail-safe below (Codex PR#512 P1 — otherwise a `sudo ssh` leaves the
         // depth-0 pane trusted-local and a later fill discloses to the remote).
         // A READABLE non-ssh descendant genuinely cannot be an in-bound login ⇒ skip.
-        const descName = snap.identify(pid).name;
+        const descName = id.name;
         if (descName === "") return true; // unreadable LIVE descendant ⇒ possibly interactive ssh (decline)
         if (descName !== SSH_PROGRAM) continue; // readable non-ssh ⇒ not an in-bound login
         // Fail-safe on ANY non-classifiable ssh: unreadable (null) OR an EMPTY argv — an ssh we cannot

--- a/tests/unit/key-locker-ssh-session-watch.test.ts
+++ b/tests/unit/key-locker-ssh-session-watch.test.ts
@@ -628,6 +628,19 @@ describe("SshSessionWatch — W-2b PID-based exempt (§0-CORR.2, the fire-after-
     expect(sink.unknowns).toEqual(["pane-2"]); // pane-1 exempt, pane-2 still flags
   });
 
+  it("a lurking interactive ssh CHILD UNDER the exempt pid STILL flags (the exempt pid's subtree is walked)", () => {
+    // The exempt pid is skipped from flagging, but its subtree is still scanned — a nested unregistered login
+    // beneath it must not slip through (guards the frontier.push-before-continue ordering).
+    const { watch, sink } = setup(localPane({
+      2000: { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "deploy@host-a"] },   // assistant's (exempt)
+      2001: { parent: 2000, name: "ssh", start: 21, argv: ["ssh", "user@host-evil"] },  // a lurking login UNDER it
+    }));
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 0);
+    watch.tick({ paneId: "pane-1", pid: 2000 });
+    expect(sink.unknowns).toEqual(["pane-1"]); // 2000 exempt, but its child 2001 still flags
+  });
+
   it("no exempt (a sudo/non-ssh dispatch, the periodic timer, or an ambiguous delta) ⇒ full scan flags", () => {
     const { watch, sink } = setup(localPane({ 2000: { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "deploy@host-a"] } }));
     watch.watchPane("pane-1", 1000);

--- a/tests/unit/key-locker-ssh-session-watch.test.ts
+++ b/tests/unit/key-locker-ssh-session-watch.test.ts
@@ -560,3 +560,71 @@ describe("SshSessionWatch — W-2b: an UNREGISTERED interactive ssh on a LOCAL p
     expect(sink.ends).toEqual([]);
   });
 });
+
+describe("SshSessionWatch — W-2b SURGICAL exempt (§0-CORR.2, the fire-after-delivery correction)", () => {
+  // With the S-A hook firing AFTER delivery, an `ssh host-a` the ASSISTANT dispatched is already in the tree
+  // when onDispatch drives the tick. `tick({ paneId, host })` exempts ONLY the host-matching interactive
+  // descendant of that pane, so the assistant's own login is not mis-flagged — while a DIFFERENT-host user ssh,
+  // an unreadable ssh, and every other pane still flag.
+  const localPane = (extra: Record<number, Proc>): Record<number, Proc> => ({ ...SHELL_ONLY, ...extra });
+
+  it("the assistant's OWN host-matched ssh is NOT flagged when exempt names that host", () => {
+    const { watch, sink } = setup(localPane({ 2000: { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "deploy@host-a"] } }));
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 0);
+    watch.tick({ paneId: "pane-1", host: "host-a" }); // the assistant just dispatched `ssh …@host-a`
+    expect(sink.unknowns).toEqual([]); // exempt → not sunk → the assistant's own login can be armed/filled
+  });
+
+  it("a DIFFERENT-host ssh STILL flags even under an exempt (a lurking user ssh)", () => {
+    const { watch, sink } = setup(localPane({ 2100: { parent: 1000, name: "ssh", start: 21, argv: ["ssh", "user@host-evil"] } }));
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 0);
+    watch.tick({ paneId: "pane-1", host: "host-a" }); // assistant dispatched host-a, but the tree has host-evil
+    expect(sink.unknowns).toEqual(["pane-1"]); // surgical: host-evil ≠ host-a ⇒ still sunk (no disclosure)
+  });
+
+  it("exempt host-a + a lurking user ssh to host-evil ⇒ STILL flags (the OTHER login trips it)", () => {
+    const { watch, sink } = setup(localPane({
+      2000: { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "deploy@host-a"] },       // assistant's own
+      2100: { parent: 1000, name: "ssh", start: 21, argv: ["ssh", "user@host-evil"] },      // user's, unregistered
+    }));
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 0);
+    watch.tick({ paneId: "pane-1", host: "host-a" });
+    expect(sink.unknowns).toEqual(["pane-1"]); // host-a exempt, but host-evil still flags
+  });
+
+  it("an UNREADABLE ssh descendant STILL flags even under an exempt (can't confirm it is the exempt one)", () => {
+    const { watch, sink } = setup(localPane({ 4000: { parent: 1000, name: "ssh", start: 40 /* argv null */ } }));
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 0);
+    watch.tick({ paneId: "pane-1", host: "host-a" });
+    expect(sink.unknowns).toEqual(["pane-1"]); // fail-safe: unreadable ⇒ flag regardless of exempt
+  });
+
+  it("the exempt applies ONLY to its named pane — another pane's ssh still flags in the same tick", () => {
+    const procs: Record<number, Proc> = {
+      500: { parent: 0, name: "windowsterminal", start: 1 },
+      1000: { parent: 500, name: "powershell", start: 10 },
+      1100: { parent: 500, name: "powershell", start: 11 },
+      2000: { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "deploy@host-a"] },  // pane-1's (exempt)
+      2100: { parent: 1100, name: "ssh", start: 21, argv: ["ssh", "user@host-a"] },    // pane-2's (NOT exempt)
+    };
+    const { watch, sink } = setup(procs);
+    watch.watchPane("pane-1", 1000);
+    watch.watchPane("pane-2", 1100);
+    sink.setDepth("pane-1", 0);
+    sink.setDepth("pane-2", 0);
+    watch.tick({ paneId: "pane-1", host: "host-a" }); // exempt names pane-1 only
+    expect(sink.unknowns).toEqual(["pane-2"]); // pane-1 exempt, pane-2 (same host, but not exempt) still flags
+  });
+
+  it("no exempt (a sudo/non-ssh dispatch or the periodic timer) ⇒ full scan, host-a still flags", () => {
+    const { watch, sink } = setup(localPane({ 2000: { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "deploy@host-a"] } }));
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 0);
+    watch.tick(); // omitting exempt preserves the pre-correction behavior
+    expect(sink.unknowns).toEqual(["pane-1"]);
+  });
+});

--- a/tests/unit/key-locker-ssh-session-watch.test.ts
+++ b/tests/unit/key-locker-ssh-session-watch.test.ts
@@ -572,7 +572,7 @@ describe("SshSessionWatch — W-2b PID-based exempt (§0-CORR.2, the fire-after-
     const { watch, sink } = setup(localPane({ 2000: { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "deploy@host-a"] } }));
     watch.watchPane("pane-1", 1000);
     sink.setDepth("pane-1", 0);
-    watch.tick({ paneId: "pane-1", pid: 2000 }); // driver proved pid 2000 is the just-dispatched login
+    watch.tick({ paneId: "pane-1", pid: 2000, startTimeMs: 20 }); // driver proved pid 2000 is the just-dispatched login
     expect(sink.unknowns).toEqual([]); // exempt → not sunk → the assistant's own login can be armed/filled
   });
 
@@ -585,7 +585,7 @@ describe("SshSessionWatch — W-2b PID-based exempt (§0-CORR.2, the fire-after-
     }));
     watch.watchPane("pane-1", 1000);
     sink.setDepth("pane-1", 0);
-    watch.tick({ paneId: "pane-1", pid: 2000 });
+    watch.tick({ paneId: "pane-1", pid: 2000, startTimeMs: 20 });
     expect(sink.unknowns).toEqual(["pane-1"]); // pid 2000 exempt, but the user's pid 2100 (same host) still flags
   });
 
@@ -596,7 +596,7 @@ describe("SshSessionWatch — W-2b PID-based exempt (§0-CORR.2, the fire-after-
     }));
     watch.watchPane("pane-1", 1000);
     sink.setDepth("pane-1", 0);
-    watch.tick({ paneId: "pane-1", pid: 2000 });
+    watch.tick({ paneId: "pane-1", pid: 2000, startTimeMs: 20 });
     expect(sink.unknowns).toEqual(["pane-1"]);
   });
 
@@ -607,7 +607,7 @@ describe("SshSessionWatch — W-2b PID-based exempt (§0-CORR.2, the fire-after-
     }));
     watch.watchPane("pane-1", 1000);
     sink.setDepth("pane-1", 0);
-    watch.tick({ paneId: "pane-1", pid: 2000 });
+    watch.tick({ paneId: "pane-1", pid: 2000, startTimeMs: 20 });
     expect(sink.unknowns).toEqual(["pane-1"]); // unreadable ≠ exempt pid ⇒ flags
   });
 
@@ -624,7 +624,7 @@ describe("SshSessionWatch — W-2b PID-based exempt (§0-CORR.2, the fire-after-
     watch.watchPane("pane-2", 1100);
     sink.setDepth("pane-1", 0);
     sink.setDepth("pane-2", 0);
-    watch.tick({ paneId: "pane-1", pid: 2000 }); // exempt names pane-1 only
+    watch.tick({ paneId: "pane-1", pid: 2000, startTimeMs: 20 }); // exempt names pane-1 only
     expect(sink.unknowns).toEqual(["pane-2"]); // pane-1 exempt, pane-2 still flags
   });
 
@@ -637,8 +637,19 @@ describe("SshSessionWatch — W-2b PID-based exempt (§0-CORR.2, the fire-after-
     }));
     watch.watchPane("pane-1", 1000);
     sink.setDepth("pane-1", 0);
-    watch.tick({ paneId: "pane-1", pid: 2000 });
+    watch.tick({ paneId: "pane-1", pid: 2000, startTimeMs: 20 });
     expect(sink.unknowns).toEqual(["pane-1"]); // 2000 exempt, but its child 2001 still flags
+  });
+
+  it("a REUSED exempt pid (same pid, DIFFERENT creation time) is NOT exempt — flags (Codex W-0.5 P2)", () => {
+    // The assistant's dispatched ssh (pid 2000, start 20) exited; Windows reassigned pid 2000 to a USER's ssh
+    // (start 99). The exempt names { pid 2000, startTimeMs 20 }, but the live pid 2000 now reads start 99 ⇒ not
+    // skipped ⇒ flags. Without the creation-time match this reused pid would leak trusted-local.
+    const { watch, sink } = setup(localPane({ 2000: { parent: 1000, name: "ssh", start: 99, argv: ["ssh", "user@host-evil"] } }));
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 0);
+    watch.tick({ paneId: "pane-1", pid: 2000, startTimeMs: 20 }); // exempt time 20 ≠ the live pid's time 99
+    expect(sink.unknowns).toEqual(["pane-1"]);
   });
 
   it("no exempt (a sudo/non-ssh dispatch, the periodic timer, or an ambiguous delta) ⇒ full scan flags", () => {

--- a/tests/unit/key-locker-ssh-session-watch.test.ts
+++ b/tests/unit/key-locker-ssh-session-watch.test.ts
@@ -563,9 +563,11 @@ describe("SshSessionWatch — W-2b: an UNREGISTERED interactive ssh on a LOCAL p
 
 describe("SshSessionWatch — W-2b PID-based exempt (§0-CORR.2, the fire-after-delivery correction)", () => {
   // With the S-A hook firing AFTER delivery, the `ssh host-a` the ASSISTANT dispatched is already in the tree
-  // when onDispatch drives the tick. `tick({ paneId, pid })` exempts EXACTLY the driver-proven pid — a user's
-  // ssh to the SAME host is a DIFFERENT pid and STILL flags (a host match could not prove which process is the
-  // dispatched one — Codex W-0.5 P1). Unreadable descendants and every other pane still flag.
+  // when onDispatch drives the tick. `tick({ paneId, pid, startTimeMs })` exempts EXACTLY the driver-proven pid,
+  // matched on BOTH pid AND creation time — a user's ssh to the SAME host is a DIFFERENT pid and STILL flags (a
+  // host match could not prove which process is the dispatched one — Codex W-0.5 P1), and a REUSED pid reads a
+  // different creation time so it is NOT exempt (Codex W-0.5 P2). Unreadable descendants and every other pane
+  // still flag.
   const localPane = (extra: Record<number, Proc>): Record<number, Proc> => ({ ...SHELL_ONLY, ...extra });
 
   it("the assistant's OWN dispatched ssh (proven pid) is NOT flagged", () => {

--- a/tests/unit/key-locker-ssh-session-watch.test.ts
+++ b/tests/unit/key-locker-ssh-session-watch.test.ts
@@ -561,49 +561,57 @@ describe("SshSessionWatch — W-2b: an UNREGISTERED interactive ssh on a LOCAL p
   });
 });
 
-describe("SshSessionWatch — W-2b SURGICAL exempt (§0-CORR.2, the fire-after-delivery correction)", () => {
-  // With the S-A hook firing AFTER delivery, an `ssh host-a` the ASSISTANT dispatched is already in the tree
-  // when onDispatch drives the tick. `tick({ paneId, host })` exempts ONLY the host-matching interactive
-  // descendant of that pane, so the assistant's own login is not mis-flagged — while a DIFFERENT-host user ssh,
-  // an unreadable ssh, and every other pane still flag.
+describe("SshSessionWatch — W-2b PID-based exempt (§0-CORR.2, the fire-after-delivery correction)", () => {
+  // With the S-A hook firing AFTER delivery, the `ssh host-a` the ASSISTANT dispatched is already in the tree
+  // when onDispatch drives the tick. `tick({ paneId, pid })` exempts EXACTLY the driver-proven pid — a user's
+  // ssh to the SAME host is a DIFFERENT pid and STILL flags (a host match could not prove which process is the
+  // dispatched one — Codex W-0.5 P1). Unreadable descendants and every other pane still flag.
   const localPane = (extra: Record<number, Proc>): Record<number, Proc> => ({ ...SHELL_ONLY, ...extra });
 
-  it("the assistant's OWN host-matched ssh is NOT flagged when exempt names that host", () => {
+  it("the assistant's OWN dispatched ssh (proven pid) is NOT flagged", () => {
     const { watch, sink } = setup(localPane({ 2000: { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "deploy@host-a"] } }));
     watch.watchPane("pane-1", 1000);
     sink.setDepth("pane-1", 0);
-    watch.tick({ paneId: "pane-1", host: "host-a" }); // the assistant just dispatched `ssh …@host-a`
+    watch.tick({ paneId: "pane-1", pid: 2000 }); // driver proved pid 2000 is the just-dispatched login
     expect(sink.unknowns).toEqual([]); // exempt → not sunk → the assistant's own login can be armed/filled
   });
 
-  it("a DIFFERENT-host ssh STILL flags even under an exempt (a lurking user ssh)", () => {
-    const { watch, sink } = setup(localPane({ 2100: { parent: 1000, name: "ssh", start: 21, argv: ["ssh", "user@host-evil"] } }));
-    watch.watchPane("pane-1", 1000);
-    sink.setDepth("pane-1", 0);
-    watch.tick({ paneId: "pane-1", host: "host-a" }); // assistant dispatched host-a, but the tree has host-evil
-    expect(sink.unknowns).toEqual(["pane-1"]); // surgical: host-evil ≠ host-a ⇒ still sunk (no disclosure)
-  });
-
-  it("exempt host-a + a lurking user ssh to host-evil ⇒ STILL flags (the OTHER login trips it)", () => {
+  it("a SAME-HOST user ssh with a DIFFERENT pid STILL flags (closes Codex W-0.5 P1 — host is not identity)", () => {
+    // The user already `ssh host-a`'d in (pid 2100); the assistant then dispatches `ssh host-a` (proven pid 2000).
+    // A host-only exempt would have skipped the user's ssh too — the pid exempt does NOT.
     const { watch, sink } = setup(localPane({
-      2000: { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "deploy@host-a"] },       // assistant's own
-      2100: { parent: 1000, name: "ssh", start: 21, argv: ["ssh", "user@host-evil"] },      // user's, unregistered
+      2000: { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "deploy@host-a"] },   // assistant's own (exempt)
+      2100: { parent: 1000, name: "ssh", start: 19, argv: ["ssh", "user@host-a"] },     // user's, SAME host, unregistered
     }));
     watch.watchPane("pane-1", 1000);
     sink.setDepth("pane-1", 0);
-    watch.tick({ paneId: "pane-1", host: "host-a" });
-    expect(sink.unknowns).toEqual(["pane-1"]); // host-a exempt, but host-evil still flags
+    watch.tick({ paneId: "pane-1", pid: 2000 });
+    expect(sink.unknowns).toEqual(["pane-1"]); // pid 2000 exempt, but the user's pid 2100 (same host) still flags
   });
 
-  it("an UNREADABLE ssh descendant STILL flags even under an exempt (can't confirm it is the exempt one)", () => {
-    const { watch, sink } = setup(localPane({ 4000: { parent: 1000, name: "ssh", start: 40 /* argv null */ } }));
+  it("a lurking user ssh to a DIFFERENT host STILL flags under an exempt", () => {
+    const { watch, sink } = setup(localPane({
+      2000: { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "deploy@host-a"] },   // assistant's (exempt)
+      2100: { parent: 1000, name: "ssh", start: 21, argv: ["ssh", "user@host-evil"] },  // user's
+    }));
     watch.watchPane("pane-1", 1000);
     sink.setDepth("pane-1", 0);
-    watch.tick({ paneId: "pane-1", host: "host-a" });
-    expect(sink.unknowns).toEqual(["pane-1"]); // fail-safe: unreadable ⇒ flag regardless of exempt
+    watch.tick({ paneId: "pane-1", pid: 2000 });
+    expect(sink.unknowns).toEqual(["pane-1"]);
   });
 
-  it("the exempt applies ONLY to its named pane — another pane's ssh still flags in the same tick", () => {
+  it("an UNREADABLE ssh descendant (a different pid) STILL flags under an exempt (fail-safe)", () => {
+    const { watch, sink } = setup(localPane({
+      2000: { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "deploy@host-a"] },   // assistant's (exempt)
+      4000: { parent: 1000, name: "ssh", start: 40 /* argv null ⇒ unreadable */ },      // a different, unreadable ssh
+    }));
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 0);
+    watch.tick({ paneId: "pane-1", pid: 2000 });
+    expect(sink.unknowns).toEqual(["pane-1"]); // unreadable ≠ exempt pid ⇒ flags
+  });
+
+  it("the exempt applies ONLY to its named pane — another pane's ssh (even same pid-space) still flags", () => {
     const procs: Record<number, Proc> = {
       500: { parent: 0, name: "windowsterminal", start: 1 },
       1000: { parent: 500, name: "powershell", start: 10 },
@@ -616,11 +624,11 @@ describe("SshSessionWatch — W-2b SURGICAL exempt (§0-CORR.2, the fire-after-d
     watch.watchPane("pane-2", 1100);
     sink.setDepth("pane-1", 0);
     sink.setDepth("pane-2", 0);
-    watch.tick({ paneId: "pane-1", host: "host-a" }); // exempt names pane-1 only
-    expect(sink.unknowns).toEqual(["pane-2"]); // pane-1 exempt, pane-2 (same host, but not exempt) still flags
+    watch.tick({ paneId: "pane-1", pid: 2000 }); // exempt names pane-1 only
+    expect(sink.unknowns).toEqual(["pane-2"]); // pane-1 exempt, pane-2 still flags
   });
 
-  it("no exempt (a sudo/non-ssh dispatch or the periodic timer) ⇒ full scan, host-a still flags", () => {
+  it("no exempt (a sudo/non-ssh dispatch, the periodic timer, or an ambiguous delta) ⇒ full scan flags", () => {
     const { watch, sink } = setup(localPane({ 2000: { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "deploy@host-a"] } }));
     watch.watchPane("pane-1", 1000);
     sink.setDepth("pane-1", 0);


### PR DESCRIPTION
## What this is

**W-0.5** — a small, surgical prep change to the 6-round-hardened `ssh-session-watch.ts`, ahead of the fire-AFTER-delivery driver redesign (plan §0-CORR).

## Why

The merged W-1 (#511) fires the S-A dispatch hook **only after a confirmed delivery** (`terminal.ts:903-913` / `2137-2145`). So an `ssh host-a` the **assistant** dispatched is already in the process tree when the driver drives its reconcile tick — and the W-2b unregistered-ssh scan would mis-flag the assistant's **own** login as a lurking *user* ssh and `markUnknown` the pane (this is Codex PR #513 R8 P1, which surfaced that the whole W-2 driver assumed *fire-before-delivery*).

## The change

`tick(exempt?: { paneId, pid, startTimeMs })` — **conditional + surgical** (per the Opus plan review, then hardened to a PID identity over two Codex rounds — see below):
- The driver passes `exempt` **only when the dispatched command itself opens an interactive ssh** and it has **proven** (via a before/after ssh-descendant delta) the exact child pid THIS dispatch spawned; a `sudo`/non-ssh dispatch, the periodic timer, and an ambiguous/unproven delta pass nothing → **full scan everywhere**.
- When present, inside the W-2b scan for `exempt.paneId`, a descendant is skipped **only if its pid === `exempt.pid` AND its creation time === `exempt.startTimeMs`** (and a zero creation time never matches — the module's doubt sentinel). Any **other** interactive ssh — including a real user `ssh` to the **same host** (a **different pid**) — **still flags**; an **unreadable** ssh descendant (name `""` / argv `null`) **still flags** (fail-safe); the exempt pid's **own subtree is still walked** (a lurking child under it still flags); every **other pane** scans in full.
- The exempt is a **strict narrowing** of the opportunistic W-2b scan — it never touches the hardened wrong-target pop / markUnknown core.

## Why identity is pid+creation-time, not host (Codex W-0.5 P1 → P2)

- **P1 (host is not identity):** an earlier draft matched on the argv *host*. Codex flagged that a user's own `ssh host-a` to the **same host** the assistant just dispatched would inherit the exemption → a lurking user login goes unflagged → disclosure. Fixed by matching the **proven pid** the driver correlated, not the host.
- **P2 (pid reuse):** a bare pid match can be fooled if the dispatched ssh exits and Windows reassigns its pid to a user's ssh before the snapshot. Fixed by also matching the **creation time** (mirrors this module's existing `session.startedAt` reuse discipline) — a reused pid reads a different creation time ⇒ NOT exempt ⇒ still flags.

## Why it's safe (Opus plan-review 2 rounds + HEAD review, CONVERGED)

- The naive **unconditional** exempt was rejected as a **P1 disclosure** (a `sudo` dispatch over a lurking user ssh would skip the scan → local secret into the remote prompt). The conditional gate closes it.
- **Same-host collision** (`ssh host-a` dispatched while a user also has `ssh host-a` open): the two are **distinct pids** — only the proven-pid child is skipped, the user's is a different pid and still flags. (And the driver's `correlateDispatchedSsh` seeing `>1` host-matching child → `markUnknown`, with the post-record-sink gate re-reading `isKnownSession` **after** that, is a second layer.) No gap.

## Tests (8 exempt-specific; 47 ssh-watch total)

proven-pid exempt not flagged / same-host DIFFERENT-pid still flags (P1) / different-host still flags under exempt / unreadable descendant still flags (fail-safe) / exempt scoped to its named pane only / lurking child UNDER the exempt pid still flags (subtree walked) / REUSED exempt pid — same pid, different creation time — still flags (P2) / no-exempt full scan (backward-compat).

## Verification

```
npm run build && npm run lint            # clean
npx vitest run --project unit tests/unit/key-locker-*.test.ts   # green
```

No public tool change. The redesigned synchronous driver (W-2 REDO) consumes this exempt.

Plan: `desktop-touch-mcp-internal@fad05e8:docs/adr-014-v2-r3-l3-4-live-wiring-plan.md` (§0-CORR.2, §0-CORR.5 W-0.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
