### PR TITLE
chore(deps-dev): bump @types/node, block Dependabot TypeScript major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,12 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    ignore:
+      # typescript-eslint (8.63.0, latest) still declares peer typescript ">=4.8.4 <6.1.0".
+      # A TypeScript major bump therefore breaks `npm ci` with ERESOLVE (see PR #530).
+      # Drop this once typescript-eslint ships a release that accepts TypeScript 7.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       dev-dependencies:
         patterns:

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@modelcontextprotocol/sdk": "^1.10.0",
         "@napi-rs/cli": "^3.7.2",
         "@nut-tree-fork/nut-js": "^4.2.6",
-        "@types/node": "^26.1.0",
+        "@types/node": "^26.1.1",
         "@types/ws": "^8.18.1",
         "eslint": "^10.6.0",
         "fast-check": "^4.8.0",
@@ -3373,9 +3373,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
-      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "@modelcontextprotocol/sdk": "^1.10.0",
     "@napi-rs/cli": "^3.7.2",
     "@nut-tree-fork/nut-js": "^4.2.6",
-    "@types/node": "^26.1.0",
+    "@types/node": "^26.1.1",
     "@types/ws": "^8.18.1",
     "eslint": "^10.6.0",
     "fast-check": "^4.8.0",


### PR DESCRIPTION
## Why

Dependabot PR #530 bumped TypeScript from `^6.0.2` to `^7.0.2`. Both CI jobs (`build`, `docker-build`) fail at `npm ci`:

```
npm error ERESOLVE could not resolve
npm error While resolving: typescript-eslint@8.62.1
npm error Found: typescript@7.0.2
npm error Could not resolve dependency:
npm error peer typescript@">=4.8.4 <6.1.0" from typescript-eslint@8.62.1
```

`typescript-eslint@8.63.0` (latest) still declares `peer typescript ">=4.8.4 <6.1.0"`, so there is no version of it we can pair with TypeScript 7 today.

## What

- `@types/node` `^26.1.0` → `^26.1.1` (the harmless half of #530).
- TypeScript stays on `^6.0.2`.
- `.github/dependabot.yml`: ignore `version-update:semver-major` for `typescript`, with a comment noting the condition for removing it (typescript-eslint shipping TS 7 support).

`npm run build` (tsc) passes locally.

Closes #530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)