### PR TITLE
ADR-014 v2 R3 Key Locker — L3-4 W-3: manager owns tracker/watch + Win32 snapshot adapter

### DIFF
--- a/src/engine/key-locker/key-locker-manager.ts
+++ b/src/engine/key-locker/key-locker-manager.ts
@@ -132,9 +132,12 @@ export class KeyLockerManager {
   }
 
   /**
-   * One live process-tree snapshot for the watch/driver reconcile (W-3 §2.1 — the Win32 adapter). Wires the
-   * real (or injected) `buildProcessParentMap` + `getProcessIdentity` + `getProcessCommandLine` into the pure
-   * `ProcessSnapshot` shape. Two adaptations the watch's contract requires:
+   * One live process-tree snapshot for the watch/driver reconcile (W-3 §2.1 — the Win32 adapter). PUBLIC so
+   * the wiring root (W-4) can build the capture-driver's `snapshot` seam from the SAME manager-owned adapter
+   * the watch uses — passing `() => manager.snapshotProcessTree()` — rather than duplicating it and risking
+   * production/test drift (Codex W-3). Wires the real (or injected) `buildProcessParentMap` +
+   * `getProcessIdentity` + `getProcessCommandLine` into the pure `ProcessSnapshot` shape. Two adaptations the
+   * watch's contract requires:
    *   - `identify().name` is the native `processName` LOWERCASED (win32 does NOT lowercase at source; the watch
    *     compares against the lowercase literal `"ssh"`), with `startTimeMs` from `processStartTimeMs`.
    *   - `commandLine(pid)` passes `getProcessCommandLine` through verbatim (null on ANY read failure — the
@@ -143,7 +146,7 @@ export class KeyLockerManager {
    * empty identity (`{ name: "", startTimeMs: 0 }`) — the watch tolerates both (it skips a degenerate tick and
    * treats "" as gone-or-unreadable), so this adapter never throws.
    */
-  private snapshotProcessTree(): ProcessSnapshot {
+  snapshotProcessTree(): ProcessSnapshot {
     const w = this.opts.win32;
     const parentMapOf = w?.buildProcessParentMap ?? buildProcessParentMap;
     const identityOf = w?.getProcessIdentity ?? getProcessIdentityByPid;

--- a/src/engine/key-locker/key-locker-manager.ts
+++ b/src/engine/key-locker/key-locker-manager.ts
@@ -20,6 +20,9 @@ import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { HELPER_EXE, KeyLockerHost, type KeyLockerStartOptions } from "../key-locker-host.js";
+import { buildProcessParentMap, getProcessCommandLineByPid, getProcessIdentityByPid } from "../win32.js";
+import { SessionTracker } from "./session-tracker.js";
+import { SshSessionWatch, type ProcessSnapshot } from "./ssh-session-watch.js";
 
 /** Typed reject when a secret op is attempted before first-run consent is accepted (L4 §2). */
 export class KeyLockerConsentRequiredError extends Error {
@@ -76,6 +79,16 @@ export interface KeyLockerManagerOptions extends KeyLockerStartOptions {
   storeDir?: string;
   /** Injected monotonic-ish clock for idle-dispose dormancy (default `Date.now`); overridden in tests. */
   now?: () => number;
+  /**
+   * Win32 process-tree seams for the SshSessionWatch snapshot adapter (W-3, §2.1). Default to the real
+   * `win32.ts` bindings; tests inject a fake tree so the watch reconciliation unit-tests without native calls.
+   */
+  win32?: {
+    buildProcessParentMap: () => Map<number, number>;
+    /** Raw identity (native `processName` is NOT lowercased at source — the adapter lowercases it). */
+    getProcessIdentity: (pid: number) => { processName: string; processStartTimeMs: number };
+    getProcessCommandLine: (pid: number) => string[] | null;
+  };
 }
 
 /**
@@ -91,10 +104,58 @@ export class KeyLockerManager {
   private inFlight = 0;        // secret ops currently running through withHost (idle-dispose never runs mid-op)
   private lastActivityMs = 0;  // clock stamp of the last withHost completion (idle-dispose dormancy timer)
 
-  constructor(private readonly opts: KeyLockerManagerOptions = {}) {}
+  // W-3 (§2.1): the single live session tracker + ssh session-end watch this manager owns. The watch is
+  // built with a snapshot seam that adapts the real Win32 process-tree bindings (or a test fake) into the
+  // pure `ProcessSnapshot` shape the watch/driver reconcile against. The capture-DRIVER (W-2) is constructed
+  // with these (`{ tracker, watch, snapshot }`) + the loop seams by the wiring root (W-4); the wiring drives
+  // the DRIVER's `tickWatch()` (which owns the correlate + baseline-advance + hygiene reconcile) on a timer —
+  // this manager provides the tracker/watch/snapshot infrastructure, not the reconcile loop itself.
+  private readonly sessionTracker = new SessionTracker();
+  private readonly sshWatch: SshSessionWatch;
+
+  constructor(private readonly opts: KeyLockerManagerOptions = {}) {
+    this.sshWatch = new SshSessionWatch({ snapshot: () => this.snapshotProcessTree(), tracker: this.sessionTracker });
+  }
 
   private now(): number {
     return (this.opts.now ?? Date.now)();
+  }
+
+  /** The live per-pane session tracker (the driver anchors/records/forgets it). */
+  get tracker(): SessionTracker {
+    return this.sessionTracker;
+  }
+
+  /** The live ssh session-end watch (the driver registers/reconciles session ssh children through it). */
+  get watch(): SshSessionWatch {
+    return this.sshWatch;
+  }
+
+  /**
+   * One live process-tree snapshot for the watch/driver reconcile (W-3 §2.1 — the Win32 adapter). Wires the
+   * real (or injected) `buildProcessParentMap` + `getProcessIdentity` + `getProcessCommandLine` into the pure
+   * `ProcessSnapshot` shape. Two adaptations the watch's contract requires:
+   *   - `identify().name` is the native `processName` LOWERCASED (win32 does NOT lowercase at source; the watch
+   *     compares against the lowercase literal `"ssh"`), with `startTimeMs` from `processStartTimeMs`.
+   *   - `commandLine(pid)` passes `getProcessCommandLine` through verbatim (null on ANY read failure — the
+   *     W-2b argv scan treats null as "possibly interactive" and fails safe).
+   * A snapshot failure surfaces as an EMPTY `parentMap` (`buildProcessParentMap` swallows errors → {}) / an
+   * empty identity (`{ name: "", startTimeMs: 0 }`) — the watch tolerates both (it skips a degenerate tick and
+   * treats "" as gone-or-unreadable), so this adapter never throws.
+   */
+  private snapshotProcessTree(): ProcessSnapshot {
+    const w = this.opts.win32;
+    const parentMapOf = w?.buildProcessParentMap ?? buildProcessParentMap;
+    const identityOf = w?.getProcessIdentity ?? getProcessIdentityByPid;
+    const commandLineOf = w?.getProcessCommandLine ?? getProcessCommandLineByPid;
+    return {
+      parentMap: parentMapOf(),
+      identify: (pid) => {
+        const id = identityOf(pid);
+        return { name: id.processName.toLowerCase(), startTimeMs: id.processStartTimeMs };
+      },
+      commandLine: (pid) => commandLineOf(pid),
+    };
   }
 
   /** The store dir this manager reads consent + bindings from. */

--- a/tests/unit/key-locker-manager.test.ts
+++ b/tests/unit/key-locker-manager.test.ts
@@ -258,3 +258,64 @@ describe("KeyLockerManager.disposeIfIdle — dormancy", () => {
     expect(mgr.disposed).toBe(1);
   });
 });
+
+describe("KeyLockerManager — W-3 tracker/watch ownership + Win32 snapshot adapter (§2.1)", () => {
+  // A fake process tree (pid → {parent, name, start, argv}) so the snapshot adapter + watch reconcile
+  // without native calls. `name` is given in raw win32 casing (e.g. "SSH") to prove the adapter lowercases it.
+  interface Proc { parent: number; name: string; start: number; argv?: string[] }
+  const win32Of = (procs: Record<number, Proc>) => ({
+    buildProcessParentMap: () => new Map(Object.entries(procs).map(([pid, p]) => [Number(pid), p.parent])),
+    getProcessIdentity: (pid: number) => {
+      const p = procs[pid];
+      return p !== undefined ? { processName: p.name, processStartTimeMs: p.start } : { processName: "", processStartTimeMs: 0 };
+    },
+    getProcessCommandLine: (pid: number) => procs[pid]?.argv ?? null,
+  });
+
+  it("exposes the same live tracker + watch instances (owned, not per-call)", () => {
+    const mgr = new KeyLockerManager({ storeDir: freshDir() });
+    expect(mgr.tracker).toBe(mgr.tracker); // stable identity
+    expect(mgr.watch).toBe(mgr.watch);
+    expect(mgr.watch.isWatching("pane-x")).toBe(false); // a fresh, usable watch
+  });
+
+  it("the snapshot adapter LOWERCASES processName + maps creation time (a raw-cased 'SSH' registers as 'ssh')", () => {
+    const tree = { 500: { parent: 0, name: "explorer", start: 1 }, 1000: { parent: 500, name: "PowerShell", start: 10 }, 2000: { parent: 1000, name: "SSH", start: 20, argv: ["ssh", "deploy@host-a"] } };
+    const mgr = new KeyLockerManager({ storeDir: freshDir(), win32: win32Of(tree) });
+    mgr.tracker.beginLocalSession("pane-1");
+    mgr.watch.watchPane("pane-1", 1000);
+    mgr.tracker.recordDispatch("pane-1", "ssh deploy@host-a"); // push host-a
+    mgr.watch.noteSshOpened("pane-1", 2000);                    // register — needs identify("SSH")→"ssh" + non-zero start
+    expect(mgr.tracker.get("pane-1")).toEqual({ execHost: "host-a", isRemote: true });
+    expect(mgr.tracker.remoteDepth("pane-1")).toBe(1); // proves the adapter's lowercase + creation-time mapping took
+  });
+
+  it("driving the watch tick through the adapter reconciles a session-end POP", () => {
+    let tree: Record<number, Proc> = { 500: { parent: 0, name: "explorer", start: 1 }, 1000: { parent: 500, name: "powershell", start: 10 }, 2000: { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "deploy@host-a"] } };
+    const mgr = new KeyLockerManager({
+      storeDir: freshDir(),
+      win32: {
+        buildProcessParentMap: () => new Map(Object.entries(tree).map(([pid, p]) => [Number(pid), p.parent])),
+        getProcessIdentity: (pid) => { const p = tree[pid]; return p ? { processName: p.name, processStartTimeMs: p.start } : { processName: "", processStartTimeMs: 0 }; },
+        getProcessCommandLine: (pid) => tree[pid]?.argv ?? null,
+      },
+    });
+    mgr.tracker.beginLocalSession("pane-1");
+    mgr.watch.watchPane("pane-1", 1000);
+    mgr.tracker.recordDispatch("pane-1", "ssh deploy@host-a");
+    mgr.watch.noteSshOpened("pane-1", 2000);
+    expect(mgr.tracker.remoteDepth("pane-1")).toBe(1);
+
+    tree = { 500: { parent: 0, name: "explorer", start: 1 }, 1000: { parent: 500, name: "powershell", start: 10 } }; // ssh 2000 exits
+    mgr.watch.tick(); // the adapter re-snapshots the (mutated) tree → the watch pops the dead session
+    expect(mgr.tracker.get("pane-1")).toEqual({ execHost: "localhost", isRemote: false });
+  });
+
+  it("a degenerate snapshot (native failure ⇒ empty parentMap) is tolerated: the tick is a no-op, no throw", () => {
+    const mgr = new KeyLockerManager({ storeDir: freshDir(), win32: { buildProcessParentMap: () => new Map(), getProcessIdentity: () => ({ processName: "", processStartTimeMs: 0 }), getProcessCommandLine: () => null } });
+    mgr.tracker.beginLocalSession("pane-1");
+    mgr.watch.watchPane("pane-1", 1000);
+    expect(() => mgr.watch.tick()).not.toThrow(); // empty parentMap ⇒ skip, never markUnknown every pane
+    expect(mgr.tracker.get("pane-1")).toEqual({ execHost: "localhost", isRemote: false });
+  });
+});

--- a/tests/unit/key-locker-manager.test.ts
+++ b/tests/unit/key-locker-manager.test.ts
@@ -311,6 +311,16 @@ describe("KeyLockerManager — W-3 tracker/watch ownership + Win32 snapshot adap
     expect(mgr.tracker.get("pane-1")).toEqual({ execHost: "localhost", isRemote: false });
   });
 
+  it("exposes the snapshot adapter PUBLICLY so W-4 can build the driver's snapshot seam from the same source (Codex W-3)", () => {
+    const tree = { 500: { parent: 0, name: "explorer", start: 1 }, 2000: { parent: 500, name: "SSH", start: 20, argv: ["ssh", "deploy@host-a"] } };
+    const mgr = new KeyLockerManager({ storeDir: freshDir(), win32: win32Of(tree) });
+    const snap = mgr.snapshotProcessTree(); // the public seam the wiring passes to the driver
+    expect(snap.parentMap.get(2000)).toBe(500);
+    expect(snap.identify(2000)).toEqual({ name: "ssh", startTimeMs: 20 }); // lowercased through the manager-owned adapter
+    expect(snap.commandLine(2000)).toEqual(["ssh", "deploy@host-a"]);
+    expect(snap.identify(9999)).toEqual({ name: "", startTimeMs: 0 }); // gone pid
+  });
+
   it("a degenerate snapshot (native failure ⇒ empty parentMap) is tolerated: the tick is a no-op, no throw", () => {
     const mgr = new KeyLockerManager({ storeDir: freshDir(), win32: { buildProcessParentMap: () => new Map(), getProcessIdentity: () => ({ processName: "", processStartTimeMs: 0 }), getProcessCommandLine: () => null } });
     mgr.tracker.beginLocalSession("pane-1");


### PR DESCRIPTION
## What this is

**W-3** — additive to `KeyLockerManager` (plan §2.1). The manager becomes the single owner of the live `SessionTracker` + `SshSessionWatch`, the latter built with a `snapshot()` adapter that wires the real Win32 process-tree bindings into the pure `ProcessSnapshot` shape the watch + capture-driver (W-2, merged) reconcile against.

## The adapter (§2.1)

- `buildProcessParentMap` → `parentMap`
- `getProcessIdentityByPid` → `identify()`: **`processName` LOWERCASED** into `name` (win32 does not lowercase at source; the watch compares against the literal `"ssh"`), `processStartTimeMs` → `startTimeMs`
- `getProcessCommandLineByPid` → `commandLine(pid)` (null passthrough — the W-2b argv scan treats null as "possibly interactive" and fails safe)

A snapshot failure surfaces as an empty `parentMap` / empty identity, both of which the watch already tolerates (skip a degenerate tick; treat `""` as gone-or-unreadable), so the adapter never throws.

The Win32 fns are **injectable options** (default = real bindings) so the watch reconciliation unit-tests with a fake tree. Exposes `tracker` + `watch` getters for the driver + the wiring root (W-4).

## Interpretation note (for review)

§2.1 mentions the manager exposing a `tickWatch()`. But the merged **W-2 driver already owns the authoritative `tickWatch`** (correlate stragglers + advance the sshBaseline + `watch.tick()` + arm-hygiene). So this manager provides the tracker/watch/snapshot **infrastructure**, and the wiring root (W-4) drives the **driver's** `tickWatch` on a timer — no redundant/incomplete reconcile loop is added here. Flagging so the reviewer can confirm this is the intended split.

## Tests (4 new; 22 manager total)

adapter lowercases `processName` + maps creation time (a raw-cased `"SSH"` registers as `"ssh"`) / driving the watch tick through the adapter reconciles a session-end POP / degenerate empty snapshot tolerated (no-op tick, no throw) / stable owned tracker+watch identity.

## Verification

```
npm run build && npm run lint                                   # clean
npx vitest run --project unit tests/unit/key-locker-*.test.ts   # 373 passed
check:stub-catalog / check:failwith-fixtures                    # no drift (no new tool / failWith callsite)
```

No public tool change. Next: W-4 (tools-layer wiring root — bind seams to real hooks + Win32, start timers, consent/kill-switch gated) → live dogfood → release.

Plan: `desktop-touch-mcp-internal@c86a03e:docs/adr-014-v2-r3-l3-4-live-wiring-plan.md` (§2.1, §4 W-3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)