### PR TITLE
docs(key-locker): sync README / system-overview / site with v1.12.0

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -352,8 +352,8 @@ terminal({ action:'send', paneId:'12345678', input:'ssh user@host' })
 - **自動入力は `launch_console` で開いたコンソールでのみ発火** — 既存のターミナルには決して入力しません。開くのは通常の可視な Windows コンソールなので、目視でき、任意のプロンプトで人間が引き継いで直接入力もできます。
 - **既定では自動入力の度に確認ダイアログ**が出ます。binding 単位で `set_policy` により確認を省略可。保存済み認証情報の管理は `list` / `status` / `forget`。
 - `terminal` の `read` / `send` は `windowTitle` の代わりに `paneId` を受け取れます — `ssh` ログインでウィンドウタイトルが変わっても同じ窓を正確に狙えます。
-- 対応 binding URI: `ssh://user@host:22`、`sudo://host/user`、`https-cred://host`、SSH 鍵パスフレーズ（`sshkey://SHA256:…`）。`ssh` の登録はホスト鍵が `known_hosts` にあることが前提です（先に一度手動で接続してください）。
-- Windows 専用。機能全体の無効化は `DESKTOP_TOUCH_DISABLE_KEY_LOCKER=1`。
+- 対応 binding URI: `ssh://user@host:22`、`sudo://host/user`、`https-cred://host`、SSH 鍵パスフレーズ（`sshkey:SHA256:…`）。`ssh` の登録はホスト鍵が `known_hosts` にあることが前提です（先に一度手動で接続してください）。
+- Windows 専用。機能全体の無効化は `DESKTOP_TOUCH_DISABLE_KEY_LOCKER=1`。セキュアダイアログは未署名の実行ファイルのため、初回起動時に Windows SmartScreen の「発行元不明」警告が出ることがあります（[前提環境](#前提環境)の注意参照）。
 
 ---
 ## ブラウザ CDP 自動化

--- a/README.ja.md
+++ b/README.ja.md
@@ -22,6 +22,7 @@ npx -y @harusame64/desktop-touch-mcp
 - **⚡ 高性能 Rust ネイティブコア** — UIA ブリッジと画像差分エンジンを Rust (`napi-rs` + `windows-rs`) で実装し、ネイティブ `.node` アドオンとしてロード。専用 MTA スレッドからの直接 COM 呼び出しにより PowerShell プロセス起動を排除 — `getFocusedElement` は **2ms**（160 倍高速）、`getUiElements` はバッチ型 BFS アルゴリズムでクロスプロセス RPC を最小化し **約 100ms** で完了。画像差分は **SSE2 SIMD** で 13〜15 倍のスループット。ネイティブエンジンが利用不可の場合、全関数が PowerShell に透過フォールバック — 設定不要。
 - **🎯 Set-of-Marks (SoM) ビジュアルフォールバック** — ゲーム・RDP・非対応 Electron アプリで UIA が完全に機能しない場合でも、`screenshot(detail="text")` が Hybrid Non-CDP パイプラインを自動起動。Rust 画像前処理 → Windows OCR → クラスタリング → 赤い枠線 + 番号バッジ（`[1]`、`[2]`…）付き PNG 画像を生成し、`clickAt` 座標付きの要素リストを返します。CDP 不要。
 - **🔁 視覚のみ対象での 1 コール確認** — UIA が効かない対象（Electron・PWA・ゲーム・自前描画キャンバス・RDP ウィンドウ）では、`desktop_act` が操作後の確認を応答自体に畳み込めます。成功時にオプションの `roiCapture` ——「変化した領域だけ」を切り出した PNG ＋ そこに今ある要素の lease なしプレビュー —— を同梱するので、別途 `desktop_state` ＋ `screenshot` を呼ばずに「クリックの結果」と「次の対象」を確認できます。視覚のみ対象では変化があれば**デフォルトで付与**されます（`returnCapture:"on-change"`）。`returnCapture:"never"` で抑止、`"always"` で常時付与。構造化対象（ブラウザ/CDP・UIA リッチなネイティブ）には付与されないため、それらの応答は不変です（そこは `desktop_state` の方が安価かつ正確）。
+- **🔐 Key Locker — SSH / sudo のパスワードをターミナルが自動入力** — 認証情報はロッカー自身のセキュアダイアログに一度だけ入力して、この PC 上に暗号化保存（Windows DPAPI）— アシスタントには一切見えません。以後は `key_locker(action='launch_console')` で開いたコンソールで `ssh` / `sudo` を実行するだけで、隠しパスワードプロンプトに自動入力されます（既定では入力毎に確認あり）。詳細は [Key Locker](#key-locker-ターミナル認証情報の自動入力) 参照。
 - **LLM ネイティブ設計** — 人間の操作を模倣するのではなく、「LLM がいかにコンテキストを消費せず高速に動けるか」を前提に設計。`run_macro` による複数操作の一括実行（API 往復の削減）と、**MPEG P-frame 方式のレイヤー差分** (`diffMode`) を組み合わせることで、無駄な画像転送や推論ループを極限まで削ぎ落とす。
 - **Reactive Perception Graph** — ウィンドウやブラウザタブに `lensId` を登録し、以後の action tool に渡すだけで、操作前の安全 guard と操作後の `post.perception` フィードバックを受け取れます。`screenshot` / `desktop_state` の反復を減らし、別ウィンドウへの誤入力や古い座標クリックを防ぎます。
 - **日本語/CJK 完全対応** — ウィンドウタイトル取得に Win32 `GetWindowTextW` を使用。nut-js の文字化けを回避。IME バイパス入力にも対応。
@@ -330,6 +331,29 @@ terminal({
 - **first-class shell:** `bash` と `powershell`。`cmd.exe` は未対応（`ExitModeShellUnsupported`）。
 - **未完の構文で終わる入力は即座に reject**（`ExitModeUnsafeInput`）。閉じていない引用符 / here-doc / `$(…)` / 末尾の `\` または PowerShell バッククォートなどはハングせず弾きます。
 - exit mode は配送を自前制御するため、配送系の `sendOptions`（`method` / `preferClipboard` / `pressEnter` / `chunkSize` / `pasteKey`）は `InvalidArgs` で reject します（focus 系オプションは利用可）。
+
+---
+
+## Key Locker (ターミナル認証情報の自動入力)
+
+`ssh user@host` や `sudo …` は通常、アシスタントが安全に入力できない「隠しパスワードプロンプト」で止まります。Key Locker は SSH 鍵のパスフレーズや sudo / ログインパスワードをこの PC 上に暗号化保存し（Windows DPAPI, current user）、対象コマンドがプロンプトに達すると自動で入力します。秘密情報の入力はロッカー自身のセキュアダイアログへの一度きり — アシスタントには一切見えず、MCP チャネルを通ることもありません。
+
+```js
+// 1. 認証情報を一度だけ登録 — デスクトップにセキュアダイアログが開く
+key_locker({ action:'save', uri:'ssh://user@host:22' })
+
+// 2. 自動入力対応コンソールを起動（paneId が返る）
+key_locker({ action:'launch_console' })   // → { paneId:'12345678', windowTitle:'…' }
+
+// 3. その pane にコマンドを流す — プロンプトでパスワードが自動入力される
+terminal({ action:'send', paneId:'12345678', input:'ssh user@host' })
+```
+
+- **自動入力は `launch_console` で開いたコンソールでのみ発火** — 既存のターミナルには決して入力しません。開くのは通常の可視な Windows コンソールなので、目視でき、任意のプロンプトで人間が引き継いで直接入力もできます。
+- **既定では自動入力の度に確認ダイアログ**が出ます。binding 単位で `set_policy` により確認を省略可。保存済み認証情報の管理は `list` / `status` / `forget`。
+- `terminal` の `read` / `send` は `windowTitle` の代わりに `paneId` を受け取れます — `ssh` ログインでウィンドウタイトルが変わっても同じ窓を正確に狙えます。
+- 対応 binding URI: `ssh://user@host:22`、`sudo://host/user`、`https-cred://host`、SSH 鍵パスフレーズ（`sshkey://SHA256:…`）。`ssh` の登録はホスト鍵が `known_hosts` にあることが前提です（先に一度手動で接続してください）。
+- Windows 専用。機能全体の無効化は `DESKTOP_TOUCH_DISABLE_KEY_LOCKER=1`。
 
 ---
 ## ブラウザ CDP 自動化

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ npx -y @harusame64/desktop-touch-mcp
 - **⚡ High-performance Rust Native Core** — The UIA bridge and image-diff engine are written in Rust (`napi-rs` + `windows-rs`) and loaded as a native `.node` addon. Direct COM calls from a dedicated MTA thread eliminate PowerShell process spawning — `getFocusedElement` completes in **2 ms** (160× faster), and `getUiElements` returns full trees in **~100 ms** with a batch BFS algorithm that minimizes cross-process RPC. Image-diff operations use **SSE2 SIMD** for 13–15× throughput. When the native engine is unavailable, every function transparently falls back to PowerShell — zero config required.
 - **🎯 Set-of-Marks (SoM) visual fallback** — Games, RDP sessions, and non-accessible Electron apps return clickable elements even when UIA is completely blind. `screenshot(detail="text")` automatically detects UIA sparsity and activates a Hybrid Non-CDP pipeline: Rust-powered grayscale + bilinear upscale → Windows OCR → clustering → red bounding-box annotation with numbered badges (`[1]`, `[2]`…). Two parallel representations returned: a visual PNG for spatial orientation and a semantic `elements[]` list with `clickAt` coords — no CDP required.
 - **🔁 One-call confirmation on visual-only targets** — On UIA-blind targets (Electron, PWAs, games, custom canvases, RDP windows), `desktop_act` can fold the post-action confirmation into its own response: an optional `roiCapture` carrying a PNG crop of *just the region that changed* plus a lease-less preview of the controls now visible there. The agent confirms what its click did and finds the next target without a separate `desktop_state` + `screenshot`. On visual-only targets it is **on by default** for a visible change (`returnCapture:"on-change"`); pass `returnCapture:"never"` to suppress it, or `"always"` to force it. Never attached on structured targets (browser/CDP, UIA-rich native), where `desktop_state` is cheaper and exact — so those responses are unchanged.
+- **🔐 Key Locker — the terminal autofills your SSH / sudo passwords** — Save a credential once into the locker's own secure dialog (stored encrypted on your machine with Windows DPAPI; never shown to the assistant), then run `ssh` / `sudo` in a console opened by `key_locker(action='launch_console')` — the password is filled in automatically when the hidden prompt appears, with a per-fill confirmation prompt by default. See [Key Locker](#key-locker-terminal-credential-autofill).
 - **LLM-native design** — Built around how LLMs think, not how humans click. `run_macro` batches multiple operations into a single API call; `diffMode` sends only the windows that changed since the last frame. Minimal tokens, minimal round-trips.
 - **Reactive Perception Graph** — Register a `lensId` for a window or browser tab, pass it to action tools, and get guard-checked `post.perception` feedback after each action. It reduces repeated `screenshot` / `desktop_state` calls and prevents wrong-window typing or stale-coordinate clicks.
 - **Full CJK support** — Uses Win32 `GetWindowTextW` for window titles, avoiding nut-js garbling. IME bypass input supported for Japanese/Chinese/Korean environments.
@@ -291,6 +292,40 @@ terminal({
 - Exit mode controls its own delivery, so delivery-shaping `sendOptions`
   (`method` / `preferClipboard` / `pressEnter` / `chunkSize` / `pasteKey`) are
   rejected with `InvalidArgs`; focus options remain accepted.
+
+---
+
+## Key Locker (terminal credential autofill)
+
+Running `ssh user@host` or `sudo …` normally stops at a hidden password prompt an
+assistant can't safely type into. Key Locker stores your SSH key passphrases and
+sudo / login passwords encrypted on your machine (Windows DPAPI, current user) and
+fills them in automatically when a bound command reaches its prompt. The secret is
+typed once into the locker's own secure dialog — it is never shown to the assistant
+and never travels through the MCP channel.
+
+```js
+// 1. Save the credential once — opens a secure dialog on your desktop
+key_locker({ action:'save', uri:'ssh://user@host:22' })
+
+// 2. Open an autofill-capable console (returns its paneId)
+key_locker({ action:'launch_console' })   // → { paneId:'12345678', windowTitle:'…' }
+
+// 3. Run the command through that pane — the password is filled at the prompt
+terminal({ action:'send', paneId:'12345678', input:'ssh user@host' })
+```
+
+- **Autofill only fires in a console opened by `launch_console`** — a pre-existing
+  terminal is never autofilled. The console is a classic visible Windows console,
+  so you can watch it and take over at any prompt yourself.
+- **Every autofill asks you to confirm by default**; opt a binding out with
+  `set_policy`. `list` / `status` / `forget` manage saved credentials.
+- `terminal` `read` / `send` accept `paneId` as an alternative to `windowTitle` —
+  it targets that exact window even after an `ssh` login renames its title.
+- Supported binding URIs: `ssh://user@host:22`, `sudo://host/user`,
+  `https-cred://host`, and SSH key passphrases (`sshkey://SHA256:…`). An `ssh`
+  save needs the host key already in `known_hosts` (connect to the host once first).
+- Windows only. Disable the whole feature with `DESKTOP_TOUCH_DISABLE_KEY_LOCKER=1`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -323,9 +323,12 @@ terminal({ action:'send', paneId:'12345678', input:'ssh user@host' })
 - `terminal` `read` / `send` accept `paneId` as an alternative to `windowTitle` —
   it targets that exact window even after an `ssh` login renames its title.
 - Supported binding URIs: `ssh://user@host:22`, `sudo://host/user`,
-  `https-cred://host`, and SSH key passphrases (`sshkey://SHA256:…`). An `ssh`
+  `https-cred://host`, and SSH key passphrases (`sshkey:SHA256:…`). An `ssh`
   save needs the host key already in `known_hosts` (connect to the host once first).
 - Windows only. Disable the whole feature with `DESKTOP_TOUCH_DISABLE_KEY_LOCKER=1`.
+  The secure dialog is an unsigned helper executable — Windows SmartScreen may show
+  an "unknown publisher" warning on first run (see the note under
+  [Requirements](#requirements)).
 
 ---
 

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -589,6 +589,12 @@ Reads the current buffer of PowerShell / cmd / Windows Terminal via UIA `TextPat
 #### `terminal(action='send')`
 Sends raw input to a terminal. `waitForPrompt` blocks until the next prompt reappears.
 
+> **Targeting by `paneId`.** `read` / `send` accept an optional `paneId` (the decimal
+> window handle returned by `key_locker(action='launch_console')`) as an alternative to
+> `windowTitle` — provide one of the two; `paneId` takes precedence. It targets that
+> exact window even after its title changes (e.g. an `ssh` login renaming the window to
+> `user@host`), so a follow-up `send` / `read` still reaches the same pane.
+
 ---
 
 ### 📊 Office (Excel)
@@ -622,24 +628,34 @@ excel({ action:'run_vba',
 #### `key_locker`
 Manage credentials the terminal autofills for you (SSH key passphrases, sudo / login
 passwords). The secret is entered once into the locker's own secure dialog (a separate
-signed helper process) and stored encrypted on this machine (Windows DPAPI, current
-user); it is **never** shown to the assistant or sent through this tool. Autofill then
-happens automatically when a bound command triggers a credential prompt — there is no
-manual fill action.
+helper process) and stored encrypted on this machine (Windows DPAPI, current user); it
+is **never** shown to the assistant or sent through this tool. Autofill then happens
+automatically when a bound command reaches its credential prompt — there is no manual
+fill action. But autofill **only fires in a console opened by `launch_console`** — a
+pre-existing terminal is never autofilled.
 
+- `action='launch_console'` launches (or reuses) an autofill-capable anchored console
+  and returns `{ paneId, windowTitle }`. Run the `ssh` / `sudo` command into it with
+  `terminal({ action:'send', paneId })`. The console is a classic visible Windows
+  console the human can watch and type into — you can take over at any prompt. Pass
+  `fresh:true` to force a new console instead of reusing the current one.
 - `action='save'` enrolls a credential for a binding URI (`ssh://user@host:22`,
-  `sudo://host/root`, `https-cred://host:443`, `sshkey://SHA256:…`): it opens the secure
-  dialog and stores the secret. The first `save` also shows a one-time enable
-  confirmation (first-run consent).
+  `sudo://host/user`, `https-cred://host:443`, `sshkey://SHA256:…`): it opens the secure
+  dialog and stores the secret. The first `save` (or `launch_console`) also shows a
+  one-time enable confirmation (first-run consent). An `ssh` save needs the host key
+  already in `known_hosts` — connect to the host once first.
 - `action='list'` shows saved bindings (metadata only). `action='forget'` deletes a
   binding and its secret. `action='set_policy'` toggles per-binding autofill
-  confirmation. `action='status'` reports whether the locker is enabled and the binding
-  count.
+  confirmation (every autofill asks by default). `action='status'` reports whether the
+  locker is enabled and the binding count.
 - Windows-only. Disable the whole feature with `DESKTOP_TOUCH_DISABLE_KEY_LOCKER=1`.
+  The helper executable is currently unsigned, so Windows SmartScreen / antivirus may
+  show an "unknown publisher" warning on first run (expected; code signing is planned).
 
 ```js
-key_locker({ action:'status' })                             // → { consentAccepted:false, bindingCount:0 }
-key_locker({ action:'save', uri:'sudo://buildbox/root' })   // opens the secure dialog → { captured:true }
+key_locker({ action:'save', uri:'ssh://user@host:22' })     // opens the secure dialog → { captured:true }
+key_locker({ action:'launch_console' })                     // → { paneId:'12345678', windowTitle:'dtm-locker-console-…' }
+terminal({ action:'send', paneId:'12345678', input:'ssh user@host' })  // password fills at the prompt
 ```
 
 ---

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -591,9 +591,11 @@ Sends raw input to a terminal. `waitForPrompt` blocks until the next prompt reap
 
 > **Targeting by `paneId`.** `read` / `send` accept an optional `paneId` (the decimal
 > window handle returned by `key_locker(action='launch_console')`) as an alternative to
-> `windowTitle` — provide one of the two; `paneId` takes precedence. It targets that
-> exact window even after its title changes (e.g. an `ssh` login renaming the window to
-> `user@host`), so a follow-up `send` / `read` still reaches the same pane.
+> `windowTitle` — provide one of the two; `paneId` takes precedence. `send` binds
+> directly to that exact window even after its title changes (e.g. an `ssh` login
+> renaming the window to `user@host`). `read` resolves the pane's current title under
+> the hood and declines — rather than risk reading a same-title sibling — when that
+> title is no longer unique among open windows.
 
 ---
 
@@ -640,7 +642,7 @@ pre-existing terminal is never autofilled.
   console the human can watch and type into — you can take over at any prompt. Pass
   `fresh:true` to force a new console instead of reusing the current one.
 - `action='save'` enrolls a credential for a binding URI (`ssh://user@host:22`,
-  `sudo://host/user`, `https-cred://host:443`, `sshkey://SHA256:…`): it opens the secure
+  `sudo://host/user`, `https-cred://host:443`, `sshkey:SHA256:…`): it opens the secure
   dialog and stores the secret. The first `save` (or `launch_console`) also shows a
   one-time enable confirmation (first-run consent). An `ssh` save needs the host key
   already in `known_hosts` — connect to the host once first.

--- a/site/index.html
+++ b/site/index.html
@@ -102,6 +102,10 @@
             <h2>Project Milestones</h2>
             <p>As the project evolves, we document major architectural shifts and milestones here.</p>
             <div class="three-up">
+              <a class="mini-card" href="https://github.com/Harusame64/desktop-touch-mcp/releases/tag/v1.12.0">
+                <h3>v1.12: Key Locker — the Terminal Autofills Your Passwords</h3>
+                <p>Running <code>ssh</code> or <code>sudo</code> normally stops at a hidden password prompt an agent can't safely type into. The new <code>key_locker</code> tool stores SSH key passphrases and sudo / login passwords encrypted on your machine (Windows DPAPI) and fills them in when a bound command reaches its prompt — the secret is entered once into the locker's own secure dialog and is never shown to the assistant. Autofill only fires in a console opened by <code>key_locker(action='launch_console')</code>, a classic visible console the human can take over at any prompt, and every fill asks for confirmation by default. The returned <code>paneId</code> also gives <code>terminal</code> a title-change-proof way to keep driving the same pane through an <code>ssh</code> login (32 tools total).</p>
+              </a>
               <a class="mini-card" href="https://github.com/Harusame64/desktop-touch-mcp/releases/tag/v1.11.0">
                 <h3>v1.11: Screenshots That Cost Less and See More</h3>
                 <p>Screenshots stop inlining their pixels into every response: <code>screenshot</code> (and the Set-of-Mark, diff, scroll, workspace, and <code>desktop_act</code> crop results) now return a cheap <code>screenshot://by-ref/{id}</code> link to an image saved on disk, so routine look-act-confirm loops cost a fraction of the tokens — pixels are spent only when the link is opened. A Windows.Graphics.Capture path lets GPU-rendered and occluded windows return real pixels instead of black, with a <code>captureBlocked</code> signal when content genuinely can't be captured, and two new tools — <code>screenshot_query</code> and <code>screenshot_gc</code> (31 tools total) — inspect and prune the self-bounding cache.</p>

--- a/site/index.md
+++ b/site/index.md
@@ -98,6 +98,10 @@ It is trying to document an active line of engineering and research.
 
 As the project evolves, we document major architectural shifts and milestones here.
 
+### v1.12: Key Locker — the Terminal Autofills Your Passwords
+Running `ssh` or `sudo` normally stops at a hidden password prompt an agent can't safely type into. The new `key_locker` tool stores SSH key passphrases and sudo / login passwords encrypted on your machine (Windows DPAPI) and fills them in when a bound command reaches its prompt — the secret is entered once into the locker's own secure dialog and is never shown to the assistant. Autofill only fires in a console opened by `key_locker(action='launch_console')`, a classic visible console the human can take over at any prompt, and every fill asks for confirmation by default. The returned `paneId` also gives `terminal` a title-change-proof way to keep driving the same pane through an `ssh` login (32 tools total).
+- [v1.12.0 release notes](https://github.com/Harusame64/desktop-touch-mcp/releases/tag/v1.12.0)
+
 ### v1.11: Screenshots That Cost Less and See More
 Screenshots stop inlining their pixels into every response. `screenshot` — and the Set-of-Mark overlays, diff frames, scroll captures, workspace snapshots, and `desktop_act`'s changed-region crop — now hand back a cheap `screenshot://by-ref/{id}` link to an image saved on disk, so routine look-act-confirm loops cost a fraction of the tokens; the agent spends them on pixels only when it actually opens the link. The same release adds a Windows.Graphics.Capture path so GPU-rendered and occluded windows return real pixels instead of black (with a `captureBlocked` signal when content genuinely can't be captured), plus two new tools — `screenshot_query` and `screenshot_gc` (31 tools total) — to inspect and prune the self-bounding on-disk cache.
 - [v1.11.0 release notes](https://github.com/Harusame64/desktop-touch-mcp/releases/tag/v1.11.0)


### PR DESCRIPTION
## Summary

Sync user-facing docs with the v1.12.0 Key Locker release. The CHANGELOG entry shipped with the release, but the README feature list, `docs/system-overview.md`, and the public site had no (or stale) Key Locker coverage.

- **README.md / README.ja.md**: add a Key Locker bullet to the Features list and a usage mini-section (save → `launch_console` → `terminal send` flow, `paneId` targeting, security model: DPAPI encryption, secret never shown to the assistant, per-fill confirmation, anchored-console-only autofill).
- **docs/system-overview.md**: sync the `key_locker` section with the shipped v1.12 surface — document `action='launch_console'` + the `paneId` flow and the anchored-console-only autofill constraint, and fix the stale "signed helper process" wording (the helper is currently **unsigned**; SmartScreen note added, matching README/CHANGELOG). Also document `terminal` `read`/`send` `paneId` targeting.
- **site/index.html + site/index.md**: add a v1.12 milestone mini-card (same pattern as the v1.11 card — links to the GitHub release notes).

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
