### PR TITLE
ADR-014 v2 R3 Key Locker — L3-4 W-4a: hot-path seams for the wiring (gap1/gap2/gap6)

### DIFF
--- a/src/engine/key-locker/key-locker-manager.ts
+++ b/src/engine/key-locker/key-locker-manager.ts
@@ -204,21 +204,24 @@ export class KeyLockerManager {
     // the human to type into (the cooperative model); we never read its stdio.
     const child = spawn("conhost.exe", [shellExe], { detached: true, stdio: "ignore", windowsHide: false });
     child.on("error", () => { /* spawn failure surfaces as the poll timing out below */ });
+    // The console is a SEPARATE window the human owns — do NOT pin Node's event loop on its lifetime (else a
+    // clean MCP shutdown would hang until the user closes the console). The wiring may kill `shellPid` on
+    // teardown if it wants the console gone; otherwise it outlives the session by design (Opus W-4a P2-1).
+    child.unref();
     const childPid = child.pid;
+    // A failed spawn has no pid ⇒ nothing to claim ⇒ time out rather than grab an unrelated console.
+    if (childPid === undefined) throw new KeyLockerError("KeyLockerSpawnFailed", "conhost spawn returned no pid");
 
     const deadline = this.now() + timeoutMs;
     for (;;) {
+      // Claim ONLY the new console OUR conhost child owns — an exact `childPid` match (Opus W-4a P3-1: a
+      // pid-0-fallback could grab a DIFFERENT console that momentarily reads owner-pid 0 during its own
+      // creation, returning the wrong hwnd/shellPid). The owner pid may read 0 transiently for ours too, so
+      // we simply keep polling until it resolves to `childPid`.
       const fresh = enumWindowsInZOrder().find(
-        (w) =>
-          w.className === CONSOLE_WINDOW_CLASS &&
-          !before.has(w.hwnd) &&
-          // Prefer the window owned by OUR conhost child; fall back to any new console if the pid is unresolved
-          // (the owner can briefly read 0 during creation).
-          (childPid === undefined || getWindowProcessId(w.hwnd) === childPid || getWindowProcessId(w.hwnd) === 0),
+        (w) => w.className === CONSOLE_WINDOW_CLASS && !before.has(w.hwnd) && getWindowProcessId(w.hwnd) === childPid,
       );
-      if (fresh !== undefined && getWindowProcessId(fresh.hwnd) !== 0) {
-        return { hwnd: fresh.hwnd, shellPid: getWindowProcessId(fresh.hwnd) };
-      }
+      if (fresh !== undefined) return { hwnd: fresh.hwnd, shellPid: childPid };
       if (this.now() >= deadline) {
         try { child.kill(); } catch { /* best-effort */ }
         throw new KeyLockerError("KeyLockerSpawnFailed", "anchored console window did not appear");

--- a/src/engine/key-locker/key-locker-manager.ts
+++ b/src/engine/key-locker/key-locker-manager.ts
@@ -19,8 +19,14 @@ import { spawn } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { HELPER_EXE, KeyLockerHost, type KeyLockerStartOptions } from "../key-locker-host.js";
-import { buildProcessParentMap, getProcessCommandLineByPid, getProcessIdentityByPid } from "../win32.js";
+import { HELPER_EXE, KeyLockerError, KeyLockerHost, type KeyLockerStartOptions } from "../key-locker-host.js";
+import {
+  buildProcessParentMap,
+  enumWindowsInZOrder,
+  getProcessCommandLineByPid,
+  getProcessIdentityByPid,
+  getWindowProcessId,
+} from "../win32.js";
 import { SessionTracker } from "./session-tracker.js";
 import { SshSessionWatch, type ProcessSnapshot } from "./ssh-session-watch.js";
 
@@ -53,6 +59,9 @@ function defaultStoreDir(): string {
 }
 
 const CONSENT_FILE = "consent.json";
+/** The Win32 class of a CLASSIC conhost console window — the ONLY window L2 injection can target (the
+ *  `Injection.cs` ReVerify positive-allowlist). Windows Terminal is a XAML host with a different class. */
+const CONSOLE_WINDOW_CLASS = "ConsoleWindowClass";
 
 /** Read the persisted first-run consent flag (fail-closed: absent/corrupt/wrong-shape ⇒ false). */
 export function consentAccepted(storeDir?: string): boolean {
@@ -164,6 +173,58 @@ export class KeyLockerManager {
   /** The store dir this manager reads consent + bindings from. */
   get storeDir(): string {
     return this.opts.storeDir ?? defaultStoreDir();
+  }
+
+  /**
+   * W-4 (gap1, §3 W1): launch a KNOWN-LOCAL, INJECTABLE terminal pane the Key Locker can anchor. Code-verified
+   * constraints (Fable 2026-07-08): the ONLY injectable window is a CLASSIC conhost (`ConsoleWindowClass` — the
+   * L2 `Injection.cs` ReVerify positive-allowlist; Windows Terminal is a XAML host ⇒ `target_multiplexed`), and
+   * `workspace_launch` blocks all shells, and R1's cooperative terminal is headless-only (the visible-console
+   * launch is R2's unshipped S2). So the manager spawns `conhost.exe <shell>` DIRECTLY (an internal spawn — it
+   * does NOT route through `workspace_launch`'s executable blocklist, which exists to stop the ASSISTANT from
+   * launching arbitrary shells; this is a locker-owned, fixed, local shell) and polls for the new
+   * `ConsoleWindowClass` window it owns. Returns `{ hwnd, shellPid }` (shellPid = the conhost pid = the window
+   * owner; the shell + any ssh run as subtree descendants, which `sshDescendants` walks). The wiring fires
+   * `onLocalPaneLaunched(String(hwnd), shellPid)`. **Dogfood-verified (§5): the exact `conhost.exe` invocation
+   * that yields a classic console + injectable target is confirmed on the real desktop, not unit-testable.**
+   * Throws if no console window appears within `timeoutMs`.
+   */
+  async launchAnchoredConsole(
+    shellExe = "powershell.exe",
+    o: { timeoutMs?: number; pollMs?: number } = {},
+  ): Promise<{ hwnd: bigint; shellPid: number }> {
+    const timeoutMs = o.timeoutMs ?? 8000;
+    const pollMs = o.pollMs ?? 150;
+    // Snapshot existing console hwnds so we claim only the NEW one this spawn creates.
+    const before = new Set(
+      enumWindowsInZOrder().filter((w) => w.className === CONSOLE_WINDOW_CLASS).map((w) => w.hwnd),
+    );
+    // `conhost.exe <shell>` forces a CLASSIC conhost regardless of the user's default-terminal (WT) setting —
+    // the only form L2 can inject into. Detached + no stdio redirect so the child's console stays on screen for
+    // the human to type into (the cooperative model); we never read its stdio.
+    const child = spawn("conhost.exe", [shellExe], { detached: true, stdio: "ignore", windowsHide: false });
+    child.on("error", () => { /* spawn failure surfaces as the poll timing out below */ });
+    const childPid = child.pid;
+
+    const deadline = this.now() + timeoutMs;
+    for (;;) {
+      const fresh = enumWindowsInZOrder().find(
+        (w) =>
+          w.className === CONSOLE_WINDOW_CLASS &&
+          !before.has(w.hwnd) &&
+          // Prefer the window owned by OUR conhost child; fall back to any new console if the pid is unresolved
+          // (the owner can briefly read 0 during creation).
+          (childPid === undefined || getWindowProcessId(w.hwnd) === childPid || getWindowProcessId(w.hwnd) === 0),
+      );
+      if (fresh !== undefined && getWindowProcessId(fresh.hwnd) !== 0) {
+        return { hwnd: fresh.hwnd, shellPid: getWindowProcessId(fresh.hwnd) };
+      }
+      if (this.now() >= deadline) {
+        try { child.kill(); } catch { /* best-effort */ }
+        throw new KeyLockerError("KeyLockerSpawnFailed", "anchored console window did not appear");
+      }
+      await new Promise((r) => setTimeout(r, pollMs));
+    }
   }
 
   /** Consent state for `status` (readable Node-side without spawning the locker). */

--- a/src/engine/key-locker/key-locker-manager.ts
+++ b/src/engine/key-locker/key-locker-manager.ts
@@ -16,6 +16,7 @@
 // into.
 
 import { spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -185,24 +186,31 @@ export class KeyLockerManager {
    * launching arbitrary shells; this is a locker-owned, fixed, local shell) and polls for the new
    * `ConsoleWindowClass` window it owns. Returns `{ hwnd, shellPid }` (shellPid = the conhost pid = the window
    * owner; the shell + any ssh run as subtree descendants, which `sshDescendants` walks). The wiring fires
-   * `onLocalPaneLaunched(String(hwnd), shellPid)`. **Dogfood-verified (§5): the exact `conhost.exe` invocation
-   * that yields a classic console + injectable target is confirmed on the real desktop, not unit-testable.**
-   * Throws if no console window appears within `timeoutMs`.
+   * `onLocalPaneLaunched(String(hwnd), shellPid)`. The console gets a UNIQUE window title (`dtm-locker-console-
+   * <nonce>`) so the title-keyed read/inject seams resolve to EXACTLY this pane — `resolveTitleByHwnd` declines
+   * any pane whose title is not substring-unique, so without this a second console (or a same-titled user
+   * window) would never autofill (Codex W-4a R3 read-path). **Dogfood-verified (§5): the exact `conhost.exe`
+   * invocation that yields a classic console + injectable target (and that the title command takes) is confirmed
+   * on the real desktop, not unit-testable.** Throws if no console window appears within `timeoutMs`.
    */
   async launchAnchoredConsole(
-    shellExe = "powershell.exe",
     o: { timeoutMs?: number; pollMs?: number } = {},
-  ): Promise<{ hwnd: bigint; shellPid: number }> {
+  ): Promise<{ hwnd: bigint; shellPid: number; title: string }> {
     const timeoutMs = o.timeoutMs ?? 8000;
     const pollMs = o.pollMs ?? 150;
+    const title = `dtm-locker-console-${randomBytes(8).toString("hex")}`; // globally unique ⇒ unambiguous title read
     // Snapshot existing console hwnds so we claim only the NEW one this spawn creates.
     const before = new Set(
       enumWindowsInZOrder().filter((w) => w.className === CONSOLE_WINDOW_CLASS).map((w) => w.hwnd),
     );
-    // `conhost.exe <shell>` forces a CLASSIC conhost regardless of the user's default-terminal (WT) setting —
-    // the only form L2 can inject into. Detached + no stdio redirect so the child's console stays on screen for
-    // the human to type into (the cooperative model); we never read its stdio.
-    const child = spawn("conhost.exe", [shellExe], { detached: true, stdio: "ignore", windowsHide: false });
+    // `conhost.exe powershell …` forces a CLASSIC conhost regardless of the user's default-terminal (WT)
+    // setting — the only form L2 can inject into. The `-Command` sets the UNIQUE window title then leaves an
+    // interactive prompt (`-NoExit`) for the human to type into (the cooperative model); we never read its stdio.
+    const child = spawn(
+      "conhost.exe",
+      ["powershell.exe", "-NoExit", "-Command", `$Host.UI.RawUI.WindowTitle = '${title}'`],
+      { detached: true, stdio: "ignore", windowsHide: false },
+    );
     child.on("error", () => { /* spawn failure surfaces as the poll timing out below */ });
     // The console is a SEPARATE window the human owns — do NOT pin Node's event loop on its lifetime (else a
     // clean MCP shutdown would hang until the user closes the console). The wiring may kill `shellPid` on
@@ -221,7 +229,7 @@ export class KeyLockerManager {
       const fresh = enumWindowsInZOrder().find(
         (w) => w.className === CONSOLE_WINDOW_CLASS && !before.has(w.hwnd) && getWindowProcessId(w.hwnd) === childPid,
       );
-      if (fresh !== undefined) return { hwnd: fresh.hwnd, shellPid: childPid };
+      if (fresh !== undefined) return { hwnd: fresh.hwnd, shellPid: childPid, title };
       if (this.now() >= deadline) {
         try { child.kill(); } catch { /* best-effort */ }
         throw new KeyLockerError("KeyLockerSpawnFailed", "anchored console window did not appear");

--- a/src/engine/key-locker/key-locker-manager.ts
+++ b/src/engine/key-locker/key-locker-manager.ts
@@ -27,6 +27,7 @@ import {
   getProcessCommandLineByPid,
   getProcessIdentityByPid,
   getWindowProcessId,
+  getWindowTitleW,
 } from "../win32.js";
 import { SessionTracker } from "./session-tracker.js";
 import { SshSessionWatch, type ProcessSnapshot } from "./ssh-session-watch.js";
@@ -227,7 +228,14 @@ export class KeyLockerManager {
       // creation, returning the wrong hwnd/shellPid). The owner pid may read 0 transiently for ours too, so
       // we simply keep polling until it resolves to `childPid`.
       const fresh = enumWindowsInZOrder().find(
-        (w) => w.className === CONSOLE_WINDOW_CLASS && !before.has(w.hwnd) && getWindowProcessId(w.hwnd) === childPid,
+        (w) =>
+          w.className === CONSOLE_WINDOW_CLASS &&
+          !before.has(w.hwnd) &&
+          getWindowProcessId(w.hwnd) === childPid &&
+          // Wait until the `-Command` has APPLIED the unique title — else the pane's live title is still the
+          // default and `resolveTitleByHwnd` would transiently decline it (Opus W-4a R4 P3). Returning a
+          // title-applied pane makes it immediately usable.
+          getWindowTitleW(w.hwnd) === title,
       );
       if (fresh !== undefined) return { hwnd: fresh.hwnd, shellPid: childPid, title };
       if (this.now() >= deadline) {

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -526,11 +526,13 @@ export function buildExitCommand(input: string, shell: ExitShell, nonce: string)
  * `<token>|<code>|…`, parsed by the SAME `parseExitSentinel`. It does NOT reset `$LASTEXITCODE` first (that would
  * clobber the value being read). Send it with `notifyDispatch:false` (it is read-only, not a credential command).
  *
- * CAVEAT (PowerShell, cmdlet-only credential command): because `buildExitCommand` resets `$LASTEXITCODE=$null`
- * before its input but a PROBE cannot (Opus W-4a P3-2), a credential command that ran NO native exe leaves
- * `$LASTEXITCODE` at a STALE value from an earlier native exe, which `parseExitSentinel` prefers over `$?`. Key
- * Locker's real Mode-A credentials are native (`ssh`/`git`/`sudo`), so this is not hit in practice; the
- * asymmetry with `buildExitCommand`'s reset is noted here.
+ * PowerShell STALE-`$LASTEXITCODE` FIX (Opus/Codex W-4a P3-2): `buildExitCommand` resets `$LASTEXITCODE=$null`
+ * before its input so a cmdlet-only command reports via `$?`; a PROBE cannot reset (it would clobber the value
+ * it observes), so reading `$LASTEXITCODE` would emit a STALE native exit code that `parseExitSentinel` prefers
+ * over `$?`. Since Mode-A landed detection only needs SUCCESS-vs-FAILURE (`isExitAccepted` = `exitCode===0`),
+ * the PS probe emits ONLY `$?` (empty code field ⇒ `parseExitSentinel` maps the trailing bool True→0 / False→1)
+ * — ALWAYS the just-finished command's result, stale-immune, for cmdlets AND native exes alike. (bash `$?` is
+ * already the fresh numeric exit code, so bash keeps the precise code.)
  */
 export function buildExitProbe(shell: ExitShell, nonce: string): string {
   const head = EXIT_TOKEN_HEAD;
@@ -538,9 +540,9 @@ export function buildExitProbe(shell: ExitShell, nonce: string): string {
   if (shell === "bash") {
     return `__dtmcp_rc=$?; printf '%s%s|%d|\\n' '${head}' "${tail}" "$__dtmcp_rc"`;
   }
-  // powershell — read the prior command's $?/$LASTEXITCODE with NO pre-reset (buildExitCommand resets before
-  // running the input; a probe must preserve the value it is observing).
-  return `$dtmcp_ok=$?; $dtmcp_c=$LASTEXITCODE; ('${head}'+"${tail}")+'|'+([string]$dtmcp_c)+'|'+$dtmcp_ok`;
+  // powershell — emit ONLY `$?` (bool), NOT `$LASTEXITCODE` (which a probe cannot reset and would read stale
+  // for a cmdlet-only command). Empty code field ⇒ parseExitSentinel uses the bool ⇒ fresh success/failure.
+  return `$dtmcp_ok=$?; ('${head}'+"${tail}")+'|'+'|'+$dtmcp_ok`;
 }
 
 /**

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -247,7 +247,7 @@ const HIDDEN_INPUT_PROMPT_PATTERNS: readonly RegExp[] = [
  * TextPattern snapshot — the cursor row. ANSI is stripped here so callers can
  * pass either ANSI-laden or pre-cleaned text. Returns null for null/blank input.
  */
-function lastNonEmptyPromptLine(baselineRaw: string | null): string | null {
+export function lastNonEmptyPromptLine(baselineRaw: string | null): string | null {
   if (!baselineRaw) return null;
   const cleaned = stripAnsi(baselineRaw).replace(/\r\n/g, "\n");
   const lines = cleaned.split("\n");
@@ -514,6 +514,42 @@ export function buildExitCommand(input: string, shell: ExitShell, nonce: string)
     `$global:LASTEXITCODE = $null # ${nonce}\n${input}\n` +
     `$dtmcp_ok=$?; $dtmcp_c=$LASTEXITCODE; ('${head}'+"${tail}")+'|'+([string]$dtmcp_c)+'|'+$dtmcp_ok`
   );
+}
+
+/**
+ * The EPILOGUE-ONLY exit probe (ADR-014 R3 L3-4 W-4, gap6): the same echo-immune sentinel as
+ * `buildExitCommand` but WITHOUT re-sending the command. The Key Locker wiring's Mode-A landed detection uses
+ * this to read the exit code of an ALREADY-RUN credential command (fire-after: the command is running/done, its
+ * prompt already answered), NEVER re-executing it — re-running a non-idempotent one-shot (`git push`) would be
+ * a fatal double-execute. Send this as the NEXT command once the prompt has returned; it reads the just-finished
+ * command's `$?` / `$LASTEXITCODE` (unchanged since — the shell was idle at the prompt) and prints
+ * `<token>|<code>|…`, parsed by the SAME `parseExitSentinel`. It does NOT reset `$LASTEXITCODE` first (that would
+ * clobber the value being read). Send it with `notifyDispatch:false` (it is read-only, not a credential command).
+ */
+export function buildExitProbe(shell: ExitShell, nonce: string): string {
+  const head = EXIT_TOKEN_HEAD;
+  const tail = EXIT_TOKEN_TAIL_PREFIX + nonce;
+  if (shell === "bash") {
+    return `__dtmcp_rc=$?; printf '%s%s|%d|\\n' '${head}' "${tail}" "$__dtmcp_rc"`;
+  }
+  // powershell — read the prior command's $?/$LASTEXITCODE with NO pre-reset (buildExitCommand resets before
+  // running the input; a probe must preserve the value it is observing).
+  return `$dtmcp_ok=$?; $dtmcp_c=$LASTEXITCODE; ('${head}'+"${tail}")+'|'+([string]$dtmcp_c)+'|'+$dtmcp_ok`;
+}
+
+/**
+ * Resolve a pane's hwnd (decimal string = the Key Locker `paneId`) to its EXACT window title, or null if no
+ * live window has that hwnd (ADR-014 R3 L3-4 W-4, gap2). The title-keyed terminal seams (`readTerminalRaw` /
+ * `terminalRunHandler`) partial-match on title, so two panes to the SAME host share a title and
+ * `findTerminalWindow` could grab the wrong window → a false-positive prompt would inject a secret into a
+ * promptless pane. The wiring resolves the title by EXACT hwnd here (the stable per-pane key), so a stale/
+ * duplicate title can never redirect the read/inject. Uses `enumWindowsInZOrder` (the same source
+ * `findTerminalWindow` reads). A vanished hwnd ⇒ null ⇒ the wiring declines.
+ */
+export function resolveTitleByHwnd(paneId: string): string | null {
+  const target = BigInt(paneId);
+  const win = enumWindowsInZOrder().find((w) => w.hwnd === target);
+  return win !== undefined ? win.title : null;
 }
 
 /**

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -525,6 +525,12 @@ export function buildExitCommand(input: string, shell: ExitShell, nonce: string)
  * command's `$?` / `$LASTEXITCODE` (unchanged since — the shell was idle at the prompt) and prints
  * `<token>|<code>|…`, parsed by the SAME `parseExitSentinel`. It does NOT reset `$LASTEXITCODE` first (that would
  * clobber the value being read). Send it with `notifyDispatch:false` (it is read-only, not a credential command).
+ *
+ * CAVEAT (PowerShell, cmdlet-only credential command): because `buildExitCommand` resets `$LASTEXITCODE=$null`
+ * before its input but a PROBE cannot (Opus W-4a P3-2), a credential command that ran NO native exe leaves
+ * `$LASTEXITCODE` at a STALE value from an earlier native exe, which `parseExitSentinel` prefers over `$?`. Key
+ * Locker's real Mode-A credentials are native (`ssh`/`git`/`sudo`), so this is not hit in practice; the
+ * asymmetry with `buildExitCommand`'s reset is noted here.
  */
 export function buildExitProbe(shell: ExitShell, nonce: string): string {
   const head = EXIT_TOKEN_HEAD;
@@ -538,18 +544,26 @@ export function buildExitProbe(shell: ExitShell, nonce: string): string {
 }
 
 /**
- * Resolve a pane's hwnd (decimal string = the Key Locker `paneId`) to its EXACT window title, or null if no
- * live window has that hwnd (ADR-014 R3 L3-4 W-4, gap2). The title-keyed terminal seams (`readTerminalRaw` /
- * `terminalRunHandler`) partial-match on title, so two panes to the SAME host share a title and
- * `findTerminalWindow` could grab the wrong window → a false-positive prompt would inject a secret into a
- * promptless pane. The wiring resolves the title by EXACT hwnd here (the stable per-pane key), so a stale/
- * duplicate title can never redirect the read/inject. Uses `enumWindowsInZOrder` (the same source
- * `findTerminalWindow` reads). A vanished hwnd ⇒ null ⇒ the wiring declines.
+ * Resolve a pane's hwnd (decimal string = the Key Locker `paneId`) to a window title the title-keyed seams
+ * (`readTerminalRaw` / `terminalRunHandler`) will resolve BACK to the SAME hwnd — else null (ADR-014 R3 L3-4
+ * W-4, gap2). Those seams partial-match on title via `findTerminalWindow` (FIRST z-order hit), so two panes to
+ * the SAME host (e.g. two `conhost.exe powershell.exe` windows) share a title: a naive hwnd→title lookup would
+ * hand back a title that `findTerminalWindow` then resolves to a DIFFERENT window → a read/inject targets the
+ * wrong pane (a false-positive prompt on pane B → the secret typed into promptless pane A as a command, a
+ * disclosure — L2 ReVerify pid-anchors the INJECT hwnd but cannot see that the prompt was on another pane).
+ * So this ROUND-TRIPS: find the exact hwnd's title, then require `findTerminalWindow(title)` to resolve to the
+ * SAME hwnd. If the title is ambiguous (a same-title sibling wins the z-order match), it returns null ⇒ the
+ * wiring declines rather than act on the wrong pane. Residual: a UIA/z-order TOCTOU sliver between this check
+ * and the seam's own lookup (OQ-W-9 class). A vanished hwnd ⇒ null.
  */
 export function resolveTitleByHwnd(paneId: string): string | null {
-  const target = BigInt(paneId);
+  let target: bigint;
+  try { target = BigInt(paneId); } catch { return null; } // malformed paneId ⇒ decline (never throw — contract is null-on-miss)
   const win = enumWindowsInZOrder().find((w) => w.hwnd === target);
-  return win !== undefined ? win.title : null;
+  if (win === undefined) return null;
+  // Guard the downstream partial-title match: the seams will call findTerminalWindow(title); only proceed if
+  // that unambiguously resolves back to THIS pane's hwnd.
+  return findTerminalWindow(win.title)?.hwnd === target ? win.title : null;
 }
 
 /**

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -561,11 +561,21 @@ export function buildExitProbe(shell: ExitShell, nonce: string): string {
 export function resolveTitleByHwnd(paneId: string): string | null {
   let target: bigint;
   try { target = BigInt(paneId); } catch { return null; } // malformed paneId ⇒ decline (never throw — contract is null-on-miss)
-  const win = enumWindowsInZOrder().find((w) => w.hwnd === target);
+  const wins = enumWindowsInZOrder();
+  const win = wins.find((w) => w.hwnd === target);
   if (win === undefined) return null;
-  // Guard the downstream partial-title match: the seams will call findTerminalWindow(title); only proceed if
-  // that unambiguously resolves back to THIS pane's hwnd.
-  return findTerminalWindow(win.title)?.hwnd === target ? win.title : null;
+  // The downstream read/find seams resolve by SUBSTRING title, and via DIFFERENT orders: `findTerminalWindow`
+  // takes the z-order-first `title.includes(query)`, while `readTerminalRaw`'s `getTextViaTextPattern` does its
+  // OWN UIA search `Name -like '*query*'` (UIA-tree order) — so guarding only findTerminalWindow is NOT enough
+  // (Codex W-4a R3: the read can still hit a same-title sibling in a different order → read pane B's prompt,
+  // inject into pane A ⇒ wrong-pane disclosure). The title is safe to hand those seams ONLY if EXACTLY ONE live
+  // window's title CONTAINS it — then every substring search, in any order, resolves to this one window. An
+  // empty title never qualifies. (`launchAnchoredConsole` gives its consoles a unique title so they pass;
+  // ambiguous panes decline — bounded-safe.)
+  const t = win.title.toLowerCase();
+  if (t.length === 0) return null;
+  const matches = wins.filter((w) => w.title.toLowerCase().includes(t));
+  return matches.length === 1 && matches[0].hwnd === target ? win.title : null;
 }
 
 /**

--- a/tests/fixtures/failwith-callsite-shapes.json
+++ b/tests/fixtures/failwith-callsite-shapes.json
@@ -517,28 +517,28 @@
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 794,
+      "line": 830,
       "tool": "terminal:read",
       "errKind": "identifier",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 864,
+      "line": 900,
       "tool": "terminal:read",
       "errKind": "identifier",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 1205,
+      "line": 1241,
       "tool": "terminal:send",
       "errKind": "new-error",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 1494,
+      "line": 1530,
       "tool": "terminal:send",
       "errKind": "identifier",
       "contextShape": "object-plain"

--- a/tests/fixtures/failwith-callsite-shapes.json
+++ b/tests/fixtures/failwith-callsite-shapes.json
@@ -517,28 +517,28 @@
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 846,
+      "line": 856,
       "tool": "terminal:read",
       "errKind": "identifier",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 916,
+      "line": 926,
       "tool": "terminal:read",
       "errKind": "identifier",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 1257,
+      "line": 1267,
       "tool": "terminal:send",
       "errKind": "new-error",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 1546,
+      "line": 1556,
       "tool": "terminal:send",
       "errKind": "identifier",
       "contextShape": "object-plain"

--- a/tests/fixtures/failwith-callsite-shapes.json
+++ b/tests/fixtures/failwith-callsite-shapes.json
@@ -517,28 +517,28 @@
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 830,
+      "line": 844,
       "tool": "terminal:read",
       "errKind": "identifier",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 900,
+      "line": 914,
       "tool": "terminal:read",
       "errKind": "identifier",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 1241,
+      "line": 1255,
       "tool": "terminal:send",
       "errKind": "new-error",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 1530,
+      "line": 1544,
       "tool": "terminal:send",
       "errKind": "identifier",
       "contextShape": "object-plain"

--- a/tests/fixtures/failwith-callsite-shapes.json
+++ b/tests/fixtures/failwith-callsite-shapes.json
@@ -517,28 +517,28 @@
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 844,
+      "line": 846,
       "tool": "terminal:read",
       "errKind": "identifier",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 914,
+      "line": 916,
       "tool": "terminal:read",
       "errKind": "identifier",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 1255,
+      "line": 1257,
       "tool": "terminal:send",
       "errKind": "new-error",
       "contextShape": "object-plain"
     },
     {
       "file": "src/tools/terminal.ts",
-      "line": 1544,
+      "line": 1546,
       "tool": "terminal:send",
       "errKind": "identifier",
       "contextShape": "object-plain"

--- a/tests/unit/issue-386-exit-mode-sentinel.test.ts
+++ b/tests/unit/issue-386-exit-mode-sentinel.test.ts
@@ -192,6 +192,13 @@ describe("buildExitProbe — epilogue-only probe (W-4 gap6: observe, never re-ru
     expect(parseExitSentinel(`${probe}\n${TOKEN}|0|True`, NONCE, "powershell")).toEqual({ matched: true, exitCode: 0 });
     expect(parseExitSentinel(`${probe}\n${TOKEN}||False`, NONCE, "powershell")).toEqual({ matched: true, exitCode: 1 });
   });
+
+  it("drift-guard: the probe IS the exit epilogue of buildExitCommand (same sentinel machinery)", () => {
+    // If buildExitCommand's epilogue ever changes, the probe must track it (else Mode-A landed silently breaks).
+    for (const shell of ["bash", "powershell"] as const) {
+      expect(buildExitCommand("<cmd>", shell, NONCE).endsWith(buildExitProbe(shell, NONCE))).toBe(true);
+    }
+  });
 });
 
 describe("detectShell — process name → shell + confidence", () => {

--- a/tests/unit/issue-386-exit-mode-sentinel.test.ts
+++ b/tests/unit/issue-386-exit-mode-sentinel.test.ts
@@ -182,22 +182,23 @@ describe("buildExitProbe — epilogue-only probe (W-4 gap6: observe, never re-ru
     expect(parseExitSentinel(`${probe}\n${TOKEN}|127|`, NONCE, "bash")).toEqual({ matched: true, exitCode: 127 });
   });
 
-  it("powershell: reads $?/$LASTEXITCODE with NO pre-reset (must not clobber the value being observed)", () => {
+  it("powershell: emits ONLY $? (stale-immune) — NOT $LASTEXITCODE, which a probe cannot reset (Codex P3-2)", () => {
     const probe = buildExitProbe("powershell", NONCE);
-    // buildExitCommand resets `$global:LASTEXITCODE = $null` BEFORE running its input; a probe observing an
-    // ALREADY-run command must NOT reset — else it reads null instead of the real exit code.
+    // A probe cannot reset $LASTEXITCODE (that would clobber the value it observes), so reading it would emit a
+    // STALE native exit code for a cmdlet-only command. The probe emits only $? (bool) — always fresh; landed
+    // detection only needs success/failure. Empty code field ⇒ parseExitSentinel maps the bool.
+    expect(probe).not.toContain("$LASTEXITCODE");
     expect(probe).not.toContain("= $null");
-    expect(probe).toContain("$LASTEXITCODE");
+    expect(probe).toContain("$?");
     expect(probe).not.toContain(TOKEN);
-    expect(parseExitSentinel(`${probe}\n${TOKEN}|0|True`, NONCE, "powershell")).toEqual({ matched: true, exitCode: 0 });
+    expect(parseExitSentinel(`${probe}\n${TOKEN}||True`, NONCE, "powershell")).toEqual({ matched: true, exitCode: 0 });
     expect(parseExitSentinel(`${probe}\n${TOKEN}||False`, NONCE, "powershell")).toEqual({ matched: true, exitCode: 1 });
   });
 
-  it("drift-guard: the probe IS the exit epilogue of buildExitCommand (same sentinel machinery)", () => {
-    // If buildExitCommand's epilogue ever changes, the probe must track it (else Mode-A landed silently breaks).
-    for (const shell of ["bash", "powershell"] as const) {
-      expect(buildExitCommand("<cmd>", shell, NONCE).endsWith(buildExitProbe(shell, NONCE))).toBe(true);
-    }
+  it("drift-guard: the BASH probe IS the exit epilogue of buildExitCommand (same sentinel machinery)", () => {
+    // bash: $? is the fresh numeric exit code, so the probe re-uses buildExitCommand's exact epilogue. (PS
+    // deliberately DIVERGES — the probe drops $LASTEXITCODE for $? to stay stale-immune; see the PS test above.)
+    expect(buildExitCommand("<cmd>", "bash", NONCE).endsWith(buildExitProbe("bash", NONCE))).toBe(true);
   });
 });
 

--- a/tests/unit/issue-386-exit-mode-sentinel.test.ts
+++ b/tests/unit/issue-386-exit-mode-sentinel.test.ts
@@ -18,6 +18,7 @@
 import { describe, it, expect } from "vitest";
 import {
   buildExitCommand,
+  buildExitProbe,
   parseExitSentinel,
   detectShell,
   isUnsafeForExitMode,
@@ -164,6 +165,32 @@ describe("buildExitCommand → parseExitSentinel round-trip (simulated buffer)",
     expect(parseExitSentinel(cmd, NONCE, "powershell").matched).toBe(false);
     const buffer = `${cmd}\n${TOKEN}||True`;
     expect(parseExitSentinel(buffer, NONCE, "powershell")).toEqual({ matched: true, exitCode: 0 });
+  });
+});
+
+describe("buildExitProbe — epilogue-only probe (W-4 gap6: observe, never re-run)", () => {
+  it("bash: contains NO command (never re-runs), and its OUTPUT round-trips to the exit code", () => {
+    const probe = buildExitProbe("bash", NONCE);
+    // The probe re-sends NO credential command — only the `$?`-reading epilogue. This is the whole point:
+    // re-running a non-idempotent one-shot (`git push`) would double-execute.
+    expect(probe).not.toContain("git push");
+    expect(probe).toContain("$?");
+    expect(probe).not.toContain(TOKEN); // echo-immune: the SENT text never has the contiguous token
+    // echo alone defers; the runtime OUTPUT (reading the prior command's $? = 0) matches.
+    expect(parseExitSentinel(probe, NONCE, "bash").matched).toBe(false);
+    expect(parseExitSentinel(`${probe}\n${TOKEN}|0|`, NONCE, "bash")).toEqual({ matched: true, exitCode: 0 });
+    expect(parseExitSentinel(`${probe}\n${TOKEN}|127|`, NONCE, "bash")).toEqual({ matched: true, exitCode: 127 });
+  });
+
+  it("powershell: reads $?/$LASTEXITCODE with NO pre-reset (must not clobber the value being observed)", () => {
+    const probe = buildExitProbe("powershell", NONCE);
+    // buildExitCommand resets `$global:LASTEXITCODE = $null` BEFORE running its input; a probe observing an
+    // ALREADY-run command must NOT reset — else it reads null instead of the real exit code.
+    expect(probe).not.toContain("= $null");
+    expect(probe).toContain("$LASTEXITCODE");
+    expect(probe).not.toContain(TOKEN);
+    expect(parseExitSentinel(`${probe}\n${TOKEN}|0|True`, NONCE, "powershell")).toEqual({ matched: true, exitCode: 0 });
+    expect(parseExitSentinel(`${probe}\n${TOKEN}||False`, NONCE, "powershell")).toEqual({ matched: true, exitCode: 1 });
   });
 });
 


### PR DESCRIPTION
## What this is

**W-4a** — the production-side (hot-path) seams the W-4b wiring root will compose. A Fable design review of the W-4 plan surfaced **three P1 blockers**; this PR is the hot-path half of their resolution (terminal.ts + the manager). W-4b (the pure `key-locker-wiring.ts` + registration) follows.

## The three gaps (Fable-resolved, code-verified)

- **gap6 — Mode-A landed must OBSERVE, not RE-RUN (`terminal.ts buildExitProbe`).** `terminalRunHandler until:exit` re-sends via `buildExitCommand` = re-executes the credential command — fatal for a non-idempotent one-shot (`git push` twice) under fire-after (the command already ran). New `buildExitProbe(shell, nonce)` is the **epilogue-only** echo-immune sentinel: sent as the next command once the prompt returns, it reads the just-finished command's `$?`/`$LASTEXITCODE` and prints the sentinel, **never re-sending the command**. No PS `$LASTEXITCODE` pre-reset (that would clobber the value being observed). Parsed by the same `parseExitSentinel`.
- **gap2 — wrong-pane secret injection (`terminal.ts resolveTitleByHwnd`).** The title-keyed seams partial-match on title, so two panes to the SAME host share a title → a false-positive prompt could plaintext-inject a secret into the wrong (promptless) pane. `resolveTitleByHwnd(paneId)` resolves the EXACT hwnd (the stable per-pane key) → title, so a stale/duplicate title can't redirect the read/inject.
- **gap1 — no anchorable+injectable pane exists (`manager.launchAnchoredConsole`).** Code-verified: R1's cooperative terminal is HEADLESS-only (the visible console is R2's unshipped S2), the ONLY injectable window is a classic `ConsoleWindowClass` conhost (the L2 `Injection.cs` positive-allowlist; wt.exe is `target_multiplexed`), and `workspace_launch` blocks all shells. So the manager spawns `conhost.exe <shell>` directly (a locker-owned local shell — it does not route through the assistant-facing workspace_launch blocklist) + polls for the new console window → `{ hwnd, shellPid }`. The minimum of R2's visible-pane capability so R3 autofill can land on a real injectable pane. **Dogfood-verified (§5)** — the exact conhost invocation is confirmed on the real desktop; not unit-testable.
- **gap5 — `export lastNonEmptyPromptLine`** for the wiring's readPromptTail/readPaneAfterAuth composition (no duplication).

## Tests

`buildExitProbe` unit tests: round-trips `parseExitSentinel` (bash + PS, exit 0/127/cmdlet-false); re-sends NO command (never double-executes); PS has no `$LASTEXITCODE` pre-reset. `resolveTitleByHwnd` + `launchAnchoredConsole` are win32/GUI ⇒ dogfood-verified (like `capture`'s dialog).

## Verification

```
npm run build && npm run lint                                   # clean
npx vitest run --project unit tests/unit/issue-386-*.test.ts    # 53 passed (buildExitProbe incl.)
key-locker + terminal unit                                      # green
check:stub-catalog                                              # no drift
check:failwith-fixtures                                         # regenerated (terminal.ts callsite line shifts only)
```

No public MCP tool change. Next: **W-4b** (`key-locker-wiring.ts` — composes these seams into the driver + timers + registration).

Plan: `desktop-touch-mcp-internal@cb8b2e3:docs/adr-014-v2-r3-l3-4-live-wiring-plan.md` (W-4 gap1/gap2/gap6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)