### PR TITLE
fix(key-locker): DF-5 console-buffer injector (AttachConsole + WriteConsoleInput)

### DIFF
--- a/src/engine/key-locker-host.ts
+++ b/src/engine/key-locker-host.ts
@@ -8,7 +8,7 @@
 // NamedPipeClientStream). What differs from S1 is the CONTROL VERBS and the trust story:
 //
 //   * The locker opens a WPF PasswordBox secure dialog on `capture`, DPAPI-encrypts the secret
-//     at rest, and serves it to consumers (askpass / SendInput — L2) — never over THIS pipe.
+//     at rest, and serves it to consumers (askpass / console-buffer inject — L2) — never over THIS pipe.
 //   * The SECRET NEVER CROSSES THIS PIPE. The wire carries opaque ids + control only; `capture`
 //     replies with {captured, rt} booleans, not the secret. So the pipe's integrity guarantee
 //     (kernel client-verify, below) protects the CONTROL channel — a squatter-server is inert
@@ -105,7 +105,7 @@ export interface LockerReply {
 
 // L2 wire contracts (the locker owns these frame shapes; the injector orchestrator consumes them).
 
-/** The dedicated-console target of a SendInput (`inject`) — §2.1 of the L2 plan. */
+/** The dedicated-console target of a console-buffer injection (`inject`) — §2.1 of the L2 plan. */
 export interface InjectTarget {
   /** The console window HWND (decimal string). */
   hwnd: string;
@@ -460,10 +460,11 @@ export class KeyLockerHost {
   }
 
   /**
-   * SendInput the secret stored under `key` into a dedicated console `target`, AFTER the locker
-   * re-verifies the target at the injection instant (§2.2: HWND/consolePid, ConsoleWindowClass,
-   * foreground, titleFp). The secret NEVER crosses the pipe — only {injected, verified} come back;
-   * an abort returns the typed reason.
+   * Write the secret stored under `key` into a dedicated console `target` via the console-buffer
+   * injector (DF-5: AttachConsole + WriteConsoleInput), AFTER the locker re-verifies the target IDENTITY
+   * at the injection instant (§2.2: HWND/consolePid, ConsoleWindowClass, titleFp — no foreground gate; the
+   * write is addressed to the verified console pid). The secret NEVER crosses the pipe — only
+   * {injected, verified} come back; an abort returns the typed reason.
    */
   async inject(key: string, target: InjectTarget): Promise<InjectClientResult> {
     const reply = await this.request("inject", key, REQUEST_TIMEOUT_MS, { t: target });

--- a/src/engine/key-locker-host.ts
+++ b/src/engine/key-locker-host.ts
@@ -130,7 +130,9 @@ export interface MintTicketContext {
   path?: string;
 }
 
-/** Every abort reason the `inject` verb can return (§2.1 reply contract). */
+/** Every abort reason the `inject` verb can return (§2.1 reply contract). `not_foreground` is no longer
+ *  emitted since DF-5 (the console-buffer injector has no foreground gate — Injection.cs `InjectAbort`),
+ *  but stays in the union for wire back-compat so `normalizeAbort` never downgrades an in-flight old reply. */
 export type InjectAbortCode =
   | "target_mismatch" | "target_gone" | "not_foreground" | "target_multiplexed"
   | "no_secret" | "bad_target" | "executor_failed";

--- a/src/engine/key-locker/capture-loop.ts
+++ b/src/engine/key-locker/capture-loop.ts
@@ -14,7 +14,7 @@
 //     exit — reject / not-landed / [Not now]/[Never] / any throw — DELETES the captured secret from the
 //     locker (Opus L3-R1 P2-1 reverse-orphan closure of L1 §5.3).
 //
-// SCOPE (L3-2): this is the PANE (SendInput) channel loop — the fully-reactive "echo-off prompt appeared,
+// SCOPE (L3-2): this is the PANE (console-buffer inject) channel loop — the fully-reactive "echo-off prompt appeared,
 // fill it now" flow (`sudo`/`ssh` password prompts). The `askpass` / `git-credential` channels fill via a
 // helper the CONSUMER spawn consults, so their inject happens at DISPATCH time (env pre-set) and their
 // landed signal spans the consumer's whole lifetime — a different control flow that does not fit the
@@ -73,7 +73,7 @@ export type CaptureLoopOutcome =
   | { kind: "confirm_rejected" }
   /** MATCH path: a stored secret was autofilled. `verified` = the locker's injection-instant re-verify. */
   | { kind: "filled_from_store"; verified: boolean }
-  /** Inject returned a typed abort (target_mismatch / not_foreground / …). `matched` distinguishes the
+  /** Inject returned a typed abort (target_mismatch / target_multiplexed / …). `matched` distinguishes the
    *  MATCH autofill from a NO-MATCH just-captured fill (the latter also deletes the capture). */
   | { kind: "fill_aborted"; matched: boolean; code: string }
   /** NO-MATCH path: the user cancelled the secure dialog — no secret captured, no binding. */
@@ -102,7 +102,7 @@ export interface CaptureLoopDeps {
   capture(opaqueId: string): Promise<{ captured: boolean }>;
   /** Delete the locker entry for `opaqueId` (the reverse-orphan closure; a no-op on an absent key). */
   deleteSecret(opaqueId: string): Promise<void>;
-  /** Assemble the pane InjectTarget (§4) and SendInput the secret under `opaqueId` (L2, "pane" channel). */
+  /** Assemble the pane InjectTarget (§4) and console-buffer inject the secret under `opaqueId` (L2, "pane" channel). */
   injectPane(binding: BindingUri, opaqueId: string, submit: boolean): Promise<InjectResult>;
   /** The §2 two-mode landed gate for the dispatched command (Mode A exit-0 / Mode B auth-accepted). */
   awaitLanded(command: string): Promise<LandedResult>;
@@ -153,7 +153,7 @@ export async function runCaptureLoop(deps: CaptureLoopDeps, event: CredentialEve
   const binding = await deps.deriveBinding(dispatchedCommand, session);
   if (binding === null) return { kind: "declined", reason: "not_a_credential" };
 
-  // PANE-CHANNEL scope: only `sudo`/`ssh` fill via the pane SendInput. An `sshkey` (always askpass — P3-2)
+  // PANE-CHANNEL scope: only `sudo`/`ssh` fill via the pane console-buffer inject. An `sshkey` (always askpass — P3-2)
   // or `https-cred` (git-credential) binding is NOT pane-injectable and is handled by the forward
   // askpass/git-credential flow (SP-L3-OQ-5), so decline this loop rather than mis-route to the pane.
   if (!selectInjector(binding.scheme, "pane").ok) return { kind: "declined", reason: "not_pane_channel" };
@@ -240,9 +240,9 @@ export async function runCaptureLoop(deps: CaptureLoopDeps, event: CredentialEve
   return outcome;
 }
 
-/** The pane channel only ever runs the `sendinput` injector; read its re-verify bit (else false). */
+/** The pane channel only ever runs the `console` injector; read its re-verify bit (else false). */
 function injectVerified(r: InjectResult): boolean {
-  return r.ok && r.injector === "sendinput" ? r.verified : false;
+  return r.ok && r.injector === "console" ? r.verified : false;
 }
 
 /**

--- a/src/engine/key-locker/inject-target.ts
+++ b/src/engine/key-locker/inject-target.ts
@@ -1,9 +1,9 @@
-// ADR-014 v2 R3 Key Locker — L3 §4: InjectTarget assembly for the `pane` (SendInput) channel.
+// ADR-014 v2 R3 Key Locker — L3 §4: InjectTarget assembly for the `pane` (console-buffer inject) channel.
 //
 // Plan: desktop-touch-mcp-internal@<plan>:docs/adr-014-v2-r3-l3-capture-plan.md (§4, THE LOCKED
 // CONTRACT #4)
 //
-// For a pane SendInput injection L3 must hand the locker an `InjectTarget {hwnd, consolePid, titleFp,
+// For a pane console-buffer injection L3 must hand the locker an `InjectTarget {hwnd, consolePid, titleFp,
 // submit}` (L2 §2.1). The hwnd is already in hand — the terminal/tool layer that observed the
 // credential prompt located the console window — so this module only reads the two derived fields
 // (consolePid, titleFp) via the SAME Win32 APIs the locker re-verifies with, so both match by

--- a/src/engine/key-locker/injector.ts
+++ b/src/engine/key-locker/injector.ts
@@ -5,8 +5,9 @@
 //
 // Three injectors (D4(iii) has two transports — askpass stdout + git credential protocol — that share
 // machinery) behind one decision:
-//   * SendInput → pane  — the LOCKER types the secret into a dedicated console after an injection-
-//     instant re-verify (secret never leaves the locker).
+//   * console → pane   — the LOCKER writes the secret into a dedicated console's input buffer
+//     (AttachConsole + WriteConsoleInput) after an injection-instant identity re-verify (secret never
+//     leaves the locker).
 //   * askpass streaming — a compiled helper streams the secret locker→consumer off the MCP path,
 //     authorized by a single-use ticket; the engine only assembles the env/git-config.
 //   * env var          — R4-gated; a hard `RequiresRedaction` reject (no flag) until R4 lands.
@@ -27,7 +28,7 @@ const ASKPASS_EXE = join(dirname(fileURLToPath(import.meta.url)), "..", "..", ".
 /** Which consumer channel L3 observed for this credential event (drives injector selection). */
 export type InjectChannel = "pane" | "askpass" | "git-credential" | "env";
 
-export type InjectorKind = "sendinput" | "askpass";
+export type InjectorKind = "console" | "askpass";
 
 export type SelectErrorCode = "NoInjectorForBinding" | "RequiresRedaction";
 
@@ -45,8 +46,8 @@ export function selectInjector(scheme: BindingUri["scheme"], channel: InjectChan
   if (channel === "env") return { ok: false, code: "RequiresRedaction" };
   switch (channel) {
     case "pane":
-      // Interactive echo-off prompt in the pane → the locker SendInputs.
-      if (scheme === "sudo" || scheme === "ssh") return { ok: true, injector: "sendinput" };
+      // Interactive echo-off prompt in the pane → the locker writes into the console input buffer.
+      if (scheme === "sudo" || scheme === "ssh") return { ok: true, injector: "console" };
       return { ok: false, code: "NoInjectorForBinding" };
     case "askpass":
       // ssh login routed to SSH_ASKPASS, or an ssh-key passphrase.
@@ -85,14 +86,14 @@ export interface ConsumerSpawnConfig {
 }
 
 export type InjectResult =
-  | { ok: true; injector: "sendinput"; verified: boolean }
+  | { ok: true; injector: "console"; verified: boolean }
   | { ok: true; injector: "askpass"; spawn: ConsumerSpawnConfig }
-  // `InjectAbortCode` (the locker-side SendInput abort reasons, §2.1) is the SSOT in key-locker-host.
+  // `InjectAbortCode` (the locker-side inject abort reasons, §2.1) is the SSOT in key-locker-host.
   | { ok: false; code: SelectErrorCode | "target_required" | InjectAbortCode };
 
 /**
  * Orchestrate an injection. Returns booleans / config / typed reasons — NEVER a secret.
- * `pane` → the locker SendInputs (needs `target`); `askpass`/`git-credential` → mint a ticket + return
+ * `pane` → the locker writes into the console buffer (needs `target`); `askpass`/`git-credential` → mint a ticket + return
  * the consumer spawn config (the secret path is helper↔locker only); `env` → `RequiresRedaction`.
  */
 export async function inject(
@@ -105,11 +106,11 @@ export async function inject(
   const selected = selectInjector(binding.scheme, channel);
   if (!selected.ok) return { ok: false, code: selected.code };
 
-  if (selected.injector === "sendinput") {
+  if (selected.injector === "console") {
     if (target === null) return { ok: false, code: "target_required" };
     const r = await host.inject(opaqueId, target);
     return r.ok
-      ? { ok: true, injector: "sendinput", verified: r.verified }
+      ? { ok: true, injector: "console", verified: r.verified }
       : { ok: false, code: r.code };
   }
 

--- a/src/engine/key-locker/key-locker-capture-driver.ts
+++ b/src/engine/key-locker/key-locker-capture-driver.ts
@@ -135,7 +135,7 @@ export interface CaptureDriverDeps {
   capture(opaqueId: string): Promise<{ captured: boolean }>;
   /** Delete the locker entry for `opaqueId` (the reverse-orphan closure). */
   deleteSecret(opaqueId: string): Promise<void>;
-  /** Assemble the pane InjectTarget for `paneId` (`assembleInjectTarget`) + SendInput (`inject`, "pane"). */
+  /** Assemble the pane InjectTarget for `paneId` (`assembleInjectTarget`) + console-buffer inject (`inject`, "pane"). */
   injectPane(paneId: string, binding: BindingUri, opaqueId: string, submit: boolean): Promise<InjectResult>;
   /** The D2 backstop confirm before a MATCH autofill. */
   confirmInjection(binding: BindingUri): Promise<boolean>;

--- a/tests/e2e/key-locker.e2e.test.ts
+++ b/tests/e2e/key-locker.e2e.test.ts
@@ -95,6 +95,26 @@ describe("key-locker DPAPI store (-SelfTest, headless)", () => {
     const storeJson = readFileSync(join(storeDir, "store.json"), "utf8");
     expect(storeJson).not.toContain("L2-SERVE-SECRET");
   }, 30_000);
+
+  // DF-5: the console-buffer injector (AttachConsole + WriteConsoleInput) is foreground/UIPI-immune and
+  // replaces the SendInput path that returned `sent=0`. `-SelfTestInjectConsole` runs the REAL production
+  // `Win32Input.ReVerifyAndType` against a self-spawned child console (echo-off cooked-read) and asserts a
+  // unicode+surrogate secret round-trips — a deterministic proof that needs no live ssh. (The live native
+  // OpenSSH leg is dogfood-only, like capture's dialog.)
+  it("types a unicode+surrogate secret into another process's console and it cooked-reads it back (-SelfTestInjectConsole)", async () => {
+    expect(existsSync(HELPER_EXE)).toBe(true);
+
+    const { code, stdout } = await new Promise<{ code: number | null; stdout: string }>((resolve) => {
+      const c = spawn(HELPER_EXE, ["-SelfTestInjectConsole"], { stdio: ["ignore", "pipe", "ignore"], windowsHide: true });
+      let out = "";
+      c.stdout!.on("data", (d) => { out += d.toString("utf8"); });
+      c.on("exit", (code) => resolve({ code, stdout: out }));
+      setTimeout(() => { killTree(c.pid); resolve({ code: -999, stdout: out }); }, 25_000);
+    });
+
+    expect(code).toBe(0);
+    expect(JSON.parse(stdout.trim())).toEqual({ ok: true });
+  }, 40_000);
 });
 
 describe("key-locker live smoke (pipe control plane)", () => {

--- a/tests/unit/key-locker-capture-driver.test.ts
+++ b/tests/unit/key-locker-capture-driver.test.ts
@@ -46,7 +46,7 @@ function snapshotOf(procs: Record<number, Proc>): ProcessSnapshot {
   };
 }
 
-const SENDINPUT_OK = (verified = true): InjectResult => ({ ok: true, injector: "sendinput", verified });
+const CONSOLE_INJECT_OK = (verified = true): InjectResult => ({ ok: true, injector: "console", verified });
 const PROMPT = (isCredentialPrompt: boolean): PromptVerdict => ({ isCredentialPrompt, tail: "", stillHiddenPrompt: false });
 const sshProc = (parent: number, host: string, start: number): Proc =>
   ({ parent, name: "ssh", start, argv: ["ssh", `deploy@${host}`] });
@@ -90,7 +90,7 @@ function makeHarness(o: Partial<CaptureDriverDeps> = {}, initialTree: Record<num
     confirmPolicyFor: vi.fn(() => false),
     capture: vi.fn(async () => ({ captured: true })),
     deleteSecret: vi.fn(async () => {}),
-    injectPane: vi.fn(async () => SENDINPUT_OK()),
+    injectPane: vi.fn(async () => CONSOLE_INJECT_OK()),
     confirmInjection: vi.fn(async () => true),
     offerSave: vi.fn(async () => "save"),
     mintOpaqueId: vi.fn(() => "opaque-1"),

--- a/tests/unit/key-locker-capture-loop.test.ts
+++ b/tests/unit/key-locker-capture-loop.test.ts
@@ -19,7 +19,7 @@ const SSH: BindingUri = { scheme: "ssh", user: "deploy", host: "prod", port: 22,
 const SSHKEY: BindingUri = { scheme: "sshkey", keyFp: "SHA256:zzz" };
 const HTTPS: BindingUri = { scheme: "https-cred", host: "github.com", port: 443, user: "octocat" };
 
-const SENDINPUT_OK = (verified = true): InjectResult => ({ ok: true, injector: "sendinput", verified });
+const CONSOLE_INJECT_OK = (verified = true): InjectResult => ({ ok: true, injector: "console", verified });
 const ABORT = (code: string): InjectResult => ({ ok: false, code: code as never });
 const LANDED = (accepted: boolean, reason = accepted ? "exit_0" : "not_exit_0:timeout"): LandedResult =>
   ({ accepted, mode: "one-shot", reason });
@@ -36,7 +36,7 @@ function makeDeps(o: Partial<CaptureLoopDeps> = {}): CaptureLoopDeps {
     confirmPolicyFor: vi.fn(() => true),
     capture: vi.fn(async () => ({ captured: true })),
     deleteSecret: vi.fn(async () => {}),
-    injectPane: vi.fn(async () => SENDINPUT_OK()),
+    injectPane: vi.fn(async () => CONSOLE_INJECT_OK()),
     awaitLanded: vi.fn(async () => LANDED(true)),
     confirmInjection: vi.fn(async () => true),
     offerSave: vi.fn(async () => "save"),
@@ -177,7 +177,7 @@ describe("runCaptureLoop — MATCH (autofill a stored secret)", () => {
   it("filled_from_store.verified passes through the locker re-verify bit", async () => {
     const deps = makeDeps({
       resolveBinding: vi.fn(async () => ({ opaqueId: "stored-1" })),
-      injectPane: vi.fn(async () => SENDINPUT_OK(false)),
+      injectPane: vi.fn(async () => CONSOLE_INJECT_OK(false)),
     });
     expect(await runCaptureLoop(deps, EVENT)).toEqual({ kind: "filled_from_store", verified: false });
   });

--- a/tests/unit/key-locker-injector.test.ts
+++ b/tests/unit/key-locker-injector.test.ts
@@ -17,8 +17,8 @@ const target: InjectTarget = { hwnd: "12345", consolePid: 4242, titleFp: "abc", 
 
 describe("selectInjector (§1 selection rule) — total, typed rejects", () => {
   const cases: Array<[BindingUri["scheme"], InjectChannel, string]> = [
-    ["sudo", "pane", "sendinput"],
-    ["ssh", "pane", "sendinput"],
+    ["sudo", "pane", "console"],
+    ["ssh", "pane", "console"],
     ["ssh", "askpass", "askpass"],       // ssh login routed to SSH_ASKPASS
     ["sshkey", "askpass", "askpass"],    // key passphrase
     ["https-cred", "git-credential", "askpass"],
@@ -76,7 +76,7 @@ describe("inject orchestrator (§5) — never returns a secret", () => {
   it("pane → calls host.inject with the target, returns verified only", async () => {
     const host = fakeHost();
     const r = await inject(host, sudo, "op-1", "pane", target);
-    expect(r).toEqual({ ok: true, injector: "sendinput", verified: true });
+    expect(r).toEqual({ ok: true, injector: "console", verified: true });
     expect(host.inject).toHaveBeenCalledWith("op-1", target);
   });
 

--- a/tools/key-locker/Injection.cs
+++ b/tools/key-locker/Injection.cs
@@ -1,11 +1,16 @@
-// ADR-014 v2 R3 Key Locker — L2 injection (C# side): the SendInput injector with injection-instant
-// re-verify, and the askpass serving path (single-use ticket + per-injection serving pipe).
+// ADR-014 v2 R3 Key Locker — L2 injection (C# side): the console-buffer injector with injection-instant
+// identity re-verify, and the askpass serving path (single-use ticket + per-injection serving pipe).
 //
-// Plan: desktop-touch-mcp-internal@<plan>:docs/adr-014-v2-r3-l2-injection-plan.md (§2, §3)
+// Plan: desktop-touch-mcp-internal@<plan>:docs/adr-014-v2-r3-l2-injection-plan.md (§2, §3);
+//       DF-5 fix: desktop-touch-mcp-internal@<plan>:docs/adr-014-v2-r3-df5-writeconsoleinput-impl-plan.md
 //
-// The secret NEVER crosses the control pipe and never reaches Node: SendInput happens HERE (the
+// The secret NEVER crosses the control pipe and never reaches Node: the keystroke write happens HERE (the
 // locker holds the plaintext); the askpass helper fetches it over a SEPARATE serving pipe this file
 // creates. Plaintext is decrypted transiently (LockerStore.WithDecrypted) and zeroized after use.
+//
+// DF-5 (2026-07-08): injection is `AttachConsole` + `WriteConsoleInputW` into the target console's input
+// buffer (foreground/UIPI-immune), NOT SendInput (which returned `sent=0` under a foreground-ownership
+// gate). See the Win32Input class doc for the mechanism + the re-expressed security property.
 
 using System.IO;
 using System.IO.Pipes;
@@ -17,10 +22,11 @@ using System.Text.Json;
 // Global namespace (matches Program.cs's `internal static class KeyLocker`; a `namespace KeyLocker`
 // here would collide with that class name).
 
-/// The dedicated-console target of a SendInput, parsed off the `inject` frame's `t` field (§2.1).
+/// The dedicated-console target of an injection, parsed off the `inject` frame's `t` field (§2.1).
 /// `ConsolePid` is the WINDOW-OWNING pid (`GetWindowThreadProcessId(hwnd)`) — L3 sends
 /// `getWindowProcessId(hwnd)` and this side re-reads the same API on the same hwnd, so it matches by
-/// construction (not asserted to be a specific conhost-vs-shell process).
+/// construction (not asserted to be a specific conhost-vs-shell process). DF-5 also uses `ConsolePid`
+/// as the `AttachConsole` target — the same window-owning pid identifies the console to attach to.
 internal readonly record struct InjectTarget(nint Hwnd, uint ConsolePid, string TitleFp, bool Submit);
 
 /// The abort reasons the re-verify predicate can raise (§2.2); null = passed.
@@ -28,41 +34,83 @@ internal static class InjectAbort
 {
     public const string Gone = "target_gone";
     public const string Multiplexed = "target_multiplexed";
+    // DF-5: no longer emitted (the console-buffer injector has no foreground gate). Retained so the wire
+    // enum + the Node-side InjectAbortCode union stay byte-stable for any in-flight old reply.
     public const string NotForeground = "not_foreground";
     public const string Mismatch = "target_mismatch";
     public const string NoSecret = "no_secret";
 }
 
-/// Win32 SendInput + the injection-instant re-verify (§2.2). Foreground-routed input demands the
-/// target be re-checked at the SEND instant, inside the locker, immediately before the first key.
+/// Win32 CONSOLE-BUFFER injector (DF-5 fix) + the injection-instant re-verify.
+///
+/// DF-5 (live dogfood 2026-07-08): the previous `SendInput` path returned `sent=0/N, GetLastError()==0`
+/// — a foreground-OWNERSHIP gate (the input was refused because this process is not the foreground-input
+/// owner; NOT UIPI, which would return the full count with events silently dropped). A window-less
+/// helper cannot acquire foreground ownership without a fragile cross-process AllowSetForegroundWindow +
+/// foreground-steal ladder. So injection now writes `KEY_EVENT` records DIRECTLY into the target
+/// console's input buffer via `AttachConsole(consolePid)` + `WriteConsoleInputW(CONIN$)`, which the shell
+/// cooked-reads (`ReadConsole`) — foreground- and UIPI-immune, self-contained in the helper, and a
+/// natural fit because the Key Locker only ever targets a classic conhost (`ConsoleWindowClass`).
+///
+/// The old "inject only when the target is FOREGROUND" property is re-expressed as "inject only into the
+/// verified `consolePid`'s console input buffer": the write is ADDRESSED to that console (not broadcast to
+/// whatever is foreground), and a two-stage identity re-verify (before attach + after CONIN$ open) pins
+/// that the hwnd/pid/class/title still name the same console — so mis-delivery to a wrong window is
+/// structurally impossible. Spike-proven (scratchpad/df5-spike, 4/4): cross-process WriteConsoleInput is
+/// cooked-read; Unicode/BMP/surrogate round-trip; a `wScan`-only mapping types ZERO chars (a cooked-read
+/// cooks `UnicodeChar`, NOT `wScan`).
 internal static class Win32Input
 {
     private const string ConsoleClass = "ConsoleWindowClass"; // the console window-class name (class-name origin, not a pid claim — intentionally retained through the R1 P3-1 conhost doc-fix)
 
-    [StructLayout(LayoutKind.Sequential)]
-    private struct INPUT { public uint type; public InputUnion U; }
+    // A console INPUT_RECORD carrying a KEY_EVENT. EventType is at offset 0 (WORD); the union member is at
+    // offset 4 on x64 (2 bytes of alignment padding after EventType). sizeof(INPUT_RECORD) = 20.
     [StructLayout(LayoutKind.Explicit)]
-    private struct InputUnion { [FieldOffset(0)] public KEYBDINPUT ki; }
+    private struct INPUT_RECORD { [FieldOffset(0)] public ushort EventType; [FieldOffset(4)] public KEY_EVENT_RECORD KeyEvent; }
     [StructLayout(LayoutKind.Sequential)]
-    private struct KEYBDINPUT { public ushort wVk; public ushort wScan; public uint dwFlags; public uint time; public nint dwExtraInfo; }
+    private struct KEY_EVENT_RECORD
+    {
+        public int bKeyDown;            // BOOL
+        public ushort wRepeatCount;     // MUST be 1 — a repeat count of 0 emits nothing
+        public ushort wVirtualKeyCode;
+        public ushort wVirtualScanCode;
+        public ushort UnicodeChar;      // the field a cooked-read cooks (NOT wVirtualScanCode)
+        public uint dwControlKeyState;
+    }
 
-    private const uint INPUT_KEYBOARD = 1;
-    private const uint KEYEVENTF_KEYUP = 0x0002;
-    private const uint KEYEVENTF_UNICODE = 0x0004;
+    private const ushort KEY_EVENT = 0x0001;
     private const ushort VK_RETURN = 0x0D;
+    private const uint GENERIC_READ = 0x80000000, GENERIC_WRITE = 0x40000000;
+    private const uint FILE_SHARE_READ = 1, FILE_SHARE_WRITE = 2, OPEN_EXISTING = 3;
+    private const int STD_INPUT_HANDLE = -10, STD_OUTPUT_HANDLE = -11, STD_ERROR_HANDLE = -12;
+    private static readonly nint INVALID_HANDLE = -1;
 
-    [DllImport("user32.dll", SetLastError = true)]
-    private static extern uint SendInput(uint nInputs, [In] INPUT[] pInputs, int cbSize);
-    [DllImport("user32.dll")] private static extern nint GetForegroundWindow();
+    // Console-buffer injection surface (kernel32). AttachConsole/FreeConsole are PROCESS-GLOBAL: the
+    // helper attaches to the target console only transiently for one inject, then detaches.
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern bool AttachConsole(uint dwProcessId);
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern bool FreeConsole();
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern bool WriteConsoleInputW(nint hConsoleInput, [In] INPUT_RECORD[] lpBuffer, uint nLength, out uint lpNumberOfEventsWritten);
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)] private static extern nint CreateFileW(string lpFileName, uint dwDesiredAccess, uint dwShareMode, nint lpSecurityAttributes, uint dwCreationDisposition, uint dwFlagsAndAttributes, nint hTemplateFile);
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern bool CloseHandle(nint hObject);
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern nint GetStdHandle(int nStdHandle);
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern bool SetStdHandle(int nStdHandle, nint hHandle);
+
     [DllImport("user32.dll")] private static extern bool IsWindow(nint hWnd);
     [DllImport("user32.dll", SetLastError = true)] private static extern uint GetWindowThreadProcessId(nint hWnd, out uint lpdwProcessId);
     [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)] private static extern int GetClassName(nint hWnd, StringBuilder lpClassName, int nMaxCount);
     [DllImport("user32.dll", CharSet = CharSet.Unicode)] private static extern int GetWindowText(nint hWnd, StringBuilder lpString, int nMaxCount);
     [DllImport("user32.dll")] private static extern int GetWindowTextLength(nint hWnd);
 
-    /// Re-verify the target at the injection instant (§2.2). Returns an InjectAbort code on any
+    /// Re-verify the target IDENTITY at the injection instant. Returns an InjectAbort code on any
     /// mismatch, or null if all predicates pass. POSITIVE allowlist: the window MUST be the classic
     /// console class AND owned by the tracked window-owning pid — anything else is `target_multiplexed`.
+    ///
+    /// DF-5: there is NO foreground check — the console-buffer injector addresses the write to the
+    /// verified `consolePid` (it does not broadcast to the foreground window), so foreground is no longer
+    /// the delivery gate; identity (hwnd alive + class + owning pid + title fp) is. This predicate runs
+    /// TWICE per inject (before AttachConsole and again after the CONIN$ handle opens) so the console
+    /// cannot be swapped out from under the attached handle. `InjectAbort.NotForeground` is therefore no
+    /// longer emitted (kept in the wire enum for back-compat only).
     private static string? ReVerify(in InjectTarget t)
     {
         if (t.Hwnd == 0 || !IsWindow(t.Hwnd)) return InjectAbort.Gone;
@@ -74,8 +122,6 @@ internal static class Win32Input
         _ = GetWindowThreadProcessId(t.Hwnd, out var pid);
         if (pid == 0) return InjectAbort.Gone;
         if (pid != t.ConsolePid) return InjectAbort.Multiplexed;
-
-        if (GetForegroundWindow() != t.Hwnd) return InjectAbort.NotForeground;
 
         // Secondary anchor (defense-in-depth): the live title hash must match the expected fp.
         // Skipped when the engine supplied no fp.
@@ -93,46 +139,97 @@ internal static class Win32Input
         return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(sb.ToString()))).ToLowerInvariant();
     }
 
-    /// Build the keystrokes, re-verify the target at the LAST moment, then type the secret + Enter
-    /// if `submit`. Returns (injected, abortCode). BOTH plaintext-bearing buffers — the decoded
-    /// char[] AND the INPUT[] (the secret lives in each `KEYBDINPUT.wScan`) — are zeroized in the
-    /// finally, upholding §2.2 step 5's zeroize discipline (Opus R1 P2-1). Building into a sized
-    /// INPUT[] (not a List) avoids a hidden backing-array copy that would survive uncleared.
+    /// Build the KEY_EVENT records, re-verify the target identity, ATTACH to the target console, re-verify
+    /// again, then write the secret + Enter (if `submit`) into that console's input buffer. Returns
+    /// (injected, abortCode). BOTH plaintext-bearing buffers — the decoded char[] AND the INPUT_RECORD[]
+    /// (the secret lives in each `KEY_EVENT_RECORD.UnicodeChar`) — are zeroized in the finally, upholding
+    /// the zeroize discipline. Building into a sized array (not a List) avoids a hidden backing-array copy
+    /// that would survive uncleared.
+    ///
+    /// DF-5 delivery mechanism = `AttachConsole(consolePid)` + `WriteConsoleInputW(CONIN$)` (foreground-
+    /// and UIPI-immune), replacing the SendInput foreground path that returned `sent=0`. AttachConsole is
+    /// PROCESS-GLOBAL and rebinds the std handles, so the 3 std handles are saved before FreeConsole and
+    /// restored after, and NO `Console.Error` (or any std-stream) write may happen between AttachConsole
+    /// and the final FreeConsole — a hard invariant: a diagnostic there would leak onto the USER's console.
     public static (bool injected, string? abort) ReVerifyAndType(in InjectTarget t, byte[] secret)
     {
         char[] chars = Encoding.UTF8.GetChars(secret);
+        // One down + one up record per UTF-16 code unit (surrogate pairs => 2 code units => 2 records),
+        // plus a VK_RETURN down/up when submitting. The secret rides in each record's UnicodeChar.
         var n = chars.Length * 2 + (t.Submit ? 2 : 0);
-        var arr = new INPUT[n];
+        var arr = new INPUT_RECORD[n];
         try
         {
             var j = 0;
-            foreach (var ch in chars) { arr[j++] = UnicodeKey(ch, false); arr[j++] = UnicodeKey(ch, true); }
-            if (t.Submit) { arr[j++] = VkKey(VK_RETURN, false); arr[j++] = VkKey(VK_RETURN, true); }
+            foreach (var ch in chars) { arr[j++] = KeyRecord(ch, 0, true); arr[j++] = KeyRecord(ch, 0, false); }
+            if (t.Submit) { arr[j++] = KeyRecord('\r', VK_RETURN, true); arr[j++] = KeyRecord('\r', VK_RETURN, false); }
 
-            // Re-verify IMMEDIATELY before the send — the tightest TOCTOU window (Opus R1 P3-2). An
-            // abort here types nothing; the built (secret-bearing) INPUT[] is still zeroized below.
+            // Stage-1 identity re-verify (cheap early-out before we perturb the process console state).
             var abort = ReVerify(in t);
             if (abort != null) return (false, abort);
 
-            var sent = SendInput((uint)arr.Length, arr, Marshal.SizeOf<INPUT>());
-            return (sent == (uint)arr.Length, sent == (uint)arr.Length ? null : "executor_failed");
+            return AttachAndWrite(in t, arr);
         }
         finally
         {
             Array.Clear(chars, 0, chars.Length);
-            Array.Clear(arr, 0, arr.Length); // the INPUT[] holds the secret in each wScan
+            Array.Clear(arr, 0, arr.Length); // the INPUT_RECORD[] holds the secret in each UnicodeChar
         }
     }
 
-    private static INPUT UnicodeKey(char ch, bool up) => new()
+    /// The attach bracket: save std handles → FreeConsole → AttachConsole(consolePid) → open CONIN$ →
+    /// STAGE-2 re-verify (after the handle exists, so the console can't be swapped underneath) → write.
+    /// Everything is torn down in the finally (close CONIN$, FreeConsole, restore std handles). NO
+    /// std-stream write may occur inside this bracket (see ReVerifyAndType doc).
+    private static (bool injected, string? abort) AttachAndWrite(in InjectTarget t, INPUT_RECORD[] arr)
     {
-        type = INPUT_KEYBOARD,
-        U = new InputUnion { ki = new KEYBDINPUT { wVk = 0, wScan = ch, dwFlags = KEYEVENTF_UNICODE | (up ? KEYEVENTF_KEYUP : 0) } },
-    };
-    private static INPUT VkKey(ushort vk, bool up) => new()
+        nint savedIn = GetStdHandle(STD_INPUT_HANDLE);
+        nint savedOut = GetStdHandle(STD_OUTPUT_HANDLE);
+        nint savedErr = GetStdHandle(STD_ERROR_HANDLE);
+        nint conin = INVALID_HANDLE;
+        var attached = false;
+        try
+        {
+            FreeConsole(); // detach from any console we already hold (the helper is a WinExe: usually none)
+            if (!AttachConsole(t.ConsolePid)) return (false, InjectAbort.Gone); // target console is gone
+            attached = true;
+
+            conin = CreateFileW("CONIN$", GENERIC_READ | GENERIC_WRITE,
+                FILE_SHARE_READ | FILE_SHARE_WRITE, 0, OPEN_EXISTING, 0, 0);
+            if (conin == INVALID_HANDLE) return (false, "executor_failed");
+
+            // Stage-2 re-verify: now that the CONIN$ handle is open, confirm the hwnd/pid/class/title
+            // STILL name the same console — closes the attach→write TOCTOU window (Opus R1 P2-3).
+            var abort = ReVerify(in t);
+            if (abort != null) return (false, abort);
+
+            var ok = WriteConsoleInputW(conin, arr, (uint)arr.Length, out var written);
+            return (ok && written == (uint)arr.Length, ok && written == (uint)arr.Length ? null : "executor_failed");
+        }
+        finally
+        {
+            if (conin != INVALID_HANDLE) CloseHandle(conin);
+            if (attached) FreeConsole();
+            // Restore the std handles AttachConsole/FreeConsole rebound, so later verbs' diagnostics go
+            // back to the helper's original streams, not the user's console (Opus R1 P2-1).
+            SetStdHandle(STD_INPUT_HANDLE, savedIn);
+            SetStdHandle(STD_OUTPUT_HANDLE, savedOut);
+            SetStdHandle(STD_ERROR_HANDLE, savedErr);
+        }
+    }
+
+    private static INPUT_RECORD KeyRecord(char ch, ushort vk, bool down) => new()
     {
-        type = INPUT_KEYBOARD,
-        U = new InputUnion { ki = new KEYBDINPUT { wVk = vk, wScan = 0, dwFlags = up ? KEYEVENTF_KEYUP : 0 } },
+        EventType = KEY_EVENT,
+        KeyEvent = new KEY_EVENT_RECORD
+        {
+            bKeyDown = down ? 1 : 0,
+            wRepeatCount = 1,
+            wVirtualKeyCode = vk,
+            wVirtualScanCode = 0,
+            UnicodeChar = ch,
+            dwControlKeyState = 0,
+        },
     };
 }
 
@@ -253,8 +350,9 @@ internal sealed class ServingRegistry
     }
 
     /// Headless deterministic proof of the serving/ticket contract (§3, §3.1): valid fetch,
-    /// single-use (replay refused), forged ticket refused, git context_mismatch refused. SendInput
-    /// needs a live foreground conhost and is exercised by the e2e suite, not here.
+    /// single-use (replay refused), forged ticket refused, git context_mismatch refused. The
+    /// console-buffer injection path needs a live conhost and is exercised by `-SelfTestInjectConsole`
+    /// (headless, self-spawned console) + the e2e suite, not here.
     public bool SelfTest()
     {
         const string id = "l2-selftest-id";
@@ -295,5 +393,129 @@ internal sealed class ServingRegistry
             return true;
         }
         finally { _store.Delete(id); }
+    }
+}
+
+/// DF-5 headless self-test for the console-buffer injector (`-SelfTestInjectConsole`). Deterministic proof
+/// — no live ssh — that `Win32Input.ReVerifyAndType` (AttachConsole + WriteConsoleInput) types a
+/// unicode+surrogate secret into ANOTHER process's console and that its cooked-read (echo OFF) reads it
+/// back exactly. Forces a CLASSIC conhost (`ConsoleWindowClass`, so the `ReVerify` allowlist passes) by
+/// spawning the child under `conhost.exe` with CREATE_NEW_CONSOLE (DF-1's conhost-forcing), independent of
+/// the machine's Default Terminal — so it is stable on CI and a WT-default desktop alike.
+internal static class ConsoleInjectSelfTest
+{
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct STARTUPINFO
+    {
+        public int cb;
+        public string? lpReserved, lpDesktop, lpTitle;
+        public int dwX, dwY, dwXSize, dwYSize, dwXCountChars, dwYCountChars, dwFillAttribute, dwFlags;
+        public short wShowWindow, cbReserved2;
+        public nint lpReserved2, hStdInput, hStdOutput, hStdError;
+    }
+    [StructLayout(LayoutKind.Sequential)]
+    private struct PROCESS_INFORMATION { public nint hProcess, hThread; public uint dwProcessId, dwThreadId; }
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern bool CreateProcessW(string? app, StringBuilder cmd, nint pa, nint ta, bool inherit, uint flags, nint env, string? cwd, ref STARTUPINFO si, out PROCESS_INFORMATION pi);
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern uint WaitForSingleObject(nint h, uint ms);
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern bool CloseHandle(nint h);
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern bool GetConsoleMode(nint h, out uint mode);
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern bool SetConsoleMode(nint h, uint mode);
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)] private static extern bool ReadConsoleW(nint h, [Out] char[] buf, uint toRead, out uint read, nint pInputControl);
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)] private static extern nint CreateFileW(string name, uint access, uint share, nint sa, uint disp, uint flags, nint template);
+    [DllImport("kernel32.dll")] private static extern nint GetConsoleWindow();
+    [DllImport("user32.dll", SetLastError = true)] private static extern uint GetWindowThreadProcessId(nint hWnd, out uint pid);
+
+    private const uint GENERIC_READ = 0x80000000, GENERIC_WRITE = 0x40000000;
+    private const uint FILE_SHARE_READ = 1, FILE_SHARE_WRITE = 2, OPEN_EXISTING = 3;
+    private const uint ENABLE_PROCESSED_INPUT = 0x0001, ENABLE_LINE_INPUT = 0x0002, ENABLE_ECHO_INPUT = 0x0004;
+    private const uint ENABLE_WINDOW_INPUT = 0x0008, ENABLE_MOUSE_INPUT = 0x0010;
+    private const uint CREATE_NEW_CONSOLE = 0x0010;
+    private static readonly nint INVALID = -1;
+
+    // A secret with an ASCII mix, BMP non-ASCII (Ω, ✓), and a surrogate pair (😀) — exercises the
+    // "1 UTF-16 code unit = 1 record" claim end-to-end.
+    private const string TestSecret = "Pw-Ω✓-😀-9";
+
+    /// CHILD role (`-InjectConsoleChild <ready> <out>`): we run as conhost's client, so we already own a
+    /// classic console. Arm echo-off line input, publish our console hwnd via the ready file, cooked-read
+    /// one line, and record it. Returns 0 always (the parent judges by the recorded line).
+    public static int RunChild(string readyPath, string outPath)
+    {
+        try
+        {
+            // Guarantee our OWN console: key-locker.exe is a GUI-subsystem WinExe, which CREATE_NEW_CONSOLE
+            // does NOT reliably auto-attach — AllocConsole gives us a fresh classic conhost we fully own.
+            FreeConsole(); AllocConsole();
+            nint hwnd = GetConsoleWindow();
+            nint conin = CreateFileW("CONIN$", GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, 0, OPEN_EXISTING, 0, 0);
+            if (conin == INVALID) { File.WriteAllText(outPath, "<conin-open-failed>"); return 0; }
+            GetConsoleMode(conin, out uint mode);
+            SetConsoleMode(conin, (mode | ENABLE_PROCESSED_INPUT | ENABLE_LINE_INPUT) & ~(ENABLE_ECHO_INPUT | ENABLE_MOUSE_INPUT | ENABLE_WINDOW_INPUT));
+            File.WriteAllText(readyPath, ((long)hwnd).ToString()); // signal + hand the parent our console hwnd
+            var buf = new char[512];
+            bool ok = ReadConsoleW(conin, buf, (uint)buf.Length, out uint read, 0);
+            File.WriteAllText(outPath, ok ? new string(buf, 0, (int)read).TrimEnd('\r', '\n') : "<readconsole-failed>");
+            CloseHandle(conin);
+        }
+        catch (Exception e) { try { File.WriteAllText(outPath, "<child-exn:" + e.Message + ">"); } catch { } }
+        return 0;
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern bool FreeConsole();
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern bool AllocConsole();
+
+    /// PARENT role: spawn the child under conhost, derive the InjectTarget from the child's console hwnd
+    /// exactly as L3 does (`consolePid = GetWindowThreadProcessId(hwnd)`), run the REAL production injector,
+    /// and assert the child cooked-read the exact secret. titleFp is left empty (the title anchor is
+    /// unchanged pre-existing logic; this test covers the DF-5 attach/write path).
+    public static bool Run()
+    {
+        string tmp = Path.GetTempPath();
+        string tag = Convert.ToHexString(RandomNumberGenerator.GetBytes(8));
+        string readyPath = Path.Combine(tmp, $"dtm-inj-ready-{tag}.txt");
+        string outPath = Path.Combine(tmp, $"dtm-inj-out-{tag}.txt");
+        var pi = default(PROCESS_INFORMATION);
+        var spawned = false;
+        try
+        {
+            string self = Environment.ProcessPath!;
+            var cmd = new StringBuilder($"\"{self}\" -InjectConsoleChild \"{readyPath}\" \"{outPath}\"");
+            var si = new STARTUPINFO { cb = Marshal.SizeOf<STARTUPINFO>() };
+            if (!CreateProcessW(self, cmd, 0, 0, false, CREATE_NEW_CONSOLE, 0, tmp, ref si, out pi)) return false;
+            spawned = true;
+
+            if (!PollFile(readyPath, 8000)) return false;
+            if (!long.TryParse(File.ReadAllText(readyPath).Trim(), out var hraw) || hraw == 0) return false;
+            nint hwnd = (nint)hraw;
+            _ = GetWindowThreadProcessId(hwnd, out uint consolePid); // derive exactly as L3 does
+            if (consolePid == 0) return false;
+
+            var target = new InjectTarget(hwnd, consolePid, "", true);
+            var (injected, _) = Win32Input.ReVerifyAndType(in target, Encoding.UTF8.GetBytes(TestSecret));
+            if (!injected) return false;
+
+            WaitForSingleObject(pi.hProcess, 8000);
+            if (!PollFile(outPath, 8000)) return false;
+            return File.ReadAllText(outPath) == TestSecret;
+        }
+        catch { return false; }
+        finally
+        {
+            if (spawned) { try { CloseHandle(pi.hThread); CloseHandle(pi.hProcess); } catch { } }
+            foreach (var p in new[] { readyPath, outPath }) { try { if (File.Exists(p)) File.Delete(p); } catch { } }
+        }
+    }
+
+    private static bool PollFile(string path, int timeoutMs)
+    {
+        long deadline = Environment.TickCount64 + timeoutMs;
+        while (Environment.TickCount64 < deadline)
+        {
+            if (File.Exists(path)) return true;
+            Thread.Sleep(30);
+        }
+        return File.Exists(path);
     }
 }

--- a/tools/key-locker/Injection.cs
+++ b/tools/key-locker/Injection.cs
@@ -399,9 +399,14 @@ internal sealed class ServingRegistry
 /// DF-5 headless self-test for the console-buffer injector (`-SelfTestInjectConsole`). Deterministic proof
 /// — no live ssh — that `Win32Input.ReVerifyAndType` (AttachConsole + WriteConsoleInput) types a
 /// unicode+surrogate secret into ANOTHER process's console and that its cooked-read (echo OFF) reads it
-/// back exactly. Forces a CLASSIC conhost (`ConsoleWindowClass`, so the `ReVerify` allowlist passes) by
-/// spawning the child under `conhost.exe` with CREATE_NEW_CONSOLE (DF-1's conhost-forcing), independent of
-/// the machine's Default Terminal — so it is stable on CI and a WT-default desktop alike.
+/// back exactly. The parent spawns a child copy of THIS exe with CREATE_NEW_CONSOLE; the child (a
+/// GUI-subsystem WinExe, which CREATE_NEW_CONSOLE does not reliably auto-attach) calls
+/// `FreeConsole`+`AllocConsole` to own a fresh console, and the parent then attaches to it by the
+/// window-owning pid. On a classic-conhost machine (CI, and the default Windows desktop) `AllocConsole`
+/// yields a `ConsoleWindowClass` window so the `ReVerify` allowlist passes. LIMITATION: on a desktop whose
+/// Default Terminal is Windows Terminal, `AllocConsole` may hand off to a ConPTY pseudoconsole whose window
+/// is NOT `ConsoleWindowClass`, in which case `ReVerify` aborts `target_multiplexed` and this self-test can
+/// fail — that path (like OQ-DF-7/8) is covered by the live dogfood, not this headless proof.
 internal static class ConsoleInjectSelfTest
 {
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]

--- a/tools/key-locker/Injection.cs
+++ b/tools/key-locker/Injection.cs
@@ -424,6 +424,7 @@ internal static class ConsoleInjectSelfTest
     [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
     private static extern bool CreateProcessW(string? app, StringBuilder cmd, nint pa, nint ta, bool inherit, uint flags, nint env, string? cwd, ref STARTUPINFO si, out PROCESS_INFORMATION pi);
     [DllImport("kernel32.dll", SetLastError = true)] private static extern uint WaitForSingleObject(nint h, uint ms);
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern bool TerminateProcess(nint h, uint exitCode);
     [DllImport("kernel32.dll", SetLastError = true)] private static extern bool CloseHandle(nint h);
     [DllImport("kernel32.dll", SetLastError = true)] private static extern bool GetConsoleMode(nint h, out uint mode);
     [DllImport("kernel32.dll", SetLastError = true)] private static extern bool SetConsoleMode(nint h, uint mode);
@@ -508,7 +509,17 @@ internal static class ConsoleInjectSelfTest
         catch { return false; }
         finally
         {
-            if (spawned) { try { CloseHandle(pi.hThread); CloseHandle(pi.hProcess); } catch { } }
+            if (spawned)
+            {
+                // Kill the child if it is still blocked in ReadConsoleW on a FAILURE path (on success the
+                // injected Enter already terminated its cooked-read and it exited). Otherwise a failed
+                // self-test — e.g. the WT-default `target_multiplexed` case, or `ReVerifyAndType`
+                // returning false — orphans a `key-locker.exe` (+ its AllocConsole'd conhost, which
+                // self-exits once its last client dies) blocked on input on the CI machine (Codex P2).
+                // TerminateProcess on an already-exited process is a harmless no-op.
+                try { TerminateProcess(pi.hProcess, 1); } catch { }
+                try { CloseHandle(pi.hThread); CloseHandle(pi.hProcess); } catch { }
+            }
             foreach (var p in new[] { readyPath, outPath }) { try { if (File.Exists(p)) File.Delete(p); } catch { } }
         }
     }

--- a/tools/key-locker/Program.cs
+++ b/tools/key-locker/Program.cs
@@ -501,7 +501,7 @@ internal sealed class LockerStore
     /// Transiently decrypt the stored secret and hand the plaintext BYTES to `use`, then zeroize
     /// the buffer — the plaintext lives only for the callback and NEVER leaves the locker process
     /// (L2 §0 invariant). Returns false if the id is absent or the blob won't decrypt. Used by the
-    /// SendInput injector and the askpass serving path.
+    /// console-buffer injector and the askpass serving path.
     public bool WithDecrypted(string id, Action<byte[]> use)
     {
         if (!_entries.TryGetValue(id, out var b64)) return false;

--- a/tools/key-locker/Program.cs
+++ b/tools/key-locker/Program.cs
@@ -59,6 +59,8 @@ internal static class KeyLocker
         string? storeDir = null;
         var selfTest = false;
         var selfTestL2 = false;
+        var selfTestInject = false;
+        string? injectChildReady = null, injectChildOut = null;
         var consent = false;
         for (var i = 0; i < args.Length; i++)
         {
@@ -69,6 +71,10 @@ internal static class KeyLocker
                 case "-StoreDir" when i + 1 < args.Length: storeDir = args[++i]; break;
                 case "-SelfTest": selfTest = true; break;
                 case "-SelfTestL2": selfTestL2 = true; break;
+                // DF-5 headless console-injector proof (no store, no pipe, no ssh): `-SelfTestInjectConsole`
+                // runs the parent role; `-InjectConsoleChild <ready> <out>` is the self-spawned child role.
+                case "-SelfTestInjectConsole": selfTestInject = true; break;
+                case "-InjectConsoleChild" when i + 2 < args.Length: injectChildReady = args[++i]; injectChildOut = args[++i]; break;
                 case "-Consent": consent = true; break;
                 // TEST-ONLY headless seam (e2e verb round-trip, no GUI): auto-answer `prompt` with this choice.
                 // A CLI ARG on purpose — NOT an env var: `KeyLockerHost.start()` never passes it, so a production
@@ -87,6 +93,18 @@ internal static class KeyLocker
         // ASK is allowed pre-consent (the gate is on secret effects, not process spawn). Runs before the
         // store is even opened.
         if (consent) return RunConsent(storeDir);
+
+        // DF-5 console-injector self-test seams — no store/pipe/GUI. The child role runs as conhost's
+        // client and cooked-reads a line; the parent role spawns it, runs the real Win32Input injector,
+        // and prints {ok}. Both are pre-store early returns (like -Consent).
+        if (injectChildReady != null && injectChildOut != null)
+            return ConsoleInjectSelfTest.RunChild(injectChildReady, injectChildOut);
+        if (selfTestInject)
+        {
+            var okInject = ConsoleInjectSelfTest.Run();
+            Console.WriteLine(JsonSerializer.Serialize(new { ok = okInject }));
+            return okInject ? 0 : 1;
+        }
 
         _store = new LockerStore(storeDir);
         _serving = new ServingRegistry(_store);
@@ -257,10 +275,11 @@ internal static class KeyLocker
         WriteReply(server, id, true, choice, null);
     }
 
-    /// SendInput the secret under `key` into the frame's dedicated-conhost target, AFTER the
-    /// injection-instant re-verify (§2.2). The secret NEVER crosses the pipe — the reply carries
-    /// only {injected, verified}; an abort carries the typed reason. The plaintext is decrypted
-    /// transiently inside the locker and zeroized (WithDecrypted).
+    /// Write the secret under `key` into the frame's dedicated-conhost target via the console-buffer
+    /// injector (DF-5: AttachConsole + WriteConsoleInput), AFTER the injection-instant identity re-verify
+    /// (§2.2). The secret NEVER crosses the pipe — the reply carries only {injected, verified}; an abort
+    /// carries the typed reason. The plaintext is decrypted transiently inside the locker and zeroized
+    /// (WithDecrypted).
     private static void HandleInject(NamedPipeServerStream server, long id, string key, string line)
     {
         if (string.IsNullOrEmpty(key)) { WriteReply(server, id, false, "", InjectAbort.NoSecret); return; }


### PR DESCRIPTION
## DF-5 (BLOCKER) — SendInput returned `sent=0`; switch to a console-buffer injector

Found in the live dogfood (2026-07-08). The SendInput injector returned `sent=0/N, GetLastError()==0` — a foreground-**ownership** gate (input refused because the window-less helper is not the foreground-input owner; **not** UIPI, which returns the full count with events silently dropped). A window-less helper cannot acquire foreground ownership without a fragile cross-process `AllowSetForegroundWindow` + foreground-steal ladder.

### Fix — Option B (adjudicated by Fable, design-reviewed by Opus)
Replace SendInput with a **console-buffer injector**: `AttachConsole(consolePid)` + `WriteConsoleInputW(CONIN$)` writing `KEY_EVENT` records that the shell cooked-reads (`ReadConsole`). Foreground- and UIPI-immune, self-contained in the helper, and a natural fit since the Key Locker only ever targets a classic conhost (`ConsoleWindowClass`).

The old *"inject only when the target is FOREGROUND"* property is **re-expressed** as *"inject only into the verified `consolePid`'s console buffer"*: the write is **addressed** to that console (not broadcast to whatever is foreground), and a **two-stage identity re-verify** (before attach + after the CONIN$ handle opens) pins that hwnd/pid/class/title still name the same console — so mis-delivery to a wrong window is structurally impossible.

### Key details
- Keystrokes ride in each record's **`UnicodeChar`** (a cooked-read cooks `UnicodeChar`, **not** the SendInput-style `wScan`) with `wRepeatCount=1`; 1 UTF-16 code unit = 1 down/up pair (surrogate pairs handled).
- The 3 std handles `AttachConsole`/`FreeConsole` rebind are **saved/restored** around the bracket; **no diagnostic may write** between `AttachConsole` and the final `FreeConsole` (would leak onto the user's console).
- `not_foreground` is **no longer emitted** (kept in the wire enum for back-compat).
- **No wire-protocol change**; change confined to `tools/key-locker/Injection.cs` + `Program.cs` wiring.

### Testing
- **`-SelfTestInjectConsole`** (new, headless): runs the **real** `Win32Input.ReVerifyAndType` against a self-spawned child console (echo-off cooked-read) and asserts a unicode+surrogate secret round-trips — deterministic, no live ssh. Added as an e2e case.
- Pre-impl spike (`scratchpad`, 4/4 PASS) proved the mechanism + that a `wScan`-only mapping types zero chars.
- All green: `dotnet build`, `-SelfTest` / `-SelfTestL2` / `-SelfTestInjectConsole`, `tsc`, key-locker unit suite (378/378), e2e self-test cases.

### Not in this PR
Phase 6 live dogfood (native OpenSSH cooked-read leg — OQ-DF-6; Git-MSYS ConPTY — OQ-DF-8) needs the real desktop and runs after review.

### Notes
- Stacked on #521 (DF-2/DF-3) so the rebuilt `bin/key-locker.exe` inherits DF-2's `InvariantGlobalization=false`. Merge #521 first.

Design / adjudication / Opus review / spike: `desktop-touch-mcp-internal@main:docs/adr-014-v2-r3-l3-4-live-wiring-followups.md` (DF-5)
Impl plan: `desktop-touch-mcp-internal@main:docs/adr-014-v2-r3-df5-writeconsoleinput-impl-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)