### PR TITLE
feat(key-locker): shell-anchor creation-time reuse detection (S-pid PR1)

### DIFF
--- a/src/engine/key-locker/ssh-session-watch.ts
+++ b/src/engine/key-locker/ssh-session-watch.ts
@@ -51,10 +51,14 @@
 // `markUnknown` sets the tracker stack to null and does NOT auto-recover on the session's later exit —
 // `recordDispatch` early-returns on a null stack — so an unknown pane re-anchors only when the wiring calls
 // `beginLocalSession` at a fresh local prompt (SP-L3-OQ-8 territory), not via exit observation. Safe
-// (declines), just degraded longer. RESIDUAL (P3, plan §Risks): the shell anchor is liveness-only
-// (`!parentMap.has(shellPid)`) with no startTime check — a reused shell pid can mask shell death; it
-// self-heals (the dead shell's ssh child dies/reparents ⇒ the session check catches it) and is tracked in
-// the plan, not gated on.
+// (declines), just degraded longer. SHELL-ANCHOR REUSE (S-pid gate PR1, formerly the liveness-only P3
+// residual, NOW CLOSED): the shell anchor carries the shell's CREATION TIME (`WatchedPane.shellStartTimeMs`,
+// captured at `watchPane`), so `tick` case (a2) declines a pane whose live `shellPid` reads a DIFFERENT
+// non-zero creation time (a reused pid = the anchored shell died) instead of trusting the foreign process.
+// A 0 baseline (shell not snapshot-visible at registration — never in production) or a transient 0 current
+// read (a GetProcessTimes glitch on a still-live shell) falls back to liveness-only, the safe pre-hardening
+// behavior. This is the shell-side of the S-pid identity re-base that also carries pid+creation-time into
+// the L2 InjectTarget re-verify (PR2).
 //
 // SCOPE / FIXED POINT (Opus PR#505 closing sweep): this pure module reconciles every STEADY (watch,tracker)
 // state to safety — any desync self-heals within one `tick`, so at rest there is no wrong-target. What a
@@ -144,6 +148,16 @@ export interface SshWatchDeps {
 /** A registered pane: the shell pid (liveness anchor) + the outermost session ssh currently watched. */
 interface WatchedPane {
   shellPid: number;
+  /** The shell's process CREATION TIME (ms since the Windows epoch), captured from the snapshot at
+   *  registration — the pid-reuse baseline for `tick` case (a). A real running process never has creation
+   *  time 0 (S-pid gate §4), so **0 = "no reliable baseline"** (the shell was unreadable at registration —
+   *  never in production, where `launchAnchoredConsole` polls until the shell is live): the pane falls back
+   *  to LIVENESS-ONLY (the pre-hardening behavior). A NON-ZERO baseline enables reuse detection: a live
+   *  `shellPid` whose creation time later reads a DIFFERENT non-zero value is a REUSED pid (the anchored
+   *  shell died and Windows reassigned its pid), so the pane is declined — this closes the documented
+   *  liveness-only residual (a reused shell pid could previously mask shell death). Mirrors the
+   *  `session.startedAt` non-zero discipline. */
+  shellStartTimeMs: number;
   /** The outermost interactive-session ssh child, or null when the pane holds no live ssh session. */
   session: { pid: number; startedAt: number } | null;
 }
@@ -165,6 +179,14 @@ export class SshSessionWatch {
    * Start watching `paneId`, anchored at its shell pid (`getWindowProcessId(hwnd)` — the window-owning
    * pid, value-consistent with L2's re-verify). No session ssh is watched until `noteSshOpened`.
    * Re-registering a pane resets it (drops any tracked session).
+   *
+   * The shell's CREATION TIME is captured here from the live snapshot — the same source + integer-ms value
+   * L2's `assembleInjectTarget` and (S-pid gate PR2) the C# re-verify read — so `tick` can distinguish a
+   * still-alive anchored shell from a REUSED pid (the pre-hardening liveness-only check could not). Read from
+   * the watch's own snapshot (not plumbed as a param) exactly as `noteSshOpened` reads the session ssh's
+   * creation time: one source of truth (the live process tree), no cross-layer plumbing to drift. A shell not
+   * yet visible in the snapshot reads 0 ⇒ liveness-only fallback (never happens in production —
+   * `launchAnchoredConsole` polls until the shell owns the console window with a non-zero owner pid).
    */
   watchPane(paneId: string, shellPid: number): void {
     // Re-anchoring a pane that STILL holds a live ssh session: silently resetting to a trusted-local slot
@@ -172,7 +194,10 @@ export class SshSessionWatch {
     // the live-remote-vs-local contradiction), leaving a live remote login derived as local. Decline first,
     // then reset — a re-anchor over a live session is doubt, so sink it (Opus/Codex R6).
     if (this.panes.get(paneId)?.session != null) this.deps.tracker.markUnknown(paneId);
-    this.panes.set(paneId, { shellPid, session: null });
+    // Capture the shell's creation-time baseline (0 when the pid is not yet snapshot-visible ⇒ liveness-only).
+    const snap = this.deps.snapshot();
+    const shellStartTimeMs = snap.parentMap.has(shellPid) ? snap.identify(shellPid).startTimeMs : 0;
+    this.panes.set(paneId, { shellPid, shellStartTimeMs, session: null });
   }
 
   /** Stop watching a pane (its window closed / the tracker forgot it). Idempotent. */
@@ -259,6 +284,22 @@ export class SshSessionWatch {
         this.deps.tracker.markUnknown(paneId);
         this.panes.delete(paneId);
         continue;
+      }
+      // (a2) Shell pid REUSED (closes the liveness-only residual): the pid is alive, but if it now names a
+      //      process with a DIFFERENT non-zero creation time than the registered baseline, the anchored shell
+      //      DIED and Windows reassigned its pid to an unrelated process — the pane is no longer observable, so
+      //      fail-safe to UNKNOWN + unwatch (the subtree walked from a foreign pid could otherwise mis-derive).
+      //      Gated on a non-zero baseline (0 = liveness-only fallback) AND a non-zero current read (0 = a
+      //      transient GetProcessTimes glitch on a still-live shell — the doubt sentinel; keep watching, the
+      //      Toolhelp liveness authority says alive, and a real reuse re-reads non-zero next tick). Mirrors the
+      //      `session.startedAt` reuse discipline applied to the session ssh.
+      if (pane.shellStartTimeMs !== 0) {
+        const shellNow = snap.identify(pane.shellPid).startTimeMs;
+        if (shellNow !== 0 && shellNow !== pane.shellStartTimeMs) {
+          this.deps.tracker.markUnknown(paneId);
+          this.panes.delete(paneId);
+          continue;
+        }
       }
       // No interactive ssh registered. Normally nothing to pop — but a pane that holds a remote frame with
       // NO live watch (a non-atomic push↔register window, or a registration that could not confirm a live

--- a/tests/unit/key-locker-ssh-session-watch.test.ts
+++ b/tests/unit/key-locker-ssh-session-watch.test.ts
@@ -176,6 +176,57 @@ describe("SshSessionWatch — P2-A: a NON-session ssh must never pop the frame",
   });
 });
 
+describe("SshSessionWatch — PR1: shell-pid REUSE detection (closes the liveness-only residual)", () => {
+  it("shell pid alive but a DIFFERENT non-zero creation time ⇒ markUnknown + unwatch (reused pid)", () => {
+    const { watch, sink, set } = setup(SHELL_WITH_SSH); // shell 1000 start=10 captured at registration
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 0);
+    // The anchored shell died; Windows reassigned pid 1000 to an unrelated process (a new creation time).
+    set({ 500: { parent: 0, name: "windowsterminal", start: 1 }, 1000: { parent: 500, name: "cmd", start: 777 } });
+    watch.tick();
+    expect(sink.unknowns).toEqual(["pane-1"]); // fail-safe: the pane is no longer observable
+    expect(sink.ends).toEqual([]);
+    expect(watch.isWatching("pane-1")).toBe(false); // unwatched — a foreign pid must not be walked
+  });
+
+  it("shell pid alive with the SAME creation time ⇒ no signal (steady-state undisturbed)", () => {
+    // SHELL_ONLY (no ssh child) so this isolates the a2 reuse check — a SHELL_WITH_SSH subtree would trip the
+    // separate W-2b unregistered-ssh scan (its ssh child has no argv ⇒ fail-safe markUnknown), unrelated to a2.
+    const { watch, sink } = setup(SHELL_ONLY);
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 0);
+    watch.tick(); // same tree — shell 1000 still start=10
+    expect(sink.unknowns).toEqual([]);
+    expect(sink.ends).toEqual([]);
+    expect(watch.isWatching("pane-1")).toBe(true);
+  });
+
+  it("shell alive but a transient ZERO creation-time read ⇒ NOT reused (doubt sentinel, keep watching)", () => {
+    const { watch, sink, set } = setup(SHELL_WITH_SSH); // baseline 10 captured
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 0);
+    // A GetProcessTimes glitch: shell 1000 still ALIVE (parentMap key) but its creation time reads 0 this tick.
+    set({ 500: { parent: 0, name: "windowsterminal", start: 1 }, 1000: { parent: 500, name: "powershell", start: 0 } });
+    watch.tick();
+    expect(sink.unknowns).toEqual([]); // 0 = doubt, never treated as a confirmed reuse
+    expect(watch.isWatching("pane-1")).toBe(true); // still watched; a real reuse re-reads non-zero next tick
+  });
+
+  it("shell NOT snapshot-visible at registration (0 baseline) ⇒ liveness-only, a later start change does NOT markUnknown", () => {
+    // Register when pid 1000 is absent from the tree ⇒ baseline 0 ⇒ liveness-only fallback (pre-hardening).
+    const { watch, sink, set } = setup(SHELL_ONLY); // no 1000 here? SHELL_ONLY HAS 1000 — use a tree without it
+    // Build a tree WITHOUT the shell so watchPane captures a 0 baseline.
+    set({ 500: { parent: 0, name: "windowsterminal", start: 1 } });
+    watch.watchPane("pane-1", 1000); // 1000 absent ⇒ shellStartTimeMs = 0
+    sink.setDepth("pane-1", 0);
+    // Now 1000 appears with some creation time; with a 0 baseline there is nothing to compare ⇒ no reuse fire.
+    set({ 500: { parent: 0, name: "windowsterminal", start: 1 }, 1000: { parent: 500, name: "powershell", start: 42 } });
+    watch.tick();
+    expect(sink.unknowns).toEqual([]); // liveness-only: no baseline ⇒ the a2 reuse guard is skipped
+    expect(watch.isWatching("pane-1")).toBe(true);
+  });
+});
+
 describe("SshSessionWatch — R2 P2: a live-but-UNREADABLE session ssh must not pop-to-local", () => {
   it("present in parentMap but identify() empty ⇒ markUnknown, NEVER noteSessionEnd (no pop-to-local)", () => {
     const sink = new FakeSink();


### PR DESCRIPTION
## What & why

First slice of the **S-pid identity re-base** (the groundwork for Windows Terminal autofill). It closes the shell-anchor **liveness-only residual** the ssh session-end watch has carried since L3-3 (documented at `ssh-session-watch.ts:55`).

Before: the watch anchored a pane on its shell pid and treated the pid merely being *alive* as "same shell". A reused pid (the anchored shell dies, Windows reassigns its pid to an unrelated process) could mask shell death, and the subtree walked from a foreign pid could mis-derive a binding.

After: the watch captures the shell's **process creation time** at `watchPane` (from its own snapshot — the same source `noteSshOpened` already uses for the session ssh, so there is one source of truth and no cross-layer plumbing to drift). `tick` case (a2) declines a pane whose live `shellPid` reads a **different non-zero creation time** (a reused pid) via `markUnknown` + unwatch.

Fail-safe fallbacks (no new spurious declines):
- **0 baseline** — the shell was not snapshot-visible at registration (never happens in production; `launchAnchoredConsole` polls until the shell owns the console window) ⇒ liveness-only, the pre-hardening behavior.
- **transient 0 current read** — a `GetProcessTimes` glitch on a still-live shell ⇒ keep watching (0 is the doubt sentinel); a real reuse re-reads non-zero next tick.

This mirrors the existing `session.startedAt` non-zero reuse discipline, applied to the shell anchor.

## Scope

- No signature changes, no launch-side changes, fully back-compat. The creation-time is sourced internally, so **existing tests are untouched** and every consumer keeps its current call shape.
- The launch-side `PaneAnchor` capture + the L2 `InjectTarget` re-verify (pid+creation-time) land in **PR2**; WT autofill in **PR3**.

## Tests

`tests/unit/key-locker-ssh-session-watch.test.ts` + 4 cases: reused pid (different non-zero time) ⇒ markUnknown+unwatch; same time ⇒ steady state undisturbed; transient 0 read ⇒ keep watching; 0 baseline ⇒ liveness-only. Full key-locker unit suite green (396/396).

## Plan

`desktop-touch-mcp-internal@55d99f0:docs/adr-014-v2-r3x-s-pid-gate.md` (E5) — Opus-GO design gate, OQ-S-3 read-path spike cleared on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
