### PR TITLE
ADR-014 v2 R3 Key Locker — L3-4 W-4b: the live-wiring composition root

### DIFF
--- a/src/engine/key-locker/binding-store.ts
+++ b/src/engine/key-locker/binding-store.ts
@@ -134,13 +134,20 @@ export class BindingStore {
    * (a map row proves only "canonical → opaqueId", not "the secret survives"); a stale row is
    * pruned and reported as no binding. One cheap local pipe round-trip per autofill offer.
    */
-  async resolve(canonicalKey: string): Promise<{ opaqueId: string } | undefined> {
+  async resolve(canonicalKey: string, opts: { prune?: boolean } = {}): Promise<{ opaqueId: string } | undefined> {
     if (this.existsInLocker === undefined) throw new LockerNotBoundError("resolve");
     const row = this.data.bindings[canonicalKey];
     if (row === undefined) return undefined;
     if (!(await this.existsInLocker(row.opaqueId))) {
-      delete this.data.bindings[canonicalKey];
-      this.save();
+      // `prune: false` (the live-wiring hot path — it loads a FRESH store per op): DO NOT delete+save. A
+      // stale-row prune here rewrites the WHOLE snapshot, and this async `existsInLocker` await can straddle a
+      // concurrent user `key_locker` save/set_policy on ANOTHER binding — the prune would then clobber that
+      // write with its pre-write snapshot (Codex W-4b). A stale row is harmless (reported as no-binding); it
+      // is pruned only from a pruning caller (the L4 tool) whose writes are user-initiated, not a 500ms loop.
+      if (opts.prune !== false) {
+        delete this.data.bindings[canonicalKey];
+        this.save();
+      }
       return undefined;
     }
     return { opaqueId: row.opaqueId };

--- a/src/server-windows.ts
+++ b/src/server-windows.ts
@@ -38,6 +38,7 @@ import { registerScreenshotQueryTool } from "./tools/screenshot-query.js";
 import { registerScreenshotGcTool } from "./tools/screenshot-gc.js";
 import { registerServerStatusTool } from "./tools/server-status.js";
 import { registerKeyLockerTools } from "./tools/key-locker-tool.js";
+import { registerKeyLockerWiring } from "./tools/key-locker-wiring.js";
 import { logAutoGuardStartup } from "./tools/_action-guard.js";
 import {
   stopNativeRuntime,
@@ -234,6 +235,9 @@ function createMcpServer(): McpServer {
   // ADR-014 R3 — the key locker management tool (self-gates on the kill switch, so a disabled
   // locker registers nothing).
   registerKeyLockerTools(s);
+  // ADR-014 R3 L3-4 W-4 — the live autofill wiring (S-A dispatch hook + reconcile/idle timers). No-op when
+  // kill-switched; returns a teardown the shutdown path clears (timers + event-bus + hooks).
+  disposeKeyLockerWiring = registerKeyLockerWiring();
 
   // Screenshot by-ref resource (always-on: the screenshot tool returns
   // resource_link refs by default, so this read handler must be available).
@@ -322,6 +326,8 @@ let shuttingDown = false;
 const inflightIds = new Set<string | number>();
 let shutdownPending = false;
 let shutdownTimer: NodeJS.Timeout | null = null;
+/** Teardown for the ADR-014 R3 live wiring (timers + event-bus + dispatch hook), set at registration. */
+let disposeKeyLockerWiring: (() => void) | null = null;
 const SHUTDOWN_GRACE_MS = 60_000;
 
 function shutdown(exitCode = 0): void {
@@ -333,6 +339,8 @@ function shutdown(exitCode = 0): void {
     shutdownTimer = null;
   }
   console.error("[desktop-touch] Shutting down...");
+  disposeKeyLockerWiring?.(); // ADR-014 R3 L3-4 W-4: clear the wiring's timers + event-bus + dispatch hook
+  disposeKeyLockerWiring = null;
   stopNativeRuntime();
   // ADR-019 Stage 5 sub-plan §6 R2 + ADR-020 SR-4 PR-SR4-2 — release the
   // shared DXGI duplication broker so the GPU session does not leak past

--- a/src/server-windows.ts
+++ b/src/server-windows.ts
@@ -326,8 +326,10 @@ let shuttingDown = false;
 const inflightIds = new Set<string | number>();
 let shutdownPending = false;
 let shutdownTimer: NodeJS.Timeout | null = null;
-/** Teardown for the ADR-014 R3 live wiring (timers + event-bus + dispatch hook), set at registration. */
-let disposeKeyLockerWiring: (() => void) | null = null;
+/** Teardown for the ADR-014 R3 live wiring (timers + event-bus + dispatch hook + host dispose), set at
+ *  registration. Returns a promise the shutdown path AWAITS so the detached key-locker.exe is killed before
+ *  process.exit (Codex W-4b). */
+let disposeKeyLockerWiring: (() => Promise<void>) | null = null;
 const SHUTDOWN_GRACE_MS = 60_000;
 
 function shutdown(exitCode = 0): void {
@@ -339,7 +341,10 @@ function shutdown(exitCode = 0): void {
     shutdownTimer = null;
   }
   console.error("[desktop-touch] Shutting down...");
-  disposeKeyLockerWiring?.(); // ADR-014 R3 L3-4 W-4: clear the wiring's timers + event-bus + dispatch hook
+  // ADR-014 R3 L3-4 W-4: the teardown clears the wiring's timers + event-bus + dispatch hook SYNCHRONOUSLY now
+  // and returns the host-dispose PROMISE, which we AWAIT in the flush Promise.all below so the detached
+  // key-locker.exe is killed before process.exit (Codex W-4b :127).
+  const keyLockerWiringTeardown = disposeKeyLockerWiring?.() ?? Promise.resolve();
   disposeKeyLockerWiring = null;
   stopNativeRuntime();
   // ADR-019 Stage 5 sub-plan §6 R2 + ADR-020 SR-4 PR-SR4-2 — release the
@@ -359,6 +364,7 @@ function shutdown(exitCode = 0): void {
   Promise.all([
     uiPatternStore.flushImmediateForShutdown(),
     macroOutcomeStore.flushImmediateForShutdown(),
+    keyLockerWiringTeardown, // ADR-014 R3 W-4: await the locker host dispose (shutdown frame + kill) before exit
   ])
     .catch(() => {})
     .finally(() => {

--- a/src/tools/key-locker-tool.ts
+++ b/src/tools/key-locker-tool.ts
@@ -102,6 +102,13 @@ function manager(): KeyLockerManager {
   return (managerSingleton ??= new KeyLockerManager());
 }
 
+/** The shared `KeyLockerManager` singleton — the L4 tool AND the W-4 live wiring MUST use the SAME instance so
+ *  they share the one host + the one `tracker`/`watch`/`snapshotProcessTree` (Explore gap4). Lazy-constructs on
+ *  first use; honors `__setKeyLockerManagerForTest`. */
+export function keyLockerManager(): KeyLockerManager {
+  return manager();
+}
+
 /** TEST-ONLY seam: inject a manager (e.g. a fake-host subclass) or reset (null) the singleton. */
 export function __setKeyLockerManagerForTest(mgr: KeyLockerManager | null): void {
   managerSingleton = mgr;

--- a/src/tools/key-locker-wiring.ts
+++ b/src/tools/key-locker-wiring.ts
@@ -40,6 +40,7 @@ import {
   buildExitProbe,
   generateExitNonce,
   isSecretInputPrompt,
+  lastNonEmptyPromptLine,
   parseExitSentinel,
   readTerminalRaw,
   resolveTitleByHwnd,
@@ -205,13 +206,20 @@ export class KeyLockerWiring {
     return this.manager.withHost((h) => inject(h, binding, opaqueId, "pane", target));
   }
 
-  /** S-B readPromptTail: resolve the pane's title (substring-unique or null → decline) → read → classify. */
+  /** S-B readPromptTail: resolve the pane's title (substring-unique or null → decline) → read → classify.
+   *  Stricter than a bare `isSecretInputPrompt` for the INJECT trigger: also require the cursor row to END IN A
+   *  COLON. A real hidden-input prompt (`[sudo] password for alice:`, `Enter passphrase:`, `Password:`) ends in
+   *  `:`; a COMMAND ECHO / OUTPUT that merely ends in a credential word (`sudo tail -f /tmp/password`, cached
+   *  sudo, no prompt) does NOT — and `isSecretInputPrompt` alone would match it and inject the stored secret
+   *  into the running process (Codex W-4b disclosure). A colon-less real prompt is rare ⇒ it declines and the
+   *  human types it (never a wrong-inject). A proper echo-off detector is the robust follow-up (OQ-W-17-bis). */
   private async readPromptTail(paneId: string): Promise<PromptVerdict | null> {
     const title = resolveTitleByHwnd(paneId);
     if (title === null) return null; // ambiguous / vanished title ⇒ decline (never read a same-title sibling)
     const raw = await readTerminalRaw(title);
     if (raw === null) return null;
-    const isCredentialPrompt = isSecretInputPrompt(raw.text);
+    const line = lastNonEmptyPromptLine(raw.text);
+    const isCredentialPrompt = line !== null && /:\s*$/.test(line) && isSecretInputPrompt(raw.text);
     return { isCredentialPrompt, tail: raw.text, stillHiddenPrompt: isCredentialPrompt };
   }
 

--- a/src/tools/key-locker-wiring.ts
+++ b/src/tools/key-locker-wiring.ts
@@ -97,7 +97,9 @@ export class KeyLockerWiring {
       if (!this.enabled()) return; // runtime consent/kill re-check — never arm/record for an un-consented user
       this.driver.onDispatch(ev.paneId, ev.command);
     });
-    this.eventSubId = subscribe(["window_disappeared"]);
+    // NOTE: the event-bus subscription is NOT taken here — it is subscribed LAZILY in `tick()` only while
+    // consent is active (Codex W-4b :100). On a default install where the locker was never enabled, subscribing
+    // here would run the event-bus's 500ms EnumWindows sweep forever even though every tick returns early.
     this.tickTimer = setInterval(() => this.tick(), TICK_MS);
     this.tickTimer.unref?.();
     // ALWAYS `.catch()` a floating drive: `server-windows.ts` turns an unhandledRejection into a full
@@ -141,12 +143,17 @@ export class KeyLockerWiring {
 
   // ── the reconcile tick ────────────────────────────────────────────────────────────────────────────────
   private tick(): void {
-    if (!this.enabled()) return;
+    if (!this.enabled()) {
+      // Un-consented / kill-switched: drop our event-bus subscription (if consent was revoked) so we stop
+      // paying the 500ms EnumWindows sweep, and do nothing else (Codex W-4b :100).
+      if (this.eventSubId !== null) { unsubscribe(this.eventSubId); this.eventSubId = null; }
+      return;
+    }
+    // Consent is active — subscribe LAZILY on the first enabled tick (so a default install never paid for it).
+    if (this.eventSubId === null) this.eventSubId = subscribe(["window_disappeared"]);
     // gap3: a closed pane → forget it (W2 close atomicity is inside onPaneClosed).
-    if (this.eventSubId !== null) {
-      for (const ev of pollEvents(this.eventSubId)) {
-        if (ev.type === "window_disappeared") this.driver.onPaneClosed(ev.hwnd);
-      }
+    for (const ev of pollEvents(this.eventSubId)) {
+      if (ev.type === "window_disappeared") this.driver.onPaneClosed(ev.hwnd);
     }
     // Periodic reconcile (correlate stragglers + advance baselines + watch.tick + arm-hygiene).
     this.driver.tickWatch();

--- a/src/tools/key-locker-wiring.ts
+++ b/src/tools/key-locker-wiring.ts
@@ -69,18 +69,25 @@ const EXIT_POLL_MS = 300;
  */
 export class KeyLockerWiring {
   private readonly driver: KeyLockerCaptureDriver;
-  private readonly bindings: BindingStore;
-  private readonly nevers: NeverStore;
   private tickTimer: NodeJS.Timeout | null = null;
   private idleTimer: NodeJS.Timeout | null = null;
   private eventSubId: string | null = null;
 
   constructor(private readonly manager: KeyLockerManager) {
-    // The BindingStore verifies each candidate secret still EXISTS in the locker (prune stale rows) via the
-    // host `exists` verb, and the NeverStore holds tombstones — both keyed off the manager's store dir.
-    this.bindings = BindingStore.load(manager.storeDir, (id) => manager.withHost((h) => h.exists(id)));
-    this.nevers = NeverStore.load(manager.storeDir);
     this.driver = new KeyLockerCaptureDriver(this.buildDeps());
+  }
+
+  // The binding + never stores are loaded FRESH per operation (from disk), NOT cached on the instance — the L4
+  // `key_locker` tool writes a fresh `BindingStore`/never-store on every `save`/`set_policy`/`forget`, so a
+  // cached copy would make a credential saved (or a policy changed) IN THE SAME SESSION invisible to autofill
+  // until a process restart (Codex W-4b — the pre-seed flow would fall back to a no-match capture). `load` is
+  // cheap (a JSON read) and matches the tool's own per-call load. The BindingStore verifies each candidate
+  // still EXISTS in the locker (prune stale rows) via the host `exists` verb.
+  private bindings(): BindingStore {
+    return BindingStore.load(this.manager.storeDir, (id) => this.manager.withHost((h) => h.exists(id)));
+  }
+  private nevers(): NeverStore {
+    return NeverStore.load(this.manager.storeDir);
   }
 
   /** Install the S-A dispatch hook + subscribe the event-bus + start the timers. Idempotent-ish (call once). */
@@ -152,11 +159,11 @@ export class KeyLockerWiring {
       snapshot: () => m.snapshotProcessTree(),
 
       deriveBinding: (command: string, session: SessionContext) => deriveBinding(command, session),
-      resolveBinding: (k) => this.bindings.resolve(k),
-      bindBinding: (k, id, meta) => this.bindings.bind(k, id, meta),
-      confirmPolicyFor: (k) => this.bindings.getPolicy(k),
-      isNever: (k) => this.nevers.has(k),
-      onNever: (k) => this.nevers.add(k),
+      resolveBinding: (k) => this.bindings().resolve(k),
+      bindBinding: (k, id, meta) => this.bindings().bind(k, id, meta),
+      confirmPolicyFor: (k) => this.bindings().getPolicy(k),
+      isNever: (k) => this.nevers().has(k),
+      onNever: (k) => this.nevers().add(k),
 
       capture: (id) => m.withHost((h) => h.capture(id)).then((r) => ({ captured: r.captured })),
       deleteSecret: (id) => m.withHost((h) => h.delete(id)).then(() => undefined),

--- a/src/tools/key-locker-wiring.ts
+++ b/src/tools/key-locker-wiring.ts
@@ -260,16 +260,18 @@ let wiringSingleton: KeyLockerWiring | null = null;
  */
 export function registerKeyLockerWiring(): () => void {
   if (keyLockerDisabled()) return () => { /* feature off */ };
-  const wiring = new KeyLockerWiring(keyLockerManager());
-  wiringSingleton = wiring;
-  wiring.start();
-  // Capture the LOCAL instance so a (contract-forbidden) double-register's first teardown stops the FIRST
-  // wiring, not whichever one the module var currently points at (Opus W-4b P3). Only clear the singleton if it
-  // still points at us.
-  return () => {
-    wiring.stop();
-    if (wiringSingleton === wiring) wiringSingleton = null;
-  };
+  // IDEMPOTENT — start the timers/hook/subscription ONCE PER PROCESS. In HTTP transport `createMcpServer()`
+  // runs for EVERY `/mcp` request (`server-windows.ts` request path), so a non-idempotent register would leak
+  // a new 500ms reconcile timer + event-bus subscription + dispatch hook on every RPC (Codex W-4b). The wiring
+  // is a process-global resource (one dispatch-hook slot, one tracker/watch), so reuse the singleton.
+  if (wiringSingleton === null) {
+    const wiring = new KeyLockerWiring(keyLockerManager());
+    wiring.start();
+    wiringSingleton = wiring;
+  }
+  // Every caller's teardown stops the ONE process-global wiring (called at process shutdown; safe to null and
+  // re-init on a later register). Not a per-request teardown — HTTP request cleanup must NOT stop it.
+  return () => { wiringSingleton?.stop(); wiringSingleton = null; };
 }
 
 /** The live wiring instance (for the dogfood `launchAndAnchorConsole` entry), or null if not registered. */

--- a/src/tools/key-locker-wiring.ts
+++ b/src/tools/key-locker-wiring.ts
@@ -104,6 +104,13 @@ export class KeyLockerWiring {
     // retries next check (Opus W-4b P1).
     this.idleTimer = setInterval(() => { void this.manager.disposeIfIdle(IDLE_DISPOSE_MS).catch(() => {}); }, IDLE_CHECK_MS);
     this.idleTimer.unref?.();
+    // PRODUCTION ANCHORING TRIGGER (Codex W-4b): nothing else calls `launchAndAnchorConsole`, and `onDispatch`
+    // DROPS any pane the driver never anchored (P1-B) — so without an anchored pane the autofill loop never
+    // arms. For the R3 dogfood (§5-3) an env flag auto-launches + anchors ONE classic conhost at startup so the
+    // loop has a real pane. A general tool-driven anchoring flow (beyond dogfood) is a follow-up (OQ-W-16-bis).
+    if (process.env.DESKTOP_TOUCH_KEY_LOCKER_DOGFOOD === "1") {
+      void this.launchAndAnchorConsole().catch(() => { /* dogfood-only; a failed launch just means no pane */ });
+    }
   }
 
   /** Tear EVERYTHING down (the "dispose stops the timers" obligation carried from W-3): clear both timers,
@@ -113,6 +120,11 @@ export class KeyLockerWiring {
     if (this.idleTimer !== null) { clearInterval(this.idleTimer); this.idleTimer = null; }
     if (this.eventSubId !== null) { unsubscribe(this.eventSubId); this.eventSubId = null; }
     setTerminalDispatchHook(null);
+    // Dispose the shared locker host too: autofill may have spawned a DETACHED `key-locker.exe`, and `dispose()`
+    // is the path that sends it `shutdown` + kills it. Without this, exiting before the idle timer fires would
+    // ORPHAN the helper (Codex W-4b). Fire-and-forget (`stop` is sync, called from the shutdown path) — the
+    // graceful shutdown frame + kill are best-effort on exit.
+    void this.manager.dispose().catch(() => {});
   }
 
   /**
@@ -206,16 +218,20 @@ export class KeyLockerWiring {
    *  immediate read would see the still-present prompt and false-reject, discarding the correct secret. Returns
    *  the settled `{ tail, stillHiddenPrompt }`; `isAuthAccepted` then checks a denial line + the cleared prompt. */
   private async readPaneAfterAuth(paneId: string): Promise<{ tail: string; stillHiddenPrompt: boolean }> {
-    const title = resolveTitleByHwnd(paneId);
-    if (title === null) return { tail: "", stillHiddenPrompt: true }; // can't read ⇒ fail-safe reject
     const deadline = Date.now() + AUTH_SETTLE_MS;
     let last = { tail: "", stillHiddenPrompt: true };
     for (;;) {
-      const raw = await readTerminalRaw(title);
-      if (raw !== null) {
-        const stillHiddenPrompt = isSecretInputPrompt(raw.text);
-        last = { tail: raw.text, stillHiddenPrompt };
-        if (!stillHiddenPrompt) return last; // prompt cleared → settled (accepted iff no denial line)
+      // RE-RESOLVE the title EACH iteration (Codex W-4b): an interactive login (ssh) updates the console title
+      // AFTER auth, so a title cached before the loop would stop resolving mid-poll → the correct secret would
+      // false-reject as auth_rejected. Re-resolving keeps the read bound to the pane's hwnd across the change.
+      const title = resolveTitleByHwnd(paneId);
+      if (title !== null) {
+        const raw = await readTerminalRaw(title);
+        if (raw !== null) {
+          const stillHiddenPrompt = isSecretInputPrompt(raw.text);
+          last = { tail: raw.text, stillHiddenPrompt };
+          if (!stillHiddenPrompt) return last; // prompt cleared → settled (accepted iff no denial line)
+        }
       }
       if (Date.now() >= deadline) return last; // still prompting at timeout → stillHiddenPrompt:true → reject
       await sleep(AUTH_POLL_MS);
@@ -243,10 +259,15 @@ export class KeyLockerWiring {
     }
     const deadline = Date.now() + EXIT_PROBE_MS;
     for (;;) {
-      const raw = await readTerminalRaw(title);
-      if (raw !== null) {
-        const m = parseExitSentinel(raw.text, nonce, shell);
-        if (m.matched) return { reason: "exited", exitCode: m.exitCode };
+      // RE-RESOLVE the title each read (Codex W-4b): the ran command may have changed the console title; the
+      // probe was already sent to the send-time window, but the READ must track the pane's current title.
+      const rtitle = resolveTitleByHwnd(paneId);
+      if (rtitle !== null) {
+        const raw = await readTerminalRaw(rtitle);
+        if (raw !== null) {
+          const m = parseExitSentinel(raw.text, nonce, shell);
+          if (m.matched) return { reason: "exited", exitCode: m.exitCode };
+        }
       }
       if (Date.now() >= deadline) return { reason: "timeout" };
       await sleep(EXIT_POLL_MS);

--- a/src/tools/key-locker-wiring.ts
+++ b/src/tools/key-locker-wiring.ts
@@ -114,17 +114,16 @@ export class KeyLockerWiring {
   }
 
   /** Tear EVERYTHING down (the "dispose stops the timers" obligation carried from W-3): clear both timers,
-   *  unsubscribe the event-bus (its 500ms EnumWindows sweep), and detach the dispatch hook. Idempotent. */
-  stop(): void {
+   *  unsubscribe the event-bus (its 500ms EnumWindows sweep), detach the dispatch hook, and dispose the locker
+   *  host. Returns the host-dispose PROMISE so the shutdown path can AWAIT it before `process.exit()` — a
+   *  fire-and-forget dispose could exit before `KeyLockerHost.dispose()` sends its shutdown frame + `killTree`,
+   *  orphaning the detached `key-locker.exe` (Codex W-4b :127). Idempotent (dispose is a no-op with no host). */
+  stop(): Promise<void> {
     if (this.tickTimer !== null) { clearInterval(this.tickTimer); this.tickTimer = null; }
     if (this.idleTimer !== null) { clearInterval(this.idleTimer); this.idleTimer = null; }
     if (this.eventSubId !== null) { unsubscribe(this.eventSubId); this.eventSubId = null; }
     setTerminalDispatchHook(null);
-    // Dispose the shared locker host too: autofill may have spawned a DETACHED `key-locker.exe`, and `dispose()`
-    // is the path that sends it `shutdown` + kills it. Without this, exiting before the idle timer fires would
-    // ORPHAN the helper (Codex W-4b). Fire-and-forget (`stop` is sync, called from the shutdown path) — the
-    // graceful shutdown frame + kill are best-effort on exit.
-    void this.manager.dispose().catch(() => {});
+    return this.manager.dispose().catch(() => {});
   }
 
   /**
@@ -171,7 +170,9 @@ export class KeyLockerWiring {
       snapshot: () => m.snapshotProcessTree(),
 
       deriveBinding: (command: string, session: SessionContext) => deriveBinding(command, session),
-      resolveBinding: (k) => this.bindings().resolve(k),
+      // `prune:false` — the live hot path is READ-ONLY: a stale-row prune-save here would clobber a concurrent
+      // user `key_locker` write (Codex W-4b). Fresh-loaded per op, so a stale row is just reported no-match.
+      resolveBinding: (k) => this.bindings().resolve(k, { prune: false }),
       bindBinding: (k, id, meta) => this.bindings().bind(k, id, meta),
       confirmPolicyFor: (k) => this.bindings().getPolicy(k),
       isNever: (k) => this.nevers().has(k),
@@ -286,8 +287,8 @@ let wiringSingleton: KeyLockerWiring | null = null;
  * feature is kill-switched. Returns a teardown fn (clears timers + hooks) for a clean shutdown. Shares the ONE
  * `keyLockerManager()` singleton with the L4 tool (so both use the same host + tracker/watch).
  */
-export function registerKeyLockerWiring(): () => void {
-  if (keyLockerDisabled()) return () => { /* feature off */ };
+export function registerKeyLockerWiring(): () => Promise<void> {
+  if (keyLockerDisabled()) return () => Promise.resolve(); /* feature off */
   // IDEMPOTENT — start the timers/hook/subscription ONCE PER PROCESS. In HTTP transport `createMcpServer()`
   // runs for EVERY `/mcp` request (`server-windows.ts` request path), so a non-idempotent register would leak
   // a new 500ms reconcile timer + event-bus subscription + dispatch hook on every RPC (Codex W-4b). The wiring
@@ -298,8 +299,9 @@ export function registerKeyLockerWiring(): () => void {
     wiringSingleton = wiring;
   }
   // Every caller's teardown stops the ONE process-global wiring (called at process shutdown; safe to null and
-  // re-init on a later register). Not a per-request teardown — HTTP request cleanup must NOT stop it.
-  return () => { wiringSingleton?.stop(); wiringSingleton = null; };
+  // re-init on a later register). Not a per-request teardown — HTTP request cleanup must NOT stop it. Returns
+  // the stop() PROMISE (host dispose) so shutdown can AWAIT it before exit (Codex W-4b :127).
+  return () => { const p = wiringSingleton?.stop() ?? Promise.resolve(); wiringSingleton = null; return p; };
 }
 
 /** The live wiring instance (for the dogfood `launchAndAnchorConsole` entry), or null if not registered. */

--- a/src/tools/key-locker-wiring.ts
+++ b/src/tools/key-locker-wiring.ts
@@ -92,7 +92,10 @@ export class KeyLockerWiring {
     this.eventSubId = subscribe(["window_disappeared"]);
     this.tickTimer = setInterval(() => this.tick(), TICK_MS);
     this.tickTimer.unref?.();
-    this.idleTimer = setInterval(() => { void this.manager.disposeIfIdle(IDLE_DISPOSE_MS); }, IDLE_CHECK_MS);
+    // ALWAYS `.catch()` a floating drive: `server-windows.ts` turns an unhandledRejection into a full
+    // `shutdown(1)` (all tools down). A locker-pipe hiccup during dispose must NOT crash the server — it
+    // retries next check (Opus W-4b P1).
+    this.idleTimer = setInterval(() => { void this.manager.disposeIfIdle(IDLE_DISPOSE_MS).catch(() => {}); }, IDLE_CHECK_MS);
     this.idleTimer.unref?.();
   }
 
@@ -128,8 +131,12 @@ export class KeyLockerWiring {
     }
     // Periodic reconcile (correlate stragglers + advance baselines + watch.tick + arm-hygiene).
     this.driver.tickWatch();
-    // Poll every armed pane for a credential prompt (pollBusy serializes; the loop runs on a hit).
-    for (const paneId of this.driver.armedPaneIds()) void this.driver.poll(paneId);
+    // Poll every armed pane for a credential prompt (pollBusy serializes; the loop runs on a hit). ALWAYS
+    // `.catch()` — a rejected poll (a locker-pipe hiccup mid-fill: the capture loop's pre-`try` seams
+    // resolveBinding/confirmInjection/injectPane can reject through `withHost`) would otherwise become an
+    // unhandledRejection → `server-windows.ts` `shutdown(1)` = ALL tools down (Opus W-4b P1). A swallowed poll
+    // just re-polls next tick — bounded-safe, the fill-failure north-star. Never crash the server for a fill.
+    for (const paneId of this.driver.armedPaneIds()) void this.driver.poll(paneId).catch(() => {});
   }
 
   private enabled(): boolean {
@@ -253,9 +260,16 @@ let wiringSingleton: KeyLockerWiring | null = null;
  */
 export function registerKeyLockerWiring(): () => void {
   if (keyLockerDisabled()) return () => { /* feature off */ };
-  wiringSingleton = new KeyLockerWiring(keyLockerManager());
-  wiringSingleton.start();
-  return () => { wiringSingleton?.stop(); wiringSingleton = null; };
+  const wiring = new KeyLockerWiring(keyLockerManager());
+  wiringSingleton = wiring;
+  wiring.start();
+  // Capture the LOCAL instance so a (contract-forbidden) double-register's first teardown stops the FIRST
+  // wiring, not whichever one the module var currently points at (Opus W-4b P3). Only clear the singleton if it
+  // still points at us.
+  return () => {
+    wiring.stop();
+    if (wiringSingleton === wiring) wiringSingleton = null;
+  };
 }
 
 /** The live wiring instance (for the dogfood `launchAndAnchorConsole` entry), or null if not registered. */

--- a/src/tools/key-locker-wiring.ts
+++ b/src/tools/key-locker-wiring.ts
@@ -1,0 +1,267 @@
+// ADR-014 v2 R3 Key Locker — L3-4 W-4b: the live-wiring composition root (THE impure root).
+//
+// Plan: desktop-touch-mcp-internal:docs/adr-014-v2-r3-l3-4-live-wiring-plan.md (§2.3, §4 W-4)
+//
+// Everything below the driver is pure + unit-tested; THIS file is the one impure seam that binds the merged
+// pipeline into a running loop — it imports the real terminal hooks (S-A/B/C), Win32, the locker host, the
+// BindingStore/NeverStore, and the injector, and drives the driver's timers. It is NOT unit-tested (it is the
+// wiring); it is covered by the §5 live dogfood. Gated: it does nothing unless consent is accepted and the
+// kill switch is off (both re-checked at RUNTIME, not just registration, so an un-consented user never spawns
+// a locker for a `sudo`).
+//
+// The six gaps the plan enumerated (Fable review) are resolved in the seams here + the W-4a hot-path helpers:
+//   gap1 anchor  — `manager.launchAnchoredConsole()` (a classic injectable conhost) → `onLocalPaneLaunched`.
+//   gap2 read    — every title-keyed read/inject goes through `resolveTitleByHwnd(paneId)` (substring-unique or
+//                  decline), so a same-title sibling can never redirect it.
+//   gap3 close   — the tick timer polls the event-bus `window_disappeared` → `onPaneClosed`.
+//   gap5 auth    — `readPaneAfterAuth` is a BOUNDED POLL (not a single read) so an in-progress prompt does not
+//                  false-reject and discard the correct secret.
+//   gap6 landed  — `runToExit` OBSERVES the already-run command's exit via an epilogue-only probe
+//                  (`buildExitProbe`), NEVER re-running it.
+
+import type { BindingMeta } from "../engine/key-locker/binding-store.js";
+import { BindingStore } from "../engine/key-locker/binding-store.js";
+import type { BindingUri } from "../engine/key-locker/binding.js";
+import { formatBindingUri } from "../engine/key-locker/binding.js";
+import { deriveBinding, type SessionContext } from "../engine/key-locker/command-derivation.js";
+import { assembleInjectTarget } from "../engine/key-locker/inject-target.js";
+import { inject } from "../engine/key-locker/injector.js";
+import {
+  KeyLockerCaptureDriver,
+  type CaptureDriverDeps,
+  type PromptVerdict,
+} from "../engine/key-locker/key-locker-capture-driver.js";
+import { keyLockerDisabled, KeyLockerManager } from "../engine/key-locker/key-locker-manager.js";
+import type { ExitCompletion } from "../engine/key-locker/landed-detection.js";
+import { NeverStore } from "../engine/key-locker/never-store.js";
+import { randomUUID } from "node:crypto";
+import { poll as pollEvents, subscribe, unsubscribe } from "../engine/event-bus.js";
+import {
+  buildExitProbe,
+  generateExitNonce,
+  isSecretInputPrompt,
+  parseExitSentinel,
+  readTerminalRaw,
+  resolveTitleByHwnd,
+  setTerminalDispatchHook,
+  terminalSendHandler,
+  type ExitShell,
+} from "./terminal.js";
+import { keyLockerManager } from "./key-locker-tool.js";
+
+/** How often the wiring reconciles: event-bus close events → tickWatch → poll each armed pane. Fast enough to
+ *  catch a session-end promptly, slow enough to be cheap (one Toolhelp snapshot per tick). */
+const TICK_MS = 500;
+/** Idle-dispose cadence — tear the locker host down after this long with no secret op (dormancy). */
+const IDLE_DISPOSE_MS = 60_000;
+const IDLE_CHECK_MS = 30_000;
+/** Bounded auth-settle window for Mode-B `readPaneAfterAuth` (poll until the hidden prompt clears / timeout). */
+const AUTH_SETTLE_MS = 8_000;
+const AUTH_POLL_MS = 300;
+/** Bounded exit-probe window for Mode-A `runToExit` (send the probe, poll for its sentinel / timeout). */
+const EXIT_PROBE_MS = 10_000;
+const EXIT_POLL_MS = 300;
+
+/**
+ * The live composition root. Constructed once at server startup (behind the kill switch); it builds the driver
+ * from the shared manager's tracker/watch/snapshot + the real seams, installs the S-A dispatch hook, and runs
+ * the reconcile + idle-dispose timers. `stop()` tears it ALL down (timers + event-bus + hooks).
+ */
+export class KeyLockerWiring {
+  private readonly driver: KeyLockerCaptureDriver;
+  private readonly bindings: BindingStore;
+  private readonly nevers: NeverStore;
+  private tickTimer: NodeJS.Timeout | null = null;
+  private idleTimer: NodeJS.Timeout | null = null;
+  private eventSubId: string | null = null;
+
+  constructor(private readonly manager: KeyLockerManager) {
+    // The BindingStore verifies each candidate secret still EXISTS in the locker (prune stale rows) via the
+    // host `exists` verb, and the NeverStore holds tombstones — both keyed off the manager's store dir.
+    this.bindings = BindingStore.load(manager.storeDir, (id) => manager.withHost((h) => h.exists(id)));
+    this.nevers = NeverStore.load(manager.storeDir);
+    this.driver = new KeyLockerCaptureDriver(this.buildDeps());
+  }
+
+  /** Install the S-A dispatch hook + subscribe the event-bus + start the timers. Idempotent-ish (call once). */
+  start(): void {
+    setTerminalDispatchHook((ev) => {
+      if (!this.enabled()) return; // runtime consent/kill re-check — never arm/record for an un-consented user
+      this.driver.onDispatch(ev.paneId, ev.command);
+    });
+    this.eventSubId = subscribe(["window_disappeared"]);
+    this.tickTimer = setInterval(() => this.tick(), TICK_MS);
+    this.tickTimer.unref?.();
+    this.idleTimer = setInterval(() => { void this.manager.disposeIfIdle(IDLE_DISPOSE_MS); }, IDLE_CHECK_MS);
+    this.idleTimer.unref?.();
+  }
+
+  /** Tear EVERYTHING down (the "dispose stops the timers" obligation carried from W-3): clear both timers,
+   *  unsubscribe the event-bus (its 500ms EnumWindows sweep), and detach the dispatch hook. Idempotent. */
+  stop(): void {
+    if (this.tickTimer !== null) { clearInterval(this.tickTimer); this.tickTimer = null; }
+    if (this.idleTimer !== null) { clearInterval(this.idleTimer); this.idleTimer = null; }
+    if (this.eventSubId !== null) { unsubscribe(this.eventSubId); this.eventSubId = null; }
+    setTerminalDispatchHook(null);
+  }
+
+  /**
+   * DOGFOOD/tool entry (§5-3): launch a classic conhost the locker can anchor + fill, and anchor it KNOWN-LOCAL.
+   * The only path that produces an autofillable pane (a pre-existing user pane is never anchored — P1-B).
+   * Returns the pane's hwnd string so the caller can drive `sudo`/`ssh` into it.
+   */
+  async launchAndAnchorConsole(): Promise<{ paneId: string; title: string }> {
+    const { hwnd, shellPid, title } = await this.manager.launchAnchoredConsole();
+    const paneId = String(hwnd);
+    this.driver.onLocalPaneLaunched(paneId, shellPid);
+    return { paneId, title };
+  }
+
+  // ── the reconcile tick ────────────────────────────────────────────────────────────────────────────────
+  private tick(): void {
+    if (!this.enabled()) return;
+    // gap3: a closed pane → forget it (W2 close atomicity is inside onPaneClosed).
+    if (this.eventSubId !== null) {
+      for (const ev of pollEvents(this.eventSubId)) {
+        if (ev.type === "window_disappeared") this.driver.onPaneClosed(ev.hwnd);
+      }
+    }
+    // Periodic reconcile (correlate stragglers + advance baselines + watch.tick + arm-hygiene).
+    this.driver.tickWatch();
+    // Poll every armed pane for a credential prompt (pollBusy serializes; the loop runs on a hit).
+    for (const paneId of this.driver.armedPaneIds()) void this.driver.poll(paneId);
+  }
+
+  private enabled(): boolean {
+    return !this.manager.isDisabled() && this.manager.isConsentAccepted();
+  }
+
+  // ── the driver seams (the impure bindings) ────────────────────────────────────────────────────────────
+  private buildDeps(): CaptureDriverDeps {
+    const m = this.manager;
+    return {
+      tracker: m.tracker,
+      watch: m.watch,
+      snapshot: () => m.snapshotProcessTree(),
+
+      deriveBinding: (command: string, session: SessionContext) => deriveBinding(command, session),
+      resolveBinding: (k) => this.bindings.resolve(k),
+      bindBinding: (k, id, meta) => this.bindings.bind(k, id, meta),
+      confirmPolicyFor: (k) => this.bindings.getPolicy(k),
+      isNever: (k) => this.nevers.has(k),
+      onNever: (k) => this.nevers.add(k),
+
+      capture: (id) => m.withHost((h) => h.capture(id)).then((r) => ({ captured: r.captured })),
+      deleteSecret: (id) => m.withHost((h) => h.delete(id)).then(() => undefined),
+      injectPane: (paneId, binding, opaqueId, submit) => this.injectPane(paneId, binding, opaqueId, submit),
+      // gap4 confirm/offer: the W-3.5 secret-free `prompt` verb (label-only). `confirm` → fill vs decline.
+      confirmInjection: (b) => m.withHost((h) => h.prompt("confirm", formatBindingUri(b))).then((c) => c === "autofill"),
+      offerSave: (b) => m.withHost((h) => h.prompt("offer", formatBindingUri(b))),
+
+      mintOpaqueId: () => randomUUID(),
+      now: () => new Date().toISOString(),
+
+      runToExit: (paneId, command, isRemote) => this.runToExit(paneId, isRemote),
+      readPaneAfterAuth: (paneId) => this.readPaneAfterAuth(paneId),
+      readPromptTail: (paneId) => this.readPromptTail(paneId),
+
+      nowMs: () => Date.now(),
+    };
+  }
+
+  /** injectPane: hwnd-bound target (gap2 — assembleInjectTarget takes the exact hwnd) → L2 inject over the pipe. */
+  private async injectPane(paneId: string, binding: BindingUri, opaqueId: string, submit: boolean) {
+    let hwnd: bigint;
+    try { hwnd = BigInt(paneId); } catch { return { ok: false, code: "bad_target" } as const; }
+    const target = assembleInjectTarget(hwnd, submit);
+    if (target === null) return { ok: false, code: "target_gone" } as const;
+    return this.manager.withHost((h) => inject(h, binding, opaqueId, "pane", target));
+  }
+
+  /** S-B readPromptTail: resolve the pane's title (substring-unique or null → decline) → read → classify. */
+  private async readPromptTail(paneId: string): Promise<PromptVerdict | null> {
+    const title = resolveTitleByHwnd(paneId);
+    if (title === null) return null; // ambiguous / vanished title ⇒ decline (never read a same-title sibling)
+    const raw = await readTerminalRaw(title);
+    if (raw === null) return null;
+    const isCredentialPrompt = isSecretInputPrompt(raw.text);
+    return { isCredentialPrompt, tail: raw.text, stillHiddenPrompt: isCredentialPrompt };
+  }
+
+  /** Mode-B readPaneAfterAuth (gap5): BOUNDED POLL until the hidden prompt clears or the window elapses — an
+   *  immediate read would see the still-present prompt and false-reject, discarding the correct secret. Returns
+   *  the settled `{ tail, stillHiddenPrompt }`; `isAuthAccepted` then checks a denial line + the cleared prompt. */
+  private async readPaneAfterAuth(paneId: string): Promise<{ tail: string; stillHiddenPrompt: boolean }> {
+    const title = resolveTitleByHwnd(paneId);
+    if (title === null) return { tail: "", stillHiddenPrompt: true }; // can't read ⇒ fail-safe reject
+    const deadline = Date.now() + AUTH_SETTLE_MS;
+    let last = { tail: "", stillHiddenPrompt: true };
+    for (;;) {
+      const raw = await readTerminalRaw(title);
+      if (raw !== null) {
+        const stillHiddenPrompt = isSecretInputPrompt(raw.text);
+        last = { tail: raw.text, stillHiddenPrompt };
+        if (!stillHiddenPrompt) return last; // prompt cleared → settled (accepted iff no denial line)
+      }
+      if (Date.now() >= deadline) return last; // still prompting at timeout → stillHiddenPrompt:true → reject
+      await sleep(AUTH_POLL_MS);
+    }
+  }
+
+  /** Mode-A runToExit (gap6): OBSERVE the already-run command's exit — send an EPILOGUE-ONLY probe (never the
+   *  command) with `notifyDispatch:false`, poll for its echo-immune sentinel, return the exit code. */
+  private async runToExit(paneId: string, isRemote: boolean): Promise<ExitCompletion> {
+    const title = resolveTitleByHwnd(paneId);
+    if (title === null) return { reason: "probe_error:no_title" };
+    const shell: ExitShell = isRemote ? "bash" : "powershell";
+    const nonce = generateExitNonce();
+    const probe = buildExitProbe(shell, nonce);
+    // Send the read-only probe. `notifyDispatch:false` suppresses the S-A re-fire; even if it fired, the driver
+    // drops it (loopPhase pre-landed) and it is not credential-shaped. background method = do not steal focus.
+    try {
+      await terminalSendHandler({
+        windowTitle: title, input: probe, method: "background", pressEnter: true,
+        focusFirst: false, restoreFocus: false, preferClipboard: false, pasteKey: "auto",
+        trackFocus: false, settleMs: 0, notifyDispatch: false,
+      });
+    } catch (e) {
+      return { reason: `probe_error:${e instanceof Error ? e.message : String(e)}` };
+    }
+    const deadline = Date.now() + EXIT_PROBE_MS;
+    for (;;) {
+      const raw = await readTerminalRaw(title);
+      if (raw !== null) {
+        const m = parseExitSentinel(raw.text, nonce, shell);
+        if (m.matched) return { reason: "exited", exitCode: m.exitCode };
+      }
+      if (Date.now() >= deadline) return { reason: "timeout" };
+      await sleep(EXIT_POLL_MS);
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+let wiringSingleton: KeyLockerWiring | null = null;
+
+/**
+ * Register the Key Locker live wiring at server startup (beside `registerKeyLockerTools`). No-op when the
+ * feature is kill-switched. Returns a teardown fn (clears timers + hooks) for a clean shutdown. Shares the ONE
+ * `keyLockerManager()` singleton with the L4 tool (so both use the same host + tracker/watch).
+ */
+export function registerKeyLockerWiring(): () => void {
+  if (keyLockerDisabled()) return () => { /* feature off */ };
+  wiringSingleton = new KeyLockerWiring(keyLockerManager());
+  wiringSingleton.start();
+  return () => { wiringSingleton?.stop(); wiringSingleton = null; };
+}
+
+/** The live wiring instance (for the dogfood `launchAndAnchorConsole` entry), or null if not registered. */
+export function keyLockerWiring(): KeyLockerWiring | null {
+  return wiringSingleton;
+}
+
+/** Consumed BindingMeta type re-export so a caller can build metadata without importing binding-store. */
+export type { BindingMeta };

--- a/tests/fixtures/failwith-callsite-shapes.json
+++ b/tests/fixtures/failwith-callsite-shapes.json
@@ -286,7 +286,7 @@
     },
     {
       "file": "src/tools/key-locker-tool.ts",
-      "line": 142,
+      "line": 149,
       "tool": "key_locker",
       "errKind": "identifier",
       "contextShape": "none"


### PR DESCRIPTION
## What this is

**W-4b** — the FINAL slice: `src/tools/key-locker-wiring.ts`, the one impure composition root that binds the merged pure pipeline into a running autofill loop. **NOT unit-tested** (it is the wiring); covered by the §5 live dogfood. Gated on consent + the kill switch, **re-checked at RUNTIME** (not just registration) so an un-consented user never spawns a locker for a `sudo`.

Builds on the W-4a hot-path seams (merged #518) + the whole L3/L3-3/L3-4 pipeline.

## The seams it binds (Explore-verified)

- driver ← the SHARED `keyLockerManager()` singleton's `tracker`/`watch`/`snapshotProcessTree` (the L4 tool + the wiring use ONE manager — exported accessor, gap4).
- `deriveBinding(cmd, session)` · `BindingStore.load(storeDir, existsInLocker=host.exists).resolve/bind/getPolicy` · `NeverStore.load(storeDir).has/add` · host `capture`/`delete`/`prompt` via `withHost` · `injectPane = assembleInjectTarget(BigInt(paneId), submit) → inject(h, …, "pane", target)` · `confirmInjection`/`offerSave` via the W-3.5 secret-free `prompt` verb + `formatBindingUri`.

## The gap resolutions (Fable design review) realized here

- **gap2 read** — `readPromptTail` / `readPaneAfterAuth` / `runToExit` all resolve the pane via `resolveTitleByHwnd` (substring-unique or decline — never a same-title sibling → no wrong-pane read/inject).
- **gap5 auth** — `readPaneAfterAuth` is a BOUNDED POLL (until the hidden prompt clears / timeout), so an in-progress auth prompt doesn't false-reject and discard the correct secret.
- **gap6 landed** — `runToExit` sends an EPILOGUE-ONLY `buildExitProbe` (`notifyDispatch:false`) and polls `parseExitSentinel` — it NEVER re-runs the credential command (a non-idempotent `git push` would double-execute).
- **gap3 close** — the tick polls the event-bus `window_disappeared` → `onPaneClosed`.

## Timers + lifecycle

A fast **unref** tick (`event-bus poll → tickWatch → poll each armed pane`, 500ms) + a slow idle-dispose. `stop()` (wired into `shutdown()`) clears both timers, unsubscribes the event-bus, and detaches the dispatch hook (the "dispose stops the timers" obligation from W-3). `launchAndAnchorConsole()` is the dogfood §5-3 entry (launch a classic conhost → anchor it KNOWN-LOCAL — the only path that yields an autofillable pane; a pre-existing user pane is never anchored, P1-B).

## Verification

```
npm run build && npm run lint      # clean
key-locker unit                    # 378 passed
check:stub-catalog                 # OK (no new MCP tool — this is wiring, not a server.tool)
check:failwith-fixtures            # regenerated (key-locker-tool.ts export line shift only)
```

No public MCP tool change. **Next: the §5 live dogfood on the real desktop** (the first end-to-end run — verify `launchAnchoredConsole` owner-pid, the conhost injection, and the autofill loop) → Authenticode signing → CHANGELOG → R3 release.

Plan: `desktop-touch-mcp-internal@d23a678:docs/adr-014-v2-r3-l3-4-live-wiring-plan.md` (§2.3, §4 W-4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)