### PR TITLE
fix(key-locker): self-healing launch_console reuse — skip a pane that can no longer arm (OQ-8)

### DIFF
--- a/src/engine/key-locker/key-locker-capture-driver.ts
+++ b/src/engine/key-locker/key-locker-capture-driver.ts
@@ -410,6 +410,13 @@ export class KeyLockerCaptureDriver {
     }
   }
 
+  /** Is this pane still ANCHORED (a driver record exists)? The wiring's `launch_console` reuse checks this: a
+   *  pane whose window is alive but whose record was torn down (a spurious `window_disappeared` → `onPaneClosed`,
+   *  OQ-8) can never arm, so reuse must NOT return it — it launches a fresh, re-anchored pane instead. */
+  hasPane(paneId: string): boolean {
+    return this.panes.has(paneId);
+  }
+
   /** Panes with a credential dispatch awaiting a prompt (the wiring polls exactly these). */
   armedPaneIds(): string[] {
     const out: string[] = [];

--- a/src/tools/key-locker-wiring.ts
+++ b/src/tools/key-locker-wiring.ts
@@ -52,6 +52,7 @@ import {
 import { keyLockerManager } from "./key-locker-tool.js";
 import { KeyLockerError } from "../engine/key-locker-host.js";
 import { setCredentialAdvisor, type AdvisoryHint } from "./_advisory.js";
+import { isKnownSession } from "../engine/key-locker/session-tracker.js";
 
 /** Max simultaneously-live anchored consoles the tool will open (Risk R2 — a `fresh:true` loop can't spray
  *  windows). Dead ones are pruned first, so this bounds LIVE panes, not lifetime launches. */
@@ -194,24 +195,27 @@ export class KeyLockerWiring {
   /**
    * TOOL entry (ADR-014 R3 OQ-W-16-bis, `key_locker launch_console`): return an autofill-capable anchored
    * console the assistant can drive credential commands into. Idempotent by default — reuses the most-recent
-   * still-LIVE pane this wiring launched (liveness is hwnd-direct via `findTerminalWindowByHwnd`, NOT
-   * `resolveTitleByHwnd` which would false-DEAD a live same-host pane on its non-unique post-login title). Pass
-   * `fresh` to force a NEW pane (bounded by MAX_ANCHORED_PANES live panes so a `fresh` loop can't spray
-   * windows). Returns the pane's CURRENT title (a reused pane's may already have drifted — drive it by paneId).
+   * REUSABLE pane this wiring launched (`isReusable`: window alive via hwnd-direct `findTerminalWindowByHwnd`,
+   * NOT `resolveTitleByHwnd` which would false-DEAD a same-host pane on its non-unique post-login title; AND
+   * still driver-anchored + session KNOWN, so it can actually arm — OQ-8). Pass `fresh` to force a NEW pane
+   * (bounded by MAX_ANCHORED_PANES reusable panes so a `fresh` loop can't spray windows). Returns the pane's
+   * CURRENT title (a reused pane's may already have drifted — drive it by paneId).
    */
   async ensureAnchoredConsole({ fresh = false }: { fresh?: boolean } = {}): Promise<{ paneId: string; windowTitle: string }> {
-    // Prune dead panes so both the reuse scan and the cap count only LIVE windows.
-    const live = this.launchedPaneIds.filter((pid) => this.livePaneTitle(pid) !== null);
+    // Keep only REUSABLE panes — window alive AND still driver-anchored AND session KNOWN (OQ-8). A pane whose
+    // window died, OR whose driver record was torn down by a spurious `window_disappeared` (the record is gone
+    // but the window lives), OR whose session drifted to UNKNOWN, can NEVER arm — so we neither reuse nor count
+    // it toward the cap. Dropping it here means the next launch RE-ANCHORS a working pane (a self-healing reuse,
+    // NOT a blind re-anchor of the stale pane — re-anchoring a pane mid-remote-session as local would disclose a
+    // LOCAL secret to a REMOTE prompt, the P1-B / W-2b hole). The orphaned window (if any) is left for the human.
+    const reusable = this.launchedPaneIds.filter((pid) => this.isReusable(pid));
     this.launchedPaneIds.length = 0;
-    this.launchedPaneIds.push(...live);
+    this.launchedPaneIds.push(...reusable);
 
-    if (!fresh) {
-      // Reuse the most-recent live pane (scan from the end).
-      for (let i = this.launchedPaneIds.length - 1; i >= 0; i--) {
-        const pid = this.launchedPaneIds[i];
-        const title = this.livePaneTitle(pid);
-        if (title !== null) return { paneId: pid, windowTitle: title };
-      }
+    if (!fresh && this.launchedPaneIds.length > 0) {
+      // Reuse the most-recent reusable pane.
+      const pid = this.launchedPaneIds[this.launchedPaneIds.length - 1];
+      return { paneId: pid, windowTitle: this.livePaneTitle(pid) ?? "" };
     }
     if (this.launchedPaneIds.length >= MAX_ANCHORED_PANES) {
       throw new KeyLockerError(
@@ -222,6 +226,15 @@ export class KeyLockerWiring {
     const { paneId, title } = await this.launchAndAnchorConsole();
     this.launchedPaneIds.push(paneId);
     return { paneId, windowTitle: title };
+  }
+
+  /** A launched pane is REUSABLE only if its window is a live console (hwnd-direct) AND the driver still holds
+   *  its anchor (`hasPane`) AND its tracked session is KNOWN — the three conditions the arm gate needs. Any
+   *  failure means a later dispatch would not arm, so reuse must skip it and launch fresh instead (OQ-8). */
+  private isReusable(paneId: string): boolean {
+    if (this.livePaneTitle(paneId) === null) return false;
+    if (!this.driver.hasPane(paneId)) return false;
+    return isKnownSession(this.manager.tracker.get(paneId));
   }
 
   /** The current title of a launched pane if its hwnd is still a live console, else null (hwnd-direct). */

--- a/tests/unit/key-locker-anchoring.test.ts
+++ b/tests/unit/key-locker-anchoring.test.ts
@@ -99,12 +99,15 @@ describe("ensureAnchoredConsole (Phase 2)", () => {
   // window_disappeared, or session drifted to UNKNOWN) must NOT be reused — reuse launches a fresh, re-anchored
   // pane instead (self-healing). Blind re-anchor of the stale pane is rejected (wrong-target disclosure risk).
   const driverOf = (w: KeyLockerWiring) =>
-    (w as unknown as { driver: { onPaneClosed(id: string): void } }).driver;
+    (w as unknown as { driver: { panes: Map<string, unknown> } }).driver;
 
   it("does NOT reuse a live-window pane whose driver record was torn down (OQ-8) — relaunches", async () => {
     const { wiring } = newWiring();
     const a = await wiring.ensureAnchoredConsole();
-    driverOf(wiring).onPaneClosed(a.paneId); // spurious teardown: record gone, window (liveHwnds) still live
+    // Isolate the hasPane gate: delete ONLY the driver's pane record, NOT the tracker session — so the
+    // session stays KNOWN and `hasPane` ALONE must reject the reuse (proves it is load-bearing, not shadowed
+    // by the isKnownSession check that the full onPaneClosed teardown would also trip). Window stays live.
+    driverOf(wiring).panes.delete(a.paneId);
     const b = await wiring.ensureAnchoredConsole();
     expect(b.paneId).not.toBe(a.paneId);
   });

--- a/tests/unit/key-locker-anchoring.test.ts
+++ b/tests/unit/key-locker-anchoring.test.ts
@@ -94,6 +94,28 @@ describe("ensureAnchoredConsole (Phase 2)", () => {
     liveHwnds.delete(BigInt(a.paneId)); // one dies → slot freed
     await expect(wiring.ensureAnchoredConsole({ fresh: true })).resolves.toHaveProperty("paneId");
   });
+
+  // OQ-8: a pane whose WINDOW is still live but which can no longer ARM (driver record torn down by a spurious
+  // window_disappeared, or session drifted to UNKNOWN) must NOT be reused — reuse launches a fresh, re-anchored
+  // pane instead (self-healing). Blind re-anchor of the stale pane is rejected (wrong-target disclosure risk).
+  const driverOf = (w: KeyLockerWiring) =>
+    (w as unknown as { driver: { onPaneClosed(id: string): void } }).driver;
+
+  it("does NOT reuse a live-window pane whose driver record was torn down (OQ-8) — relaunches", async () => {
+    const { wiring } = newWiring();
+    const a = await wiring.ensureAnchoredConsole();
+    driverOf(wiring).onPaneClosed(a.paneId); // spurious teardown: record gone, window (liveHwnds) still live
+    const b = await wiring.ensureAnchoredConsole();
+    expect(b.paneId).not.toBe(a.paneId);
+  });
+
+  it("does NOT reuse a pane whose session drifted to UNKNOWN (OQ-8) — relaunches", async () => {
+    const { wiring, mgr } = newWiring();
+    const a = await wiring.ensureAnchoredConsole();
+    mgr.tracker.markUnknown(a.paneId); // hypothesis B: session no longer KNOWN
+    const b = await wiring.ensureAnchoredConsole();
+    expect(b.paneId).not.toBe(a.paneId);
+  });
 });
 
 describe("credentialNudge (Phase 3)", () => {


### PR DESCRIPTION
## What & why

Live dogfood of the new `key_locker launch_console` flow surfaced **OQ-8**: a pane returned by `launch_console`'s DEFAULT reuse could be in a state where it can never autofill. Observed cleanly — a console launched at server startup and reused after sitting idle **arm-missed deterministically**, while a **fresh** pane launched right before use **filled end-to-end**.

Diagnosis (instrumented, since reverted): the arm gate itself is **healthy** — a pane arms and fills fine when its driver record is present, even after minutes idle. The real failure is a pane whose driver record was **torn down while its window stayed alive** (a spurious event-bus `window_disappeared` → `onPaneClosed`, most likely under window churn), or whose session drifted to `UNKNOWN`. Reuse only checked window-liveness, so it handed back a pane that can no longer arm.

Both Fable and Opus design-reviewed the fix approach and independently **rejected a blind "re-anchor on reuse"**: re-anchoring a pane that is mid-remote-session as local would disclose a LOCAL secret to a REMOTE prompt (the P1-B / W-2b hole).

## Fix — self-healing reuse

`ensureAnchoredConsole` reuse now requires a pane be **REUSABLE**:
- window alive (hwnd-direct `findTerminalWindowByHwnd`), AND
- still driver-anchored (`driver.hasPane`), AND
- session `KNOWN` (`isKnownSession(tracker.get(paneId))`).

A non-reusable pane is dropped from tracking and a **fresh, re-anchored pane is launched** — self-healing, robust regardless of what caused the record loss/drift. No blind re-anchor of the stale pane (avoids the wrong-target disclosure).

## Changes
- `driver.hasPane(paneId)` accessor.
- `wiring.isReusable(paneId)` + the reuse gate + cap now counts reusable panes.
- 2 self-heal tests (record torn down / session drifted → relaunches). `key-locker-*` suite: 404 green.
- No wire / tool-surface change (no stub / failwith-fixture drift).

Plan: `desktop-touch-mcp-internal:docs/adr-014-v2-r3-oq-w-16-bis-anchoring-plan.md` (OQ-8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
