### PR TITLE
fix(key-locker): anchored console needs a NEW console (`cmd /c start`) — DF-1 dogfood fix

### DIFF
--- a/src/engine/key-locker/key-locker-manager.ts
+++ b/src/engine/key-locker/key-locker-manager.ts
@@ -182,17 +182,20 @@ export class KeyLockerManager {
    * constraints (Fable 2026-07-08): the ONLY injectable window is a CLASSIC conhost (`ConsoleWindowClass` — the
    * L2 `Injection.cs` ReVerify positive-allowlist; Windows Terminal is a XAML host ⇒ `target_multiplexed`), and
    * `workspace_launch` blocks all shells, and R1's cooperative terminal is headless-only (the visible-console
-   * launch is R2's unshipped S2). So the manager spawns `conhost.exe <shell>` DIRECTLY (an internal spawn — it
-   * does NOT route through `workspace_launch`'s executable blocklist, which exists to stop the ASSISTANT from
-   * launching arbitrary shells; this is a locker-owned, fixed, local shell) and polls for the new
-   * `ConsoleWindowClass` window it owns. Returns `{ hwnd, shellPid }` (shellPid = the conhost pid = the window
-   * owner; the shell + any ssh run as subtree descendants, which `sshDescendants` walks). The wiring fires
+   * launch is R2's unshipped S2). So the manager launches a locker-owned, fixed, local conhost DIRECTLY (an
+   * internal spawn — it does NOT route through `workspace_launch`'s executable blocklist, which exists to stop
+   * the ASSISTANT from launching arbitrary shells) via `cmd /c start` and polls for the new
+   * `ConsoleWindowClass` window (DF-1: `cmd /c start` is what forces a NEW console — see the impl note below).
+   * Returns `{ hwnd, shellPid }` where `shellPid = getWindowProcessId(hwnd)` = the SHELL (powershell) process
+   * that OWNS the console window (dogfood-verified: on Win11 the console window's owner is the shell, and
+   * conhost is its PARENT). Any ssh/sudo the human runs are CHILDREN of that shell, so `shellPid` is exactly
+   * the `sshDescendants` subtree root. The wiring fires
    * `onLocalPaneLaunched(String(hwnd), shellPid)`. The console gets a UNIQUE window title (`dtm-locker-console-
-   * <nonce>`) so the title-keyed read/inject seams resolve to EXACTLY this pane — `resolveTitleByHwnd` declines
-   * any pane whose title is not substring-unique, so without this a second console (or a same-titled user
-   * window) would never autofill (Codex W-4a R3 read-path). **Dogfood-verified (§5): the exact `conhost.exe`
-   * invocation that yields a classic console + injectable target (and that the title command takes) is confirmed
-   * on the real desktop, not unit-testable.** Throws if no console window appears within `timeoutMs`.
+   * <nonce>`) — the CLAIM key here (child.pid is the transient cmd.exe, not the conhost) AND the title-keyed
+   * read/inject seams' resolver (`resolveTitleByHwnd` declines any pane whose title is not substring-unique, so
+   * without this a second console (or a same-titled user window) would never autofill — Codex W-4a R3
+   * read-path). **NOT unit-testable — the live-desktop console-allocation behavior is covered by the §5
+   * dogfood (see the DF-1 followups doc).** Throws if no console window appears within `timeoutMs`.
    */
   async launchAnchoredConsole(
     o: { timeoutMs?: number; pollMs?: number } = {},
@@ -204,42 +207,62 @@ export class KeyLockerManager {
     const before = new Set(
       enumWindowsInZOrder().filter((w) => w.className === CONSOLE_WINDOW_CLASS).map((w) => w.hwnd),
     );
-    // `conhost.exe powershell …` forces a CLASSIC conhost regardless of the user's default-terminal (WT)
-    // setting — the only form L2 can inject into. The `-Command` sets the UNIQUE window title then leaves an
-    // interactive prompt (`-NoExit`) for the human to type into (the cooperative model); we never read its stdio.
+    // DF-1 (live dogfood 2026-07-08, followups doc): a bare `spawn("conhost.exe", …)` allocates NO console
+    // window under the MCP server's context — Node's child_process cannot pass the Win32 CREATE_NEW_CONSOLE
+    // flag and the server parent has no console to share, so no console is created (verified: conhost AND
+    // powershell, detached or not + stdio:ignore, produce zero `ConsoleWindowClass` windows). `cmd /c start`
+    // is the one form that forces a NEW console. Bonus: the `start`-ed console is REPARENTED off the transient
+    // cmd.exe (which exits at once), so the console OUTLIVES this process for free — no node-side tree-kill can
+    // reach it (the "console outlives the session" requirement, Opus W-4a P2-1). Absolute System32 paths: a
+    // credential feature must never resolve its spawn executables via PATH (hijack hardening).
+    const sys32 = join(process.env.SystemRoot ?? "C:\\Windows", "System32");
+    const cmdExe = join(sys32, "cmd.exe");
+    const conhostExe = join(sys32, "conhost.exe");
+    // `start "" <conhost> powershell -NoExit -Command <title>`: the empty "" is start's window-title arg (so a
+    // quoted exe path is never mistaken for the title); `-NoExit` leaves an interactive prompt for the human
+    // (cooperative model, we never read its stdio); `-Command` applies the UNIQUE title. The title nonce is hex
+    // (no cmd `&^%` metachars), so Node's default arg quoting is safe through cmd (dogfood-verified).
     const child = spawn(
-      "conhost.exe",
-      ["powershell.exe", "-NoExit", "-Command", `$Host.UI.RawUI.WindowTitle = '${title}'`],
+      cmdExe,
+      ["/c", "start", "", conhostExe, "powershell.exe", "-NoExit", "-Command", `$Host.UI.RawUI.WindowTitle = '${title}'`],
       { detached: true, stdio: "ignore", windowsHide: false },
     );
     child.on("error", () => { /* spawn failure surfaces as the poll timing out below */ });
-    // The console is a SEPARATE window the human owns — do NOT pin Node's event loop on its lifetime (else a
-    // clean MCP shutdown would hang until the user closes the console). The wiring may kill `shellPid` on
-    // teardown if it wants the console gone; otherwise it outlives the session by design (Opus W-4a P2-1).
-    child.unref();
-    const childPid = child.pid;
-    // A failed spawn has no pid ⇒ nothing to claim ⇒ time out rather than grab an unrelated console.
-    if (childPid === undefined) throw new KeyLockerError("KeyLockerSpawnFailed", "conhost spawn returned no pid");
+    child.unref(); // never pin Node's loop on cmd's (or the console's) lifetime.
+    // A failed spawn has no pid ⇒ nothing was launched ⇒ let the poll below time out.
+    if (child.pid === undefined) throw new KeyLockerError("KeyLockerSpawnFailed", "cmd spawn returned no pid");
 
+    // CLAIM BY UNIQUE TITLE — NOT by `child.pid`: under `cmd /c start`, `child.pid` is the transient cmd.exe,
+    // never the conhost. The title is an 8-byte random nonce excluded against `before`, so a match is
+    // unambiguously OUR console (consistent with `resolveTitleByHwnd` declining non-unique titles); after the
+    // claim every read/inject is hwnd-keyed, so the title is a one-shot startup correlation only. `shellPid =
+    // getWindowProcessId(hwnd)` is the SHELL (powershell) process that owns the console window — conhost is its
+    // PARENT (dogfood-verified) — so `shellPid` is exactly the `sshDescendants` subtree root (ssh/sudo run as
+    // CHILDREN of the shell). A window's owner pid can read 0 transiently during creation, so keep polling
+    // until it resolves NON-ZERO (a 0 root would break the subtree walk).
     const deadline = this.now() + timeoutMs;
     for (;;) {
-      // Claim ONLY the new console OUR conhost child owns — an exact `childPid` match (Opus W-4a P3-1: a
-      // pid-0-fallback could grab a DIFFERENT console that momentarily reads owner-pid 0 during its own
-      // creation, returning the wrong hwnd/shellPid). The owner pid may read 0 transiently for ours too, so
-      // we simply keep polling until it resolves to `childPid`.
       const fresh = enumWindowsInZOrder().find(
-        (w) =>
-          w.className === CONSOLE_WINDOW_CLASS &&
-          !before.has(w.hwnd) &&
-          getWindowProcessId(w.hwnd) === childPid &&
-          // Wait until the `-Command` has APPLIED the unique title — else the pane's live title is still the
-          // default and `resolveTitleByHwnd` would transiently decline it (Opus W-4a R4 P3). Returning a
-          // title-applied pane makes it immediately usable.
-          getWindowTitleW(w.hwnd) === title,
+        (w) => w.className === CONSOLE_WINDOW_CLASS && !before.has(w.hwnd) && getWindowTitleW(w.hwnd) === title,
       );
-      if (fresh !== undefined) return { hwnd: fresh.hwnd, shellPid: childPid, title };
+      if (fresh !== undefined) {
+        const shellPid = getWindowProcessId(fresh.hwnd);
+        if (shellPid !== 0) return { hwnd: fresh.hwnd, shellPid, title };
+      }
       if (this.now() >= deadline) {
-        try { child.kill(); } catch { /* best-effort */ }
+        // Best-effort leak sweep: cmd.exe has already exited (`child.kill()` is a no-op), so if OUR nonce-titled
+        // console DID appear late, kill it by owner pid — a timeout must not orphan a console. Bounded to one
+        // sweep; a console materializing after this is a documented rare leak.
+        const leaked = enumWindowsInZOrder().find(
+          (w) => w.className === CONSOLE_WINDOW_CLASS && !before.has(w.hwnd) && getWindowTitleW(w.hwnd) === title,
+        );
+        if (leaked !== undefined) {
+          const pid = getWindowProcessId(leaked.hwnd);
+          if (pid !== 0) {
+            try { spawn(join(sys32, "taskkill.exe"), ["/PID", String(pid), "/T", "/F"], { stdio: "ignore" }).unref(); }
+            catch { /* best-effort */ }
+          }
+        }
         throw new KeyLockerError("KeyLockerSpawnFailed", "anchored console window did not appear");
       }
       await new Promise((r) => setTimeout(r, pollMs));

--- a/src/engine/key-locker/key-locker-manager.ts
+++ b/src/engine/key-locker/key-locker-manager.ts
@@ -218,13 +218,20 @@ export class KeyLockerManager {
     const sys32 = join(process.env.SystemRoot ?? "C:\\Windows", "System32");
     const cmdExe = join(sys32, "cmd.exe");
     const conhostExe = join(sys32, "conhost.exe");
-    // `start "" <conhost> powershell -NoExit -Command <title>`: the empty "" is start's window-title arg (so a
-    // quoted exe path is never mistaken for the title); `-NoExit` leaves an interactive prompt for the human
-    // (cooperative model, we never read its stdio); `-Command` applies the UNIQUE title. The title nonce is hex
-    // (no cmd `&^%` metachars), so Node's default arg quoting is safe through cmd (dogfood-verified).
+    // `start "" <conhost> powershell -NoProfile -NoExit -Command <title>`: the empty "" is start's window-title
+    // arg (so a quoted exe path is never mistaken for the title); `-NoExit` leaves an interactive prompt for the
+    // human (cooperative model, we never read its stdio); `-Command` applies the UNIQUE title. The title nonce is
+    // hex (no cmd `&^%` metachars), so Node's default arg quoting is safe through cmd (dogfood-verified).
+    // `-NoProfile` is LOAD-BEARING, not cosmetic (Opus W-4b R1 P2): the entire read/inject path keys on the
+    // window title (`resolveTitleByHwnd`), but a user profile with a custom `prompt` function (oh-my-posh /
+    // starship — common in this audience) RE-SETS `$Host.UI.RawUI.WindowTitle` on every REPL render, which
+    // would overwrite our nonce ~ms after `-Command` and break BOTH the claim below AND every later title read.
+    // The anchored pane is a locker-owned utility console, so dropping profile customizations is acceptable
+    // (sudo/ssh are System32/PATH exes, unaffected). A mid-session ad-hoc title change is still fail-safe
+    // (`resolveTitleByHwnd` declines ⇒ the human types the credential; never a wrong-inject).
     const child = spawn(
       cmdExe,
-      ["/c", "start", "", conhostExe, "powershell.exe", "-NoExit", "-Command", `$Host.UI.RawUI.WindowTitle = '${title}'`],
+      ["/c", "start", "", conhostExe, "powershell.exe", "-NoProfile", "-NoExit", "-Command", `$Host.UI.RawUI.WindowTitle = '${title}'`],
       { detached: true, stdio: "ignore", windowsHide: false },
     );
     child.on("error", () => { /* spawn failure surfaces as the poll timing out below */ });
@@ -233,8 +240,10 @@ export class KeyLockerManager {
     if (child.pid === undefined) throw new KeyLockerError("KeyLockerSpawnFailed", "cmd spawn returned no pid");
 
     // CLAIM BY UNIQUE TITLE — NOT by `child.pid`: under `cmd /c start`, `child.pid` is the transient cmd.exe,
-    // never the conhost. The title is an 8-byte random nonce excluded against `before`, so a match is
-    // unambiguously OUR console (consistent with `resolveTitleByHwnd` declining non-unique titles); after the
+    // never the conhost. The title is the SOLE correlation now (the old owner-pid===child.pid co-anchor is gone
+    // with the cmd middleman), so its uniqueness is LOAD-BEARING: an 8-byte random nonce excluded against the
+    // pre-spawn `before` set — do not weaken it. A match is unambiguously OUR console (consistent with
+    // `resolveTitleByHwnd` declining non-unique titles); after the
     // claim every read/inject is hwnd-keyed, so the title is a one-shot startup correlation only. `shellPid =
     // getWindowProcessId(hwnd)` is the SHELL (powershell) process that owns the console window — conhost is its
     // PARENT (dogfood-verified) — so `shellPid` is exactly the `sshDescendants` subtree root (ssh/sudo run as
@@ -259,7 +268,9 @@ export class KeyLockerManager {
         if (leaked !== undefined) {
           const pid = getWindowProcessId(leaked.hwnd);
           if (pid !== 0) {
-            try { spawn(join(sys32, "taskkill.exe"), ["/PID", String(pid), "/T", "/F"], { stdio: "ignore" }).unref(); }
+            // `windowsHide:true` (Fable W-4b R1 P2): a console app spawned from this parent CAN allocate a
+            // visible window (DF-1 is the proof), so taskkill must not flash one — matches `killTree`.
+            try { spawn(join(sys32, "taskkill.exe"), ["/PID", String(pid), "/T", "/F"], { stdio: "ignore", windowsHide: true }).unref(); }
             catch { /* best-effort */ }
           }
         }


### PR DESCRIPTION
## What / Why

Live dogfood of the R3 Key Locker surfaced a **blocker**: `KeyLockerManager.launchAnchoredConsole()` produced **no `ConsoleWindowClass` window** on the real desktop and timed out after 8s — so the autofill loop never anchored a pane (`onDispatch` drops every dispatch with no anchored pane, P1-B), i.e. **the whole R3 autofill feature does not start on a real machine.**

### Root cause (empirically established — not merely `detached:true`)
Node's `child_process` cannot pass the Win32 `CREATE_NEW_CONSOLE` flag, and the MCP server parent has no console to share, so `spawn("conhost.exe", …)` allocates **zero** console windows. Verified spawn-variant matrix on the dogfood machine (Win11, DefTerm = "Let Windows decide"):

| Variant | new `ConsoleWindowClass` window |
|---|---|
| `conhost.exe powershell …` `detached:true` (**old code**) | NONE |
| `conhost.exe powershell …` `detached:false` | NONE |
| `powershell.exe …` direct | NONE |
| `cmd.exe /c start "" conhost.exe powershell …` | ✅ appears |

Because variant B (no `detached`) also fails, the cause is the **absence of `CREATE_NEW_CONSOLE`**, not `DETACHED_PROCESS` alone. `start` is what forces a new console.

## Fix (Fable-adjudicated **Option A**, native-free)
- Launch `cmd /c start "" <System32\conhost.exe> powershell.exe -NoExit -Command <title>`. The `start`-ed console is **reparented off the transient cmd.exe** (which exits immediately), so the console **outlives the session for free** — no node-side tree-kill can reach it (the "console outlives the session" requirement, Opus W-4a P2-1).
- **Claim by unique title** (child.pid is now the transient cmd.exe, not the conhost), then `shellPid = getWindowProcessId(hwnd)`.
- **Dogfood correction:** the window owner is the **shell (powershell)** process; **conhost is its PARENT**. ssh/sudo run as the shell's children, so `shellPid` is exactly the `sshDescendants` subtree root. Comments corrected from the earlier "shellPid = conhost pid" framing. No downstream contract change.
- **owner-pid 0 guard** (keep polling; a 0 root would break the subtree walk).
- **Absolute System32 paths** for cmd/conhost/taskkill (PATH-hijack hardening — a credential feature must not resolve spawn exes via PATH).
- **Timeout leak-sweep**: kill a late nonce-titled console by owner pid so a timeout never orphans a console.

## Alternatives considered (see followups doc)
- **B (native `CreateProcessW(CREATE_NEW_CONSOLE)`):** rejected — new Rust/napi surface + conhost becomes a direct child of the MCP node process (session-end tree-kill hazard).
- **C (launch via the C# `key-locker.exe` host):** the correct **permanent** home when R2 S2 (C#-side visible console) lands, but deferred — the host's `dispose()` does `taskkill /T` on idle-timeout (every 60s) and shutdown, which would kill the user's console + in-progress ssh; safe C needs a double-spawn detach (heavier, EDR-sensitive for the signed binary).

## Verification
- Standalone `launchAnchoredConsole()` against the built `dist/` now returns a titled console in ~500ms (was 8s timeout). Tree shape verified stable across runs: `getWindowProcessId(hwnd)` = powershell, parent = conhost.
- `npm run build` green. Key-locker unit suite green (378 passed). Not unit-testable at the console-allocation layer — covered by the §5 live dogfood.

## Follow-up (deferred, recorded as OQ-DF-1)
User-selectable anchored shell (`pwsh`/`powershell`/`cmd`/`bash`) — a medium change that must thread the choice through the title-set command + Mode-A `runToExit` `ExitShell` + `buildExitProbe` shell coverage. Default stays `powershell`.

Finding + full analysis: `desktop-touch-mcp-internal@39b3e6a:docs/adr-014-v2-r3-l3-4-live-wiring-followups.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)