### PR TITLE
ci(release): pin npm publish helper to npm@11 (npm@12.0.0 missing sigstore breaks --provenance)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,8 +276,15 @@ jobs:
       # mid-self-upgrade and dies with `Cannot find module 'promise-retry'`,
       # so use npx — it stages npm 11 in a temp dir and avoids the
       # self-overwrite race.
-      - name: Publish to npm (via npx npm@latest for OIDC support)
-        run: npx -y npm@latest publish --ignore-scripts --provenance
+      # v1.12.1 fix: pin the major to npm@11 instead of npm@latest — the day
+      # npm 12.0.0 hit the `latest` dist-tag it shipped without its `sigstore`
+      # dependency, so `publish --provenance` died with MODULE_NOT_FOUND and
+      # the v1.12.1 job failed twice (published manually). A floating `latest`
+      # makes every future npm major a release-day gamble; bump this pin
+      # deliberately after verifying `npx npm@<major> publish --provenance`
+      # works on a dry run.
+      - name: Publish to npm (via npx npm@11 for OIDC support)
+        run: npx -y npm@11 publish --ignore-scripts --provenance
 
       - name: Verify npm publish
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,8 +281,8 @@ jobs:
       # dependency, so `publish --provenance` died with MODULE_NOT_FOUND and
       # the v1.12.1 job failed twice (published manually). A floating `latest`
       # makes every future npm major a release-day gamble; bump this pin
-      # deliberately after verifying `npx npm@<major> publish --provenance`
-      # works on a dry run.
+      # deliberately, and verify on the bumped major's first real release (a
+      # --dry-run does not exercise the sigstore/provenance path that broke here).
       - name: Publish to npm (via npx npm@11 for OIDC support)
         run: npx -y npm@11 publish --ignore-scripts --provenance
 


### PR DESCRIPTION
## Summary

The `npm-publish` job runs `npx -y npm@latest publish --ignore-scripts --provenance`. On 2026-07-09, npm **12.0.0** reached the `latest` dist-tag **missing its `sigstore` dependency**, so the provenance path dies with `MODULE_NOT_FOUND: Cannot find module 'sigstore'` — the v1.12.1 `npm-publish` job failed twice on this (run 29024532752; the zip job succeeded, and 1.12.1 was then published manually per the documented fallback).

This pins the helper to `npm@11` (OIDC Trusted Publishing needs ≥ 11.5.1, which the npm@11 dist-tag always satisfies), so a future npm major landing on `latest` can no longer break release day. The comment block documents when and how to bump the pin.

One-line workflow change; no effect on the zip build job or the published artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)