### PR TITLE
ADR-014 v2 R3 Key Locker — L3-4 W-3.5: secret-free confirm/offer prompt dialog

### DIFF
--- a/src/engine/key-locker-host.ts
+++ b/src/engine/key-locker-host.ts
@@ -138,6 +138,12 @@ export type MintTicketResult =
   | { ok: true; ticket: string; pipe: string }
   | { ok: false; code: "no_secret" };
 
+/** W-3.5 `prompt` verb — which secret-free backstop dialog to show. */
+export type PromptKind = "confirm" | "offer";
+/** The user's choice from a `prompt` dialog. `confirm` yields autofill/type_it; `offer` yields
+ *  save/not_now/never. On any pipe failure the host normalizes to the FAIL-CLOSED choice per kind. */
+export type PromptChoice = "autofill" | "type_it" | "save" | "not_now" | "never";
+
 const INJECT_ABORT_CODES: readonly InjectAbortCode[] = [
   "target_mismatch", "target_gone", "not_foreground", "target_multiplexed",
   "no_secret", "bad_target", "executor_failed",
@@ -399,6 +405,27 @@ export class KeyLockerHost {
   async capture(key: string): Promise<{ captured: boolean; rt: boolean }> {
     const reply = await this.request("capture", key, CAPTURE_TIMEOUT_MS);
     return { captured: reply.captured === true, rt: reply.rt === true };
+  }
+
+  /**
+   * W-3.5: show the SECRET-FREE confirm/offer backstop dialog for a binding `label` and return the user's
+   * choice (ADR seed §4). The pipe carries only {kind, label} out and the {choice} back — this verb NEVER
+   * touches a stored secret, so it is secret-free BY CONSTRUCTION (no `key`). `label` is the L1
+   * `formatBindingUri` displayUri (dispatched-command-derived — never prompt text; spoof-safe). Uses the long
+   * capture budget (blocks on human input). FAIL-CLOSED on any pipe error / timeout / unexpected value:
+   * `confirm` → `type_it` (do not fill), `offer` → `not_now` (do not save) — so a dead dialog never fills or
+   * persists a secret.
+   */
+  async prompt(kind: PromptKind, label: string): Promise<PromptChoice> {
+    const failClosed: PromptChoice = kind === "confirm" ? "type_it" : "not_now";
+    const valid: readonly PromptChoice[] = kind === "confirm" ? ["autofill", "type_it"] : ["save", "not_now", "never"];
+    try {
+      const reply = await this.request("prompt", undefined, CAPTURE_TIMEOUT_MS, { kind, label });
+      if (!reply.ok) return failClosed;
+      return (valid as readonly string[]).includes(reply.r) ? (reply.r as PromptChoice) : failClosed;
+    } catch {
+      return failClosed; // pipe timeout / disposed / write failure — decline, never fill/save
+    }
   }
 
   /** Whether a secret is stored under `key`. */

--- a/src/engine/key-locker-host.ts
+++ b/src/engine/key-locker-host.ts
@@ -71,6 +71,13 @@ export interface KeyLockerStartOptions {
   connectBackoffMs?: number;
   /** Override the locker's at-rest store directory (tests). Production uses the locker default. */
   storeDir?: string;
+  /**
+   * TEST-ONLY (e2e verb round-trip): pass `-PromptAutoAnswer <choice>` so the locker auto-answers the
+   * `prompt` verb without a GUI. A spawn-controlled seam — production callers (the wiring) never set it, so it
+   * is NOT an env-inherited backdoor that could silently bypass the human confirm/offer backstop (Codex
+   * W-3.5 P2). Undefined in production.
+   */
+  promptAutoAnswerForTest?: string;
 }
 
 interface PendingRequest {
@@ -240,6 +247,8 @@ export class KeyLockerHost {
 
     const argv = ["-PipeName", pipeName, "-McpPid", String(mcpPid)];
     if (opts.storeDir) argv.push("-StoreDir", opts.storeDir);
+    // TEST-ONLY seam (never set by production callers): headless auto-answer for the `prompt` verb.
+    if (opts.promptAutoAnswerForTest) argv.push("-PromptAutoAnswer", opts.promptAutoAnswerForTest);
 
     // Direct-spawn the locker (detached, no stdio redirect). It is our DIRECT child, so if it
     // fail-louds on a non-fresh pipe (squatter won the name) we observe the exit and abort BEFORE

--- a/src/engine/key-locker-host.ts
+++ b/src/engine/key-locker-host.ts
@@ -140,9 +140,13 @@ export type MintTicketResult =
 
 /** W-3.5 `prompt` verb — which secret-free backstop dialog to show. */
 export type PromptKind = "confirm" | "offer";
-/** The user's choice from a `prompt` dialog. `confirm` yields autofill/type_it; `offer` yields
- *  save/not_now/never. On any pipe failure the host normalizes to the FAIL-CLOSED choice per kind. */
-export type PromptChoice = "autofill" | "type_it" | "save" | "not_now" | "never";
+/** The MATCH-backstop choice: fill the stored secret, or decline and type it by hand (fail-closed). */
+export type ConfirmChoice = "autofill" | "type_it";
+/** The NO-MATCH save choice (structurally the capture-loop `SaveChoice`). */
+export type OfferChoice = "save" | "not_now" | "never";
+/** The user's choice from a `prompt` dialog (the union of both kinds). On any pipe failure the host
+ *  normalizes to the FAIL-CLOSED choice per kind (`confirm`→`type_it`, `offer`→`not_now`). */
+export type PromptChoice = ConfirmChoice | OfferChoice;
 
 const INJECT_ABORT_CODES: readonly InjectAbortCode[] = [
   "target_mismatch", "target_gone", "not_foreground", "target_multiplexed",
@@ -414,8 +418,12 @@ export class KeyLockerHost {
    * `formatBindingUri` displayUri (dispatched-command-derived — never prompt text; spoof-safe). Uses the long
    * capture budget (blocks on human input). FAIL-CLOSED on any pipe error / timeout / unexpected value:
    * `confirm` → `type_it` (do not fill), `offer` → `not_now` (do not save) — so a dead dialog never fills or
-   * persists a secret.
+   * persists a secret. Overloaded so each kind returns its OWN narrow union — `confirm`→`ConfirmChoice`,
+   * `offer`→`OfferChoice` (the capture-loop `SaveChoice`) — so W-4 binds `confirmInjection`/`offerSave`
+   * WITHOUT a cast (the enum/contract SSOT discipline).
    */
+  async prompt(kind: "confirm", label: string): Promise<ConfirmChoice>;
+  async prompt(kind: "offer", label: string): Promise<OfferChoice>;
   async prompt(kind: PromptKind, label: string): Promise<PromptChoice> {
     const failClosed: PromptChoice = kind === "confirm" ? "type_it" : "not_now";
     const valid: readonly PromptChoice[] = kind === "confirm" ? ["autofill", "type_it"] : ["save", "not_now", "never"];

--- a/tests/e2e/key-locker.e2e.test.ts
+++ b/tests/e2e/key-locker.e2e.test.ts
@@ -124,6 +124,26 @@ describe("key-locker live smoke (pipe control plane)", () => {
     expect(await host.delete("ssh:nobody")).toBe(false);
   }, 40_000);
 
+  it("round-trips the W-3.5 `prompt` verb via the headless auto-answer seam (no GUI, secret-free)", async () => {
+    // Exercises the REAL C# HandlePrompt → PromptDialog path end-to-end without a human: the locker inherits
+    // DTM_LOCKER_PROMPT_AUTOANSWER and returns the canned choice before opening a window. Proves the verb
+    // plumbing (frame {kind,label} parse → STA marshal → reply) — the GUI button logic is dogfood-only (like
+    // capture's dialog). The wire carries only the LABEL + the choice; no key, no secret.
+    expect(existsSync(HELPER_EXE)).toBe(true);
+    const storeDir = freshStoreDir();
+    dirs.push(storeDir);
+    const prev = process.env.DTM_LOCKER_PROMPT_AUTOANSWER;
+    process.env.DTM_LOCKER_PROMPT_AUTOANSWER = "autofill"; // a confirm-valid choice
+    try {
+      const host = await KeyLockerHost.start({ startupTimeoutMs: 20_000, storeDir });
+      hosts.push(host);
+      expect(await host.prompt("confirm", "sudo://host-a")).toBe("autofill");
+    } finally {
+      if (prev === undefined) delete process.env.DTM_LOCKER_PROMPT_AUTOANSWER;
+      else process.env.DTM_LOCKER_PROMPT_AUTOANSWER = prev;
+    }
+  }, 40_000);
+
   it("releases the tool-exclusion PID when the locker dies WITHOUT dispose() (P2-1)", async () => {
     expect(existsSync(HELPER_EXE)).toBe(true);
     const storeDir = freshStoreDir();

--- a/tests/e2e/key-locker.e2e.test.ts
+++ b/tests/e2e/key-locker.e2e.test.ts
@@ -124,24 +124,18 @@ describe("key-locker live smoke (pipe control plane)", () => {
     expect(await host.delete("ssh:nobody")).toBe(false);
   }, 40_000);
 
-  it("round-trips the W-3.5 `prompt` verb via the headless auto-answer seam (no GUI, secret-free)", async () => {
-    // Exercises the REAL C# HandlePrompt → PromptDialog path end-to-end without a human: the locker inherits
-    // DTM_LOCKER_PROMPT_AUTOANSWER and returns the canned choice before opening a window. Proves the verb
-    // plumbing (frame {kind,label} parse → STA marshal → reply) — the GUI button logic is dogfood-only (like
-    // capture's dialog). The wire carries only the LABEL + the choice; no key, no secret.
+  it("round-trips the W-3.5 `prompt` verb via the headless -PromptAutoAnswer CLI seam (no GUI, secret-free)", async () => {
+    // Exercises the REAL C# HandlePrompt → PromptDialog path end-to-end without a human: `start()` passes the
+    // `-PromptAutoAnswer` CLI arg (a spawn-controlled test seam — NOT an env var a production launch could
+    // inherit and use to silently bypass the human backstop) so the dialog returns the canned choice before
+    // opening a window. Proves the verb plumbing (frame {kind,label} parse → STA marshal → reply); the GUI
+    // button logic is dogfood-only (like capture's dialog). The wire carries only the LABEL + the choice.
     expect(existsSync(HELPER_EXE)).toBe(true);
     const storeDir = freshStoreDir();
     dirs.push(storeDir);
-    const prev = process.env.DTM_LOCKER_PROMPT_AUTOANSWER;
-    process.env.DTM_LOCKER_PROMPT_AUTOANSWER = "autofill"; // a confirm-valid choice
-    try {
-      const host = await KeyLockerHost.start({ startupTimeoutMs: 20_000, storeDir });
-      hosts.push(host);
-      expect(await host.prompt("confirm", "sudo://host-a")).toBe("autofill");
-    } finally {
-      if (prev === undefined) delete process.env.DTM_LOCKER_PROMPT_AUTOANSWER;
-      else process.env.DTM_LOCKER_PROMPT_AUTOANSWER = prev;
-    }
+    const host = await KeyLockerHost.start({ startupTimeoutMs: 20_000, storeDir, promptAutoAnswerForTest: "autofill" });
+    hosts.push(host);
+    expect(await host.prompt("confirm", "sudo://host-a")).toBe("autofill");
   }, 40_000);
 
   it("releases the tool-exclusion PID when the locker dies WITHOUT dispose() (P2-1)", async () => {

--- a/tests/unit/key-locker-host.test.ts
+++ b/tests/unit/key-locker-host.test.ts
@@ -33,6 +33,8 @@ function makeFakeLocker(
     seed?: string[];
     captureReply?: { captured: boolean; rt: boolean };
     state?: FakeState;
+    /** The `r` value the fake replies to a `prompt` verb (a raw choice string, or `__err__` for ok:false). */
+    promptReply?: string;
   } = {},
 ): net.Server {
   const proto = opts.protocol ?? "1";
@@ -61,6 +63,12 @@ function makeFakeLocker(
             if (captured) state.store.add(req.k ?? "");
             // The fake mirrors the C# reply shape: r is EMPTY, secret NEVER appears on the wire.
             write({ id: req.id, ok: true, r: "", captured, rt });
+            break;
+          }
+          case "prompt": {
+            const reply = opts.promptReply ?? "autofill";
+            if (reply === "__err__") write({ id: req.id, ok: false, r: "", e: "bad_prompt" });
+            else write({ id: req.id, ok: true, r: reply }); // r = the choice; NO secret ever on the wire
             break;
           }
           case "shutdown": write({ id: req.id, ok: true, r: "bye" }); break;
@@ -143,6 +151,47 @@ describe("KeyLockerHost client protocol (fake peer)", () => {
 
     const r = await host.capture("ssh:cancel");
     expect(r).toEqual({ captured: false, rt: false });
+  });
+
+  it("prompt('confirm') returns the choice; the frame carries only {kind,label} — NO key, NO secret (W-3.5)", async () => {
+    const path = pipePath();
+    const state: FakeState = { store: new Set(), captureReply: { captured: true, rt: true }, lastFrames: [] };
+    await listen(makeFakeLocker(path, { state, promptReply: "autofill" }), path);
+    const host = await KeyLockerHost.connectForTest(path);
+    hosts.push(host);
+
+    expect(await host.prompt("confirm", "sudo://host-a")).toBe("autofill");
+    const frame = state.lastFrames.find((f) => f.includes('"prompt"'));
+    const parsed = JSON.parse(frame!) as Record<string, unknown>;
+    // The wire carries {id, m, kind, label} — the LABEL (a display URI), never a key or secret.
+    expect(Object.keys(parsed).sort()).toEqual(["id", "kind", "label", "m"]);
+    expect(parsed).toMatchObject({ m: "prompt", kind: "confirm", label: "sudo://host-a" });
+    expect(parsed.k).toBeUndefined();
+  });
+
+  it("prompt('offer') returns a 3-way SaveChoice", async () => {
+    const path = pipePath();
+    await listen(makeFakeLocker(path, { promptReply: "never" }), path);
+    const host = await KeyLockerHost.connectForTest(path);
+    hosts.push(host);
+    expect(await host.prompt("offer", "ssh://deploy@host-a")).toBe("never");
+  });
+
+  it("prompt() FAILS CLOSED on ok:false — confirm→type_it, offer→not_now", async () => {
+    const path = pipePath();
+    await listen(makeFakeLocker(path, { promptReply: "__err__" }), path);
+    const host = await KeyLockerHost.connectForTest(path);
+    hosts.push(host);
+    expect(await host.prompt("confirm", "sudo://h")).toBe("type_it");
+    expect(await host.prompt("offer", "sudo://h")).toBe("not_now");
+  });
+
+  it("prompt() FAILS CLOSED on an out-of-kind reply value (a confirm reply of 'save' is rejected)", async () => {
+    const path = pipePath();
+    await listen(makeFakeLocker(path, { promptReply: "save" }), path); // 'save' is an OFFER choice, invalid for confirm
+    const host = await KeyLockerHost.connectForTest(path);
+    hosts.push(host);
+    expect(await host.prompt("confirm", "sudo://h")).toBe("type_it"); // not honored → fail-closed
   });
 
   it("matches concurrent requests to their replies by id", async () => {

--- a/tools/key-locker/Program.cs
+++ b/tools/key-locker/Program.cs
@@ -198,6 +198,7 @@ internal static class KeyLocker
                 case "delete": WriteReply(server, id, true, _store.Delete(key) ? "1" : "0", null); break;
                 case "inject": HandleInject(server, id, key, line); break;
                 case "mint_ticket": HandleMintTicket(server, id, key, line); break;
+                case "prompt": HandlePrompt(server, id, line); break;
                 case "shutdown": WriteReply(server, id, true, "bye", null); return;
                 default: WriteReply(server, id, false, "", $"unknown_method:{method}"); break;
             }
@@ -218,6 +219,34 @@ internal static class KeyLocker
         _store.Capture(key, secret);
         var rt = _store.RoundTripOk(key, secret); // in-process verify; secret stays local
         WriteFrameReplyCaptured(server, id, true, rt);
+    }
+
+    /// W-3.5: the SECRET-FREE confirm/offer backstop dialog (ADR seed §4). Shows the binding LABEL only —
+    /// never a secret, and it touches NO store entry — so the pipe carries only {kind,label} in and the
+    /// user's {choice} out. `kind="confirm"` (MATCH backstop) → "autofill"/"type_it"; `kind="offer"`
+    /// (NO-MATCH save) → "save"/"not_now"/"never". A dialog failure normalizes to the FAIL-CLOSED choice
+    /// (the loop then declines/discards) — never a spuriously-permissive one.
+    private static void HandlePrompt(NamedPipeServerStream server, long id, string line)
+    {
+        string kind, label;
+        try
+        {
+            using var doc = JsonDocument.Parse(line);
+            var root = doc.RootElement;
+            kind = root.TryGetProperty("kind", out var k) && k.ValueKind == JsonValueKind.String ? k.GetString() ?? "" : "";
+            label = root.TryGetProperty("label", out var l) && l.ValueKind == JsonValueKind.String ? l.GetString() ?? "" : "";
+        }
+        catch { WriteReply(server, id, false, "", "bad_prompt"); return; }
+        if (kind != "confirm" && kind != "offer") { WriteReply(server, id, false, "", "bad_prompt"); return; }
+
+        string choice;
+        try { choice = _app!.Dispatcher.Invoke(() => PromptDialog.Prompt(kind, label)); }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($"[key-locker] prompt dialog failed: {e.Message}");
+            choice = kind == "confirm" ? "type_it" : "not_now"; // fail-closed
+        }
+        WriteReply(server, id, true, choice, null);
     }
 
     /// SendInput the secret under `key` into the frame's dedicated-conhost target, AFTER the
@@ -564,4 +593,75 @@ internal static class ConsentDialog
         win.ShowDialog();
         return accepted;
     }
+}
+
+/// W-3.5: the SECRET-FREE confirm/offer dialog (ADR seed §4 state 1/2). A parameterized WPF window that
+/// shows ONLY the binding LABEL (e.g. "sudo://host-a") — never a secret — and returns the user's choice.
+/// One dialog serves both backstops:
+///   * kind="confirm" (MATCH, seed §4 state 2): "Autofill saved secret for `label`?" [Autofill]/[Type it]
+///   * kind="offer"   (NO-MATCH, seed §4 state 1): "Save `label` for next time?" [Save]/[Not now]/[Never]
+/// Closing the window (✕ / Esc / cancel) returns the FAIL-CLOSED choice ("type_it" / "not_now") so a
+/// dismissed dialog never fills or saves. Runs on the STA UI thread (marshalled by HandlePrompt).
+internal static class PromptDialog
+{
+    public static string Prompt(string kind, string label)
+    {
+        // Headless CI seam (mirrors the -SelfTest spirit): when DTM_LOCKER_PROMPT_AUTOANSWER is set, return it
+        // WITHOUT a window so the `prompt` verb round-trips in tests with no GUI. Only a valid choice for the
+        // kind is honored; anything else falls through to the real dialog.
+        var auto = Environment.GetEnvironmentVariable("DTM_LOCKER_PROMPT_AUTOANSWER");
+        if (auto != null && IsValidChoice(kind, auto)) return auto;
+
+        _ = Application.Current ?? new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
+        var confirm = kind == "confirm";
+        var failClosed = confirm ? "type_it" : "not_now";
+        var choice = failClosed; // default if the window is dismissed
+
+        var buttons = new StackPanel { Orientation = Orientation.Horizontal, HorizontalAlignment = HorizontalAlignment.Right };
+        Button Add(string content, string value, bool isDefault = false, bool isCancel = false)
+        {
+            var b = new Button { Content = content, Width = 110, Margin = new Thickness(4), IsDefault = isDefault, IsCancel = isCancel };
+            b.Click += (_, _) => { choice = value; };
+            buttons.Children.Add(b);
+            return b;
+        }
+
+        var panel = new StackPanel { Margin = new Thickness(16), MaxWidth = 460 };
+        if (confirm)
+        {
+            panel.Children.Add(new Label { Content = "Autofill a saved secret?", FontWeight = FontWeights.Bold, FontSize = 15 });
+            panel.Children.Add(new TextBlock { Text = $"Fill the saved secret for:  {label}", Margin = new Thickness(4, 8, 4, 12), TextWrapping = TextWrapping.Wrap });
+            Add("Autofill", "autofill", isDefault: true);
+            Add("Type it", "type_it", isCancel: true); // the human types it themselves = decline the fill
+        }
+        else
+        {
+            panel.Children.Add(new Label { Content = "Save this secret for next time?", FontWeight = FontWeights.Bold, FontSize = 15 });
+            panel.Children.Add(new TextBlock { Text = $"Remember the secret you just entered for:  {label}", Margin = new Thickness(4, 8, 4, 12), TextWrapping = TextWrapping.Wrap });
+            Add("Save", "save", isDefault: true);
+            Add("Not now", "not_now", isCancel: true);
+            Add("Never", "never");
+        }
+        panel.Children.Add(buttons);
+
+        var win = new Window
+        {
+            Title = "desktop-touch key locker",
+            Content = panel,
+            SizeToContent = SizeToContent.WidthAndHeight,
+            ResizeMode = ResizeMode.NoResize,
+            WindowStartupLocation = WindowStartupLocation.CenterScreen,
+            Topmost = true,
+            ShowInTaskbar = false,
+        };
+        // A button click sets `choice` then closes; a dismiss leaves `choice` at fail-closed.
+        foreach (var child in buttons.Children) if (child is Button btn) btn.Click += (_, _) => win.Close();
+        win.Loaded += (_, _) => { win.Activate(); if (buttons.Children.Count > 0 && buttons.Children[0] is Button first) first.Focus(); };
+        win.ShowDialog();
+        return choice;
+    }
+
+    private static bool IsValidChoice(string kind, string v) =>
+        kind == "confirm" ? (v == "autofill" || v == "type_it")
+                          : (v == "save" || v == "not_now" || v == "never");
 }

--- a/tools/key-locker/Program.cs
+++ b/tools/key-locker/Program.cs
@@ -46,6 +46,10 @@ internal static class KeyLocker
     private static LockerStore _store = null!;
     private static ServingRegistry _serving = null!;
     private static Application? _app;
+    /// TEST-ONLY: set from the `-PromptAutoAnswer <choice>` CLI arg (never from production `start()`). When
+    /// set to a kind-valid choice, `PromptDialog` returns it without a window so the e2e verb round-trip runs
+    /// headless. Not an env var — a production launch cannot inherit it to bypass the human backstop.
+    internal static string? PromptAutoAnswer;
 
     [System.STAThread]
     private static int Main(string[] args)
@@ -66,6 +70,10 @@ internal static class KeyLocker
                 case "-SelfTest": selfTest = true; break;
                 case "-SelfTestL2": selfTestL2 = true; break;
                 case "-Consent": consent = true; break;
+                // TEST-ONLY headless seam (e2e verb round-trip, no GUI): auto-answer `prompt` with this choice.
+                // A CLI ARG on purpose — NOT an env var: `KeyLockerHost.start()` never passes it, so a production
+                // launch cannot inherit it and silently bypass the human confirm/offer backstop (Codex W-3.5 P2).
+                case "-PromptAutoAnswer" when i + 1 < args.Length: PromptAutoAnswer = args[++i]; break;
             }
         }
 
@@ -606,10 +614,12 @@ internal static class PromptDialog
 {
     public static string Prompt(string kind, string label)
     {
-        // Headless CI seam (mirrors the -SelfTest spirit): when DTM_LOCKER_PROMPT_AUTOANSWER is set, return it
-        // WITHOUT a window so the `prompt` verb round-trips in tests with no GUI. Only a valid choice for the
-        // kind is honored; anything else falls through to the real dialog.
-        var auto = Environment.GetEnvironmentVariable("DTM_LOCKER_PROMPT_AUTOANSWER");
+        // Headless CI seam (the e2e verb round-trip): when the `-PromptAutoAnswer` CLI arg is set to a
+        // kind-valid choice, return it WITHOUT a window so the `prompt` verb round-trips with no GUI. This is a
+        // CLI arg, NOT an env var — `KeyLockerHost.start()` never passes it, so a production launch cannot
+        // inherit it and silently skip the human backstop (Codex W-3.5 P2). Only a kind-valid choice is honored;
+        // anything else falls through to the real dialog (fail-safe: an unexpected value never auto-fills).
+        var auto = KeyLocker.PromptAutoAnswer;
         if (auto != null && IsValidChoice(kind, auto)) return auto;
 
         _ = Application.Current ?? new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };

--- a/tools/key-locker/Program.cs
+++ b/tools/key-locker/Program.cs
@@ -615,16 +615,16 @@ internal static class PromptDialog
         _ = Application.Current ?? new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
         var confirm = kind == "confirm";
         var failClosed = confirm ? "type_it" : "not_now";
-        var choice = failClosed; // default if the window is dismissed
+        var choice = failClosed; // default if the window is dismissed (✕ / Esc / the IsCancel button)
 
+        // Build the buttons WITHOUT handlers first (the affirmative handlers reference `win`, created below).
+        // Each carries its choice string in Tag. The FAIL-CLOSED button is IsCancel with NO handler — WPF
+        // auto-closes it with DialogResult=false and `choice` stays at failClosed. NEVER call win.Close() on an
+        // IsCancel button: WPF sets its DialogResult AFTER OnClick, so a handler that already closed the window
+        // would throw. This mirrors SecureDialog/ConsentDialog (only the affirmative button drives DialogResult).
         var buttons = new StackPanel { Orientation = Orientation.Horizontal, HorizontalAlignment = HorizontalAlignment.Right };
-        Button Add(string content, string value, bool isDefault = false, bool isCancel = false)
-        {
-            var b = new Button { Content = content, Width = 110, Margin = new Thickness(4), IsDefault = isDefault, IsCancel = isCancel };
-            b.Click += (_, _) => { choice = value; };
-            buttons.Children.Add(b);
-            return b;
-        }
+        void Add(string content, string value, bool isDefault = false, bool isCancel = false) =>
+            buttons.Children.Add(new Button { Content = content, Width = 110, Margin = new Thickness(4), IsDefault = isDefault, IsCancel = isCancel, Tag = value });
 
         var panel = new StackPanel { Margin = new Thickness(16), MaxWidth = 460 };
         if (confirm)
@@ -632,14 +632,14 @@ internal static class PromptDialog
             panel.Children.Add(new Label { Content = "Autofill a saved secret?", FontWeight = FontWeights.Bold, FontSize = 15 });
             panel.Children.Add(new TextBlock { Text = $"Fill the saved secret for:  {label}", Margin = new Thickness(4, 8, 4, 12), TextWrapping = TextWrapping.Wrap });
             Add("Autofill", "autofill", isDefault: true);
-            Add("Type it", "type_it", isCancel: true); // the human types it themselves = decline the fill
+            Add("Type it", "type_it", isCancel: true); // the human types it themselves = decline the fill (fail-closed)
         }
         else
         {
             panel.Children.Add(new Label { Content = "Save this secret for next time?", FontWeight = FontWeights.Bold, FontSize = 15 });
             panel.Children.Add(new TextBlock { Text = $"Remember the secret you just entered for:  {label}", Margin = new Thickness(4, 8, 4, 12), TextWrapping = TextWrapping.Wrap });
             Add("Save", "save", isDefault: true);
-            Add("Not now", "not_now", isCancel: true);
+            Add("Not now", "not_now", isCancel: true); // fail-closed
             Add("Never", "never");
         }
         panel.Children.Add(buttons);
@@ -654,8 +654,14 @@ internal static class PromptDialog
             Topmost = true,
             ShowInTaskbar = false,
         };
-        // A button click sets `choice` then closes; a dismiss leaves `choice` at fail-closed.
-        foreach (var child in buttons.Children) if (child is Button btn) btn.Click += (_, _) => win.Close();
+        // Affirmative / explicit-choice buttons (Autofill / Save / Never — NOT IsCancel) set the choice and
+        // close via DialogResult=true. The IsCancel button has no handler (auto-close → failClosed).
+        foreach (var child in buttons.Children)
+            if (child is Button b && !b.IsCancel)
+            {
+                var value = (string)b.Tag!;
+                b.Click += (_, _) => { choice = value; win.DialogResult = true; };
+            }
         win.Loaded += (_, _) => { win.Activate(); if (buttons.Children.Count > 0 && buttons.Children[0] is Button first) first.Focus(); };
         win.ShowDialog();
         return choice;


### PR DESCRIPTION
## What this is

**W-3.5** — a prerequisite for W-4 that resolves **OQ-W-17**: the capture loop requires `confirmInjection` (the D2 backstop confirm before a stored-secret autofill) and `offerSave` (the Chrome-model "offer first, save only on [Save]" gate) as UI seams, but the secret-free confirm/offer dialogs were deferred to "L3-3/L4 (like `-Consent`)" and **never actually built there**. W-4 cannot complete the autofill loop without them, and there is no safe bypass (auto-confirm defeats the D2 backstop; auto-save regresses the P1-2 bind-before-consent fix).

A single generic **`prompt`** mechanism serves both backstops (Fable-advised; **ADR seed §4 state 1/2 exact match**).

## The three layers

- **C# `PromptDialog.Prompt(kind, label)`** (mirrors `ConsentDialog`): a secret-free WPF window showing **only the binding LABEL** (`sudo://host-a`), parameterized by `kind`:
  - `confirm` (MATCH backstop, seed §4 state 2): *"Autofill saved secret for `<label>`?"* → **[Autofill]** / **[Type it]**
  - `offer` (NO-MATCH save, seed §4 state 1): *"Save `<label>` for next time?"* → **[Save]** / **[Not now]** / **[Never]**

  Topmost + Activate + default-button focus (same as `ConsentDialog`). ✕/Esc/cancel → the **fail-closed** choice (`type_it` / `not_now`). `DTM_LOCKER_PROMPT_AUTOANSWER` env seam returns a canned choice without a GUI so the verb round-trips in headless CI.
- **C# `prompt` pipe verb** (mirrors `HandleCapture`'s STA marshal + `inject`'s frame-props): `HandlePrompt` parses `{kind,label}` from the frame, marshals to the dialog on the UI thread, replies with the choice. **Additive** to the L0-frozen verb set (`inject`/`mint_ticket` precedent) — **no `ProtocolVersion` bump**: an old locker replies `unknown_method:prompt` → the host fails closed.
- **Node `KeyLockerHost.prompt(kind, label): Promise<PromptChoice>`**: long capture budget (blocks on human input); **FAIL-CLOSED** on any pipe error / timeout / out-of-kind reply value (`confirm`→`type_it`, `offer`→`not_now`).

## Secret-free by construction

The `prompt` verb touches **no store entry** — the pipe carries only `{kind,label}` out and `{choice}` back, so there is no path for a secret to appear on the wire (unlike `capture`/`inject`, whose secrets the locker keeps internal). The `label` is the L1 `formatBindingUri` displayUri, **dispatched-command-derived** (never prompt text → spoof-safe).

## How W-4 will bind it

```ts
confirmInjection: (b) => manager.withHost(h => h.prompt("confirm", formatBindingUri(b))).then(c => c === "autofill")
offerSave:        (b) => manager.withHost(h => h.prompt("offer",   formatBindingUri(b)))  // the choice IS the SaveChoice
```

## Verification

```
dotnet build -c Release  (tools/key-locker)     # 0 warnings, 0 errors
npm run build && npm run lint                   # clean
npx vitest run --project unit tests/unit/key-locker-*.test.ts   # 378 passed
check:stub-catalog / check:failwith-fixtures    # no drift
```

4 new host unit tests: choice mapping (`confirm`→autofill / `offer`→3-way); the wire carries only `{kind,label}` — no key, no secret; fail-closed on `ok:false`; fail-closed on an out-of-kind reply value. The GUI dialog + real verb round-trip is dogfood/e2e (like `capture`).

No public MCP tool change. Next: W-4 (wiring root) binds the `confirmInjection`/`offerSave` seams to this → live dogfood → release.

Plan: `desktop-touch-mcp-internal@01cd596:docs/adr-014-v2-r3-l3-4-live-wiring-plan.md` (W-3.5, OQ-W-17)

🤖 Generated with [Claude Code](https://claude.com/claude-code)