### PR TITLE
feat(key-locker): PaneAnchor spawn capture + pid+creation-time inject re-verify (S-pid PR2)

### DIFF
--- a/src/engine/key-locker-host.ts
+++ b/src/engine/key-locker-host.ts
@@ -107,20 +107,27 @@ export interface LockerReply {
 
 // L2 wire contracts (the locker owns these frame shapes; the injector orchestrator consumes them).
 
-/** The dedicated-console target of a console-buffer injection (`inject`) — §2.1 of the L2 plan. */
+/** The anchored-pane target of a console-buffer injection (`inject`) — §2.1 of the L2 plan, re-based on
+ *  the S-pid identity (S-pid gate E3). `shellPid`/`shellStartMs` are REQUIRED for both hosts (the
+ *  locker's PRIMARY pid+creation-time re-verify); the window-derived trio is CLASSIC-ONLY (a WT pane has
+ *  no per-pane window). Additive on the wire — an un-rebuilt L0 reader ignores unknown props. */
 export interface InjectTarget {
-  /** The console window HWND (decimal string). */
-  hwnd: string;
+  /** The console window HWND (decimal string) — classic only (absent for wt). */
+  hwnd?: string;
   /**
    * The pid that OWNS the console window — whatever `GetWindowThreadProcessId(hwnd)` returns for the
    * `ConsoleWindowClass` window. L3 supplies `getWindowProcessId(hwnd)` and the locker re-verifies
    * with the SAME API on the same hwnd, so the value matches by CONSTRUCTION (L3 plan §4). The
    * `ConsoleWindowClass` allowlist is what excludes a WT multiplexer; this is the window-owning pid,
-   * not asserted to be a specific conhost-vs-shell process (Opus R1 P3-1).
+   * not asserted to be a specific conhost-vs-shell process (Opus R1 P3-1). Classic only.
    */
-  consolePid: number;
-  /** Opaque hash of the expected pane identity (secondary anchor). */
-  titleFp: string;
+  consolePid?: number;
+  /** Opaque hash of the expected pane identity (secondary anchor). Classic only. */
+  titleFp?: string;
+  /** The spawn-tracked SHELL pid — the AttachConsole target for wt, the identity root for both hosts. */
+  shellPid: number;
+  /** The shell's creation time, ms since the 1601 epoch = floor(FILETIME/10000) (gate §4). Never 0. */
+  shellStartMs: number;
   /** Append Enter after the secret. */
   submit?: boolean;
 }

--- a/src/engine/key-locker/capture-loop.ts
+++ b/src/engine/key-locker/capture-loop.ts
@@ -29,7 +29,7 @@
 //   resolve/bind      = BindingStore.resolve / .bind (locker exists()-verified)
 //   confirmPolicyFor  = the binding row's `confirmEveryInjection ?? true`  (D2, L1 §5.1 field)
 //   capture/delete    = KeyLockerHost.capture / .delete                    (L0, secret stays in the locker)
-//   injectPane        = assembleInjectTarget(hwnd, submit) + inject(host, …, "pane", target)  (§4 + L2)
+//   injectPane        = assembleInjectTarget(anchor, submit) + inject(host, …, "pane", target)  (§4 + L2)
 //   awaitLanded       = awaitLanded(landedDeps(paneId, cmd), cmd)          (§2)
 //   confirm / offer   = the locker's secret-free dialogs (like `-Consent`) — forward-wired in L3-3/L4
 //

--- a/src/engine/key-locker/inject-target.ts
+++ b/src/engine/key-locker/inject-target.ts
@@ -1,24 +1,42 @@
-// ADR-014 v2 R3 Key Locker — L3 §4: InjectTarget assembly for the `pane` (console-buffer inject) channel.
+// ADR-014 v2 R3 Key Locker — L3 §4: InjectTarget assembly for the `pane` (console-buffer inject) channel,
+// re-based on the S-pid PaneAnchor identity (ADR-014 R3.x S-pid gate §1/E4).
 //
-// Plan: desktop-touch-mcp-internal@<plan>:docs/adr-014-v2-r3-l3-capture-plan.md (§4, THE LOCKED
-// CONTRACT #4)
+// Plan: desktop-touch-mcp-internal:docs/adr-014-v2-r3-l3-capture-plan.md (§4, THE LOCKED CONTRACT #4)
+//       + desktop-touch-mcp-internal:docs/adr-014-v2-r3x-s-pid-gate.md (§1 PaneAnchor, E3 wire, E4 assembly)
 //
-// For a pane console-buffer injection L3 must hand the locker an `InjectTarget {hwnd, consolePid, titleFp,
-// submit}` (L2 §2.1). The hwnd is already in hand — the terminal/tool layer that observed the
-// credential prompt located the console window — so this module only reads the two derived fields
-// (consolePid, titleFp) via the SAME Win32 APIs the locker re-verifies with, so both match by
-// CONSTRUCTION (no TOCTOU on the identity, only the intended abort if the window changes between
-// derive and inject):
-//   * consolePid = getWindowProcessId(hwnd)          — the window-owning pid (shell for a pseudoconsole)
-//   * titleFp    = sha256hex(utf8(GetWindowTextW))   — byte-identical to Injection.cs `TitleFp`
+// Target identity is the SHELL PROCESS the locker itself spawned, named by `{shellPid, shellStartTimeMs}`
+// (unforgeable by pid reuse — a reused pid reads a different creation time). The console window, where one
+// exists (classic conhost), is an ADDITIONAL classic-only anchor, no longer the identity source:
+//   * classic: consolePid/titleFp are still derived from the hwnd via the SAME Win32 APIs the locker
+//     re-verifies with (match by CONSTRUCTION), PLUS the anchor's shellPid/shellStartMs ride the wire so
+//     the locker's PRIMARY pid+creation-time re-verify covers classic too.
+//   * wt (Windows Terminal, R3.x La): a pane has NO per-pane window — the target is pid+creation-time
+//     alone. As a cheap early decline (before a doomed pipe round-trip) the shell must still be alive
+//     with the anchored creation time; the C# re-verify remains the AUTHORITATIVE gate.
 //
-// This module holds no secret and does no I/O beyond the two read-only Win32 queries. Channel
-// selection (pane vs askpass vs git-credential) and `submit` classification are the capture-loop's
-// job (§4 second half / §5 detection); this module is handed the resolved hwnd + submit flag.
+// This module holds no secret and does no I/O beyond read-only Win32 queries. Channel selection
+// (pane vs askpass vs git-credential) and `submit` classification are the capture-loop's job.
 
 import { createHash } from "node:crypto";
-import { getWindowProcessId, getWindowTitleW } from "../win32.js";
+import { getProcessIdentityByPid, getWindowProcessId, getWindowTitleW } from "../win32.js";
 import type { InjectTarget } from "../key-locker-host.js";
+
+/**
+ * The per-pane target identity, captured AT SPAWN by the launch path (`launchAnchoredConsole`) and
+ * immutable thereafter (S-pid gate §1). One per anchored pane.
+ */
+export interface PaneAnchor {
+  kind: "classic" | "wt";
+  /** The console window hwnd — CLASSIC ONLY (a WT pane has no per-pane window). */
+  hwnd?: bigint;
+  /** The spawn-tracked SHELL pid (powershell in the tab/console) — the AttachConsole target
+   *  and the sshDescendants subtree root, in BOTH hosts. */
+  shellPid: number;
+  /** The shell's process creation time, ms since the Windows (1601) epoch, computed as
+   *  floor(FILETIME_ticks / 10000) — EXACTLY `process.rs filetime_to_ms` (gate §4). NEVER 0:
+   *  a 0 read at spawn FAILS the launch (0 is the doubt sentinel and can never anchor). */
+  shellStartTimeMs: number;
+}
 
 /**
  * The window-title fingerprint the C# locker recomputes at the injection instant
@@ -34,22 +52,41 @@ export function titleFingerprint(title: string): string {
 }
 
 /**
- * Assemble the `pane` InjectTarget for a resolved console window (L3 plan §4). Returns `null` when the
- * window is gone / the hwnd is invalid (`getWindowProcessId` yields 0 — PID 0 never owns a console
- * window): there is no valid target, so the caller DECLINES rather than round-tripping a garbage
- * target (whose `titleFp` would be `sha256("")`) to the locker.
+ * Assemble the `pane` InjectTarget for an anchored pane (S-pid gate E4). Returns `null` (the caller
+ * DECLINES — never round-trips a garbage target) when:
+ *   * classic: the window is gone / the hwnd is invalid (`getWindowProcessId` yields 0 — PID 0 never
+ *     owns a console window), exactly the pre-S-pid decline;
+ *   * wt: the shell is gone or its live creation time no longer equals the anchor's (a reused pid) —
+ *     a cheap Node-side early decline; the C# `ReVerify` pid+time check is the authoritative gate.
  *
  * `hwnd` is serialized as a DECIMAL integer string (the `InjectTarget.hwnd` contract; the locker's
- * `ParseLong` accepts a decimal string or number). `submit` appends Enter after the secret for a
- * line-oriented echo-off prompt; it is only emitted when true (the field is optional).
+ * `ParseLong` accepts a decimal string or number). `shellPid`/`shellStartMs` are carried from the
+ * spawn-captured anchor VERBATIM for BOTH hosts (never re-derived here — the anchor is the identity).
+ * `submit` appends Enter after the secret for a line-oriented echo-off prompt; it is only emitted
+ * when true (the field is optional).
  */
-export function assembleInjectTarget(hwnd: bigint, submit: boolean): InjectTarget | null {
-  const consolePid = getWindowProcessId(hwnd);
-  if (consolePid === 0) return null; // window gone / invalid hwnd — no target, caller declines
+export function assembleInjectTarget(anchor: PaneAnchor, submit: boolean): InjectTarget | null {
+  if (anchor.kind === "classic") {
+    if (anchor.hwnd === undefined) return null; // malformed classic anchor — no window to derive from
+    const consolePid = getWindowProcessId(anchor.hwnd);
+    if (consolePid === 0) return null; // window gone / invalid hwnd — no target, caller declines
+    return {
+      hwnd: anchor.hwnd.toString(10),
+      consolePid,
+      titleFp: titleFingerprint(getWindowTitleW(anchor.hwnd)),
+      shellPid: anchor.shellPid,
+      shellStartMs: anchor.shellStartTimeMs,
+      ...(submit ? { submit: true } : {}),
+    };
+  }
+  // wt: nothing window-derived exists to read. Early-decline if the shell identity already fails the
+  // anchor (dead pid reads {"",0}; a reused pid reads a DIFFERENT non-zero time) — saves a doomed
+  // round-trip; equality is EXACT (gate §4 — a tolerance would re-open the pid-reuse hole).
+  const live = getProcessIdentityByPid(anchor.shellPid).processStartTimeMs;
+  if (live === 0 || live !== anchor.shellStartTimeMs) return null;
   return {
-    hwnd: hwnd.toString(10),
-    consolePid,
-    titleFp: titleFingerprint(getWindowTitleW(hwnd)),
+    shellPid: anchor.shellPid,
+    shellStartMs: anchor.shellStartTimeMs,
     ...(submit ? { submit: true } : {}),
   };
 }

--- a/src/engine/key-locker/key-locker-capture-driver.ts
+++ b/src/engine/key-locker/key-locker-capture-driver.ts
@@ -63,6 +63,7 @@ import {
 import { tokenizeCommandSegmentsWithOps } from "./command-derivation.js";
 import type { SessionContext } from "./command-derivation.js";
 import { awaitLanded, type ExitCompletion } from "./landed-detection.js";
+import type { PaneAnchor } from "./inject-target.js";
 import type { InjectResult } from "./injector.js";
 import {
   ENV_ASSIGN_RE,
@@ -135,8 +136,10 @@ export interface CaptureDriverDeps {
   capture(opaqueId: string): Promise<{ captured: boolean }>;
   /** Delete the locker entry for `opaqueId` (the reverse-orphan closure). */
   deleteSecret(opaqueId: string): Promise<void>;
-  /** Assemble the pane InjectTarget for `paneId` (`assembleInjectTarget`) + console-buffer inject (`inject`, "pane"). */
-  injectPane(paneId: string, binding: BindingUri, opaqueId: string, submit: boolean): Promise<InjectResult>;
+  /** Assemble the pane InjectTarget from the SPAWN-captured anchor (`assembleInjectTarget`) + console-buffer
+   *  inject (`inject`, "pane"). Takes the `PaneAnchor` (S-pid gate E4, Opus P2-2) — the driver holds it on the
+   *  `PaneRecord` and passes it, so the wiring never re-derives identity from the paneId string. */
+  injectPane(anchor: PaneAnchor, binding: BindingUri, opaqueId: string, submit: boolean): Promise<InjectResult>;
   /** The D2 backstop confirm before a MATCH autofill. */
   confirmInjection(binding: BindingUri): Promise<boolean>;
   /** The Chrome-model save offer after a landed NO-MATCH fill. */
@@ -201,8 +204,10 @@ type LoopPhase = "none" | "pre-landed" | "post-landed";
 
 /** Per-pane driver state (exists iff the driver ANCHORED the pane — i.e. L3 launched it). */
 interface PaneRecord {
-  /** The window-owning shell pid (`getWindowProcessId(hwnd)`), for the sshBaseline subtree root. */
-  shellPid: number;
+  /** The SPAWN-captured pane identity (S-pid gate E4): `anchor.shellPid` is the sshBaseline subtree
+   *  root; the whole anchor flows to the inject seam so the L2 re-verify compares against the value
+   *  frozen at spawn (never a live re-derivation). Immutable for the record's lifetime. */
+  anchor: PaneAnchor;
   /** The credential dispatch awaiting a prompt, or null. */
   armed: ArmedDispatch | null;
   /** The shell subtree's ssh-descendant pids as of the LAST reconcile (§0-CORR.2). Advanced every
@@ -241,15 +246,18 @@ export class KeyLockerCaptureDriver {
 
   /**
    * W1 — anchor a pane L3 ITSELF launched from a known-local shell. `beginLocalSession` (tracker known-local)
-   * and `watchPane` (liveness anchor at `shellPid`) run in ONE synchronous turn (Edge 3): never a window
-   * where the tracker trusts local while no watch guards a later ssh-out. Re-launching resets the pane.
-   * ONLY the assistant's own launches call this — a pre-existing pane is never anchored (P1-B, §3 W1).
+   * and `watchPane` (liveness anchor at `anchor.shellPid`) run in ONE synchronous turn (Edge 3): never a
+   * window where the tracker trusts local while no watch guards a later ssh-out. Re-launching resets the
+   * pane. ONLY the assistant's own launches call this — a pre-existing pane is never anchored (P1-B, §3 W1).
+   * Takes the SPAWN-captured `PaneAnchor` (S-pid gate E4) — the record carries it verbatim to the inject
+   * seam; the watch keeps its own snapshot-sourced creation-time read (E5/PR1, bit-equal for the same
+   * process), so no time param is plumbed here.
    */
-  onLocalPaneLaunched(paneId: string, shellPid: number, cwd?: string): void {
+  onLocalPaneLaunched(paneId: string, anchor: PaneAnchor, cwd?: string): void {
     this.tracker.beginLocalSession(paneId, cwd);
-    this.watch.watchPane(paneId, shellPid);
+    this.watch.watchPane(paneId, anchor.shellPid);
     this.panes.set(paneId, {
-      shellPid,
+      anchor,
       armed: null,
       sshBaseline: new Set(),
       pendingSsh: undefined,
@@ -290,7 +298,7 @@ export class KeyLockerCaptureDriver {
     //      reconcile's W-2b scan does not mis-flag the assistant's OWN login as a lurking user ssh. A user's
     //      SAME-host ssh is a DIFFERENT pid ⇒ still flags; 0 or >1 new host-matching children ⇒ NO exempt.
     const dHost = dispatchedInteractiveSshHost(command);
-    const curSsh = sshDescendants(this.deps.snapshot(), rec.shellPid);
+    const curSsh = sshDescendants(this.deps.snapshot(), rec.anchor.shellPid);
     const preBaseline = rec.sshBaseline;
     const newHostMatch =
       dHost === null
@@ -367,7 +375,7 @@ export class KeyLockerCaptureDriver {
 
       // §0-CORR.2 straggler backstop: register a still-pending ssh child (rare in fire-after). Idempotent.
       if (rec.pendingSsh !== undefined && !rec.pendingSsh.registered) {
-        this.correlateSshChild(paneId, rec.shellPid, rec.pendingSsh);
+        this.correlateSshChild(paneId, rec.anchor.shellPid, rec.pendingSsh);
       }
 
       // Poller lifetime (OQ-W-2): a key-based ssh / cached sudo prints NO prompt — abandon (safe, no fill).
@@ -447,7 +455,7 @@ export class KeyLockerCaptureDriver {
     // (a child that appeared/exited between dispatches is folded in here). One snapshot per pane is fine at
     // the tick cadence; the watch also snapshots independently inside `tick`.
     for (const rec of this.panes.values()) {
-      rec.sshBaseline = new Set(sshDescendants(this.deps.snapshot(), rec.shellPid).keys());
+      rec.sshBaseline = new Set(sshDescendants(this.deps.snapshot(), rec.anchor.shellPid).keys());
     }
     this.watch.tick();
     // ARM HYGIENE (Codex R1-R4 line 464): this tick may have popped/markUnknown'd a pane that holds a live
@@ -492,7 +500,7 @@ export class KeyLockerCaptureDriver {
   private correlateAllPending(): void {
     for (const [paneId, rec] of this.panes) {
       const ssh = rec.pendingSsh;
-      if (ssh !== undefined && !ssh.registered) this.correlateSshChild(paneId, rec.shellPid, ssh);
+      if (ssh !== undefined && !ssh.registered) this.correlateSshChild(paneId, rec.anchor.shellPid, ssh);
     }
   }
 
@@ -546,7 +554,7 @@ export class KeyLockerCaptureDriver {
       // re-verify, which does NOT catch a session change (plan §3 W3).
       injectPane: (b, id, sub) =>
         this.liveSessionMatchesExpected(paneId, armed.expected)
-          ? this.deps.injectPane(paneId, b, id, sub)
+          ? this.deps.injectPane(rec.anchor, b, id, sub)
           : Promise.resolve({ ok: false, code: "target_mismatch" } as InjectResult),
       awaitLanded: async (cmd) => {
         const result = await awaitLanded(

--- a/src/engine/key-locker/key-locker-manager.ts
+++ b/src/engine/key-locker/key-locker-manager.ts
@@ -29,6 +29,7 @@ import {
   getWindowProcessId,
   getWindowTitleW,
 } from "../win32.js";
+import type { PaneAnchor } from "./inject-target.js";
 import { SessionTracker } from "./session-tracker.js";
 import { SshSessionWatch, type ProcessSnapshot } from "./ssh-session-watch.js";
 
@@ -186,11 +187,14 @@ export class KeyLockerManager {
    * internal spawn — it does NOT route through `workspace_launch`'s executable blocklist, which exists to stop
    * the ASSISTANT from launching arbitrary shells) via `cmd /c start` and polls for the new
    * `ConsoleWindowClass` window (DF-1: `cmd /c start` is what forces a NEW console — see the impl note below).
-   * Returns `{ hwnd, shellPid }` where `shellPid = getWindowProcessId(hwnd)` = the SHELL (powershell) process
-   * that OWNS the console window (dogfood-verified: on Win11 the console window's owner is the shell, and
-   * conhost is its PARENT). Any ssh/sudo the human runs are CHILDREN of that shell, so `shellPid` is exactly
+   * Returns the spawn-captured `PaneAnchor` (S-pid gate E1): `shellPid = getWindowProcessId(hwnd)` = the
+   * SHELL (powershell) process that OWNS the console window (dogfood-verified: on Win11 the console window's
+   * owner is the shell, and conhost is its PARENT), and `shellStartTimeMs` = that shell's creation time,
+   * polled until NON-ZERO (a just-created process can transiently fail the time read; 0 is the doubt
+   * sentinel and can NEVER anchor — a deadline with no non-zero time is a `KeyLockerSpawnFailed`, exactly
+   * like a missing window). Any ssh/sudo the human runs are CHILDREN of that shell, so `shellPid` is exactly
    * the `sshDescendants` subtree root. The wiring fires
-   * `onLocalPaneLaunched(String(hwnd), shellPid)`. The console gets a UNIQUE window title (`dtm-locker-console-
+   * `onLocalPaneLaunched(String(hwnd), anchor)`. The console gets a UNIQUE window title (`dtm-locker-console-
    * <nonce>`) — the CLAIM key here (child.pid is the transient cmd.exe, not the conhost) AND the title-keyed
    * read/inject seams' resolver (`resolveTitleByHwnd` declines any pane whose title is not substring-unique, so
    * without this a second console (or a same-titled user window) would never autofill — Codex W-4a R3
@@ -199,7 +203,7 @@ export class KeyLockerManager {
    */
   async launchAnchoredConsole(
     o: { timeoutMs?: number; pollMs?: number } = {},
-  ): Promise<{ hwnd: bigint; shellPid: number; title: string }> {
+  ): Promise<{ anchor: PaneAnchor; title: string }> {
     const timeoutMs = o.timeoutMs ?? 8000;
     const pollMs = o.pollMs ?? 150;
     const title = `dtm-locker-console-${randomBytes(8).toString("hex")}`; // globally unique ⇒ unambiguous title read
@@ -278,7 +282,17 @@ export class KeyLockerManager {
       );
       if (fresh !== undefined) {
         const shellPid = getWindowProcessId(fresh.hwnd);
-        if (shellPid !== 0) return { hwnd: fresh.hwnd, shellPid, title };
+        if (shellPid !== 0) {
+          // S-pid E1: freeze the shell's creation time INTO the anchor at spawn — the identity the L2
+          // re-verify + the wt reuse check compare against. A just-created process can transiently read
+          // 0 (the doubt sentinel, which can never anchor) — keep polling within the existing deadline;
+          // the watch's own registration read (PR1) is bit-equal for the same process (immutable value).
+          const identityOf = this.opts.win32?.getProcessIdentity ?? getProcessIdentityByPid;
+          const shellStartTimeMs = identityOf(shellPid).processStartTimeMs;
+          if (shellStartTimeMs !== 0) {
+            return { anchor: { kind: "classic", hwnd: fresh.hwnd, shellPid, shellStartTimeMs }, title };
+          }
+        }
       }
       if (this.now() >= deadline) {
         // Best-effort leak sweep: cmd.exe has already exited (`child.kill()` is a no-op), so if OUR nonce-titled
@@ -296,7 +310,10 @@ export class KeyLockerManager {
             catch { /* best-effort */ }
           }
         }
-        throw new KeyLockerError("KeyLockerSpawnFailed", "anchored console window did not appear");
+        throw new KeyLockerError(
+          "KeyLockerSpawnFailed",
+          "anchored console did not become identifiable (no claimed window / owner pid / non-zero creation time)",
+        );
       }
       await new Promise((r) => setTimeout(r, pollMs));
     }

--- a/src/tools/key-locker-wiring.ts
+++ b/src/tools/key-locker-wiring.ts
@@ -24,7 +24,7 @@ import { BindingStore } from "../engine/key-locker/binding-store.js";
 import type { BindingUri } from "../engine/key-locker/binding.js";
 import { formatBindingUri } from "../engine/key-locker/binding.js";
 import { deriveBinding, type SessionContext } from "../engine/key-locker/command-derivation.js";
-import { assembleInjectTarget } from "../engine/key-locker/inject-target.js";
+import { assembleInjectTarget, type PaneAnchor } from "../engine/key-locker/inject-target.js";
 import { inject } from "../engine/key-locker/injector.js";
 import {
   KeyLockerCaptureDriver,
@@ -186,9 +186,14 @@ export class KeyLockerWiring {
    * Returns the pane's hwnd string so the caller can drive `sudo`/`ssh` into it.
    */
   async launchAndAnchorConsole(): Promise<{ paneId: string; title: string }> {
-    const { hwnd, shellPid, title } = await this.manager.launchAnchoredConsole();
-    const paneId = String(hwnd);
-    this.driver.onLocalPaneLaunched(paneId, shellPid);
+    const { anchor, title } = await this.manager.launchAnchoredConsole();
+    // S-pid E2: a classic pane's public paneId stays `String(hwnd)` decimal (zero back-compat break);
+    // the wt paneId form (`wt:<pid>:<startMs>`) lands with the WT launch path (PR3).
+    if (anchor.kind !== "classic" || anchor.hwnd === undefined) {
+      throw new KeyLockerError("KeyLockerSpawnFailed", "launch returned a non-classic anchor (unsupported here)");
+    }
+    const paneId = String(anchor.hwnd);
+    this.driver.onLocalPaneLaunched(paneId, anchor);
     return { paneId, title };
   }
 
@@ -291,7 +296,7 @@ export class KeyLockerWiring {
 
       capture: (id) => m.withHost((h) => h.capture(id)).then((r) => ({ captured: r.captured })),
       deleteSecret: (id) => m.withHost((h) => h.delete(id)).then(() => undefined),
-      injectPane: (paneId, binding, opaqueId, submit) => this.injectPane(paneId, binding, opaqueId, submit),
+      injectPane: (anchor, binding, opaqueId, submit) => this.injectPane(anchor, binding, opaqueId, submit),
       // gap4 confirm/offer: the W-3.5 secret-free `prompt` verb (label-only). `confirm` → fill vs decline.
       confirmInjection: (b) => m.withHost((h) => h.prompt("confirm", formatBindingUri(b))).then((c) => c === "autofill"),
       offerSave: (b) => m.withHost((h) => h.prompt("offer", formatBindingUri(b))),
@@ -307,11 +312,10 @@ export class KeyLockerWiring {
     };
   }
 
-  /** injectPane: hwnd-bound target (gap2 — assembleInjectTarget takes the exact hwnd) → L2 inject over the pipe. */
-  private async injectPane(paneId: string, binding: BindingUri, opaqueId: string, submit: boolean) {
-    let hwnd: bigint;
-    try { hwnd = BigInt(paneId); } catch { return { ok: false, code: "bad_target" } as const; }
-    const target = assembleInjectTarget(hwnd, submit);
+  /** injectPane: anchor-bound target (S-pid E4 — the driver passes the SPAWN-captured `PaneAnchor`, so
+   *  identity is never re-derived from the paneId string) → L2 inject over the pipe. */
+  private async injectPane(anchor: PaneAnchor, binding: BindingUri, opaqueId: string, submit: boolean) {
+    const target = assembleInjectTarget(anchor, submit);
     if (target === null) return { ok: false, code: "target_gone" } as const;
     return this.manager.withHost((h) => inject(h, binding, opaqueId, "pane", target));
   }

--- a/tests/e2e/key-locker.e2e.test.ts
+++ b/tests/e2e/key-locker.e2e.test.ts
@@ -75,7 +75,10 @@ describe("key-locker DPAPI store (-SelfTest, headless)", () => {
   // L2 §6 #4/#7/#8 (headless slice): the serving-pipe + ticket contract — valid fetch, single-use,
   // forged ticket refused, git context_mismatch refused, context match serves. SendInput (§6 #2/#3)
   // needs a live foreground conhost and is a separate live e2e; this proves the serving path.
-  it("serves a ticketed secret once and refuses replay / forged ticket / context mismatch (-SelfTestL2)", async () => {
+  // Since S-pid PR2, `-SelfTestL2` ALSO carries the E3b wire-parse pin (a `t` frame's
+  // shellPid/shellStartMs reconstruct through the SAME ParseInjectTarget the live HandleInject uses)
+  // + the §4 FILETIME sign-extension pin — asserted here as `wireParse:true`.
+  it("serves a ticketed secret once and refuses replay / forged ticket / context mismatch (-SelfTestL2 + S-pid wire-parse pin)", async () => {
     expect(existsSync(HELPER_EXE)).toBe(true);
     const storeDir = freshStoreDir();
     dirs.push(storeDir);
@@ -89,7 +92,7 @@ describe("key-locker DPAPI store (-SelfTest, headless)", () => {
     });
 
     expect(code).toBe(0);
-    expect(JSON.parse(stdout.trim())).toEqual({ ok: true });
+    expect(JSON.parse(stdout.trim())).toEqual({ ok: true, serving: true, wireParse: true });
 
     // The serving path decrypts transiently in-process; the at-rest store never holds plaintext.
     const storeJson = readFileSync(join(storeDir, "store.json"), "utf8");

--- a/tests/unit/key-locker-anchoring.test.ts
+++ b/tests/unit/key-locker-anchoring.test.ts
@@ -28,6 +28,7 @@ vi.mock(import("../../src/tools/terminal.js"), async (importOriginal) => {
 });
 
 import { KeyLockerManager } from "../../src/engine/key-locker/key-locker-manager.js";
+import type { PaneAnchor } from "../../src/engine/key-locker/inject-target.js";
 import { KeyLockerWiring } from "../../src/tools/key-locker-wiring.js";
 import { maybeAdvisory } from "../../src/tools/_advisory.js";
 
@@ -38,10 +39,13 @@ class FakeWiringManager extends KeyLockerManager {
   constructor(dir: string) { super({ storeDir: dir }); }
   override isConsentAccepted(): boolean { return this.consent; }
   override isDisabled(): boolean { return false; }
-  override async launchAnchoredConsole(): Promise<{ hwnd: bigint; shellPid: number; title: string }> {
+  override async launchAnchoredConsole(): Promise<{ anchor: PaneAnchor; title: string }> {
     const hwnd = this.hwndSeq++;
     liveHwnds.add(hwnd); // a freshly launched console is live
-    return { hwnd, shellPid: Number(hwnd) + 1, title: `dtm-locker-console-${hwnd}` };
+    return {
+      anchor: { kind: "classic", hwnd, shellPid: Number(hwnd) + 1, shellStartTimeMs: 10 },
+      title: `dtm-locker-console-${hwnd}`,
+    };
   }
 }
 

--- a/tests/unit/key-locker-capture-driver.test.ts
+++ b/tests/unit/key-locker-capture-driver.test.ts
@@ -24,6 +24,7 @@ import {
   type CaptureDriverDeps,
   type PromptVerdict,
 } from "../../src/engine/key-locker/key-locker-capture-driver.js";
+import type { PaneAnchor } from "../../src/engine/key-locker/inject-target.js";
 import { SessionTracker, type SessionFrame } from "../../src/engine/key-locker/session-tracker.js";
 import { SshSessionWatch, type ProcessSnapshot } from "../../src/engine/key-locker/ssh-session-watch.js";
 import type { BindingUri } from "../../src/engine/key-locker/binding.js";
@@ -47,6 +48,10 @@ function snapshotOf(procs: Record<number, Proc>): ProcessSnapshot {
 }
 
 const CONSOLE_INJECT_OK = (verified = true): InjectResult => ({ ok: true, injector: "console", verified });
+/** S-pid E4: `onLocalPaneLaunched` takes the SPAWN-captured PaneAnchor (mechanical call-shape update —
+ *  the shell pid rides `anchor.shellPid`; hwnd/time values are opaque to the driver's own logic). */
+const anchorOf = (shellPid: number): PaneAnchor =>
+  ({ kind: "classic", hwnd: BigInt(shellPid), shellPid, shellStartTimeMs: 10 });
 const PROMPT = (isCredentialPrompt: boolean): PromptVerdict => ({ isCredentialPrompt, tail: "", stillHiddenPrompt: false });
 const sshProc = (parent: number, host: string, start: number): Proc =>
   ({ parent, name: "ssh", start, argv: ["ssh", `deploy@${host}`] });
@@ -115,7 +120,7 @@ const shellTree = (extra: Record<number, Proc> = {}): Record<number, Proc> => ({
 describe("KeyLockerCaptureDriver — W1 anchoring (launched panes only, P1-B)", () => {
   it("a LAUNCHED pane is anchored known-local + watched; a credential dispatch arms", () => {
     const h = makeHarness({}, shellTree());
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     expect(h.tracker.get("pane-1")).toEqual({ execHost: "localhost", isRemote: false });
     expect(h.watch.isWatching("pane-1")).toBe(true);
 
@@ -134,13 +139,13 @@ describe("KeyLockerCaptureDriver — W1 anchoring (launched panes only, P1-B)", 
 
   it("cwd from launch is anchored (for L1's configured-git-remote resolution)", () => {
     const h = makeHarness({}, shellTree());
-    h.driver.onLocalPaneLaunched("pane-1", 1000, "C:/work");
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000), "C:/work");
     expect(h.tracker.get("pane-1")).toEqual({ execHost: "localhost", isRemote: false, cwd: "C:/work" });
   });
 
   it("the anchored localhost frame is the one the loop derives from", async () => {
     const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)) }, shellTree());
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.onDispatch("pane-1", "sudo apt update");
     await h.driver.poll("pane-1");
     expect(h.deriveCalls.at(-1)?.session).toEqual({ execHost: "localhost", isRemote: false });
@@ -150,21 +155,21 @@ describe("KeyLockerCaptureDriver — W1 anchoring (launched panes only, P1-B)", 
 describe("KeyLockerCaptureDriver — arm pre-filter (looksLikeCredential, OQ-W-3)", () => {
   it("a non-credential command (`ls`) does NOT arm", () => {
     const h = makeHarness({}, shellTree());
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.onDispatch("pane-1", "ls -la");
     expect(h.driver.armedPaneIds()).toEqual([]);
   });
 
   it("`sudo`/`doas`/`su` arm; a leading env-assignment is skipped (`LC_ALL=C sudo …` still arms)", () => {
     const h = makeHarness({}, shellTree());
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.onDispatch("pane-1", "LC_ALL=C sudo apt update");
     expect(h.driver.armedPaneIds()).toEqual(["pane-1"]);
   });
 
   it("an UNKNOWN pane (sunk by reconcile) does not arm even for a credential command", () => {
     const h = makeHarness({}, shellTree());
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.tracker.markUnknown("pane-1"); // simulate a prior sink
     h.driver.onDispatch("pane-1", "sudo apt update");
     expect(h.driver.armedPaneIds()).toEqual([]);
@@ -172,7 +177,7 @@ describe("KeyLockerCaptureDriver — arm pre-filter (looksLikeCredential, OQ-W-3
 
   it("a conditional ssh that recordDispatch SINKS to UNKNOWN ⇒ decline (Codex R5 P1)", async () => {
     const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)) }, shellTree());
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     // `false && ssh host` is a conditional (skipped) ssh → recordDispatch markUnknowns the pane; the pre-record
     // frozen still looks local, so the post-record gate must decline rather than arm the skipped ssh binding.
     h.driver.onDispatch("pane-1", "false && ssh deploy@host-a ; sudo -v");
@@ -189,7 +194,7 @@ describe("KeyLockerCaptureDriver — fire-AFTER-delivery correlation (§0-CORR.2
     // proves pid 2000 is THIS dispatch's child → the W-2b scan skips it (no mis-flag) → the frame is pushed
     // and 2000 is registered synchronously in the SAME onDispatch turn.
     const h = makeHarness({}, shellTree({ 2000: sshProc(1000, "host-a", 20) }));
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.onDispatch("pane-1", "ssh deploy@host-a");
     expect(h.tracker.get("pane-1")).toEqual({ execHost: "host-a", isRemote: true }); // NOT markUnknown'd
     expect(h.tracker.remoteDepth("pane-1")).toBe(1);
@@ -205,7 +210,7 @@ describe("KeyLockerCaptureDriver — fire-AFTER-delivery correlation (§0-CORR.2
     // which is exactly why onDispatch passes the exempt. Here we drive tickWatch on a pane with a live but
     // UNregistered interactive ssh — the W-2b scan markUnknowns it (the shared-pane disclosure guard).
     const h = makeHarness({}, shellTree({ 2000: sshProc(1000, "host-a", 20) }));
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.tickWatch(); // no exempt — the unregistered interactive ssh trips the W-2b scan
     expect(h.tracker.get("pane-1")).toEqual({ unknown: true });
   });
@@ -215,7 +220,7 @@ describe("KeyLockerCaptureDriver — fire-AFTER-delivery correlation (§0-CORR.2
     // drove an in-bound ssh into. `sudo x` has no interactive-ssh host ⇒ NO exempt ⇒ the W-2b scan flags the
     // user's ssh ⇒ markUnknown ⇒ decline.
     const h = makeHarness({}, shellTree({ 2000: { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "admin@secret-host"] } }));
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.onDispatch("pane-1", "sudo x");
     expect(h.tracker.get("pane-1")).toEqual({ unknown: true }); // sunk — LOCAL secret must not reach remote
     expect(h.driver.armedPaneIds()).toEqual([]);
@@ -226,7 +231,7 @@ describe("KeyLockerCaptureDriver — fire-AFTER-delivery correlation (§0-CORR.2
     // the assistant then dispatches `ssh deploy@host-a` spawning a NEW child 2000. Only 2000 is exempt — the
     // user's 1500 is a DIFFERENT pid the W-2b scan STILL flags ⇒ markUnknown (host is not identity).
     const h = makeHarness({}, shellTree({ 1500: sshProc(1000, "host-a", 15) }));
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.tickWatch(); // fold the pre-existing 1500 into the baseline (and it markUnknowns — user ssh)
     h.tracker.beginLocalSession("pane-1"); // re-anchor (the user pane is shared; simulate the driver re-seeing local)
     // now the assistant dispatches ssh host-a → new child 2000 appears alongside the user's 1500
@@ -240,7 +245,7 @@ describe("KeyLockerCaptureDriver — fire-AFTER-delivery correlation (§0-CORR.2
 
   it("a straggler child (not visible at dispatch) is correlated on a later tick (fire-after slow-spawn backstop)", () => {
     const h = makeHarness({}, shellTree());
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // child NOT visible yet → pending correlation
     // the pane pushed host-a but has no registered child; a tick before the child appears markUnknowns (fail-safe)
     // — but here the child appears, then a tick correlates it (register), and the frame survives.
@@ -252,7 +257,7 @@ describe("KeyLockerCaptureDriver — fire-AFTER-delivery correlation (§0-CORR.2
 
   it("a straggler that never appears before a tick ⇒ the unwatched frame markUnknowns (fail-safe OQ-W-9 residual)", () => {
     const h = makeHarness({}, shellTree());
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // push, but the child has NOT spawned yet
     h.driver.tickWatch(); // child invisible ⇒ nothing to register ⇒ backstop markUnknowns (safe decline)
     expect(h.tracker.get("pane-1")).toEqual({ unknown: true }); // declines, NEVER wrong-targets
@@ -262,7 +267,7 @@ describe("KeyLockerCaptureDriver — fire-AFTER-delivery correlation (§0-CORR.2
     // The just-dispatched ssh's argv is unreadable (elevated/cross-user), so the exempt delta cannot host-match
     // it → NO exempt → the W-2b scan flags the unreadable ssh descendant → markUnknown.
     const h = makeHarness({}, shellTree({ 2000: { parent: 1000, name: "ssh", start: 20 /* no argv → null */ } }));
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.onDispatch("pane-1", "ssh deploy@host-a");
     expect(h.tracker.get("pane-1")).toEqual({ unknown: true });
   });
@@ -274,7 +279,7 @@ describe("KeyLockerCaptureDriver — fire-AFTER-delivery correlation (§0-CORR.2
       2000: sshProc(1000, "host-a", 20),
       2001: { parent: 1000, name: "ssh", start: 21, argv: ["ssh", "admin@host-a"] },
     }));
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.onDispatch("pane-1", "ssh deploy@host-a");
     expect(h.tracker.get("pane-1")).toEqual({ unknown: true });
   });
@@ -284,7 +289,7 @@ describe("KeyLockerCaptureDriver — fire-AFTER-delivery correlation (§0-CORR.2
     // spawns; only host-a is registered. Killing the TUNNEL must not pop the frame; killing the LOGIN must.
     const tunnel: Proc = { parent: 1000, name: "ssh", start: 15, argv: ["ssh", "-fNL", "9000", "host-t"] };
     const h = makeHarness({}, shellTree({ 1500: tunnel, 2000: sshProc(1000, "host-a", 20) }));
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // exempt 2000 (host-a), tunnel host is null ≠ host-a
     expect(h.tracker.get("pane-1")).toEqual({ execHost: "host-a", isRemote: true });
 
@@ -305,7 +310,7 @@ describe("KeyLockerCaptureDriver — derive-then-record ordering (§3.1 point 1)
     // pushes host-a for SUBSEQUENT commands. (A NESTED `ssh @host-b` from host-a is a different case: the module
     // deliberately declines it — depth≥2 is an unobservable inner login → markUnknown.)
     const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)) }, shellTree({ 2000: sshProc(1000, "host-a", 20) }));
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // frozen = localhost (pre-push); records host-a after
     expect(h.tracker.get("pane-1")).toEqual({ execHost: "host-a", isRemote: true }); // post-push frame
     await h.driver.poll("pane-1"); // the loop derives the armed command from the FROZEN pre-push frame
@@ -317,7 +322,7 @@ describe("KeyLockerCaptureDriver — derive-then-record ordering (§3.1 point 1)
 describe("KeyLockerCaptureDriver — RECONCILE-then-FREEZE (W3, P1-A)", () => {
   it("reconcile-at-dispatch pops a dead ssh so a post-exit `sudo x` freezes localhost, NOT stale host-a", async () => {
     const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)) }, shellTree({ 2000: sshProc(1000, "host-a", 20) }));
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // register host-a (child present)
     expect(h.tracker.remoteDepth("pane-1")).toBe(1);
 
@@ -332,7 +337,7 @@ describe("KeyLockerCaptureDriver — RECONCILE-then-FREEZE (W3, P1-A)", () => {
 
   it("a remote `sudo x` whose ssh session POPS to local between arm and fill DECLINES (Opus R2 P2 — no cross-host disclosure)", async () => {
     const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)) }, shellTree({ 2000: sshProc(1000, "host-a", 20) }));
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // register host-a
     await h.driver.poll("pane-1"); // this poll's prompt fires a loop for the ssh; ignore its outcome
 
@@ -361,7 +366,7 @@ describe("KeyLockerCaptureDriver — RECONCILE-then-FREEZE (W3, P1-A)", () => {
     // The legitimate remote fill: no external change, so live == expected == host-a → the loop derives the
     // armed command from the FROZEN host-a frame (the freeze still gives a deterministic derive).
     const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)) }, shellTree({ 2000: sshProc(1000, "host-a", 20) }));
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // register host-a
     await h.driver.poll("pane-1"); // ignore the ssh login loop
     h.driver.onDispatch("pane-1", "sudo x"); // frozen = host-a, expected = host-a (2000 still alive)
@@ -378,7 +383,7 @@ describe("KeyLockerCaptureDriver — loopPhase gate (§0-CORR.3)", () => {
     let releaseCapture!: () => void;
     const capture = vi.fn(() => new Promise<{ captured: boolean }>((res) => { releaseCapture = () => res({ captured: true }); }));
     const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)), capture }, shellTree());
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.onDispatch("pane-1", "sudo x"); // arm
 
     // start the loop; it BLOCKS in capture() → loopPhase = pre-landed (the shell is at the prompt)
@@ -400,7 +405,7 @@ describe("KeyLockerCaptureDriver — loopPhase gate (§0-CORR.3)", () => {
     let releaseOffer!: (c: SaveChoice) => void;
     const offerSave = vi.fn(() => new Promise<SaveChoice>((res) => { releaseOffer = res; }));
     const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)), offerSave }, shellTree({ 2000: sshProc(1000, "host-a", 20) }));
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // Mode-B login, arms host-a; child registered
     const pLoop = h.driver.poll("pane-1");               // runs the loop; awaitLanded(Mode B) accepts → post-landed → blocks in offerSave
     await new Promise((r) => setTimeout(r, 0));
@@ -423,7 +428,7 @@ describe("KeyLockerCaptureDriver — loopPhase gate (§0-CORR.3)", () => {
     let releaseRun!: () => void;
     const runToExit = vi.fn((): Promise<ExitCompletion> => new Promise((res) => { releaseRun = () => res({ reason: "exited", exitCode: 0 }); }));
     const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)), runToExit }, shellTree());
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.onDispatch("pane-1", "sudo x"); // Mode-A one-shot, arms
     const pLoop = h.driver.poll("pane-1");    // loop blocks in runToExit (awaitLanded Mode A) — still pre-landed
     await new Promise((r) => setTimeout(r, 0));
@@ -440,7 +445,7 @@ describe("KeyLockerCaptureDriver — a pane sunk to UNKNOWN after arming is not 
     // THE disclosure the dispatch-time reconcile cannot catch: the sink happens AFTER the freeze. Without the
     // poll's live-session re-check the loop would fill the LOCAL sudo secret into the now-REMOTE pane's prompt.
     const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)) }, shellTree());
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.onDispatch("pane-1", "sudo x"); // armed, frozen = { localhost }
     expect(h.driver.armedPaneIds()).toEqual(["pane-1"]);
 
@@ -463,7 +468,7 @@ describe("KeyLockerCaptureDriver — a pane sunk to UNKNOWN after arming is not 
     // reconcile, `tracker.get()` still reads the STALE arm-time localhost session (no tickWatch has run to
     // markUnknown it), so the live-check would PASS and fill the local secret into the now-remote prompt.
     const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)) }, shellTree());
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.onDispatch("pane-1", "sudo x"); // armed, expected = { localhost }
     // the USER hand-ssh's in — but NO tickWatch fires. The tracker is still stale-local until the poll reconciles.
     h.setTree(shellTree({ 2000: { parent: 1000, name: "ssh", start: 20, argv: ["ssh", "admin@secret-host"] } }));
@@ -481,7 +486,7 @@ describe("KeyLockerCaptureDriver — a pane sunk to UNKNOWN after arming is not 
     let releaseCapture!: () => void;
     const capture = vi.fn(() => new Promise<{ captured: boolean }>((res) => { releaseCapture = () => res({ captured: true }); }));
     const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)), capture }, shellTree({ 2000: sshProc(1000, "host-a", 20) }));
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // register host-a (child present) — no poll needed
     h.driver.onDispatch("pane-1", "sudo x");             // remote sudo, frozen = expected = host-a; re-arms
 
@@ -507,7 +512,7 @@ describe("KeyLockerCaptureDriver — a pane sunk to UNKNOWN after arming is not 
     let releasePrompt!: (v: PromptVerdict) => void;
     const readPromptTail = vi.fn(() => new Promise<PromptVerdict>((res) => { releasePrompt = res; }));
     const h = makeHarness({ readPromptTail }, shellTree());
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.onDispatch("pane-1", "sudo x"); // armed on localhost
     const p = h.driver.poll("pane-1");         // awaits the blocked prompt read
     await new Promise((r) => setTimeout(r, 0));
@@ -524,7 +529,7 @@ describe("KeyLockerCaptureDriver — single-flight + stale-arm guards", () => {
     let releasePrompt!: (v: PromptVerdict) => void;
     const readPromptTail = vi.fn(() => new Promise<PromptVerdict>((res) => { releasePrompt = res; }));
     const h = makeHarness({ readPromptTail }, shellTree());
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.onDispatch("pane-1", "sudo x");
 
     const p1 = h.driver.poll("pane-1");             // sets pollBusy, awaits the (blocked) prompt read
@@ -542,7 +547,7 @@ describe("KeyLockerCaptureDriver — single-flight + stale-arm guards", () => {
     let releasePrompt!: (v: PromptVerdict) => void;
     const readPromptTail = vi.fn(() => new Promise<PromptVerdict>((res) => { releasePrompt = res; }));
     const h = makeHarness({ readPromptTail }, shellTree());
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.onDispatch("pane-1", "sudo x"); // arm A (sudo, cached — no prompt of its own)
 
     const pA = h.driver.poll("pane-1");        // captures armed=A(sudo), awaits the blocked prompt read
@@ -562,7 +567,7 @@ describe("KeyLockerCaptureDriver — poll lifecycle + outcome pass-through", () 
     const verdicts = [PROMPT(false), PROMPT(false), PROMPT(true)];
     let i = 0;
     const h = makeHarness({ readPromptTail: vi.fn(async () => verdicts[Math.min(i++, verdicts.length - 1)]) }, shellTree());
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.onDispatch("pane-1", "sudo x");
 
     expect((await h.driver.poll("pane-1")).status).toBe("polling");
@@ -577,7 +582,7 @@ describe("KeyLockerCaptureDriver — poll lifecycle + outcome pass-through", () 
       resolveBinding: vi.fn(async () => ({ opaqueId: "stored-1" })), // MATCH
       confirmPolicyFor: vi.fn(() => false),
     }, shellTree());
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.onDispatch("pane-1", "sudo x");
     const r = await h.driver.poll("pane-1");
     expect(r).toEqual({ status: "filled", outcome: { kind: "filled_from_store", verified: true } satisfies CaptureLoopOutcome });
@@ -590,7 +595,7 @@ describe("KeyLockerCaptureDriver — poll lifecycle + outcome pass-through", () 
       confirmPolicyFor: vi.fn(() => true),
       confirmInjection: vi.fn(async () => false),
     }, shellTree());
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.onDispatch("pane-1", "sudo x");
     const r = await h.driver.poll("pane-1");
     expect(r).toEqual({ status: "filled", outcome: { kind: "confirm_rejected" } satisfies CaptureLoopOutcome });
@@ -599,7 +604,7 @@ describe("KeyLockerCaptureDriver — poll lifecycle + outcome pass-through", () 
 
   it("a NO-MATCH capture→inject→landed→[Save] flows through as { status: 'filled', outcome: saved }", async () => {
     const h = makeHarness({ readPromptTail: vi.fn(async () => PROMPT(true)) }, shellTree());
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.onDispatch("pane-1", "sudo x");
     const r = await h.driver.poll("pane-1");
     expect(r).toEqual({ status: "filled", outcome: { kind: "saved", verified: true } satisfies CaptureLoopOutcome });
@@ -611,7 +616,7 @@ describe("KeyLockerCaptureDriver — poll lifecycle + outcome pass-through", () 
       readPromptTail: vi.fn(async () => PROMPT(true)),
       capture: vi.fn(async () => ({ captured: false })),
     }, shellTree());
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.onDispatch("pane-1", "sudo x");
     const r = await h.driver.poll("pane-1");
     expect(r).toEqual({ status: "filled", outcome: { kind: "capture_cancelled" } satisfies CaptureLoopOutcome });
@@ -622,7 +627,7 @@ describe("KeyLockerCaptureDriver — poll lifecycle + outcome pass-through", () 
       readPromptTail: vi.fn(async () => PROMPT(true)),
       runToExit: vi.fn(async () => ({ reason: "timeout" })), // Mode A not exit-0
     }, shellTree());
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.driver.onDispatch("pane-1", "sudo x");
     const r = await h.driver.poll("pane-1");
     expect(r.status).toBe("filled");
@@ -632,7 +637,7 @@ describe("KeyLockerCaptureDriver — poll lifecycle + outcome pass-through", () 
 
   it("poller lifetime elapses with no prompt ⇒ timed_out + disarm (OQ-W-2)", async () => {
     const h = makeHarness({ pollTimeoutMs: 5000 }, shellTree());
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     h.clock.ms = 1000;
     h.driver.onDispatch("pane-1", "sudo x"); // armedAt = 1000
     h.clock.ms = 7000; // > 1000 + 5000
@@ -642,7 +647,7 @@ describe("KeyLockerCaptureDriver — poll lifecycle + outcome pass-through", () 
 
   it("poll on an idle / unarmed pane ⇒ idle", async () => {
     const h = makeHarness({}, shellTree());
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     expect((await h.driver.poll("pane-1")).status).toBe("idle");
     expect((await h.driver.poll("never-launched")).status).toBe("idle");
   });
@@ -658,8 +663,8 @@ describe("KeyLockerCaptureDriver — multi-pane correlation isolation", () => {
 
   it("another pane's onDispatch does NOT markUnknown pane-1's registered ssh frame", () => {
     const h = makeHarness({}, twoShells({ 2000: sshProc(1000, "host-a", 20) }));
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
-    h.driver.onLocalPaneLaunched("pane-2", 1100);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
+    h.driver.onLocalPaneLaunched("pane-2", anchorOf(1100));
     h.driver.onDispatch("pane-1", "ssh deploy@host-a"); // pane-1 registers host-a (child present)
     expect(h.tracker.get("pane-1")).toEqual({ execHost: "host-a", isRemote: true });
     h.driver.onDispatch("pane-2", "ls");                // pane-2's tick reconciles ALL panes
@@ -670,7 +675,7 @@ describe("KeyLockerCaptureDriver — multi-pane correlation isolation", () => {
 describe("KeyLockerCaptureDriver — W2 close atomicity", () => {
   it("onPaneClosed unwatches + forgets the pane (same turn)", () => {
     const h = makeHarness({}, shellTree());
-    h.driver.onLocalPaneLaunched("pane-1", 1000);
+    h.driver.onLocalPaneLaunched("pane-1", anchorOf(1000));
     expect(h.watch.isWatching("pane-1")).toBe(true);
     h.driver.onPaneClosed("pane-1");
     expect(h.watch.isWatching("pane-1")).toBe(false);

--- a/tests/unit/key-locker-inject-target.test.ts
+++ b/tests/unit/key-locker-inject-target.test.ts
@@ -1,23 +1,31 @@
-// ADR-014 v2 R3 Key Locker — L3 §4 InjectTarget assembly. Two concerns:
+// ADR-014 R3 L3 §4 InjectTarget assembly, re-based on the S-pid PaneAnchor (S-pid gate §1/E3/E4).
+// Three concerns:
 //   1. `titleFingerprint` is byte-identical to the C# locker's `Injection.cs` `TitleFp` — pinned
 //      against expected hex computed INDEPENDENTLY with .NET (`[SHA256]::HashData(UTF8.GetBytes(t))`,
 //      lowercased hex), so a divergence in the algorithm/encoding is caught here rather than as a
 //      `target_mismatch` abort at inject time.
-//   2. `assembleInjectTarget` reads consolePid/titleFp via win32 and declines (null) on a gone window.
-// Plan: desktop-touch-mcp-internal@<plan>:docs/adr-014-v2-r3-l3-capture-plan.md (§4)
+//   2. classic: `assembleInjectTarget` reads consolePid/titleFp via win32 (decline (null) on a gone
+//      window) AND carries the anchor's shellPid/shellStartMs VERBATIM onto the wire (the locker's
+//      PRIMARY pid+creation-time re-verify).
+//   3. wt: no window-derived field exists; the early decline requires the live creation time to
+//      EXACTLY equal the anchor's (dead pid / reused pid / transient-0 all decline).
+// Plan: desktop-touch-mcp-internal:docs/adr-014-v2-r3x-s-pid-gate.md (E3/E4)
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 const getWindowProcessId = vi.fn<(hwnd: unknown) => number>();
 const getWindowTitleW = vi.fn<(hwnd: unknown) => string>();
+const getProcessIdentityByPid = vi.fn<(pid: number) => { pid: number; processName: string; processStartTimeMs: number }>();
 
 vi.mock("../../src/engine/win32.js", () => ({
   getWindowProcessId: (hwnd: unknown) => getWindowProcessId(hwnd),
   getWindowTitleW: (hwnd: unknown) => getWindowTitleW(hwnd),
+  getProcessIdentityByPid: (pid: number) => getProcessIdentityByPid(pid),
 }));
 
 const { titleFingerprint, assembleInjectTarget } = await import(
   "../../src/engine/key-locker/inject-target.js"
 );
+type PaneAnchor = import("../../src/engine/key-locker/inject-target.js").PaneAnchor;
 
 // Expected values computed independently with .NET (the C# side):
 //   [Convert]::ToHexString([SHA256]::HashData([Text.Encoding]::UTF8.GetBytes($t))).ToLowerInvariant()
@@ -42,38 +50,90 @@ describe("titleFingerprint — byte-identical to C# Injection.cs TitleFp", () =>
   });
 });
 
-describe("assembleInjectTarget — §4 pane target", () => {
+const classicAnchor = (o: Partial<PaneAnchor> = {}): PaneAnchor => ({
+  kind: "classic",
+  hwnd: 0x1234n,
+  shellPid: 4242,
+  shellStartTimeMs: 13322426700123,
+  ...o,
+});
+const wtAnchor = (o: Partial<PaneAnchor> = {}): PaneAnchor => ({
+  kind: "wt",
+  shellPid: 5150,
+  shellStartTimeMs: 13322426700456,
+  ...o,
+});
+
+describe("assembleInjectTarget — classic pane target (S-pid E4)", () => {
   beforeEach(() => {
     getWindowProcessId.mockReset();
     getWindowTitleW.mockReset();
+    getProcessIdentityByPid.mockReset();
   });
 
-  it("assembles {hwnd(decimal), consolePid, titleFp} from the SAME win32 reads the locker re-verifies", () => {
+  it("assembles {hwnd(decimal), consolePid, titleFp} from the SAME win32 reads the locker re-verifies, plus the anchor's shellPid/shellStartMs verbatim", () => {
     getWindowProcessId.mockReturnValue(4242);
     getWindowTitleW.mockReturnValue("Administrator: Windows PowerShell");
-    const t = assembleInjectTarget(0x1234n, false);
+    const t = assembleInjectTarget(classicAnchor(), false);
     expect(t).toEqual({
       hwnd: "4660", // 0x1234 in decimal — the InjectTarget.hwnd contract
       consolePid: 4242,
       titleFp: "d26d14f0263a47f3a31d10eb995fa1d073a63eb79c6f7502e3bd8902cd7ea13f",
+      shellPid: 4242,
+      shellStartMs: 13322426700123, // carried from the SPAWN-captured anchor, never re-derived
     });
-    // consolePid + titleFp both read from the SAME hwnd the caller passed.
+    // consolePid + titleFp both read from the SAME hwnd the anchor carries.
     expect(getWindowProcessId).toHaveBeenCalledWith(0x1234n);
     expect(getWindowTitleW).toHaveBeenCalledWith(0x1234n);
+    // classic never consults the live process identity — the C# re-verify owns the pid+time check.
+    expect(getProcessIdentityByPid).not.toHaveBeenCalled();
   });
 
   it("emits submit:true only when requested (optional field otherwise omitted)", () => {
     getWindowProcessId.mockReturnValue(100);
     getWindowTitleW.mockReturnValue("t");
-    expect(assembleInjectTarget(1n, true)).toMatchObject({ submit: true });
-    expect(assembleInjectTarget(1n, false)).not.toHaveProperty("submit");
+    expect(assembleInjectTarget(classicAnchor({ hwnd: 1n }), true)).toMatchObject({ submit: true });
+    expect(assembleInjectTarget(classicAnchor({ hwnd: 1n }), false)).not.toHaveProperty("submit");
   });
 
   it("declines (null) when the window is gone / hwnd invalid (getWindowProcessId === 0)", () => {
     getWindowProcessId.mockReturnValue(0);
     getWindowTitleW.mockReturnValue("stale");
-    expect(assembleInjectTarget(0xdeadn, true)).toBeNull();
+    expect(assembleInjectTarget(classicAnchor({ hwnd: 0xdeadn }), true)).toBeNull();
     // A gone window must NOT round-trip a garbage target (sha256("") titleFp) to the locker.
     expect(getWindowTitleW).not.toHaveBeenCalled();
+  });
+
+  it("declines (null) on a malformed classic anchor with no hwnd", () => {
+    expect(assembleInjectTarget(classicAnchor({ hwnd: undefined }), true)).toBeNull();
+    expect(getWindowProcessId).not.toHaveBeenCalled();
+  });
+});
+
+describe("assembleInjectTarget — wt pane target (S-pid E4: pid+time only)", () => {
+  beforeEach(() => {
+    getWindowProcessId.mockReset();
+    getWindowTitleW.mockReset();
+    getProcessIdentityByPid.mockReset();
+  });
+
+  it("assembles {shellPid, shellStartMs} with NO window-derived field when the live identity matches the anchor", () => {
+    getProcessIdentityByPid.mockReturnValue({ pid: 5150, processName: "powershell", processStartTimeMs: 13322426700456 });
+    const t = assembleInjectTarget(wtAnchor(), true);
+    expect(t).toEqual({ shellPid: 5150, shellStartMs: 13322426700456, submit: true });
+    expect(getProcessIdentityByPid).toHaveBeenCalledWith(5150);
+    // Nothing window-derived exists to read for a wt pane.
+    expect(getWindowProcessId).not.toHaveBeenCalled();
+    expect(getWindowTitleW).not.toHaveBeenCalled();
+  });
+
+  it("declines (null) when the shell is gone (identity reads 0 — the doubt sentinel)", () => {
+    getProcessIdentityByPid.mockReturnValue({ pid: 5150, processName: "", processStartTimeMs: 0 });
+    expect(assembleInjectTarget(wtAnchor(), false)).toBeNull();
+  });
+
+  it("declines (null) when the pid was REUSED (a DIFFERENT non-zero creation time — exact equality, no tolerance)", () => {
+    getProcessIdentityByPid.mockReturnValue({ pid: 5150, processName: "powershell", processStartTimeMs: 13322426700457 });
+    expect(assembleInjectTarget(wtAnchor(), false)).toBeNull();
   });
 });

--- a/tests/unit/key-locker-injector.test.ts
+++ b/tests/unit/key-locker-injector.test.ts
@@ -13,7 +13,7 @@ import {
 import type { BindingUri } from "../../src/engine/key-locker/binding.js";
 import type { KeyLockerHost } from "../../src/engine/key-locker-host.js";
 
-const target: InjectTarget = { hwnd: "12345", consolePid: 4242, titleFp: "abc", submit: true };
+const target: InjectTarget = { hwnd: "12345", consolePid: 4242, titleFp: "abc", shellPid: 4242, shellStartMs: 13322426700123, submit: true };
 
 describe("selectInjector (§1 selection rule) — total, typed rejects", () => {
   const cases: Array<[BindingUri["scheme"], InjectChannel, string]> = [

--- a/tools/key-locker/Injection.cs
+++ b/tools/key-locker/Injection.cs
@@ -22,12 +22,16 @@ using System.Text.Json;
 // Global namespace (matches Program.cs's `internal static class KeyLocker`; a `namespace KeyLocker`
 // here would collide with that class name).
 
-/// The dedicated-console target of an injection, parsed off the `inject` frame's `t` field (§2.1).
+/// The anchored-pane target of an injection, parsed off the `inject` frame's `t` field (§2.1),
+/// re-based on the S-pid identity (S-pid gate E3). `ShellPid`/`ShellStartMs` are the PRIMARY identity
+/// for BOTH hosts: the spawn-tracked shell pid + its creation time (ms since 1601 = floor(FILETIME/10000),
+/// EXACTLY the Node `process.rs filetime_to_ms` formula — gate §4). The window trio is CLASSIC-ONLY:
 /// `ConsolePid` is the WINDOW-OWNING pid (`GetWindowThreadProcessId(hwnd)`) — L3 sends
 /// `getWindowProcessId(hwnd)` and this side re-reads the same API on the same hwnd, so it matches by
-/// construction (not asserted to be a specific conhost-vs-shell process). DF-5 also uses `ConsolePid`
-/// as the `AttachConsole` target — the same window-owning pid identifies the console to attach to.
-internal readonly record struct InjectTarget(nint Hwnd, uint ConsolePid, string TitleFp, bool Submit);
+/// construction. Classic keeps `AttachConsole(ConsolePid)` byte-identical; a wt pane has NO per-pane
+/// window (Hwnd == 0) and attaches by `ShellPid`.
+internal readonly record struct InjectTarget(
+    nint Hwnd, uint ConsolePid, string TitleFp, bool Submit, uint ShellPid, long ShellStartMs);
 
 /// The abort reasons the re-verify predicate can raise (§2.2); null = passed.
 internal static class InjectAbort
@@ -101,19 +105,87 @@ internal static class Win32Input
     [DllImport("user32.dll", CharSet = CharSet.Unicode)] private static extern int GetWindowText(nint hWnd, StringBuilder lpString, int nMaxCount);
     [DllImport("user32.dll")] private static extern int GetWindowTextLength(nint hWnd);
 
-    /// Re-verify the target IDENTITY at the injection instant. Returns an InjectAbort code on any
-    /// mismatch, or null if all predicates pass. POSITIVE allowlist: the window MUST be the classic
-    /// console class AND owned by the tracked window-owning pid — anything else is `target_multiplexed`.
+    // S-pid §4: the creation-time identity read. PROCESS_QUERY_LIMITED_INFORMATION works cross-session
+    // for same-user processes; an unopenable pid fails CLOSED (a failed measurement is never the safe
+    // result — seed §4c).
+    private const uint PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern nint OpenProcess(uint dwDesiredAccess, bool bInheritHandle, uint dwProcessId);
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern bool GetProcessTimes(nint hProcess, out FILETIME lpCreationTime, out FILETIME lpExitTime, out FILETIME lpKernelTime, out FILETIME lpUserTime);
+    // LOCAL FILETIME with UNSIGNED fields (S-pid gate §4, Opus P1-2): the BCL
+    // System.Runtime.InteropServices.ComTypes.FILETIME declares both dwords as SIGNED int — a
+    // dwLowDateTime with its high bit set (~50% of processes; the low dword cycles every ~430s) would
+    // SIGN-EXTEND when combined into the 64-bit value, corrupting the high half so the exact-equality
+    // check silently rejects a live shell. uint fields match `process.rs`'s u32 (`:110-111`).
+    [StructLayout(LayoutKind.Sequential)]
+    private struct FILETIME { public uint dwLowDateTime; public uint dwHighDateTime; }
+
+    /// FILETIME (100ns ticks since 1601) → integer milliseconds: floor(ticks / 10_000). MUST stay
+    /// byte-identical to the Node side (`process.rs filetime_to_ms` — same integer division on the same
+    /// source API), so the wire equality below is EXACT with no tolerance (a tolerance would re-open the
+    /// pid-reuse hole this identity closes). `| low` widens uint→ulong with NO sign extension.
+    internal static long FiletimeTicksToMs(uint low, uint high) => (long)(((((ulong)high) << 32) | low) / 10_000);
+
+    /// The creation time of `pid` in wire ms, or 0 when unreadable (0 is the doubt sentinel — it can
+    /// never match a valid anchor). Used by the inject-console self-test child to publish its own
+    /// identity; `CheckShellIdentity` below is the fail-closed re-verify variant.
+    internal static long StartTimeMsOf(uint pid)
+    {
+        nint h = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid);
+        if (h == 0) return 0;
+        try { return GetProcessTimes(h, out var created, out _, out _, out _) ? FiletimeTicksToMs(created.dwLowDateTime, created.dwHighDateTime) : 0; }
+        finally { CloseHandle(h); }
+    }
+
+    /// PRIMARY identity check, BOTH hosts (S-pid gate E3): the spawn-tracked shell must still be the
+    /// SAME process — `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION)` + `GetProcessTimes` creation-time
+    /// EXACT integer equality against the anchor. Fail-closed on every failure mode:
+    ///   * anchor time <= 0 (a 0 anchor can never exist — the launch refuses it) → Mismatch;
+    ///   * OpenProcess failure (the shell is dead, or unopenable) → Gone;
+    ///   * GetProcessTimes failure / a computed 0 (unreadable measurement) → Mismatch;
+    ///   * a DIFFERENT non-zero time → Mismatch (the pid was REUSED — the anchored shell is dead).
+    private static string? CheckShellIdentity(uint shellPid, long shellStartMs)
+    {
+        if (shellStartMs <= 0) return InjectAbort.Mismatch;
+        nint h = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, shellPid);
+        if (h == 0) return InjectAbort.Gone;
+        try
+        {
+            if (!GetProcessTimes(h, out var created, out _, out _, out _)) return InjectAbort.Mismatch;
+            long ms = FiletimeTicksToMs(created.dwLowDateTime, created.dwHighDateTime);
+            if (ms == 0) return InjectAbort.Mismatch;
+            return ms == shellStartMs ? null : InjectAbort.Mismatch;
+        }
+        finally { CloseHandle(h); }
+    }
+
+    /// Re-verify the target IDENTITY at the injection instant (host-shaped since S-pid gate E3).
+    /// Returns an InjectAbort code on any mismatch, or null if all predicates pass.
+    ///
+    /// PRIMARY (both hosts): pid + creation-time exact equality on the spawn-tracked shell
+    /// (`CheckShellIdentity`) — unforgeable by pid reuse. Then, host-shaped:
+    ///   * classic (Hwnd != 0): ADDITIONALLY the ENTIRE pre-S-pid predicate unchanged — the window MUST
+    ///     be alive, the classic console class (POSITIVE allowlist — anything else is
+    ///     `target_multiplexed`), owned by the tracked `ConsolePid`, title-fp matched — PLUS one new
+    ///     cross-check `ConsolePid == ShellPid` (the window owner and the spawn-tracked shell must be
+    ///     the same process; a divergence is an identity contradiction → Mismatch). Classic is strictly
+    ///     STRENGTHENED, never relaxed (gate charter item 4).
+    ///   * wt (Hwnd == 0): NO window predicate — a WT pane has no per-pane hwnd to check; identity is
+    ///     pid+time alone. (An OLD-Node frame can never take this branch: it always carries an hwnd, and
+    ///     its missing shellPid parses to 0 → CheckShellIdentity fails closed.)
     ///
     /// DF-5: there is NO foreground check — the console-buffer injector addresses the write to the
-    /// verified `consolePid` (it does not broadcast to the foreground window), so foreground is no longer
-    /// the delivery gate; identity (hwnd alive + class + owning pid + title fp) is. This predicate runs
-    /// TWICE per inject (before AttachConsole and again after the CONIN$ handle opens) so the console
-    /// cannot be swapped out from under the attached handle. `InjectAbort.NotForeground` is therefore no
-    /// longer emitted (kept in the wire enum for back-compat only).
+    /// verified console (it does not broadcast to the foreground window), so foreground is no longer
+    /// the delivery gate; identity is. This predicate runs TWICE per inject (before AttachConsole and
+    /// again after the CONIN$ handle opens) so the console cannot be swapped out from under the attached
+    /// handle. `InjectAbort.NotForeground` is no longer emitted (kept in the wire enum for back-compat).
     private static string? ReVerify(in InjectTarget t)
     {
-        if (t.Hwnd == 0 || !IsWindow(t.Hwnd)) return InjectAbort.Gone;
+        var primary = CheckShellIdentity(t.ShellPid, t.ShellStartMs);
+        if (primary != null) return primary;
+
+        if (t.Hwnd == 0) return null; // wt: no per-pane window exists — pid+time IS the identity
+
+        if (!IsWindow(t.Hwnd)) return InjectAbort.Gone;
 
         var cls = new StringBuilder(64);
         GetClassName(t.Hwnd, cls, cls.Capacity);
@@ -122,6 +194,7 @@ internal static class Win32Input
         _ = GetWindowThreadProcessId(t.Hwnd, out var pid);
         if (pid == 0) return InjectAbort.Gone;
         if (pid != t.ConsolePid) return InjectAbort.Multiplexed;
+        if (pid != t.ShellPid) return InjectAbort.Mismatch; // ConsolePid == ShellPid cross-check (E3)
 
         // Secondary anchor (defense-in-depth): the live title hash must match the expected fp.
         // Skipped when the engine supplied no fp.
@@ -191,7 +264,10 @@ internal static class Win32Input
         try
         {
             FreeConsole(); // detach from any console we already hold (the helper is a WinExe: usually none)
-            if (!AttachConsole(t.ConsolePid)) return (false, InjectAbort.Gone); // target console is gone
+            // Attach target (S-pid gate E3): classic stays AttachConsole(ConsolePid) byte-identical; a wt
+            // pane (no per-pane window ⇒ Hwnd == 0) attaches by the verified spawn-tracked ShellPid —
+            // spike-proven to deliver into the ConPTY'd console input buffer end-to-end.
+            if (!AttachConsole(t.Hwnd != 0 ? t.ConsolePid : t.ShellPid)) return (false, InjectAbort.Gone);
             attached = true;
 
             conin = CreateFileW("CONIN$", GENERIC_READ | GENERIC_WRITE,
@@ -445,8 +521,10 @@ internal static class ConsoleInjectSelfTest
     private const string TestSecret = "Pw-Ω✓-😀-9";
 
     /// CHILD role (`-InjectConsoleChild <ready> <out>`): we run as conhost's client, so we already own a
-    /// classic console. Arm echo-off line input, publish our console hwnd via the ready file, cooked-read
-    /// one line, and record it. Returns 0 always (the parent judges by the recorded line).
+    /// classic console. Arm echo-off line input, publish our console hwnd + our own pid + creation time
+    /// (S-pid §5: the parent threads them into the InjectTarget so the pid+time re-verify is exercised
+    /// end-to-end) via the ready file, cooked-read one line, and record it. Returns 0 always (the parent
+    /// judges by the recorded line).
     public static int RunChild(string readyPath, string outPath)
     {
         try
@@ -459,7 +537,9 @@ internal static class ConsoleInjectSelfTest
             if (conin == INVALID) { File.WriteAllText(outPath, "<conin-open-failed>"); return 0; }
             GetConsoleMode(conin, out uint mode);
             SetConsoleMode(conin, (mode | ENABLE_PROCESSED_INPUT | ENABLE_LINE_INPUT) & ~(ENABLE_ECHO_INPUT | ENABLE_MOUSE_INPUT | ENABLE_WINDOW_INPUT));
-            File.WriteAllText(readyPath, ((long)hwnd).ToString()); // signal + hand the parent our console hwnd
+            // `hwnd|pid|startMs` — the pid+time beside the hwnd (S-pid §5, additive).
+            var pid = (uint)Environment.ProcessId;
+            File.WriteAllText(readyPath, $"{(long)hwnd}|{pid}|{Win32Input.StartTimeMsOf(pid)}");
             var buf = new char[512];
             bool ok = ReadConsoleW(conin, buf, (uint)buf.Length, out uint read, 0);
             File.WriteAllText(outPath, ok ? new string(buf, 0, (int)read).TrimEnd('\r', '\n') : "<readconsole-failed>");
@@ -500,7 +580,12 @@ internal static class ConsoleInjectSelfTest
             spawned = true;
 
             if (!PollFile(readyPath, 8000)) return "fail";
-            if (!long.TryParse(File.ReadAllText(readyPath).Trim(), out var hraw) || hraw == 0) return "fail";
+            // `hwnd|pid|startMs` (S-pid §5): the child publishes its pid + creation time beside the hwnd.
+            var parts = File.ReadAllText(readyPath).Trim().Split('|');
+            if (parts.Length != 3
+                || !long.TryParse(parts[0], out var hraw) || hraw == 0
+                || !uint.TryParse(parts[1], out var childPid) || childPid == 0
+                || !long.TryParse(parts[2], out var childStartMs) || childStartMs == 0) return "fail";
             nint hwnd = (nint)hraw;
 
             // Environment gate: if the child's console is NOT a classic conhost (ConPTY handoff under a
@@ -513,7 +598,9 @@ internal static class ConsoleInjectSelfTest
             _ = GetWindowThreadProcessId(hwnd, out uint consolePid); // derive exactly as L3 does
             if (consolePid == 0) return "fail";
 
-            var target = new InjectTarget(hwnd, consolePid, "", true);
+            // Thread the child-published pid+time (S-pid §5): ReVerify's PRIMARY check + the
+            // ConsolePid == ShellPid cross-check are now exercised by this self-test end-to-end.
+            var target = new InjectTarget(hwnd, consolePid, "", true, childPid, childStartMs);
             var (injected, _) = Win32Input.ReVerifyAndType(in target, Encoding.UTF8.GetBytes(TestSecret));
             if (!injected) return "fail";
 

--- a/tools/key-locker/Program.cs
+++ b/tools/key-locker/Program.cs
@@ -114,11 +114,15 @@ internal static class KeyLocker
         if (selfTest) return RunSelfTest();
 
         // Headless L2 serving-path seam — proves the ticket + serving-pipe contract (valid fetch,
-        // single-use, forged/context_mismatch refused) without live ssh/git.
+        // single-use, forged/context_mismatch refused) without live ssh/git. Also carries the S-pid
+        // E3b wire-parse + §4 FILETIME-conversion pins (WireParseSelfTest) so a missed HandleInject
+        // parser edit or a sign-extending FILETIME regression fails this seam, not a live fill.
         if (selfTestL2)
         {
-            var ok = _serving.SelfTest();
-            Console.WriteLine(JsonSerializer.Serialize(new { ok }));
+            var serving = _serving.SelfTest();
+            var wireParse = WireParseSelfTest();
+            var ok = serving && wireParse;
+            Console.WriteLine(JsonSerializer.Serialize(new { ok, serving, wireParse }));
             return ok ? 0 : 1;
         }
 
@@ -289,11 +293,7 @@ internal static class KeyLocker
             using var doc = JsonDocument.Parse(line);
             if (!doc.RootElement.TryGetProperty("t", out var t) || t.ValueKind != JsonValueKind.Object)
             { WriteReply(server, id, false, "", "bad_target"); return; }
-            target = new InjectTarget(
-                Hwnd: (nint)ParseLong(t, "hwnd"),
-                ConsolePid: (uint)ParseLong(t, "consolePid"),
-                TitleFp: t.TryGetProperty("titleFp", out var fp) && fp.ValueKind == JsonValueKind.String ? fp.GetString() ?? "" : "",
-                Submit: t.TryGetProperty("submit", out var sub) && sub.ValueKind == JsonValueKind.True);
+            target = ParseInjectTarget(t);
         }
         catch { WriteReply(server, id, false, "", "bad_target"); return; }
 
@@ -326,6 +326,47 @@ internal static class KeyLocker
         var minted = _serving.Mint(key, ctx);
         if (minted == null) { WriteReply(server, id, false, "", InjectAbort.NoSecret); return; }
         WriteFrame(server, $"{{\"id\":{id},\"ok\":true,\"r\":{JsonSerializer.Serialize(minted.Value.ticket)},\"pipe\":{JsonSerializer.Serialize(minted.Value.pipe)}}}");
+    }
+
+    /// Materialize the `inject` frame's `t` field into the InjectTarget record (S-pid gate E3b — the
+    /// SOLE wire→record parse on the inject path; `-SelfTestInjectConsole` constructs the record
+    /// directly and BYPASSES this, so `WireParseSelfTest` pins it separately). Absent fields parse to
+    /// 0/"" WITHOUT throwing (`ParseLong` absent → 0) — a wt frame carries no hwnd/consolePid/titleFp
+    /// and must not `bad_target`; do NOT switch to a throwing accessor.
+    internal static InjectTarget ParseInjectTarget(JsonElement t) => new(
+        Hwnd: (nint)ParseLong(t, "hwnd"),
+        ConsolePid: (uint)ParseLong(t, "consolePid"),
+        TitleFp: t.TryGetProperty("titleFp", out var fp) && fp.ValueKind == JsonValueKind.String ? fp.GetString() ?? "" : "",
+        Submit: t.TryGetProperty("submit", out var sub) && sub.ValueKind == JsonValueKind.True,
+        ShellPid: (uint)ParseLong(t, "shellPid"),
+        ShellStartMs: ParseLong(t, "shellStartMs"));
+
+    /// S-pid E3b/§4 regression pins, folded into `-SelfTestL2`'s exit status:
+    ///   1. a `t` frame carrying `shellPid`/`shellStartMs` (number OR decimal-string form) reconstructs
+    ///      them through the SAME `ParseInjectTarget` the live `HandleInject` uses — so the P1-1 wire-
+    ///      parser edit can never regress silently (the inject-console self-test bypasses this path);
+    ///   2. a wt-shaped frame (NO window fields) parses to 0/"" without throwing (absent-field tolerance);
+    ///   3. the FILETIME→ms conversion does not sign-extend a high-bit-set low dword (gate §4, Opus
+    ///      P1-2): ticks = (1 << 32) | 0x8000_0000 = 6_442_450_944 → floor(/10_000) = 644_245 — the
+    ///      same vector the Node `process.rs filetime_to_ms` u32 math yields.
+    private static bool WireParseSelfTest()
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(
+                "{\"t\":{\"hwnd\":\"4660\",\"consolePid\":4242,\"titleFp\":\"ab\",\"shellPid\":\"4242\",\"shellStartMs\":13322426700123,\"submit\":true}}");
+            var t = ParseInjectTarget(doc.RootElement.GetProperty("t"));
+            if (t.Hwnd != 4660 || t.ConsolePid != 4242 || t.TitleFp != "ab" || !t.Submit
+                || t.ShellPid != 4242 || t.ShellStartMs != 13322426700123L) return false;
+
+            using var doc2 = JsonDocument.Parse("{\"t\":{\"shellPid\":77,\"shellStartMs\":42}}");
+            var t2 = ParseInjectTarget(doc2.RootElement.GetProperty("t"));
+            if (t2.Hwnd != 0 || t2.ConsolePid != 0 || t2.TitleFp != "" || t2.Submit
+                || t2.ShellPid != 77 || t2.ShellStartMs != 42L) return false;
+
+            return Win32Input.FiletimeTicksToMs(0x8000_0000u, 1u) == 644_245L;
+        }
+        catch { return false; }
     }
 
     private static long ParseLong(JsonElement obj, string name)


### PR DESCRIPTION
## What & why

Second slice of the **S-pid identity re-base** (the groundwork for Windows Terminal autofill): the launch-side `PaneAnchor` spawn capture + the L2 `InjectTarget` **pid+creation-time re-verify**.

Before: the inject target was named by a console window hwnd plus whatever pid owned it — pid liveness alone could not detect a reused pid, and the window was the identity source.

After: target identity is **the shell process the locker itself spawned**, named by `{shellPid, shellStartTimeMs}` (a reused pid reads a different creation time, so the pair is unforgeable). The window is demoted to an *additional* classic-only anchor.

## Scope (gate E1-classic / E3 / E3b / E4 / §4 / §5)

- **Launch (E1)**: `launchAnchoredConsole` freezes the anchor at spawn. The classic spawn command, title claim, and pid derivation are byte-identical; the ONE addition is the creation-time read (0 keeps polling within the existing deadline; a deadline without a non-zero read fails the launch — 0 is the doubt sentinel and can never anchor).
- **Wire (E3)**: `InjectTarget` gains required `shellPid`/`shellStartMs` for both hosts; `hwnd`/`consolePid`/`titleFp` become classic-only. Additive — the L0 reader ignores unknown props.
- **C# re-verify (E3/§4)**: a NEW PRIMARY `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION)` + `GetProcessTimes` **exact integer equality** check for both hosts, fail-closed on every failure mode (`target_gone` on open-failure, `target_mismatch` on unreadable/0/different time). Classic ADDITIONALLY keeps the entire previous predicate unchanged, plus the new `ConsolePid == ShellPid` cross-check — strictly strengthened, never relaxed. The wt branch (`Hwnd==0`: no window predicate, `AttachConsole(ShellPid)`) ships now but is unreachable until PR3 constructs a wt anchor. **Local uint-field FILETIME** (the BCL ComTypes FILETIME is signed and would sign-extend ~half of all reads — gate Opus P1-2).
- **Parser (E3b)**: `HandleInject` materializes the new fields via the extracted `ParseInjectTarget`; `-SelfTestL2` now pins the wire round-trip (number + string forms, wt-shape absent-field tolerance) AND the FILETIME sign-extension vector (`(1<<32)|0x80000000 → 644245`, the same value `process.rs filetime_to_ms` yields).
- **Seam (E4)**: driver `PaneRecord` carries the full anchor; `CaptureDriverDeps.injectPane` takes the anchor (gate Opus P2-2 — the wiring never re-derives identity from the paneId string).
- **Self-test (§5)**: `-SelfTestInjectConsole` child now publishes its pid+time beside the hwnd; the parent threads them into the target, so the PRIMARY check + cross-check run end-to-end. Verified locally: `{"ok":true,"skipped":false}`.
- `bin/key-locker.exe` rebuilt in this PR (the W-3.5 lesson).

## Out of scope (PR3)

WT launch (`wt -w 0 new-tab` + WMI pid discovery), the `wt:<pid>:<startMs>` paneId form + schema bump, the WT read/send seams (E6), and the `launch_console host:` tool surface (E7). Classic public paneId stays `String(hwnd)` — zero back-compat break.

## Tests

- key-locker unit suites green. **Call-shape-only mechanical updates** for the E4 signature changes (`onLocalPaneLaunched`/`injectPane` take the anchor; a `classicAnchor()`/`anchorOf()` helper) — no assertion rewrites.
- `key-locker-inject-target` suite extended: classic carries the anchor identity verbatim; wt assembles pid+time only and early-declines a dead/reused/transient-0 shell.
- key-locker e2e 9/9. The `-SelfTestL2` assertion now pins the richer `{ok, serving, wireParse}` output (strict toEqual kept — the shape change is this PR's designed contract extension, called out for review).
- Full suite: unit green; two unrelated live-desktop e2e blips (`terminal-hidden-input` passes on pinpoint rerun; `browser-cdp-verification` fails identically on unmodified main — pre-existing).

## Version-skew note

Old exe + new Node: the old reader ignores the new props and classic still passes its full old predicate; a wt target presents Hwnd==0 and fails closed. New exe + old Node: the missing fields parse to 0 and the PRIMARY check fails closed (no unverified inject). The exe and dist ship atomically in the release zip, so the second skew exists only in a mixed dev tree.

## Plan

`desktop-touch-mcp-internal@1c2988b:docs/adr-014-v2-r3x-s-pid-gate.md` (E1 classic, E3, E3b, E4, §4, §5) — Opus-GO design gate. PR1 = #537 (watch-side creation-time reuse detection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
