### PR TITLE
ADR-014 v2 R3 Key Locker — L3-4 W-2 REDO: synchronous capture driver (fire-after-delivery)

### DIFF
--- a/src/engine/key-locker/key-locker-capture-driver.ts
+++ b/src/engine/key-locker/key-locker-capture-driver.ts
@@ -1,0 +1,579 @@
+// ADR-014 v2 R3 Key Locker — L3-4 W-2 (REDO): the capture DRIVER (the live-wiring CRUX).
+//
+// Plan: desktop-touch-mcp-internal:docs/adr-014-v2-r3-l3-4-live-wiring-plan.md (§0-CORR, §2.2, §3)
+//
+// Every L3 pipeline module is merged, pure, and unit-tested in ISOLATION, but NOTHING wires them into a
+// running loop. This driver is that first production owner — the orchestration that turns the terminal's
+// dispatch/prompt events into "the locker learns and fills credentials", while honoring the three
+// atomicity obligations the pure `ssh-session-watch.ts` header pinned as WIRING responsibilities (W1/W2/W3).
+//
+// ⚠ FIRE-AFTER-DELIVERY (§0-CORR — SUPERSEDES the fire-before design of PR #513): the merged W-1 (#511)
+// fires the S-A dispatch hook ONLY on a CONFIRMED-successful delivery (`terminal.ts:903-913` send /
+// `:2137-2145` run). So when `onDispatch(paneId, command)` fires, the command has ALREADY been delivered and
+// is running, and a fast interactive-ssh child CAN ALREADY be in the process tree. Three structural
+// consequences vs the old fire-before design:
+//   (A) `onDispatch` is FULLY SYNCHRONOUS (OQ-W-13 fold). The old `await deriveBinding` inside the handler
+//       produced the entire await-window bug class (push→register race, late correlation, stale-arm-during-
+//       derive/read). With the sync fold the handler runs atomically — no interleaving — so `dispatchSeq` +
+//       clear-at-start + the token gate all COLLAPSE and are DELETED. Arm on a CHEAP synchronous pre-filter
+//       (`looksLikeCredential` = `programOf(first real token of any segment) ∈ {sudo,doas,ssh,su}`, a generous
+//       superset) and let the poll's capture loop run the AUTHORITATIVE `deriveBinding` it already runs. A
+//       generous pre-filter only OVER-polls (bounded-safe, OQ-W-3), never wrong-targets.
+//   (B) The W-2b scan must EXEMPT the assistant's OWN just-dispatched ssh (§0-CORR.2): with the child already
+//       visible, the reconcile's W-2b unregistered-ssh scan would classify the assistant's own `ssh host-a`
+//       as a lurking USER ssh → markUnknown → the assistant's own login never arms. The driver proves the
+//       exact child pid THIS dispatch spawned via a before/after `sshBaseline` delta (host-matched to the
+//       dispatched host) and passes `watch.tick({ paneId, pid, startTimeMs })` to skip exactly it. A user's
+//       SAME-host ssh is a DIFFERENT pid ⇒ still flags; ambiguous (>1) or unprovable (0) ⇒ NO exempt.
+//   (C) The loop admits a real `onDispatch` ONLY in its POST-LANDED window (§0-CORR.3, `loopPhase`): during
+//       the pre-landed window the shell is BLOCKED at the credential prompt, so a delivered command has NOT
+//       run — recording it would put the tracker ahead of reality. This REPLACES the old command-match /
+//       `inRunToExit` gates (both admitted the pre-auth window).
+//
+// It stays ENGINE-PURE over injected seams (no Win32 / host / terminal import) so the whole wrong-target
+// story is unit-testable with a fake process tree; the thin IMPURE composition root (W-4,
+// `key-locker-wiring.ts`) binds these seams to the real terminal hooks + Win32 and drives the timers. It
+// OWNS a live `SessionTracker` + `SshSessionWatch` (constructed by the manager, W-3) — passed in so tests
+// drive the REAL reconciliation against a controllable snapshot.
+//
+// The events it services (all per-pane, keyed by `paneId = String(hwnd)` decimal — the same key the
+// terminal, inject-target, and ssh-watch all emit, so tracker keys / InjectTarget hwnd / shellPid stay
+// consistent BY CONSTRUCTION):
+//   * onLocalPaneLaunched — W1 anchor: a pane L3 ITSELF launched from a known-local shell is anchored
+//     KNOWN-LOCAL + watched, in ONE synchronous turn. A pre-existing pane is never anchored → stays UNKNOWN
+//     → every fill declines (P1-B: anchoring on "no ssh child seen" would false-anchor a plink/mosh/renamed-
+//     ssh pane local and disclose a LOCAL secret to a REMOTE prompt).
+//   * onDispatch — the S-A dispatch hook. Fully SYNCHRONOUS: (0) drop if pre-landed; (1) correlate stragglers
+//     + compute the W-2b exempt pid via the sshBaseline delta + RECONCILE (`watch.tick(exempt)`); (2) FREEZE
+//     `tracker.get(paneId)` as the pre-effect frame the capture loop derives from; (3) record the session
+//     effect (derive-then-record) + register the proven ssh child; (4) arm the poller on the cheap pre-filter.
+//   * poll — the prompt poller (the wiring drives it on a timer). On a credential prompt, runs
+//     `runCaptureLoop` bound to the FROZEN session. Single-flight per pane (P2-E); sets `loopPhase`.
+//   * onPaneClosed — W2 close atomicity: `unwatchPane` paired same-turn with `tracker.forget`.
+
+import type { BindingMeta } from "./binding-store.js";
+import type { BindingUri } from "./binding.js";
+import {
+  runCaptureLoop,
+  type CaptureLoopDeps,
+  type CaptureLoopOutcome,
+  type CredentialEvent,
+  type SaveChoice,
+} from "./capture-loop.js";
+import { tokenizeCommandSegmentsWithOps } from "./command-derivation.js";
+import type { SessionContext } from "./command-derivation.js";
+import { awaitLanded, type ExitCompletion } from "./landed-detection.js";
+import type { InjectResult } from "./injector.js";
+import {
+  ENV_ASSIGN_RE,
+  interactiveSshTarget,
+  isKnownSession,
+  programOf,
+  type SessionFrame,
+  type SessionTracker,
+} from "./session-tracker.js";
+import { type ProcessSnapshot, type SshSessionWatch } from "./ssh-session-watch.js";
+
+/** The prompt-read verdict the S-B seam returns (the tools-layer root runs the detection — §2.2 layer
+ *  rule — so the engine driver never imports `terminal.ts`). `null` = the pane read failed this poll. */
+export interface PromptVerdict {
+  /** The cursor row is an echo-off credential prompt L3 should fill (`isSecretInputPrompt`). */
+  isCredentialPrompt: boolean;
+  /** The non-secret pane tail (Mode-B auth read reuses this shape). */
+  tail: string;
+  /** Whether a hidden-input prompt is STILL on the cursor row (Mode-B re-prompt = rejected). */
+  stillHiddenPrompt: boolean;
+}
+
+/** The result of one `poll(paneId)` — observability for the wiring's timer + the unit tests. */
+export type PollResult =
+  /** The pane is not armed (no credential dispatch pending) — nothing to do. */
+  | { status: "idle" }
+  /** Armed, but no credential prompt has appeared yet — keep polling. */
+  | { status: "polling" }
+  /** A NEWER dispatch replaced the arm during the prompt read — this poll aborts, the fresh arm polls next. */
+  | { status: "superseded" }
+  /** A poll is already in progress for this pane (serialized) — the caller should not re-drive. */
+  | { status: "busy" }
+  /** The poller lifetime elapsed with no prompt (a key-based ssh / cached sudo prints none) — disarmed. */
+  | { status: "timed_out" }
+  /** A credential prompt was found and the capture loop ran to a terminal outcome. */
+  | { status: "filled"; outcome: CaptureLoopOutcome };
+
+/**
+ * The injected effects the driver orchestrates. The wiring (W-4) binds these to the real terminal hooks +
+ * Win32 + locker host; tests drive fakes. Most are the merged `CaptureLoopDeps` / `LandedDeps` seams,
+ * pane-parameterized where the driver must bind a specific pane's hwnd/session.
+ */
+export interface CaptureDriverDeps {
+  /** The live per-pane session tracker (owned by the manager; the driver anchors/records/forgets it). */
+  tracker: SessionTracker;
+  /** The live ssh session-end watch (owned by the manager, built with the real/fake snapshot seam). */
+  watch: SshSessionWatch;
+  /** One live process-tree snapshot (win32 `buildProcessParentMap`+`getProcessIdentityByPid`+
+   *  `getProcessCommandLineByPid` in production; a fake in tests). Used ONLY for the §0-CORR.2 sshBaseline
+   *  DELTA (exempt-pid proof + straggler correlation) — the watch snapshots independently for its own `tick`. */
+  snapshot(): ProcessSnapshot;
+
+  /** L1 derivation over the dispatched command in the FROZEN session context. null ⇒ not a credential. */
+  deriveBinding(command: string, session: SessionContext): Promise<BindingUri | null>;
+  /** Binding-map lookup, locker-`exists()`-verified. */
+  resolveBinding(canonicalKey: string): Promise<{ opaqueId: string } | undefined>;
+  /** Persist the canonical→opaqueId mapping (the loop calls this ONLY on [Save]). */
+  bindBinding(canonicalKey: string, opaqueId: string, meta: BindingMeta): void;
+  /** The binding's `confirmEveryInjection` policy (default true — the D2 confirm backstop). */
+  confirmPolicyFor(canonicalKey: string): boolean;
+  /** OPTIONAL [Never] tombstone gate (NO-MATCH only) — unwired ⇒ no suppression. */
+  isNever?(canonicalKey: string): boolean;
+  /** OPTIONAL [Never] tombstone writer — unwired ⇒ "never" behaves like "not now". */
+  onNever?(canonicalKey: string): void;
+  /** Open the locker's secure dialog for `opaqueId` (secret stays in the locker). */
+  capture(opaqueId: string): Promise<{ captured: boolean }>;
+  /** Delete the locker entry for `opaqueId` (the reverse-orphan closure). */
+  deleteSecret(opaqueId: string): Promise<void>;
+  /** Assemble the pane InjectTarget for `paneId` (`assembleInjectTarget`) + SendInput (`inject`, "pane"). */
+  injectPane(paneId: string, binding: BindingUri, opaqueId: string, submit: boolean): Promise<InjectResult>;
+  /** The D2 backstop confirm before a MATCH autofill. */
+  confirmInjection(binding: BindingUri): Promise<boolean>;
+  /** The Chrome-model save offer after a landed NO-MATCH fill. */
+  offerSave(binding: BindingUri): Promise<SaveChoice>;
+  /** Mint the opaqueId the loop binds on save. */
+  mintOpaqueId(): string;
+  /** ISO-8601 timestamp for `meta.createdAt`. */
+  now(): string;
+
+  /** Mode A (§2 S-C): run `command` under `terminal until:{mode:'exit'}` (shell from the frozen isRemote,
+   *  OQ-W-4) and return its completion. */
+  runToExit(paneId: string, command: string, isRemote: boolean): Promise<ExitCompletion>;
+  /** Mode B (§2 S-B): read the pane's non-secret tail + still-hidden-prompt after an interactive login. */
+  readPaneAfterAuth(paneId: string): Promise<{ tail: string; stillHiddenPrompt: boolean }>;
+  /** The prompt-read seam (§1 S-B): the credential-prompt verdict for a pane, or null on a read failure. */
+  readPromptTail(paneId: string): Promise<PromptVerdict | null>;
+
+  /** Monotonic-ish ms clock for the poller lifetime (default `Date.now`; injected in tests). */
+  nowMs(): number;
+  /** Abandon a prompt poll after this many ms (a key-based ssh / cached sudo prints no prompt). */
+  pollTimeoutMs?: number;
+}
+
+/** A credential dispatch armed for the prompt poller (the frozen frame is the W3 closure). */
+interface ArmedDispatch {
+  /** The dispatched command — the AUTHORITATIVE binding source (never the prompt text). */
+  command: string;
+  /** The reconciled PRE-effect session the capture loop derives from (never a live tracker.get). */
+  frozen: SessionFrame;
+  /** `nowMs()` when armed (poller lifetime, OQ-W-2). */
+  armedAtMs: number;
+}
+
+/**
+ * A pending straggler ssh-child correlation (§0-CORR.2): fire-after-delivery usually makes the child
+ * present AT dispatch, so this is the RARE slow-spawn path. It carries the pre-dispatch ssh-descendant
+ * baseline + the dispatched host so a later `correlateAllPending` can still register EXACTLY the child THIS
+ * dispatch spawned (host-matched), never a pre-existing tunnel/sibling.
+ */
+interface PendingSshCorrelation {
+  /** The shell subtree's ssh-descendant pids BEFORE this dispatch (the delta baseline — a pre-existing
+   *  tunnel is in here, so it is never mis-registered as this dispatch's login; Opus R2 Q2). */
+  baseline: Set<number>;
+  /** The interactive host this dispatch's ssh targets — the child to register must host-match it. */
+  dHost: string;
+  /** Whether the correlation has resolved (registered the child, or declined) — one-shot per dispatch. */
+  registered: boolean;
+}
+
+/** Per-pane phase of the capture loop (§0-CORR.3) — gates whether `onDispatch` admits a real dispatch.
+ *  `pre-landed` = the shell is BLOCKED at the credential prompt (a delivered command has NOT run) ⇒ DROP.
+ *  `post-landed` = the login/sudo was accepted and the shell is back at a prompt ⇒ ADMIT. `none` = no loop. */
+type LoopPhase = "none" | "pre-landed" | "post-landed";
+
+/** Per-pane driver state (exists iff the driver ANCHORED the pane — i.e. L3 launched it). */
+interface PaneRecord {
+  /** The window-owning shell pid (`getWindowProcessId(hwnd)`), for the sshBaseline subtree root. */
+  shellPid: number;
+  /** The credential dispatch awaiting a prompt, or null. */
+  armed: ArmedDispatch | null;
+  /** The shell subtree's ssh-descendant pids as of the LAST reconcile (§0-CORR.2). Advanced every
+   *  `onDispatch`/`tickWatch`; the delta against a fresh snapshot identifies the newly-spawned child. */
+  sshBaseline: Set<number>;
+  /** A pending straggler ssh-child correlation (the child was not visible at dispatch), or undefined.
+   *  Resolved by `correlateAllPending` on a later tick/poll. */
+  pendingSsh: PendingSshCorrelation | undefined;
+  /** A `poll()` is in progress for this pane — serializes polls (a re-entrant poll returns `busy`) so a
+   *  slow prompt read cannot let two polls run two capture loops for one dispatch (Codex L3-4-W2 R2 P2). */
+  pollBusy: boolean;
+  /** The capture-loop phase (§0-CORR.3). `onDispatch` DROPS a dispatch while `pre-landed` (shell blocked at
+   *  the prompt), ADMITS on `post-landed`/`none`. This REPLACES the old `inRunToExit` flag: the Mode-A
+   *  `runToExit` landed re-run fires onDispatch while still `pre-landed` (awaitLanded has not returned
+   *  accepted yet) ⇒ dropped; a genuine post-auth dispatch fires after the flip to `post-landed` ⇒ admitted. */
+  loopPhase: LoopPhase;
+}
+
+const SSH_PROGRAM = "ssh";
+const DEFAULT_POLL_TIMEOUT_MS = 20_000;
+/** The cheap synchronous arm pre-filter set (§0-CORR.1 A) — a generous superset; the loop's own
+ *  `deriveBinding` is the authoritative gate, so an over-arm just declines `not_a_credential`. */
+const CREDENTIAL_PROGRAMS = new Set(["sudo", "doas", "ssh", "su"]);
+
+/**
+ * The live capture driver. Constructed once by the manager (W-3) with the shared tracker + watch + the
+ * live seams; the wiring root (W-4) calls its events from the terminal hooks + a poll/tick timer.
+ */
+export class KeyLockerCaptureDriver {
+  private readonly panes = new Map<string, PaneRecord>();
+  private readonly pollTimeoutMs: number;
+
+  constructor(private readonly deps: CaptureDriverDeps) {
+    this.pollTimeoutMs = deps.pollTimeoutMs ?? DEFAULT_POLL_TIMEOUT_MS;
+  }
+
+  /**
+   * W1 — anchor a pane L3 ITSELF launched from a known-local shell. `beginLocalSession` (tracker known-local)
+   * and `watchPane` (liveness anchor at `shellPid`) run in ONE synchronous turn (Edge 3): never a window
+   * where the tracker trusts local while no watch guards a later ssh-out. Re-launching resets the pane.
+   * ONLY the assistant's own launches call this — a pre-existing pane is never anchored (P1-B, §3 W1).
+   */
+  onLocalPaneLaunched(paneId: string, shellPid: number, cwd?: string): void {
+    this.tracker.beginLocalSession(paneId, cwd);
+    this.watch.watchPane(paneId, shellPid);
+    this.panes.set(paneId, {
+      shellPid,
+      armed: null,
+      sshBaseline: new Set(),
+      pendingSsh: undefined,
+      pollBusy: false,
+      loopPhase: "none",
+    });
+  }
+
+  /**
+   * The S-A dispatch hook — one dispatch's session bookkeeping + poller arm, FULLY SYNCHRONOUS (§0-CORR.1).
+   * No `await` anywhere: the correlate → exempt-delta → reconcile → freeze → record → register → arm sequence
+   * runs atomically, so an interleaved async tick (an external ssh child exiting) cannot reorder any of it.
+   *
+   * DROP while `loopPhase === 'pre-landed'` (§0-CORR.3): the shell is blocked at a credential prompt, so a
+   * delivered command has NOT run — recording it would put the tracker ahead of reality. This also drops the
+   * Mode-A `runToExit` landed RE-RUN (which fires onDispatch mid-loop, still pre-landed — W4-O2). A genuine
+   * post-auth dispatch fires after the flip to `post-landed` and is admitted.
+   *
+   * A pane the driver never anchored (`panes` has no record — a pre-existing user pane, P1-B) is ignored
+   * here; the tracker stays UNKNOWN for it and every fill declines. (W4-O1: fire-after means the command has
+   * already run and its ssh child may already exist — the exempt delta below skips the assistant's own child
+   * so the W-2b scan does not mis-flag it.)
+   */
+  onDispatch(paneId: string, command: string): void {
+    const rec = this.panes.get(paneId);
+    if (rec === undefined) return;
+    // (0) DROP while the shell is blocked mid-credential (§0-CORR.3). Also drops the Mode-A landed re-run.
+    if (rec.loopPhase === "pre-landed") return;
+
+    // (1a) REGISTER any pending straggler ssh child of any pane BEFORE the tick — a just-pushed-but-
+    //      unregistered remote frame (`session===null && remoteDepth>0`) would otherwise trip the watch's
+    //      unwatched-frame backstop → markUnknown (OQ-W-5). In fire-after the child is usually already
+    //      present at its own dispatch, so this straggler path rarely has work.
+    this.correlateAllPending();
+
+    // (1b) §0-CORR.2 W-2b EXEMPT: identify the SPECIFIC ssh child THIS dispatch spawned via a before/after
+    //      delta against the pane's maintained ssh-descendant baseline, and exempt ONLY that pid so the
+    //      reconcile's W-2b scan does not mis-flag the assistant's OWN login as a lurking user ssh. A user's
+    //      SAME-host ssh is a DIFFERENT pid ⇒ still flags; 0 or >1 new host-matching children ⇒ NO exempt.
+    const dHost = dispatchedInteractiveSshHost(command);
+    const curSsh = sshDescendants(this.deps.snapshot(), rec.shellPid);
+    const preBaseline = rec.sshBaseline;
+    const newHostMatch =
+      dHost === null
+        ? []
+        : [...curSsh].filter(([pid, info]) => !preBaseline.has(pid) && info.host === dHost).map(([pid]) => pid);
+    const exemptPid = newHostMatch.length === 1 ? newHostMatch[0] : null;
+
+    // (1c) RECONCILE this pane to a correct-or-UNKNOWN steady state (P1-A: pop a dead ssh so a post-exit
+    //      command doesn't freeze a stale remote; W-2b: markUnknown a user-typed in-bound ssh) — SKIPPING the
+    //      one proven exempt child. Synchronous, one Toolhelp snapshot inside `tick`.
+    this.watch.tick(
+      exemptPid !== null
+        ? { paneId, pid: exemptPid, startTimeMs: curSsh.get(exemptPid)!.startTimeMs }
+        : undefined,
+    );
+    // Advance the delta baseline for the next dispatch/tick (all current ssh descendant pids).
+    rec.sshBaseline = new Set(curSsh.keys());
+
+    // (2) FREEZE the reconciled pre-effect frame (the derive-then-record PRE-push context, §3.1 point 1).
+    const frozen = this.tracker.get(paneId);
+
+    // (3) Apply the session effect for SUBSEQUENT commands (the command ALREADY ran — fire-after). An
+    //     interactive-ssh frame push (depth delta) then REGISTERS the session ssh child so the watch can pop
+    //     it on exit.
+    const depthBefore = this.tracker.remoteDepth(paneId);
+    this.tracker.recordDispatch(paneId, command);
+    if (this.tracker.remoteDepth(paneId) > depthBefore) {
+      // A clean interactive login pushed a frame. Register EXACTLY the proven child:
+      //   - 1 new host-matching child ⇒ `noteSshOpened` (the child is already visible, fire-after).
+      //   - >1 (assistant's + a user's same-host ssh both new in this window) ⇒ markUnknown: ambiguous,
+      //     never guess (Opus R3 Q3). The current fill still uses the frozen frame; only subsequent decline.
+      //   - 0 (the child has not appeared yet — a slow spawn) ⇒ record a pending straggler correlation that
+      //     `correlateAllPending` retries; until then the unwatched-frame backstop declines (fail-safe).
+      if (newHostMatch.length === 1) {
+        this.watch.noteSshOpened(paneId, newHostMatch[0]);
+      } else if (newHostMatch.length > 1) {
+        this.tracker.markUnknown(paneId);
+      } else if (dHost !== null) {
+        rec.pendingSsh = { baseline: preBaseline, dHost, registered: false };
+      }
+    }
+
+    // (4) ARM the poller iff this is a credential-shaped command in a session KNOWN both BEFORE the record
+    //     (the derive-then-record context) AND AFTER it (post-record-sink gate, R5 — KEPT). `recordDispatch`
+    //     can SINK the pane to UNKNOWN for a conditional/ambiguous command whose effect it cannot predict;
+    //     the pre-record `frozen` still looks local, so without the post-record check the trailing prompt
+    //     would fill under a mis-derived binding (Codex L3-4-W2 R5 P1). Declining a sunk pane is fail-safe.
+    //     The arm uses only the CHEAP sync pre-filter — the authoritative `deriveBinding` runs in the loop.
+    rec.armed =
+      isKnownSession(frozen) && isKnownSession(this.tracker.get(paneId)) && looksLikeCredential(command)
+        ? { command, frozen, armedAtMs: this.deps.nowMs() }
+        : null;
+  }
+
+  /**
+   * One prompt-poll for a pane (the wiring drives this on a timer for every `armedPaneIds()`). Runs the
+   * capture loop when a credential prompt appears, bound to the FROZEN session. Returns a `PollResult` for
+   * observability; the loop's own outcome is the terminal signal.
+   */
+  async poll(paneId: string): Promise<PollResult> {
+    const rec = this.panes.get(paneId);
+    if (rec === undefined || rec.armed === null) return { status: "idle" };
+    // SERIALIZE polls per pane (Codex L3-4-W2 P2). `pollBusy` is set BEFORE the `readPromptTail` await, so a
+    // poll-timer re-entry while a prior poll is still awaiting the (slow, UIA) prompt read is dropped —
+    // otherwise BOTH would pass the guard, observe the same prompt, and run two capture loops for one armed
+    // dispatch (duplicate capture/inject/save). `pollBusy` spans the WHOLE poll incl. the capture loop.
+    if (rec.pollBusy) return { status: "busy" };
+    rec.pollBusy = true;
+    try {
+      const armed = rec.armed;
+
+      // §0-CORR.2 straggler backstop: register a still-pending ssh child (rare in fire-after). Idempotent.
+      if (rec.pendingSsh !== undefined && !rec.pendingSsh.registered) {
+        this.correlateSshChild(paneId, rec.shellPid, rec.pendingSsh);
+      }
+
+      // Poller lifetime (OQ-W-2): a key-based ssh / cached sudo prints NO prompt — abandon (safe, no fill).
+      if (this.deps.nowMs() - armed.armedAtMs > this.pollTimeoutMs) { rec.armed = null; return { status: "timed_out" }; }
+
+      const verdict = await this.deps.readPromptTail(paneId);
+      // The arm can be OVERWRITTEN during the (slow, UIA) read: onDispatch is NOT gated by `pollBusy`, so a
+      // NEWER credential dispatch to this pane replaces `rec.armed` mid-read. Acting on the STALE `armed`
+      // would fill/save the newer prompt under the OLDER binding. If the arm changed, abort — the fresh arm
+      // is polled next tick (Codex L3-4-W2 R3 P1). Never clear the newer arm.
+      if (rec.armed !== armed) return { status: "superseded" };
+      if (verdict === null || !verdict.isCredentialPrompt) return { status: "polling" };
+
+      // A credential prompt appeared → run the loop. Mark `pre-landed` (§0-CORR.3) FIRST so a command
+      // delivered while the shell is blocked at this prompt — including the Mode-A `runToExit` landed re-run
+      // — is DROPPED by onDispatch. The awaitLanded wrapper flips to `post-landed` on acceptance; the finally
+      // resets `none`.
+      rec.loopPhase = "pre-landed";
+      try {
+        const outcome = await this.runCaptureLoopFor(rec, paneId, armed);
+        return { status: "filled", outcome };
+      } finally {
+        rec.loopPhase = "none";
+        // Disarm ONLY the loop's OWN arm — a real dispatch that ran mid-loop (post-landed) may have replaced
+        // `rec.armed` with a newer arm, which must survive to be polled next.
+        if (rec.armed === armed) rec.armed = null;
+      }
+    } finally {
+      rec.pollBusy = false;
+    }
+  }
+
+  /** Panes with a credential dispatch awaiting a prompt (the wiring polls exactly these). */
+  armedPaneIds(): string[] {
+    const out: string[] = [];
+    for (const [paneId, rec] of this.panes) if (rec.armed !== null) out.push(paneId);
+    return out;
+  }
+
+  /**
+   * W2 — a pane's window closed / its hwnd was invalidated (event-bus `window_disappeared` /
+   * identity-tracker reuse). `unwatchPane` is paired SAME-turn with `tracker.forget` (Edge 7): never drop
+   * the watch while a remote frame stays trusted. Idempotent.
+   */
+  onPaneClosed(paneId: string): void {
+    this.watch.unwatchPane(paneId);
+    this.tracker.forget(paneId);
+    this.panes.delete(paneId);
+  }
+
+  /**
+   * Drive the watch's periodic reconcile (the wiring's tick timer, §2.1 mechanical half of W3). Registers
+   * any pending straggler ssh child FIRST (so the periodic tick cannot markUnknown a just-pushed-but-
+   * unregistered interactive-ssh frame), advances every pane's ssh-descendant baseline, then ticks with NO
+   * exempt (the periodic timer has no just-dispatched command to prove a child for — §0-CORR.2 full scan).
+   */
+  tickWatch(): void {
+    this.correlateAllPending();
+    // Advance each pane's delta baseline so the NEXT onDispatch's "new since last reconcile" is accurate
+    // (a child that appeared/exited between dispatches is folded in here). One snapshot per pane is fine at
+    // the tick cadence; the watch also snapshots independently inside `tick`.
+    for (const rec of this.panes.values()) {
+      rec.sshBaseline = new Set(sshDescendants(this.deps.snapshot(), rec.shellPid).keys());
+    }
+    this.watch.tick();
+  }
+
+  // ── internals ──────────────────────────────────────────────────────────────────────────────────────
+
+  private get tracker(): SessionTracker { return this.deps.tracker; }
+  private get watch(): SshSessionWatch { return this.deps.watch; }
+
+  /**
+   * Register the freshly-spawned interactive-ssh child of EVERY pane whose straggler correlation is still
+   * pending. Called before every `watch.tick()` the driver issues (`onDispatch` step 1a + `tickWatch`) so a
+   * just-pushed remote frame is registered before the tick's unwatched-frame backstop can see it. A pane
+   * whose child is not visible yet stays pending and is retried; correlation is a no-op once resolved
+   * (`registered`), so this is idempotent and O(pending panes) — usually 0.
+   */
+  private correlateAllPending(): void {
+    for (const [paneId, rec] of this.panes) {
+      const ssh = rec.pendingSsh;
+      if (ssh !== undefined && !ssh.registered) this.correlateSshChild(paneId, rec.shellPid, ssh);
+    }
+  }
+
+  /**
+   * §0-CORR.2 straggler correlation — register the interactive-ssh child THIS dispatch spawned so the
+   * session-end watch can pop it later. Among the shell subtree's ssh descendants that are NEW since the
+   * dispatch baseline AND host-match `dHost`, register the one such pid. NEVER guess: >1 ⇒ `markUnknown`
+   * (fail-safe — the current fill still uses the frozen frame, only subsequent commands decline). 0 ⇒ the
+   * child has not spawned yet, leave pending for the next poll/tick.
+   */
+  private correlateSshChild(paneId: string, shellPid: number, ssh: PendingSshCorrelation): void {
+    const snap = this.deps.snapshot();
+    if (snap.parentMap.size === 0) return; // native failure this poll — retry next poll (no baseline change)
+
+    const newMatch: number[] = [];
+    for (const [pid, info] of sshDescendants(snap, shellPid)) {
+      if (ssh.baseline.has(pid)) continue; // pre-existing (tunnel/sibling) — not this dispatch
+      if (info.host === ssh.dHost) newMatch.push(pid);
+    }
+
+    if (newMatch.length > 1) { this.tracker.markUnknown(paneId); ssh.registered = true; return; }
+    if (newMatch.length === 1) { this.watch.noteSshOpened(paneId, newMatch[0]); ssh.registered = true; }
+    // 0 ⇒ not spawned yet — leave unresolved so a later poll/tick retries.
+  }
+
+  /**
+   * Assemble the per-event `CaptureLoopDeps` bound to the FROZEN session (W3 — `getSession` returns the
+   * frozen frame, never a live `tracker.get`) and run the merged capture loop. The `awaitLanded` wrapper
+   * flips `loopPhase` to `post-landed` the instant it returns `accepted` (§0-CORR.3) — the shell is then
+   * back at a prompt, so subsequent commands genuinely run and onDispatch admits them.
+   */
+  private runCaptureLoopFor(rec: PaneRecord, paneId: string, armed: ArmedDispatch): Promise<CaptureLoopOutcome> {
+    const event: CredentialEvent = { paneId, dispatchedCommand: armed.command };
+    const loopDeps: CaptureLoopDeps = {
+      getSession: () => armed.frozen, // FROZEN pre-effect frame — the W3 closure
+      deriveBinding: (cmd, session) => this.deps.deriveBinding(cmd, session),
+      resolveBinding: (k) => this.deps.resolveBinding(k),
+      bindBinding: (k, id, meta) => this.deps.bindBinding(k, id, meta),
+      confirmPolicyFor: (k) => this.deps.confirmPolicyFor(k),
+      capture: (id) => this.deps.capture(id),
+      deleteSecret: (id) => this.deps.deleteSecret(id),
+      injectPane: (b, id, sub) => this.deps.injectPane(paneId, b, id, sub),
+      awaitLanded: async (cmd) => {
+        const result = await awaitLanded(
+          {
+            runToExit: () => this.deps.runToExit(paneId, cmd, armed.frozen.isRemote),
+            readPaneAfterAuth: () => this.deps.readPaneAfterAuth(paneId),
+          },
+          cmd,
+        );
+        // §0-CORR.3: the login/sudo is accepted and the shell is back at a prompt — admit subsequent real
+        // dispatches. A not-accepted result stays `pre-landed` (the loop then discards, no offer window).
+        if (result.accepted) rec.loopPhase = "post-landed";
+        return result;
+      },
+      confirmInjection: (b) => this.deps.confirmInjection(b),
+      offerSave: (b) => this.deps.offerSave(b),
+      mintOpaqueId: () => this.deps.mintOpaqueId(),
+      now: () => this.deps.now(),
+      ...(this.deps.isNever ? { isNever: (k: string) => this.deps.isNever!(k) } : {}),
+      ...(this.deps.onNever ? { onNever: (k: string) => this.deps.onNever!(k) } : {}),
+    };
+    return runCaptureLoop(loopDeps, event);
+  }
+}
+
+/**
+ * The ssh-named DESCENDANTS of `shellPid` in a snapshot (subtree, not just direct children — the exempt
+ * delta must see a `sudo ssh`/wrapper/tmux-reparented login the same way the W-2b scan does). For each,
+ * report its interactive-login HOST (`commandLine` → `interactiveSshTarget`, or null for a tunnel/one-shot/
+ * unreadable ssh) + its creation time (for the pid+time exempt). A `seen` set guards pid-reuse cycles.
+ */
+function sshDescendants(snap: ProcessSnapshot, shellPid: number): Map<number, { host: string | null; startTimeMs: number }> {
+  const out = new Map<number, { host: string | null; startTimeMs: number }>();
+  const seen = new Set<number>([shellPid]);
+  const children = new Map<number, number[]>();
+  for (const [pid, parentPid] of snap.parentMap) {
+    const arr = children.get(parentPid);
+    if (arr === undefined) children.set(parentPid, [pid]);
+    else arr.push(pid);
+  }
+  const frontier: number[] = [shellPid];
+  while (frontier.length > 0) {
+    const parent = frontier.pop() as number;
+    for (const pid of children.get(parent) ?? []) {
+      if (seen.has(pid)) continue;
+      seen.add(pid);
+      frontier.push(pid);
+      const id = snap.identify(pid);
+      if (id.name !== SSH_PROGRAM) continue;
+      const argv = snap.commandLine(pid);
+      const host = argv === null ? null : interactiveSshTarget(argv.slice(1));
+      out.set(pid, { host, startTimeMs: id.startTimeMs });
+    }
+  }
+  return out;
+}
+
+/**
+ * The interactive-login HOST the dispatched `command` opens (bare, lowercased), or null. Mirrors
+ * `SessionTracker.recordDispatch`'s ssh-segment detection (env/redirect skip + backgrounded/piped/leading-
+ * stdin-redirect + `interactiveSshTarget`) but returns the host instead of mutating a tracker. Used ONLY to
+ * host-match the exempt-pid delta (§0-CORR.2). This is AVAILABILITY-only, not security: any divergence from
+ * `recordDispatch` only biases toward NO exempt (the W-2b scan then flags the assistant's own login → the
+ * login declines — a bounded availability regression, never a wrong-target). Returns the FIRST segment's
+ * interactive-ssh host — the one `recordDispatch` would push a frame for.
+ */
+function dispatchedInteractiveSshHost(command: string): string | null {
+  for (const seg of tokenizeCommandSegmentsWithOps(command)) {
+    const { tokens, backgrounded, pipedStdin } = seg;
+    // Skip leading env-assignments; the redirect-skip is folded into interactiveSshTarget's own whole-argv
+    // scan below, so here we only need to find the program token past leading `FOO=bar`.
+    let start = 0;
+    while (tokens[start] !== undefined && ENV_ASSIGN_RE.test(tokens[start])) start++;
+    if (programOf(tokens[start]) !== SSH_PROGRAM) continue;
+    // A backgrounded / downstream-piped ssh takes stdin off the tty ⇒ no interactive login (mirrors
+    // recordDispatch); a leading fd-0 redirect is caught inside interactiveSshTarget's whole-argv scan.
+    if (backgrounded || pipedStdin) continue;
+    const host = interactiveSshTarget(tokens.slice(start + 1));
+    if (host !== null) return host;
+  }
+  return null;
+}
+
+/**
+ * The cheap synchronous arm pre-filter (§0-CORR.1 A): does ANY segment's first real token name a program
+ * that can prompt for a credential (`sudo`/`doas`/`ssh`/`su`)? A generous superset — the loop's own
+ * `deriveBinding` is the authoritative gate, so an over-arm just polls a little then declines. Mirrors
+ * `recordDispatch`'s env/redirect leading-token skip so `LC_ALL=C sudo …` / `>log ssh …` still arm.
+ */
+function looksLikeCredential(command: string): boolean {
+  for (const seg of tokenizeCommandSegmentsWithOps(command)) {
+    const { tokens } = seg;
+    let start = 0;
+    // Skip leading env-assignments (`FOO=bar`) — the redirect forms are rare on a credential command and a
+    // miss only under-arms a redirected credential command (bounded: the periodic tick still reconciles).
+    while (tokens[start] !== undefined && ENV_ASSIGN_RE.test(tokens[start])) start++;
+    if (CREDENTIAL_PROGRAMS.has(programOf(tokens[start]))) return true;
+  }
+  return false;
+}

--- a/src/engine/key-locker/key-locker-capture-driver.ts
+++ b/src/engine/key-locker/key-locker-capture-driver.ts
@@ -93,6 +93,9 @@ export type PollResult =
   | { status: "polling" }
   /** A NEWER dispatch replaced the arm during the prompt read — this poll aborts, the fresh arm polls next. */
   | { status: "superseded" }
+  /** The pane was SUNK to UNKNOWN (a doubt-tick — e.g. a user hand-ssh'd in) between the arm and the fill —
+   *  the frozen context is stale, so the arm is voided and the prompt is left for the human (Codex P1). */
+  | { status: "declined" }
   /** A poll is already in progress for this pane (serialized) — the caller should not re-drive. */
   | { status: "busy" }
   /** The poller lifetime elapsed with no prompt (a key-based ssh / cached sudo prints none) — disarmed. */
@@ -365,6 +368,18 @@ export class KeyLockerCaptureDriver {
       // is polled next tick (Codex L3-4-W2 R3 P1). Never clear the newer arm.
       if (rec.armed !== armed) return { status: "superseded" };
       if (verdict === null || !verdict.isCredentialPrompt) return { status: "polling" };
+
+      // LIVE-SESSION RE-CHECK before the fill (Codex W-2 REDO P1 — a disclosure the dispatch-time reconcile
+      // CANNOT catch). The arm's `frozen` was reconciled at DISPATCH, but an async tick AFTER that can sink the
+      // pane to UNKNOWN — e.g. the user hand-ssh's into a launched pane and a `tickWatch` W-2b scan
+      // markUnknowns it while a prior `sudo x` arm (frozen `{localhost}`) is still live. The frozen-derive W3
+      // closure (`getSession: () => armed.frozen`) would then fill the LOCAL secret into the now-REMOTE pane's
+      // prompt. So `poll` — the SINGLE fill chokepoint — re-reads the LIVE session here and DECLINES if it is
+      // no longer known. This reads `isKnownSession`, NOT frozen-equality: a session-changing credential like
+      // `ssh deploy@host-a` legitimately has `frozen`=local but a live POST-push host-a frame (both KNOWN), so
+      // requiring live==frozen would wrongly block that login's own prompt. Only a markUnknown (doubt) — the
+      // signal that the pane's context is no longer trustworthy — voids the arm.
+      if (!isKnownSession(this.deps.tracker.get(paneId))) { rec.armed = null; return { status: "declined" }; }
 
       // A credential prompt appeared → run the loop. Mark `pre-landed` (§0-CORR.3) FIRST so a command
       // delivered while the shell is blocked at this prompt — including the Mode-A `runToExit` landed re-run

--- a/src/engine/key-locker/key-locker-capture-driver.ts
+++ b/src/engine/key-locker/key-locker-capture-driver.ts
@@ -380,19 +380,30 @@ export class KeyLockerCaptureDriver {
       if (rec.armed !== armed) return { status: "superseded" };
       if (verdict === null || !verdict.isCredentialPrompt) return { status: "polling" };
 
+      // RECONCILE-THEN-TRUST before the fill (Codex R3 P1 — the poll can be the FIRST code to observe reality
+      // after the arm). The live-session guard below is only meaningful against a tracker that reflects the
+      // CURRENT process tree. But between arm and this poll, an external change — a user hand-ssh out of the
+      // launched pane, or a registered ssh exiting — may NOT yet have been reconciled (the separate `tickWatch`
+      // timer has not run), so `tracker.get()` would still read the STALE arm-time session and the guard would
+      // pass. So drive the SAME reconcile the dispatch path drives, HERE, right before the read: correlate any
+      // straggler child, then `watch.tick()` (NO exempt — there is no just-dispatched command to prove a child
+      // for; a user's in-bound ssh must fully flag). This is the poll-time half of reconcile-then-freeze.
+      this.correlateAllPending();
+      this.watch.tick();
+
       // LIVE-SESSION RE-CHECK before the fill (Codex R2 P1 + Opus R2 P2 — disclosures the DISPATCH-time
-      // reconcile CANNOT catch, because the change happens AFTER the freeze). The arm's `frozen` was reconciled
-      // at dispatch, but an async tick between arm and fill can move the pane out from under it:
-      //   (P1) a doubt markUnknown — the user hand-ssh's into a launched pane, the W-2b scan sinks it — while a
-      //        prior `sudo x` arm (frozen `{localhost}`) is still live ⇒ a LOCAL secret into a now-REMOTE prompt;
-      //   (P2) a session-end POP — the pane's `ssh host-a` exits, a tick pops it to local — while a remote
-      //        `sudo x` arm (frozen `host-a`) is still live ⇒ a host-a secret into a now-LOCAL prompt.
-      // Both are cross-host disclosures the frozen-derive W3 closure (`getSession: () => armed.frozen`) would
-      // fill blind. So `poll` — the SINGLE fill chokepoint — re-reads the LIVE session and requires it to STILL
-      // match `armed.expected` (the POST-record frame the command's own prompt shows in), by execHost+isRemote.
-      // NOT frozen-equality: a session-changing `ssh deploy@host-a` has `frozen`=local but `expected`=host-a
-      // (its own push), so matching `expected` permits that login's own prompt while still catching an external
-      // pop/push/sink. Any mismatch (incl. UNKNOWN) ⇒ the pane is no longer the command's context ⇒ decline.
+      // reconcile CANNOT catch, because the change happens AFTER the freeze). Now that the tracker is freshly
+      // reconciled, re-read the LIVE session and require it to STILL match `armed.expected` (the POST-record
+      // frame the command's own prompt shows in), by execHost+isRemote:
+      //   (P1a) a doubt markUnknown — the user hand-ssh's in, the W-2b scan sinks it — while a prior `sudo x`
+      //         arm (frozen `{localhost}`) is still live ⇒ live UNKNOWN ≠ expected ⇒ a LOCAL secret would reach
+      //         a now-REMOTE prompt; declined.
+      //   (P2)  a session-end POP — the pane's `ssh host-a` exits, the tick pops it to local — while a remote
+      //         `sudo x` arm (frozen `host-a`) is still live ⇒ live localhost ≠ expected host-a ⇒ a host-a
+      //         secret would reach a now-LOCAL prompt; declined.
+      // Match `expected`, NOT `frozen`: a session-changing `ssh deploy@host-a` has `frozen`=local but
+      // `expected`=host-a (its own push), so matching `expected` permits that login's own prompt while catching
+      // any external pop/push/sink. Any mismatch (incl. UNKNOWN) ⇒ the pane is no longer the command's context.
       const live = this.deps.tracker.get(paneId);
       if (!isKnownSession(live) || live.execHost !== armed.expected.execHost || live.isRemote !== armed.expected.isRemote) {
         rec.armed = null;

--- a/src/engine/key-locker/key-locker-capture-driver.ts
+++ b/src/engine/key-locker/key-locker-capture-driver.ts
@@ -69,6 +69,7 @@ import {
   interactiveSshTarget,
   isKnownSession,
   programOf,
+  type PaneSession,
   type SessionFrame,
   type SessionTracker,
 } from "./session-tracker.js";
@@ -380,35 +381,15 @@ export class KeyLockerCaptureDriver {
       if (rec.armed !== armed) return { status: "superseded" };
       if (verdict === null || !verdict.isCredentialPrompt) return { status: "polling" };
 
-      // RECONCILE-THEN-TRUST before the fill (Codex R3 P1 — the poll can be the FIRST code to observe reality
-      // after the arm). The live-session guard below is only meaningful against a tracker that reflects the
-      // CURRENT process tree. But between arm and this poll, an external change — a user hand-ssh out of the
-      // launched pane, or a registered ssh exiting — may NOT yet have been reconciled (the separate `tickWatch`
-      // timer has not run), so `tracker.get()` would still read the STALE arm-time session and the guard would
-      // pass. So drive the SAME reconcile the dispatch path drives, HERE, right before the read: correlate any
-      // straggler child, then `watch.tick()` (NO exempt — there is no just-dispatched command to prove a child
-      // for; a user's in-bound ssh must fully flag). This is the poll-time half of reconcile-then-freeze.
-      this.correlateAllPending();
-      this.watch.tick();
-
-      // LIVE-SESSION RE-CHECK before the fill (Codex R2 P1 + Opus R2 P2 — disclosures the DISPATCH-time
-      // reconcile CANNOT catch, because the change happens AFTER the freeze). Now that the tracker is freshly
-      // reconciled, re-read the LIVE session and require it to STILL match `armed.expected` (the POST-record
-      // frame the command's own prompt shows in), by execHost+isRemote:
-      //   (P1a) a doubt markUnknown — the user hand-ssh's in, the W-2b scan sinks it — while a prior `sudo x`
-      //         arm (frozen `{localhost}`) is still live ⇒ live UNKNOWN ≠ expected ⇒ a LOCAL secret would reach
-      //         a now-REMOTE prompt; declined.
-      //   (P2)  a session-end POP — the pane's `ssh host-a` exits, the tick pops it to local — while a remote
-      //         `sudo x` arm (frozen `host-a`) is still live ⇒ live localhost ≠ expected host-a ⇒ a host-a
-      //         secret would reach a now-LOCAL prompt; declined.
-      // Match `expected`, NOT `frozen`: a session-changing `ssh deploy@host-a` has `frozen`=local but
-      // `expected`=host-a (its own push), so matching `expected` permits that login's own prompt while catching
-      // any external pop/push/sink. Any mismatch (incl. UNKNOWN) ⇒ the pane is no longer the command's context.
-      const live = this.deps.tracker.get(paneId);
-      if (!isKnownSession(live) || live.execHost !== armed.expected.execHost || live.isRemote !== armed.expected.isRemote) {
-        rec.armed = null;
-        return { status: "declined" };
-      }
+      // EARLY-DECLINE before opening the capture UI (Codex R2/R3 P1). The arm's `frozen` was reconciled at
+      // DISPATCH, but an async change between arm and this poll — a user hand-ssh out of the launched pane
+      // (doubt markUnknown), or a registered ssh exiting (session-end POP) — moves the pane out from under it.
+      // `liveSessionMatchesExpected` RECONCILES (the poll can be the FIRST code to observe reality; the tracker
+      // is stale until a tick — Codex R3) then checks the live session STILL matches `armed.expected`. A
+      // mismatch here avoids opening a capture dialog on an already-changed pane. This is NOT the load-bearing
+      // guard, though — the confirm/capture awaits below can change the session AFTER this check, so the
+      // AUTHORITATIVE re-check is at the INJECTION INSTANT (`runCaptureLoopFor`'s injectPane wrapper, Codex R4).
+      if (!this.liveSessionMatchesExpected(paneId, armed.expected)) { rec.armed = null; return { status: "declined" }; }
 
       // A credential prompt appeared → run the loop. Mark `pre-landed` (§0-CORR.3) FIRST so a command
       // delivered while the shell is blocked at this prompt — including the Mode-A `runToExit` landed re-run
@@ -462,12 +443,37 @@ export class KeyLockerCaptureDriver {
       rec.sshBaseline = new Set(sshDescendants(this.deps.snapshot(), rec.shellPid).keys());
     }
     this.watch.tick();
+    // ARM HYGIENE (Codex R1-R4 line 464): this tick may have popped/markUnknown'd a pane that holds a live
+    // arm from an earlier dispatch (a user hand-ssh'd in, or the session ended). The injection-instant guard
+    // already makes a stale fill IMPOSSIBLE, but leaving the arm set wastes polls and misreports
+    // `armedPaneIds`. Disarm any pane whose (freshly-reconciled) live session no longer matches its arm's
+    // `expected`. No extra tick — the tracker is already reconciled by the `watch.tick()` above.
+    for (const [paneId, rec] of this.panes) {
+      if (rec.armed !== null && !sessionMatches(this.tracker.get(paneId), rec.armed.expected)) rec.armed = null;
+    }
   }
 
   // ── internals ──────────────────────────────────────────────────────────────────────────────────────
 
   private get tracker(): SessionTracker { return this.deps.tracker; }
   private get watch(): SshSessionWatch { return this.deps.watch; }
+
+  /**
+   * RECONCILE-then-CHECK: the single "is it still safe to fill this arm?" test. Drives the SAME reconcile the
+   * dispatch path drives (correlate stragglers + `watch.tick()`, NO exempt — a user's in-bound ssh must fully
+   * flag), THEN checks the pane's live session STILL matches the arm's `expected` frame (execHost + isRemote).
+   * Used at BOTH the poll early-decline AND the INJECTION INSTANT — because the confirm/capture UI awaits
+   * between them can take arbitrary user time, during which an async tick can pop/markUnknown the session
+   * (Codex R3 line 408 / R4 line 524). The tracker only reflects reality after a tick, so the reconcile MUST
+   * precede the read. Returns false on any mismatch (incl. UNKNOWN) ⇒ the pane is no longer the command's
+   * context ⇒ do not fill. Matches `expected`, not `frozen`: a session-changing `ssh host-a` has frozen=local
+   * but expected=host-a (its own push), so its own login prompt fills while an external pop/push/sink declines.
+   */
+  private liveSessionMatchesExpected(paneId: string, expected: SessionFrame): boolean {
+    this.correlateAllPending();
+    this.watch.tick();
+    return sessionMatches(this.tracker.get(paneId), expected);
+  }
 
   /**
    * Register the freshly-spawned interactive-ssh child of EVERY pane whose straggler correlation is still
@@ -521,7 +527,20 @@ export class KeyLockerCaptureDriver {
       confirmPolicyFor: (k) => this.deps.confirmPolicyFor(k),
       capture: (id) => this.deps.capture(id),
       deleteSecret: (id) => this.deps.deleteSecret(id),
-      injectPane: (b, id, sub) => this.deps.injectPane(paneId, b, id, sub),
+      // INJECTION-INSTANT re-check (Codex R4 line 524 — the AUTHORITATIVE disclosure guard). The poll's
+      // early-decline ran BEFORE the loop; but `confirmPolicyFor`/`confirmInjection`/`capture` (a secure UI
+      // dialog the user interacts with) await for ARBITRARY time before we get here, and an async `tickWatch`
+      // can pop the ssh frame or markUnknown the pane DURING that wait. Injecting the FROZEN binding blind
+      // would then type e.g. a remote sudo secret into a now-LOCAL prompt (the ssh exited while the confirm UI
+      // was open) — a disclosure the pre-loop check cannot see. So RECONCILE + re-verify the live session STILL
+      // matches `armed.expected` at the exact injection instant; on mismatch ABORT with `target_mismatch` (the
+      // loop maps it to `fill_aborted` and, on the NO-MATCH path, its `finally` deletes the just-captured
+      // secret — reverse-orphan). This is the local-vs-remote analog of L2's window/title injection-instant
+      // re-verify, which does NOT catch a session change (plan §3 W3).
+      injectPane: (b, id, sub) =>
+        this.liveSessionMatchesExpected(paneId, armed.expected)
+          ? this.deps.injectPane(paneId, b, id, sub)
+          : Promise.resolve({ ok: false, code: "target_mismatch" } as InjectResult),
       awaitLanded: async (cmd) => {
         const result = await awaitLanded(
           {
@@ -544,6 +563,13 @@ export class KeyLockerCaptureDriver {
     };
     return runCaptureLoop(loopDeps, event);
   }
+}
+
+/** Does a live pane session STILL match the arm's `expected` context, by execHost + isRemote? (Not cwd —
+ *  cwd only steers git-remote derivation for the https-cred scheme, which is not a pane channel, so a cwd
+ *  drift cannot move a pane-injected secret cross-host.) UNKNOWN never matches (fail-safe). */
+function sessionMatches(live: PaneSession, expected: SessionFrame): boolean {
+  return isKnownSession(live) && live.execHost === expected.execHost && live.isRemote === expected.isRemote;
 }
 
 /**

--- a/src/engine/key-locker/key-locker-capture-driver.ts
+++ b/src/engine/key-locker/key-locker-capture-driver.ts
@@ -165,6 +165,14 @@ interface ArmedDispatch {
   command: string;
   /** The reconciled PRE-effect session the capture loop derives from (never a live tracker.get). */
   frozen: SessionFrame;
+  /** The POST-record session at arm time — the state the pane is EXPECTED to hold when the armed command's
+   *  own prompt shows (sudo/su: === frozen, non-session-changing; an ssh login: frozen + its own push). `poll`
+   *  re-checks the LIVE session against this before filling: any EXTERNAL change between arm and fill — a
+   *  session-end POP, a nested push, or a doubt markUnknown — means the pane is no longer the context the
+   *  command runs in, so the frozen binding must NOT be filled (Codex R2 P1 markUnknown + Opus R2 P2 async pop:
+   *  both are cross-host disclosures the DISPATCH-time reconcile cannot catch, the sink/pop being AFTER the
+   *  freeze). Comparing execHost + isRemote (not cwd — cwd only steers git-remote derivation, not disclosure). */
+  expected: SessionFrame;
   /** `nowMs()` when armed (poller lifetime, OQ-W-2). */
   armedAtMs: number;
 }
@@ -330,9 +338,12 @@ export class KeyLockerCaptureDriver {
     //     the pre-record `frozen` still looks local, so without the post-record check the trailing prompt
     //     would fill under a mis-derived binding (Codex L3-4-W2 R5 P1). Declining a sunk pane is fail-safe.
     //     The arm uses only the CHEAP sync pre-filter — the authoritative `deriveBinding` runs in the loop.
+    //     The POST-record frame is captured as `expected` (the state the command's own prompt shows in) so
+    //     `poll` can detect an EXTERNAL change before filling (Codex R2 P1 + Opus R2 P2).
+    const postRecord = this.tracker.get(paneId);
     rec.armed =
-      isKnownSession(frozen) && isKnownSession(this.tracker.get(paneId)) && looksLikeCredential(command)
-        ? { command, frozen, armedAtMs: this.deps.nowMs() }
+      isKnownSession(frozen) && isKnownSession(postRecord) && looksLikeCredential(command)
+        ? { command, frozen, expected: postRecord, armedAtMs: this.deps.nowMs() }
         : null;
   }
 
@@ -369,17 +380,24 @@ export class KeyLockerCaptureDriver {
       if (rec.armed !== armed) return { status: "superseded" };
       if (verdict === null || !verdict.isCredentialPrompt) return { status: "polling" };
 
-      // LIVE-SESSION RE-CHECK before the fill (Codex W-2 REDO P1 — a disclosure the dispatch-time reconcile
-      // CANNOT catch). The arm's `frozen` was reconciled at DISPATCH, but an async tick AFTER that can sink the
-      // pane to UNKNOWN — e.g. the user hand-ssh's into a launched pane and a `tickWatch` W-2b scan
-      // markUnknowns it while a prior `sudo x` arm (frozen `{localhost}`) is still live. The frozen-derive W3
-      // closure (`getSession: () => armed.frozen`) would then fill the LOCAL secret into the now-REMOTE pane's
-      // prompt. So `poll` — the SINGLE fill chokepoint — re-reads the LIVE session here and DECLINES if it is
-      // no longer known. This reads `isKnownSession`, NOT frozen-equality: a session-changing credential like
-      // `ssh deploy@host-a` legitimately has `frozen`=local but a live POST-push host-a frame (both KNOWN), so
-      // requiring live==frozen would wrongly block that login's own prompt. Only a markUnknown (doubt) — the
-      // signal that the pane's context is no longer trustworthy — voids the arm.
-      if (!isKnownSession(this.deps.tracker.get(paneId))) { rec.armed = null; return { status: "declined" }; }
+      // LIVE-SESSION RE-CHECK before the fill (Codex R2 P1 + Opus R2 P2 — disclosures the DISPATCH-time
+      // reconcile CANNOT catch, because the change happens AFTER the freeze). The arm's `frozen` was reconciled
+      // at dispatch, but an async tick between arm and fill can move the pane out from under it:
+      //   (P1) a doubt markUnknown — the user hand-ssh's into a launched pane, the W-2b scan sinks it — while a
+      //        prior `sudo x` arm (frozen `{localhost}`) is still live ⇒ a LOCAL secret into a now-REMOTE prompt;
+      //   (P2) a session-end POP — the pane's `ssh host-a` exits, a tick pops it to local — while a remote
+      //        `sudo x` arm (frozen `host-a`) is still live ⇒ a host-a secret into a now-LOCAL prompt.
+      // Both are cross-host disclosures the frozen-derive W3 closure (`getSession: () => armed.frozen`) would
+      // fill blind. So `poll` — the SINGLE fill chokepoint — re-reads the LIVE session and requires it to STILL
+      // match `armed.expected` (the POST-record frame the command's own prompt shows in), by execHost+isRemote.
+      // NOT frozen-equality: a session-changing `ssh deploy@host-a` has `frozen`=local but `expected`=host-a
+      // (its own push), so matching `expected` permits that login's own prompt while still catching an external
+      // pop/push/sink. Any mismatch (incl. UNKNOWN) ⇒ the pane is no longer the command's context ⇒ decline.
+      const live = this.deps.tracker.get(paneId);
+      if (!isKnownSession(live) || live.execHost !== armed.expected.execHost || live.isRemote !== armed.expected.isRemote) {
+        rec.armed = null;
+        return { status: "declined" };
+      }
 
       // A credential prompt appeared → run the loop. Mark `pre-landed` (§0-CORR.3) FIRST so a command
       // delivered while the shell is blocked at this prompt — including the Mode-A `runToExit` landed re-run

--- a/tests/unit/key-locker-capture-driver.test.ts
+++ b/tests/unit/key-locker-capture-driver.test.ts
@@ -1,0 +1,573 @@
+// key-locker-capture-driver.test.ts — ADR-014 R3 L3-4 W-2 REDO (the live-wiring CRUX, fire-AFTER-delivery).
+//
+// The driver wires the merged pure pipeline into a running loop while honoring W1/W2/W3. These tests drive
+// the REAL SessionTracker + REAL SshSessionWatch against a mutable fake process tree (so the reconcile
+// behavior is exercised end-to-end), faking only the capture/inject/prompt seams.
+//
+// ⚠ FIRE-AFTER-DELIVERY (§0-CORR): the S-A hook fires only AFTER a confirmed delivery, so the just-dispatched
+// ssh child is USUALLY ALREADY in the process tree at `onDispatch` — the tests set the child in the tree
+// BEFORE `onDispatch` and assert it is ARMED + CORRELATED (registered), NOT markUnknown'd. `onDispatch` is
+// now SYNCHRONOUS and arms on a CHEAP pre-filter (`looksLikeCredential`); the authoritative `deriveBinding`
+// runs only in the poll's capture loop. Pins:
+//   * W1 anchor: only a LAUNCHED pane derives; a pre-existing pane stays UNKNOWN → declines (P1-B).
+//   * §0-CORR.2 exempt: the assistant's OWN just-dispatched ssh (proven pid) is NOT flagged by the W-2b scan,
+//     yet a user's pre-existing / same-host DIFFERENT-pid ssh STILL flags → markUnknown (disclosure guard).
+//   * RECONCILE-then-FREEZE (W3, P1-A): a post-exit `sudo x` freezes localhost, NOT stale host-a.
+//   * §0-CORR.3 loopPhase: a dispatch during the PRE-landed window is DROPPED; a POST-landed one is admitted.
+//   * derive-then-record: `ssh b@host-b` derives from the host-a frame (pre-push).
+//   * single-flight (pollBusy): concurrent polls run one loop; a stale arm is superseded.
+//   * every CaptureLoopOutcome flows through as { status: "filled", outcome }.
+//   * W2 close: unwatchPane + forget same-turn.
+import { describe, expect, it, vi } from "vitest";
+import {
+  KeyLockerCaptureDriver,
+  type CaptureDriverDeps,
+  type PromptVerdict,
+} from "../../src/engine/key-locker/key-locker-capture-driver.js";
+import { SessionTracker, type SessionFrame } from "../../src/engine/key-locker/session-tracker.js";
+import { SshSessionWatch, type ProcessSnapshot } from "../../src/engine/key-locker/ssh-session-watch.js";
+import type { BindingUri } from "../../src/engine/key-locker/binding.js";
+import type { InjectResult } from "../../src/engine/key-locker/injector.js";
+import type { CaptureLoopOutcome, SaveChoice } from "../../src/engine/key-locker/capture-loop.js";
+import type { ExitCompletion } from "../../src/engine/key-locker/landed-detection.js";
+
+interface Proc { parent: number; name: string; start: number; argv?: string[] }
+
+function snapshotOf(procs: Record<number, Proc>): ProcessSnapshot {
+  const parentMap = new Map<number, number>();
+  for (const [pid, p] of Object.entries(procs)) parentMap.set(Number(pid), p.parent);
+  return {
+    parentMap,
+    identify: (pid) => {
+      const p = procs[pid];
+      return p !== undefined ? { name: p.name, startTimeMs: p.start } : { name: "", startTimeMs: 0 };
+    },
+    commandLine: (pid) => procs[pid]?.argv ?? null,
+  };
+}
+
+const SENDINPUT_OK = (verified = true): InjectResult => ({ ok: true, injector: "sendinput", verified });
+const PROMPT = (isCredentialPrompt: boolean): PromptVerdict => ({ isCredentialPrompt, tail: "", stillHiddenPrompt: false });
+const sshProc = (parent: number, host: string, start: number): Proc =>
+  ({ parent, name: "ssh", start, argv: ["ssh", `deploy@${host}`] });
+
+/** Records the (command, session) passed to every deriveBinding call (the loop derives; onDispatch does not). */
+interface Harness {
+  driver: KeyLockerCaptureDriver;
+  tracker: SessionTracker;
+  watch: SshSessionWatch;
+  setTree(procs: Record<number, Proc>): void;
+  deriveCalls: { command: string; session: SessionFrame }[];
+  deps: CaptureDriverDeps;
+  clock: { ms: number };
+}
+
+function makeHarness(o: Partial<CaptureDriverDeps> = {}, initialTree: Record<number, Proc> = {}): Harness {
+  let procs = initialTree;
+  const snapshot = (): ProcessSnapshot => snapshotOf(procs);
+  const tracker = new SessionTracker();
+  const watch = new SshSessionWatch({ snapshot, tracker });
+  const deriveCalls: { command: string; session: SessionFrame }[] = [];
+  const clock = { ms: 1000 };
+
+  // Default derive (the LOOP's authoritative gate): sudo → sudo binding bound to the frozen host; ssh
+  // user@host → ssh binding for host; anything else → null. Records the frozen session it was handed.
+  const deriveBinding = vi.fn(async (command: string, session: SessionFrame): Promise<BindingUri | null> => {
+    deriveCalls.push({ command, session: { ...session } });
+    if (command.startsWith("sudo")) return { scheme: "sudo", host: session.execHost, targetUser: "root" };
+    const m = /^ssh\s+(?:\S+@)?(\S+)/.exec(command);
+    if (m) return { scheme: "ssh", user: "u", host: m[1].replace(/^\S+@/, ""), port: 22, fpSet: [`SHA256:${m[1]}`] };
+    return null;
+  });
+
+  const deps: CaptureDriverDeps = {
+    tracker,
+    watch,
+    snapshot,
+    deriveBinding,
+    resolveBinding: vi.fn(async () => undefined), // NO MATCH by default (capture path)
+    bindBinding: vi.fn(),
+    confirmPolicyFor: vi.fn(() => false),
+    capture: vi.fn(async () => ({ captured: true })),
+    deleteSecret: vi.fn(async () => {}),
+    injectPane: vi.fn(async () => SENDINPUT_OK()),
+    confirmInjection: vi.fn(async () => true),
+    offerSave: vi.fn(async () => "save"),
+    mintOpaqueId: vi.fn(() => "opaque-1"),
+    now: vi.fn(() => "2026-07-07T00:00:00.000Z"),
+    runToExit: vi.fn(async () => ({ reason: "exited", exitCode: 0 })),
+    readPaneAfterAuth: vi.fn(async () => ({ tail: "", stillHiddenPrompt: false })),
+    readPromptTail: vi.fn(async () => PROMPT(false)), // no prompt by default
+    nowMs: vi.fn(() => clock.ms),
+    ...o,
+  };
+  const driver = new KeyLockerCaptureDriver(deps);
+  return { driver, tracker, watch, setTree: (p) => { procs = p; }, deriveCalls, deps, clock };
+}
+
+// A shell (1000) under a terminal host (500), with configurable ssh children.
+const shellTree = (extra: Record<number, Proc> = {}): Record<number, Proc> => ({
+  500: { parent: 0, name: "windowsterminal", start: 1 },
+  1000: { parent: 500, name: "powershell", start: 10 },
+  ...extra,
+});
+
+describe("KeyLockerCaptureDriver — W1 anchoring (launched panes only, P1-B)", () => {
+  it("a LAUNCHED pane is anchored known-local + watched; a credential dispatch arms", () => {
+    const h = makeHarness({}, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    expect(h.tracker.get("pane-1")).toEqual({ execHost: "localhost", isRemote: false });
+    expect(h.watch.isWatching("pane-1")).toBe(true);
+
+    h.driver.onDispatch("pane-1", "sudo apt update");
+    expect(h.driver.armedPaneIds()).toEqual(["pane-1"]);
+    // onDispatch is synchronous and does NOT derive — the loop derives on poll.
+    expect(h.deriveCalls).toEqual([]);
+  });
+
+  it("a PRE-EXISTING pane (never launched) is NOT anchored: onDispatch is a no-op, no arm, unknown", () => {
+    const h = makeHarness({}, shellTree());
+    h.driver.onDispatch("pane-x", "sudo apt update"); // never launched
+    expect(h.driver.armedPaneIds()).toEqual([]);
+    expect(h.tracker.get("pane-x")).toEqual({ unknown: true });
+  });
+
+  it("cwd from launch is anchored (for L1's configured-git-remote resolution)", () => {
+    const h = makeHarness({}, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000, "C:/work");
+    expect(h.tracker.get("pane-1")).toEqual({ execHost: "localhost", isRemote: false, cwd: "C:/work" });
+  });
+
+  it("the anchored localhost frame is the one the loop derives from", async () => {
+    const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)) }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onDispatch("pane-1", "sudo apt update");
+    await h.driver.poll("pane-1");
+    expect(h.deriveCalls.at(-1)?.session).toEqual({ execHost: "localhost", isRemote: false });
+  });
+});
+
+describe("KeyLockerCaptureDriver — arm pre-filter (looksLikeCredential, OQ-W-3)", () => {
+  it("a non-credential command (`ls`) does NOT arm", () => {
+    const h = makeHarness({}, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onDispatch("pane-1", "ls -la");
+    expect(h.driver.armedPaneIds()).toEqual([]);
+  });
+
+  it("`sudo`/`doas`/`su` arm; a leading env-assignment is skipped (`LC_ALL=C sudo …` still arms)", () => {
+    const h = makeHarness({}, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onDispatch("pane-1", "LC_ALL=C sudo apt update");
+    expect(h.driver.armedPaneIds()).toEqual(["pane-1"]);
+  });
+
+  it("an UNKNOWN pane (sunk by reconcile) does not arm even for a credential command", () => {
+    const h = makeHarness({}, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.tracker.markUnknown("pane-1"); // simulate a prior sink
+    h.driver.onDispatch("pane-1", "sudo apt update");
+    expect(h.driver.armedPaneIds()).toEqual([]);
+  });
+
+  it("a conditional ssh that recordDispatch SINKS to UNKNOWN ⇒ decline (Codex R5 P1)", async () => {
+    const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)) }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    // `false && ssh host` is a conditional (skipped) ssh → recordDispatch markUnknowns the pane; the pre-record
+    // frozen still looks local, so the post-record gate must decline rather than arm the skipped ssh binding.
+    h.driver.onDispatch("pane-1", "false && ssh deploy@host-a ; sudo -v");
+    expect(h.tracker.get("pane-1")).toEqual({ unknown: true }); // recordDispatch sank it
+    expect(h.driver.armedPaneIds()).toEqual([]);                 // declined — not armed
+    expect((await h.driver.poll("pane-1")).status).toBe("idle");
+    expect(h.deps.capture).not.toHaveBeenCalled();               // the sudo prompt is left for the human
+  });
+});
+
+describe("KeyLockerCaptureDriver — fire-AFTER-delivery correlation (§0-CORR.2)", () => {
+  it("the child is ALREADY visible at dispatch ⇒ armed + correlated (noteSshOpened), NOT markUnknown'd", () => {
+    // THE fire-after case: `ssh deploy@host-a`'s child is in the tree when onDispatch fires. The exempt delta
+    // proves pid 2000 is THIS dispatch's child → the W-2b scan skips it (no mis-flag) → the frame is pushed
+    // and 2000 is registered synchronously in the SAME onDispatch turn.
+    const h = makeHarness({}, shellTree({ 2000: sshProc(1000, "host-a", 20) }));
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onDispatch("pane-1", "ssh deploy@host-a");
+    expect(h.tracker.get("pane-1")).toEqual({ execHost: "host-a", isRemote: true }); // NOT markUnknown'd
+    expect(h.tracker.remoteDepth("pane-1")).toBe(1);
+
+    // PROOF the registration took: kill 2000 → the watch pops the frame to local.
+    h.setTree(shellTree());
+    h.driver.tickWatch();
+    expect(h.tracker.get("pane-1")).toEqual({ execHost: "localhost", isRemote: false });
+  });
+
+  it("without the exempt the assistant's OWN ssh would be mis-flagged — so the exempt is load-bearing", () => {
+    // Demonstrate the negative: a plain `tickWatch` (no exempt) over the same tree DOES flag the ssh child,
+    // which is exactly why onDispatch passes the exempt. Here we drive tickWatch on a pane with a live but
+    // UNregistered interactive ssh — the W-2b scan markUnknowns it (the shared-pane disclosure guard).
+    const h = makeHarness({}, shellTree({ 2000: sshProc(1000, "host-a", 20) }));
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.tickWatch(); // no exempt — the unregistered interactive ssh trips the W-2b scan
+    expect(h.tracker.get("pane-1")).toEqual({ unknown: true });
+  });
+
+  it("a USER hand-ssh (unregistered) + assistant `sudo x` (dHost null, no exempt) ⇒ markUnknown (disclosure guard)", () => {
+    // The security crux: a local secret must never reach a remote prompt in a shared L3-launched pane the user
+    // drove an in-bound ssh into. `sudo x` has no interactive-ssh host ⇒ NO exempt ⇒ the W-2b scan flags the
+    // user's ssh ⇒ markUnknown ⇒ decline.
+    const h = makeHarness({}, shellTree({ 2000: { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "admin@secret-host"] } }));
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onDispatch("pane-1", "sudo x");
+    expect(h.tracker.get("pane-1")).toEqual({ unknown: true }); // sunk — LOCAL secret must not reach remote
+    expect(h.driver.armedPaneIds()).toEqual([]);
+  });
+
+  it("a PRE-EXISTING user ssh to the SAME host still flags even though the assistant's NEW child is exempt", () => {
+    // §0-CORR.2 counterexample: the user has an ssh to host-a open (pid 1500, in the baseline after a tick);
+    // the assistant then dispatches `ssh deploy@host-a` spawning a NEW child 2000. Only 2000 is exempt — the
+    // user's 1500 is a DIFFERENT pid the W-2b scan STILL flags ⇒ markUnknown (host is not identity).
+    const h = makeHarness({}, shellTree({ 1500: sshProc(1000, "host-a", 15) }));
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.tickWatch(); // fold the pre-existing 1500 into the baseline (and it markUnknowns — user ssh)
+    h.tracker.beginLocalSession("pane-1"); // re-anchor (the user pane is shared; simulate the driver re-seeing local)
+    // now the assistant dispatches ssh host-a → new child 2000 appears alongside the user's 1500
+    h.setTree(shellTree({ 1500: sshProc(1000, "host-a", 15), 2000: sshProc(1000, "host-a", 20) }));
+    h.driver.onDispatch("pane-1", "ssh deploy@host-a");
+    // 2000 is the assistant's (new since the baseline) and exempt; 1500 is pre-existing (in baseline) and NOT
+    // exempt → the W-2b scan flags it → markUnknown. The assistant's login does not get trusted over a lurking
+    // user session.
+    expect(h.tracker.get("pane-1")).toEqual({ unknown: true });
+  });
+
+  it("a straggler child (not visible at dispatch) is correlated on a later tick (fire-after slow-spawn backstop)", () => {
+    const h = makeHarness({}, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // child NOT visible yet → pending correlation
+    // the pane pushed host-a but has no registered child; a tick before the child appears markUnknowns (fail-safe)
+    // — but here the child appears, then a tick correlates it (register), and the frame survives.
+    h.setTree(shellTree({ 2000: sshProc(1000, "host-a", 20) }));
+    h.driver.tickWatch();
+    expect(h.tracker.get("pane-1")).toEqual({ execHost: "host-a", isRemote: true });
+    expect(h.tracker.remoteDepth("pane-1")).toBe(1);
+  });
+
+  it("a straggler that never appears before a tick ⇒ the unwatched frame markUnknowns (fail-safe OQ-W-9 residual)", () => {
+    const h = makeHarness({}, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // push, but the child has NOT spawned yet
+    h.driver.tickWatch(); // child invisible ⇒ nothing to register ⇒ backstop markUnknowns (safe decline)
+    expect(h.tracker.get("pane-1")).toEqual({ unknown: true }); // declines, NEVER wrong-targets
+  });
+
+  it("an argv-UNREADABLE new ssh child ⇒ NO exempt ⇒ markUnknown (fail-safe, never guess)", () => {
+    // The just-dispatched ssh's argv is unreadable (elevated/cross-user), so the exempt delta cannot host-match
+    // it → NO exempt → the W-2b scan flags the unreadable ssh descendant → markUnknown.
+    const h = makeHarness({}, shellTree({ 2000: { parent: 1000, name: "ssh", start: 20 /* no argv → null */ } }));
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onDispatch("pane-1", "ssh deploy@host-a");
+    expect(h.tracker.get("pane-1")).toEqual({ unknown: true });
+  });
+
+  it(">1 new same-host ssh at dispatch ⇒ ambiguous ⇒ NO exempt ⇒ markUnknown", () => {
+    // The assistant's ssh AND a user's same-host ssh both appear new in this window → newHostMatch length 2 →
+    // exemptPid null → the W-2b scan flags them → markUnknown (never guess which is the assistant's).
+    const h = makeHarness({}, shellTree({
+      2000: sshProc(1000, "host-a", 20),
+      2001: { parent: 1000, name: "ssh", start: 21, argv: ["ssh", "admin@host-a"] },
+    }));
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onDispatch("pane-1", "ssh deploy@host-a");
+    expect(h.tracker.get("pane-1")).toEqual({ unknown: true });
+  });
+
+  it("a pre-existing background TUNNEL is not mis-registered as the interactive login", () => {
+    // A pre-existing `ssh -fNL` tunnel (host-t, non-interactive) is a sibling. The interactive login to host-a
+    // spawns; only host-a is registered. Killing the TUNNEL must not pop the frame; killing the LOGIN must.
+    const tunnel: Proc = { parent: 1000, name: "ssh", start: 15, argv: ["ssh", "-fNL", "9000", "host-t"] };
+    const h = makeHarness({}, shellTree({ 1500: tunnel, 2000: sshProc(1000, "host-a", 20) }));
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // exempt 2000 (host-a), tunnel host is null ≠ host-a
+    expect(h.tracker.get("pane-1")).toEqual({ execHost: "host-a", isRemote: true });
+
+    h.setTree(shellTree({ 2000: sshProc(1000, "host-a", 20) })); // kill the tunnel, keep the login
+    h.driver.tickWatch();
+    expect(h.tracker.remoteDepth("pane-1")).toBe(1); // still remote — the registered login lives
+
+    h.setTree(shellTree()); // kill the login
+    h.driver.tickWatch();
+    expect(h.tracker.get("pane-1")).toEqual({ execHost: "localhost", isRemote: false });
+  });
+});
+
+describe("KeyLockerCaptureDriver — derive-then-record ordering (§3.1 point 1)", () => {
+  it("`ssh deploy@host-a` from localhost derives its OWN binding from the PRE-push (localhost) frame", async () => {
+    // The login command IS a credential (its ssh password prompt) AND session-changing. Its own binding must
+    // derive from the LOCALHOST frame it authenticates FROM (the frozen pre-push frame), while `recordDispatch`
+    // pushes host-a for SUBSEQUENT commands. (A NESTED `ssh @host-b` from host-a is a different case: the module
+    // deliberately declines it — depth≥2 is an unobservable inner login → markUnknown.)
+    const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)) }, shellTree({ 2000: sshProc(1000, "host-a", 20) }));
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // frozen = localhost (pre-push); records host-a after
+    expect(h.tracker.get("pane-1")).toEqual({ execHost: "host-a", isRemote: true }); // post-push frame
+    await h.driver.poll("pane-1"); // the loop derives the armed command from the FROZEN pre-push frame
+    const loopDerive = h.deriveCalls.find((c) => c.command === "ssh deploy@host-a");
+    expect(loopDerive?.session).toEqual({ execHost: "localhost", isRemote: false });
+  });
+});
+
+describe("KeyLockerCaptureDriver — RECONCILE-then-FREEZE (W3, P1-A)", () => {
+  it("reconcile-at-dispatch pops a dead ssh so a post-exit `sudo x` freezes localhost, NOT stale host-a", async () => {
+    const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)) }, shellTree({ 2000: sshProc(1000, "host-a", 20) }));
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // register host-a (child present)
+    expect(h.tracker.remoteDepth("pane-1")).toBe(1);
+
+    // the ssh session ended (2000 gone) — but the tracker STILL holds the stale host-a frame
+    h.setTree(shellTree());
+    // a later credential dispatch: reconcile-at-dispatch (tick) must pop host-a BEFORE the freeze
+    h.driver.onDispatch("pane-1", "sudo x");
+    expect(h.tracker.get("pane-1")).toEqual({ execHost: "localhost", isRemote: false });
+    await h.driver.poll("pane-1");
+    expect(h.deriveCalls.at(-1)).toEqual({ command: "sudo x", session: { execHost: "localhost", isRemote: false } });
+  });
+
+  it("the FROZEN frame survives an interleaved tick that pops the session before the prompt loop runs", async () => {
+    const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)) }, shellTree({ 2000: sshProc(1000, "host-a", 20) }));
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // register host-a
+    await h.driver.poll("pane-1"); // this poll's prompt fires a loop for the ssh; ignore its outcome
+
+    // dispatch a REMOTE `sudo x` (frozen = host-a)
+    h.driver.onDispatch("pane-1", "sudo x");
+    // an EXTERNAL event pops the ssh: 2000 exits + a tick reconciles → tracker now local
+    h.setTree(shellTree());
+    h.driver.tickWatch();
+    expect(h.tracker.get("pane-1")).toEqual({ execHost: "localhost", isRemote: false });
+
+    // the prompt loop for `sudo x` must still use the FROZEN host-a frame, not the now-local live value
+    h.deriveCalls.length = 0;
+    await h.driver.poll("pane-1");
+    const loopDerive = h.deriveCalls.find((c) => c.command === "sudo x");
+    expect(loopDerive?.session).toEqual({ execHost: "host-a", isRemote: true });
+  });
+});
+
+describe("KeyLockerCaptureDriver — loopPhase gate (§0-CORR.3)", () => {
+  it("a dispatch during the PRE-landed window (shell blocked at the prompt) is DROPPED (not recorded)", async () => {
+    let releaseCapture!: () => void;
+    const capture = vi.fn(() => new Promise<{ captured: boolean }>((res) => { releaseCapture = () => res({ captured: true }); }));
+    const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)), capture }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onDispatch("pane-1", "sudo x"); // arm
+
+    // start the loop; it BLOCKS in capture() → loopPhase = pre-landed (the shell is at the prompt)
+    const loopP = h.driver.poll("pane-1");
+    await new Promise((r) => setTimeout(r, 0));
+    expect(capture).toHaveBeenCalledTimes(1);
+
+    // a command delivered while the shell is blocked has NOT run — onDispatch must DROP it (no recordDispatch).
+    const derivesBefore = h.deriveCalls.length;
+    h.driver.onDispatch("pane-1", "ssh admin@host-b"); // would push host-b if wrongly admitted
+    expect(h.tracker.get("pane-1")).toEqual({ execHost: "localhost", isRemote: false }); // NOT host-b — dropped
+
+    releaseCapture();
+    expect((await loopP).status).toBe("filled"); // the original loop still completes correctly
+    expect(h.deriveCalls.length).toBeGreaterThanOrEqual(derivesBefore); // (the loop's own derive may run)
+  });
+
+  it("a REAL dispatch during a Mode-B loop's POST-landed window IS admitted (armed), not dropped", async () => {
+    let releaseOffer!: (c: SaveChoice) => void;
+    const offerSave = vi.fn(() => new Promise<SaveChoice>((res) => { releaseOffer = res; }));
+    const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)), offerSave }, shellTree({ 2000: sshProc(1000, "host-a", 20) }));
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // Mode-B login, arms host-a; child registered
+    const pLoop = h.driver.poll("pane-1");               // runs the loop; awaitLanded(Mode B) accepts → post-landed → blocks in offerSave
+    await new Promise((r) => setTimeout(r, 0));
+    expect(offerSave).toHaveBeenCalledTimes(1);
+    expect(h.tracker.get("pane-1")).toEqual({ execHost: "host-a", isRemote: true }); // logged into host-a
+
+    // the login SUCCEEDED (post-landed) — a genuine remote `sudo x2` now arrives while the loop is in offerSave.
+    // It must be ADMITTED (a fresh arm on host-a), not dropped as it would be during the pre-landed window.
+    h.driver.onDispatch("pane-1", "sudo x2");
+
+    releaseOffer("save");
+    await pLoop;
+    // PROOF of admission: the loop's finally clears ONLY its own (`ssh deploy@host-a`) arm. If `sudo x2` had
+    // been DROPPED, rec.armed would still BE that ssh arm → cleared → []. armedPaneIds=[pane-1] means a NEW arm
+    // (x2, admitted) replaced it and survived. (Contrast the pre-landed-drop test above, which stays localhost.)
+    expect(h.driver.armedPaneIds()).toEqual(["pane-1"]);
+  });
+
+  it("the Mode-A landed re-run fires onDispatch while still PRE-landed ⇒ dropped (W4-O2)", async () => {
+    let releaseRun!: () => void;
+    const runToExit = vi.fn((): Promise<ExitCompletion> => new Promise((res) => { releaseRun = () => res({ reason: "exited", exitCode: 0 }); }));
+    const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)), runToExit }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onDispatch("pane-1", "sudo x"); // Mode-A one-shot, arms
+    const pLoop = h.driver.poll("pane-1");    // loop blocks in runToExit (awaitLanded Mode A) — still pre-landed
+    await new Promise((r) => setTimeout(r, 0));
+    const derivesBefore = h.deriveCalls.length;
+    h.driver.onDispatch("pane-1", "sudo x");  // the SAME-command Mode-A re-run → must be dropped (pre-landed)
+    expect(h.deriveCalls.length).toBe(derivesBefore); // no new arm-derive path ran (dropped)
+    releaseRun();
+    await pLoop;
+  });
+});
+
+describe("KeyLockerCaptureDriver — single-flight + stale-arm guards", () => {
+  it("concurrent polls for one pane run only ONE capture loop (pollBusy serialize)", async () => {
+    let releasePrompt!: (v: PromptVerdict) => void;
+    const readPromptTail = vi.fn(() => new Promise<PromptVerdict>((res) => { releasePrompt = res; }));
+    const h = makeHarness({ readPromptTail }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onDispatch("pane-1", "sudo x");
+
+    const p1 = h.driver.poll("pane-1");             // sets pollBusy, awaits the (blocked) prompt read
+    await new Promise((r) => setTimeout(r, 0));
+    const p2 = await h.driver.poll("pane-1");        // re-entrant while p1 pends → dropped
+    expect(p2.status).toBe("busy");
+    expect(readPromptTail).toHaveBeenCalledTimes(1);
+
+    releasePrompt(PROMPT(true));
+    expect((await p1).status).toBe("filled");
+    expect(h.deps.capture).toHaveBeenCalledTimes(1); // exactly ONE capture loop
+  });
+
+  it("a poll whose arm was overwritten mid-read aborts (superseded) — never fills the newer prompt under the older binding", async () => {
+    let releasePrompt!: (v: PromptVerdict) => void;
+    const readPromptTail = vi.fn(() => new Promise<PromptVerdict>((res) => { releasePrompt = res; }));
+    const h = makeHarness({ readPromptTail }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onDispatch("pane-1", "sudo x"); // arm A (sudo, cached — no prompt of its own)
+
+    const pA = h.driver.poll("pane-1");        // captures armed=A(sudo), awaits the blocked prompt read
+    await new Promise((r) => setTimeout(r, 0));
+    // a NEWER credential command lands while the read is pending — onDispatch is not gated by pollBusy
+    h.driver.onDispatch("pane-1", "sudo -u alice other"); // overwrites rec.armed = B
+    releasePrompt(PROMPT(true));
+
+    expect((await pA).status).toBe("superseded");   // aborts — does NOT fill the newer prompt under A
+    expect(h.deps.capture).not.toHaveBeenCalled();
+    expect(h.driver.armedPaneIds()).toEqual(["pane-1"]); // the newer arm B survives to be polled next
+  });
+});
+
+describe("KeyLockerCaptureDriver — poll lifecycle + outcome pass-through", () => {
+  it("polls until a credential prompt appears, then runs the loop and disarms", async () => {
+    const verdicts = [PROMPT(false), PROMPT(false), PROMPT(true)];
+    let i = 0;
+    const h = makeHarness({ readPromptTail: vi.fn(async () => verdicts[Math.min(i++, verdicts.length - 1)]) }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onDispatch("pane-1", "sudo x");
+
+    expect((await h.driver.poll("pane-1")).status).toBe("polling");
+    expect((await h.driver.poll("pane-1")).status).toBe("polling");
+    expect((await h.driver.poll("pane-1")).status).toBe("filled");
+    expect(h.driver.armedPaneIds()).toEqual([]); // disarmed after the loop
+  });
+
+  it("a MATCH autofill flows through as { status: 'filled', outcome: filled_from_store }", async () => {
+    const h = makeHarness({
+      readPromptTail: vi.fn(async () => PROMPT(true)),
+      resolveBinding: vi.fn(async () => ({ opaqueId: "stored-1" })), // MATCH
+      confirmPolicyFor: vi.fn(() => false),
+    }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onDispatch("pane-1", "sudo x");
+    const r = await h.driver.poll("pane-1");
+    expect(r).toEqual({ status: "filled", outcome: { kind: "filled_from_store", verified: true } satisfies CaptureLoopOutcome });
+  });
+
+  it("a rejected D2 confirm on a MATCH flows through as { status: 'filled', outcome: confirm_rejected }", async () => {
+    const h = makeHarness({
+      readPromptTail: vi.fn(async () => PROMPT(true)),
+      resolveBinding: vi.fn(async () => ({ opaqueId: "stored-1" })),
+      confirmPolicyFor: vi.fn(() => true),
+      confirmInjection: vi.fn(async () => false),
+    }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onDispatch("pane-1", "sudo x");
+    const r = await h.driver.poll("pane-1");
+    expect(r).toEqual({ status: "filled", outcome: { kind: "confirm_rejected" } satisfies CaptureLoopOutcome });
+    expect(h.deps.injectPane).not.toHaveBeenCalled();
+  });
+
+  it("a NO-MATCH capture→inject→landed→[Save] flows through as { status: 'filled', outcome: saved }", async () => {
+    const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)) }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onDispatch("pane-1", "sudo x");
+    const r = await h.driver.poll("pane-1");
+    expect(r).toEqual({ status: "filled", outcome: { kind: "saved", verified: true } satisfies CaptureLoopOutcome });
+    expect(h.deps.bindBinding).toHaveBeenCalledOnce();
+  });
+
+  it("a cancelled capture flows through as { status: 'filled', outcome: capture_cancelled }", async () => {
+    const h = makeHarness({
+      readPromptTail: vi.fn(async () => PROMPT(true)),
+      capture: vi.fn(async () => ({ captured: false })),
+    }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onDispatch("pane-1", "sudo x");
+    const r = await h.driver.poll("pane-1");
+    expect(r).toEqual({ status: "filled", outcome: { kind: "capture_cancelled" } satisfies CaptureLoopOutcome });
+  });
+
+  it("a not-landed credential flows through as discarded/not_landed + reverse-orphan delete", async () => {
+    const h = makeHarness({
+      readPromptTail: vi.fn(async () => PROMPT(true)),
+      runToExit: vi.fn(async () => ({ reason: "timeout" })), // Mode A not exit-0
+    }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onDispatch("pane-1", "sudo x");
+    const r = await h.driver.poll("pane-1");
+    expect(r.status).toBe("filled");
+    expect((r as { outcome: CaptureLoopOutcome }).outcome).toMatchObject({ kind: "discarded", reason: "not_landed" });
+    expect(h.deps.deleteSecret).toHaveBeenCalledOnce();
+  });
+
+  it("poller lifetime elapses with no prompt ⇒ timed_out + disarm (OQ-W-2)", async () => {
+    const h = makeHarness({ pollTimeoutMs: 5000 }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.clock.ms = 1000;
+    h.driver.onDispatch("pane-1", "sudo x"); // armedAt = 1000
+    h.clock.ms = 7000; // > 1000 + 5000
+    expect((await h.driver.poll("pane-1")).status).toBe("timed_out");
+    expect(h.driver.armedPaneIds()).toEqual([]);
+  });
+
+  it("poll on an idle / unarmed pane ⇒ idle", async () => {
+    const h = makeHarness({}, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    expect((await h.driver.poll("pane-1")).status).toBe("idle");
+    expect((await h.driver.poll("never-launched")).status).toBe("idle");
+  });
+});
+
+describe("KeyLockerCaptureDriver — multi-pane correlation isolation", () => {
+  const twoShells = (extra: Record<number, Proc> = {}): Record<number, Proc> => ({
+    500: { parent: 0, name: "windowsterminal", start: 1 },
+    1000: { parent: 500, name: "powershell", start: 10 },
+    1100: { parent: 500, name: "powershell", start: 11 },
+    ...extra,
+  });
+
+  it("another pane's onDispatch does NOT markUnknown pane-1's registered ssh frame", () => {
+    const h = makeHarness({}, twoShells({ 2000: sshProc(1000, "host-a", 20) }));
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-2", 1100);
+    h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // pane-1 registers host-a (child present)
+    expect(h.tracker.get("pane-1")).toEqual({ execHost: "host-a", isRemote: true });
+    h.driver.onDispatch("pane-2", "ls");                // pane-2's tick reconciles ALL panes
+    expect(h.tracker.get("pane-1")).toEqual({ execHost: "host-a", isRemote: true }); // pane-1 survives
+  });
+});
+
+describe("KeyLockerCaptureDriver — W2 close atomicity", () => {
+  it("onPaneClosed unwatches + forgets the pane (same turn)", () => {
+    const h = makeHarness({}, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    expect(h.watch.isWatching("pane-1")).toBe(true);
+    h.driver.onPaneClosed("pane-1");
+    expect(h.watch.isWatching("pane-1")).toBe(false);
+    expect(h.tracker.get("pane-1")).toEqual({ unknown: true });
+  });
+});

--- a/tests/unit/key-locker-capture-driver.test.ts
+++ b/tests/unit/key-locker-capture-driver.test.ts
@@ -330,24 +330,45 @@ describe("KeyLockerCaptureDriver — RECONCILE-then-FREEZE (W3, P1-A)", () => {
     expect(h.deriveCalls.at(-1)).toEqual({ command: "sudo x", session: { execHost: "localhost", isRemote: false } });
   });
 
-  it("the FROZEN frame survives an interleaved tick that pops the session before the prompt loop runs", async () => {
+  it("a remote `sudo x` whose ssh session POPS to local between arm and fill DECLINES (Opus R2 P2 — no cross-host disclosure)", async () => {
     const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)) }, shellTree({ 2000: sshProc(1000, "host-a", 20) }));
     h.driver.onLocalPaneLaunched("pane-1", 1000);
     h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // register host-a
     await h.driver.poll("pane-1"); // this poll's prompt fires a loop for the ssh; ignore its outcome
 
-    // dispatch a REMOTE `sudo x` (frozen = host-a)
+    // dispatch a REMOTE `sudo x` (frozen = host-a, expected = host-a)
     h.driver.onDispatch("pane-1", "sudo x");
-    // an EXTERNAL event pops the ssh: 2000 exits + a tick reconciles → tracker now local
+    // an EXTERNAL event pops the ssh: 2000 exits + a tick reconciles → tracker now LOCAL (a valid pop, still KNOWN)
     h.setTree(shellTree());
     h.driver.tickWatch();
     expect(h.tracker.get("pane-1")).toEqual({ execHost: "localhost", isRemote: false });
 
-    // the prompt loop for `sudo x` must still use the FROZEN host-a frame, not the now-local live value
+    // the arm's expected=host-a no longer matches the live localhost → filling frozen host-a's secret into the
+    // now-LOCAL pane would be a cross-host disclosure. DECLINE (isKnownSession alone would MISS this — both
+    // frames are KNOWN — which is why the guard matches execHost+isRemote against `expected`).
     h.deriveCalls.length = 0;
-    await h.driver.poll("pane-1");
+    vi.mocked(h.deps.capture).mockClear();      // the earlier ssh-login poll captured; isolate the sudo-x poll
+    vi.mocked(h.deps.injectPane).mockClear();
+    const r = await h.driver.poll("pane-1");
+    expect(r.status).toBe("declined");
+    expect(h.deps.capture).not.toHaveBeenCalled();
+    expect(h.deps.injectPane).not.toHaveBeenCalled();
+    expect(h.deriveCalls).toEqual([]); // never even derived
+  });
+
+  it("a remote `sudo x` whose session is UNCHANGED between arm and fill DOES fill from the frozen host-a frame", async () => {
+    // The legitimate remote fill: no external change, so live == expected == host-a → the loop derives the
+    // armed command from the FROZEN host-a frame (the freeze still gives a deterministic derive).
+    const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)) }, shellTree({ 2000: sshProc(1000, "host-a", 20) }));
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // register host-a
+    await h.driver.poll("pane-1"); // ignore the ssh login loop
+    h.driver.onDispatch("pane-1", "sudo x"); // frozen = host-a, expected = host-a (2000 still alive)
+    h.deriveCalls.length = 0;
+    const r = await h.driver.poll("pane-1");
+    expect(r.status).toBe("filled");
     const loopDerive = h.deriveCalls.find((c) => c.command === "sudo x");
-    expect(loopDerive?.session).toEqual({ execHost: "host-a", isRemote: true });
+    expect(loopDerive?.session).toEqual({ execHost: "host-a", isRemote: true }); // derived from the frozen frame
   });
 });
 

--- a/tests/unit/key-locker-capture-driver.test.ts
+++ b/tests/unit/key-locker-capture-driver.test.ts
@@ -413,6 +413,44 @@ describe("KeyLockerCaptureDriver — loopPhase gate (§0-CORR.3)", () => {
   });
 });
 
+describe("KeyLockerCaptureDriver — a pane sunk to UNKNOWN after arming is not filled (Codex W-2 REDO P1)", () => {
+  it("a launched pane armed for `sudo x` (frozen localhost), then user-ssh'd in + markUnknown'd by a tick, DECLINES the fill", async () => {
+    // THE disclosure the dispatch-time reconcile cannot catch: the sink happens AFTER the freeze. Without the
+    // poll's live-session re-check the loop would fill the LOCAL sudo secret into the now-REMOTE pane's prompt.
+    const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)) }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onDispatch("pane-1", "sudo x"); // armed, frozen = { localhost }
+    expect(h.driver.armedPaneIds()).toEqual(["pane-1"]);
+
+    // the USER hand-ssh's into the shared launched pane; a periodic tick's W-2b scan markUnknowns the pane
+    h.setTree(shellTree({ 2000: { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "admin@secret-host"] } }));
+    h.driver.tickWatch();
+    expect(h.tracker.get("pane-1")).toEqual({ unknown: true });
+
+    // a poll must DECLINE (the frozen localhost binding must NOT reach the remote prompt) and disarm
+    const r = await h.driver.poll("pane-1");
+    expect(r.status).toBe("declined");
+    expect(h.deps.capture).not.toHaveBeenCalled();
+    expect(h.deps.injectPane).not.toHaveBeenCalled();
+    expect(h.driver.armedPaneIds()).toEqual([]); // disarmed — no stale arm lingers
+  });
+
+  it("a pane sunk to UNKNOWN mid prompt-read (async) declines rather than fills", async () => {
+    let releasePrompt!: (v: PromptVerdict) => void;
+    const readPromptTail = vi.fn(() => new Promise<PromptVerdict>((res) => { releasePrompt = res; }));
+    const h = makeHarness({ readPromptTail }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onDispatch("pane-1", "sudo x"); // armed on localhost
+    const p = h.driver.poll("pane-1");         // awaits the blocked prompt read
+    await new Promise((r) => setTimeout(r, 0));
+    // the pane is sunk WHILE the prompt read is pending (a user ssh'd in + an interleaved tick)
+    h.tracker.markUnknown("pane-1");
+    releasePrompt(PROMPT(true));
+    expect((await p).status).toBe("declined");
+    expect(h.deps.capture).not.toHaveBeenCalled();
+  });
+});
+
 describe("KeyLockerCaptureDriver — single-flight + stale-arm guards", () => {
   it("concurrent polls for one pane run only ONE capture loop (pollBusy serialize)", async () => {
     let releasePrompt!: (v: PromptVerdict) => void;

--- a/tests/unit/key-locker-capture-driver.test.ts
+++ b/tests/unit/key-locker-capture-driver.test.ts
@@ -456,6 +456,23 @@ describe("KeyLockerCaptureDriver — a pane sunk to UNKNOWN after arming is not 
     expect(h.driver.armedPaneIds()).toEqual([]); // disarmed — no stale arm lingers
   });
 
+  it("the poll RECONCILES before trusting the live session — a user hand-ssh'd in with NO tickWatch between still declines (Codex R3 P1)", async () => {
+    // The deepest form: the poll is the FIRST code to observe reality after the arm. Without a poll-time
+    // reconcile, `tracker.get()` still reads the STALE arm-time localhost session (no tickWatch has run to
+    // markUnknown it), so the live-check would PASS and fill the local secret into the now-remote prompt.
+    const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)) }, shellTree());
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onDispatch("pane-1", "sudo x"); // armed, expected = { localhost }
+    // the USER hand-ssh's in — but NO tickWatch fires. The tracker is still stale-local until the poll reconciles.
+    h.setTree(shellTree({ 2000: { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "admin@secret-host"] } }));
+    expect(h.tracker.get("pane-1")).toEqual({ execHost: "localhost", isRemote: false }); // STALE — not yet reconciled
+
+    const r = await h.driver.poll("pane-1"); // the poll's own reconcile must W-2b-markUnknown the pane, then decline
+    expect(r.status).toBe("declined");
+    expect(h.deps.capture).not.toHaveBeenCalled();
+    expect(h.tracker.get("pane-1")).toEqual({ unknown: true }); // the poll reconcile sank it
+  });
+
   it("a pane sunk to UNKNOWN mid prompt-read (async) declines rather than fills", async () => {
     let releasePrompt!: (v: PromptVerdict) => void;
     const readPromptTail = vi.fn(() => new Promise<PromptVerdict>((res) => { releasePrompt = res; }));

--- a/tests/unit/key-locker-capture-driver.test.ts
+++ b/tests/unit/key-locker-capture-driver.test.ts
@@ -338,19 +338,20 @@ describe("KeyLockerCaptureDriver — RECONCILE-then-FREEZE (W3, P1-A)", () => {
 
     // dispatch a REMOTE `sudo x` (frozen = host-a, expected = host-a)
     h.driver.onDispatch("pane-1", "sudo x");
-    // an EXTERNAL event pops the ssh: 2000 exits + a tick reconciles → tracker now LOCAL (a valid pop, still KNOWN)
+    // an EXTERNAL event pops the ssh: 2000 exits + a tick reconciles → tracker now LOCAL (a valid pop, still
+    // KNOWN). The tick's arm-hygiene sees the arm's expected=host-a no longer matches the live localhost — a
+    // cross-host mismatch (isKnownSession alone would MISS it: both frames are KNOWN) — and disarms.
     h.setTree(shellTree());
     h.driver.tickWatch();
     expect(h.tracker.get("pane-1")).toEqual({ execHost: "localhost", isRemote: false });
+    expect(h.driver.armedPaneIds()).toEqual([]); // disarmed by the hygiene — host-a secret can't reach the now-local pane
 
-    // the arm's expected=host-a no longer matches the live localhost → filling frozen host-a's secret into the
-    // now-LOCAL pane would be a cross-host disclosure. DECLINE (isKnownSession alone would MISS this — both
-    // frames are KNOWN — which is why the guard matches execHost+isRemote against `expected`).
+    // a subsequent poll is idle; frozen host-a's secret is NEVER filled into the now-local pane
     h.deriveCalls.length = 0;
     vi.mocked(h.deps.capture).mockClear();      // the earlier ssh-login poll captured; isolate the sudo-x poll
     vi.mocked(h.deps.injectPane).mockClear();
     const r = await h.driver.poll("pane-1");
-    expect(r.status).toBe("declined");
+    expect(r.status).toBe("idle");
     expect(h.deps.capture).not.toHaveBeenCalled();
     expect(h.deps.injectPane).not.toHaveBeenCalled();
     expect(h.deriveCalls).toEqual([]); // never even derived
@@ -443,17 +444,18 @@ describe("KeyLockerCaptureDriver — a pane sunk to UNKNOWN after arming is not 
     h.driver.onDispatch("pane-1", "sudo x"); // armed, frozen = { localhost }
     expect(h.driver.armedPaneIds()).toEqual(["pane-1"]);
 
-    // the USER hand-ssh's into the shared launched pane; a periodic tick's W-2b scan markUnknowns the pane
+    // the USER hand-ssh's into the shared launched pane; a periodic tick's W-2b scan markUnknowns the pane AND
+    // the tick's arm-hygiene disarms it (the live session no longer matches the arm's expected localhost).
     h.setTree(shellTree({ 2000: { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "admin@secret-host"] } }));
     h.driver.tickWatch();
     expect(h.tracker.get("pane-1")).toEqual({ unknown: true });
+    expect(h.driver.armedPaneIds()).toEqual([]); // the tick's hygiene already disarmed — no stale arm lingers
 
-    // a poll must DECLINE (the frozen localhost binding must NOT reach the remote prompt) and disarm
+    // a subsequent poll finds nothing to do (idle); the frozen localhost binding NEVER reaches the remote prompt
     const r = await h.driver.poll("pane-1");
-    expect(r.status).toBe("declined");
+    expect(r.status).toBe("idle");
     expect(h.deps.capture).not.toHaveBeenCalled();
     expect(h.deps.injectPane).not.toHaveBeenCalled();
-    expect(h.driver.armedPaneIds()).toEqual([]); // disarmed — no stale arm lingers
   });
 
   it("the poll RECONCILES before trusting the live session — a user hand-ssh'd in with NO tickWatch between still declines (Codex R3 P1)", async () => {
@@ -471,6 +473,34 @@ describe("KeyLockerCaptureDriver — a pane sunk to UNKNOWN after arming is not 
     expect(r.status).toBe("declined");
     expect(h.deps.capture).not.toHaveBeenCalled();
     expect(h.tracker.get("pane-1")).toEqual({ unknown: true }); // the poll reconcile sank it
+  });
+
+  it("the session changes DURING the capture/confirm await ⇒ the injection instant re-checks and ABORTS (Codex R4 line 524)", async () => {
+    // The deepest disclosure: the poll's pre-loop check passed, but the capture UI (arbitrary user time) is
+    // open when the ssh exits. The injection-instant re-check must catch it — the pre-loop check cannot.
+    let releaseCapture!: () => void;
+    const capture = vi.fn(() => new Promise<{ captured: boolean }>((res) => { releaseCapture = () => res({ captured: true }); }));
+    const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)), capture }, shellTree({ 2000: sshProc(1000, "host-a", 20) }));
+    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // register host-a (child present) — no poll needed
+    h.driver.onDispatch("pane-1", "sudo x");             // remote sudo, frozen = expected = host-a; re-arms
+
+    const loopP = h.driver.poll("pane-1");               // pre-loop check passes (live host-a); loop BLOCKS in capture()
+    await new Promise((r) => setTimeout(r, 0));
+    expect(capture).toHaveBeenCalledTimes(1);
+    vi.mocked(h.deps.injectPane).mockClear();
+
+    // WHILE the capture dialog is open, the ssh session ends (2000 exits). No explicit tickWatch — the
+    // injection-instant re-check drives its own reconcile.
+    h.setTree(shellTree());
+    releaseCapture();
+    const r = await loopP;
+
+    // the injection instant reconciled → live localhost ≠ expected host-a → ABORT before injectPane
+    expect(r.status).toBe("filled");
+    expect((r as { outcome: CaptureLoopOutcome }).outcome).toMatchObject({ kind: "fill_aborted", code: "target_mismatch" });
+    expect(h.deps.injectPane).not.toHaveBeenCalled();     // never delivered the secret
+    expect(h.deps.deleteSecret).toHaveBeenCalled();       // reverse-orphan: the captured secret is deleted
   });
 
   it("a pane sunk to UNKNOWN mid prompt-read (async) declines rather than fills", async () => {


### PR DESCRIPTION
## What this is

**W-2 REDO** — the capture DRIVER, the CRUX of the Key Locker live wiring, redesigned for the **fire-AFTER-delivery** model (plan §0-CORR). Supersedes PR #513's fire-before driver (now draft/on-hold): Codex's 8-round review of #513 surfaced that the merged W-1 (#511) fires the S-A dispatch hook **only on a confirmed-successful delivery**, so `onDispatch` reacts to a command that has ALREADY run and whose ssh child can ALREADY be in the process tree — a foundational timing assumption the fire-before design got wrong.

Engine-pure over injected seams (no Win32/host/terminal import), so the whole wrong-target story is unit-tested with a fake process tree. The thin impure composition root (W-4) binds the seams to real hooks + Win32.

## The three fire-after consequences (§0-CORR)

- **(A) `onDispatch` is FULLY SYNCHRONOUS (OQ-W-13 fold).** The old `await deriveBinding` inside the handler produced the entire await-window bug class (#513 R2–R5). With the sync fold the handler runs atomically — no interleaving — so `dispatchSeq` + clear-at-start + the token gate all **collapse and are deleted**. It arms on a cheap `looksLikeCredential` pre-filter (`programOf(first real token of any segment) ∈ {sudo,doas,ssh,su}`, a generous superset); the poll's capture loop runs the authoritative `deriveBinding`. Over-arming just declines `not_a_credential`.
- **(B) The W-2b scan EXEMPTS the assistant's OWN just-dispatched ssh (§0-CORR.2).** With the child already visible, the reconcile's W-2b scan would classify the assistant's own `ssh host-a` as a lurking USER ssh → markUnknown → its login never arms. The driver proves the exact child pid via a per-pane **`sshBaseline` delta** (host-matched to the dispatched host) and passes `watch.tick({ paneId, pid, startTimeMs })` (the W-0.5 exempt, #514) to skip only that one process. A user's **same-host ssh is a DIFFERENT pid ⇒ still flags**; **0 or >1 candidates ⇒ NO exempt** (fail-safe). Host is not identity (Codex W-0.5 P1); pid+creation-time closes reuse (P2).
- **(C) Post-LANDED loop-admit gate (§0-CORR.3, `loopPhase`).** During the pre-landed window the shell is BLOCKED at the credential prompt, so a delivered command has NOT run — recording it would put the tracker ahead of reality. `onDispatch` DROPS on `pre-landed`; the `awaitLanded` wrapper flips to `post-landed` on acceptance → subsequent real dispatches admitted. This REPLACES the `inRunToExit` / command-match gates (both admitted the pre-auth window). The Mode-A `runToExit` landed re-run fires while still pre-landed ⇒ dropped (W4-O2).

## What SURVIVES from #513 (unchanged security spine)

Reconcile-then-freeze (P1-A) + the post-record-sink gate (R5) + the frozen-derive W3 closure + `correlateAllPending` straggler backstop (OQ-W-5) + `pollBusy` single-flight + the `superseded` re-validation + `onPaneClosed` W2 + the wrong-target invariants. **Deleted:** `dispatchSeq`/clear/token, `inRunToExit`, the §3.1 dispatch-time baseline (replaced by the continuous `sshBaseline`).

## Design notes for review

- **`dispatchedInteractiveSshHost` is AVAILABILITY-only, not security.** It host-matches the exempt delta. Any divergence from `recordDispatch`'s ssh detection only biases toward NO exempt → the W-2b scan then flags the assistant's own login → it declines (a bounded availability regression), never a wrong-target. So it mirrors `recordDispatch` without needing the hardened module's full rigor.
- **Nested logins decline by design.** A nested `ssh @host-b` from a host-a session pushes depth-2 → `noteSshOpened` markUnknowns (the inner login runs on the remote host, locally unobservable). The tests pin this (they do NOT expect a trusted host-b frame).

## Tests (35, fire-after)

W1 anchoring (launched-only, P1-B) / arm pre-filter (env-skip, unknown-pane decline, conditional-ssh sink) / **child ALREADY visible at dispatch ⇒ armed + correlated, NOT markUnknown'd** / **exempt is load-bearing (negative demo)** / **user hand-ssh + sudo ⇒ markUnknown (disclosure guard)** / **pre-existing same-host user ssh still flags under an exempt** / straggler correlation + fail-safe residual / argv-unreadable & >1 ⇒ markUnknown / tunnel not mis-registered / derive-then-record (pre-push frame) / reconcile-then-freeze (P1-A) + frozen survives interleaved tick / **loopPhase: pre-landed DROP, post-landed ADMIT, Mode-A re-run dropped** / single-flight + superseded / all CaptureLoopOutcomes / multi-pane isolation / W2 close.

## Verification

```
npm run build && npm run lint                                      # clean
npx vitest run --project unit tests/unit/key-locker-*.test.ts      # 364 passed
check:stub-catalog / check:failwith-fixtures                       # no drift (no new tool / failWith callsite)
```

No public tool change. Next: W-3 (manager tracker/watch ownership + Win32 snapshot adapter) → W-4 (wiring root) → live dogfood → release.

Plan: `desktop-touch-mcp-internal@fad05e8:docs/adr-014-v2-r3-l3-4-live-wiring-plan.md` (§0-CORR, §2.2, §3, §4 W-2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
