### PR TITLE
fix(key-locker): DF-2 WPF culture crash + DF-3 Git-MSYS ssh known_hosts (dogfood blockers)

### DIFF
--- a/src/engine/key-locker/ssh-resolve.ts
+++ b/src/engine/key-locker/ssh-resolve.ts
@@ -16,7 +16,6 @@
 
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { canonicalFpSet, canonicalKey, type BindingUri } from "./binding.js";
@@ -196,7 +195,14 @@ export async function knownHostsFingerprints(
 ): Promise<string[]> {
   const found = new Set<string>();
   for (const file of new Set(files)) {
-    if (!existsSync(file)) continue;
+    // NO `existsSync(file)` pre-filter (DF-3, live dogfood 2026-07-08): `ssh -G` reports known_hosts
+    // paths in the SSH BINARY'S OWN world. Git-for-Windows' MSYS OpenSSH — very commonly first on a
+    // Windows PATH — prints POSIX paths like `/c/Users/you/.ssh/known_hosts` that Windows
+    // `fs.existsSync` cannot stat, so the old guard dropped EVERY candidate file ⇒ the host was always
+    // "not known" ⇒ the derivation returned null ⇒ autofill SILENTLY never fired for anyone whose PATH
+    // `ssh` is Git's. `ssh-keygen -F -f <file>` already returns non-zero for an absent/unreadable file
+    // (skipped just below), so it is the sole, format-correct arbiter — and Node resolves the SAME ssh
+    // family for `ssh-keygen`, so an MSYS path emitted by MSYS `ssh -G` is read by MSYS `ssh-keygen`.
     for (const token of new Set(tokens)) {
       const { code, stdout } = await exec("ssh-keygen", ["-l", "-F", token, "-f", file]);
       if (code !== 0) continue; // host not in this file under this token — skip, keep unioning

--- a/tools/key-locker/key-locker.csproj
+++ b/tools/key-locker/key-locker.csproj
@@ -19,7 +19,15 @@
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>false</SelfContained>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-    <InvariantGlobalization>true</InvariantGlobalization>
+    <!-- DF-2 (live dogfood 2026-07-08): InvariantGlobalization MUST stay off. The WPF secure
+         PasswordBox, on Focus(), queries the CURRENT INPUT LANGUAGE culture
+         (InputLanguageSource.CurrentInputLanguage). On a non-en keyboard layout (e.g. Japanese,
+         LCID 1041) that CultureInfo ctor throws CultureNotFoundException under invariant mode —
+         an UNHANDLED dispatcher exception that fail-fasts the whole locker (exit 0xC0000409) the
+         instant `capture` opens the dialog, surfacing to Node as `pipe closed`. Invariant mode
+         only ever saved a little startup cost; WPF text input is fundamentally incompatible with
+         it on international systems. DPAPI/store are culture-independent (self-test unaffected). -->
+    <InvariantGlobalization>false</InvariantGlobalization>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
 


### PR DESCRIPTION
Two live-dogfood blockers found after the anchored console (DF-1, #520) started working. Both are invisible to English CI / unit tests — they only reproduce on the real machine.

## DF-2 — WPF secure dialog fail-fasts on a non-en input language
`key_locker save` returned `pipe closed`. The C# host fail-fasts (0xC0000409) the instant `capture` opens the WPF PasswordBox: on focus, WPF queries the current input-language culture (`InputLanguageSource.CurrentInputLanguage`); on a Japanese layout that is LCID 1041, whose `CultureInfo` ctor throws under `InvariantGlobalization=true`. It is an unhandled WPF dispatcher exception (not caught by `HandleCapture`), so the host dies and Node sees `pipe closed`. `new Application()` at startup does not touch culture, hiding it until the first real dialog.
**Fix:** `InvariantGlobalization=false` + rebuilt `bin/key-locker.exe`. DPAPI/store are culture-independent (the `-SelfTest` round-trip is unaffected). Verified end-to-end: `save` returns `{captured:true}` on the ja-JP desktop.

## DF-3 — autofill silently never fires when the PATH `ssh` is Git-for-Windows MSYS OpenSSH
With the console up and the secret saved, `deriveBinding` returned null. `resolveCanonicalForSshCommand` checks the host key via `ssh-keygen -F` over the known_hosts files `ssh -G` reports, but Node resolves `ssh`/`ssh-keygen` via the Windows PATH — where Git-for-Windows MSYS OpenSSH is very commonly first. Git's `ssh -G` prints `userknownhostsfile` as MSYS POSIX paths (`/c/Users/you/.ssh/known_hosts`); the `existsSync(file)` pre-filter (Windows fs) is false for those, so every candidate was dropped, `ssh-keygen` was never called, and the host was always host-not-known → null → autofill never fires for anyone whose PATH ssh is Git's.
**Fix:** drop the `existsSync` pre-filter; `ssh-keygen -F` already returns non-zero for an absent/unreadable file, and Node resolves the same ssh family for `ssh-keygen`, so an MSYS path from MSYS `ssh -G` is read by MSYS `ssh-keygen`. Unit suite green (378); `deriveBinding` now returns the binding whose canonicalKey equals the stored `bindings.json` key.

## Status / review
- Root causes each confirmed by direct instrumentation on the live desktop.
- Design consulted with Opus + Fable; a formal Opus + Fable review of THESE diffs is still pending (do before merge).
- The autofill loop is otherwise fully validated end-to-end; the last remaining blocker (DF-5, `SendInput sent=0` foreground-ownership gate) is documented separately and NOT in this PR.

Findings: `desktop-touch-mcp-internal@48bfb27:docs/adr-014-v2-r3-l3-4-live-wiring-followups.md` (DF-2, DF-3, DF-5, OQ-DF-4/5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)