### PR TITLE
fix(key-locker): WT-capable Mode-A exit probe channel (Codex P1 follow-up to #539)

### DIFF
--- a/src/tools/key-locker-wiring.ts
+++ b/src/tools/key-locker-wiring.ts
@@ -19,6 +19,7 @@
 //   gap6 landed  — `runToExit` OBSERVES the already-run command's exit via an epilogue-only probe
 //                  (`buildExitProbe`), NEVER re-running it.
 
+import type { ToolResult } from "./_types.js";
 import type { BindingMeta } from "../engine/key-locker/binding-store.js";
 import { BindingStore } from "../engine/key-locker/binding-store.js";
 import type { BindingUri } from "../engine/key-locker/binding.js";
@@ -420,16 +421,33 @@ export class KeyLockerWiring {
     const nonce = generateExitNonce();
     const probe = buildExitProbe(shell, nonce);
     // Send the read-only probe. `notifyDispatch:false` suppresses the S-A re-fire; even if it fired, the driver
-    // drops it (loopPhase pre-landed) and it is not credential-shaped. background method = do not steal focus.
+    // drops it (loopPhase pre-landed) and it is not credential-shaped.
+    //
+    // S-pid E6 / Codex PR3 R1 P1: the exit probe MUST ride a WT-CAPABLE send channel for a wt pane. WT's
+    // XAML pipeline REJECTS background WM_CHAR (`terminal.ts` `wt_xaml_pipeline`), so a background probe to a
+    // wt pane is NEVER delivered — the sentinel never writes, this poll times out, and `awaitLanded` then
+    // DISCARDS a WORKING just-captured one-shot credential (the fill itself rides AttachConsole, pid-addressed,
+    // and is UNAFFECTED; only completion-detection breaks). `foreground_flash` resolves to the NO-STEAL
+    // `wm_char` path for a CLASSIC console (byte-equivalent to the prior background probe — classic unchanged)
+    // and to the `clipboard_flash` path for WT (a brief ~60ms focus flash of a BENIGN non-secret sentinel; the
+    // SECRET never rides this path — it rides AttachConsole/WriteConsoleInputW). Gate E6 anticipated exactly
+    // this ("the Mode-A exit probe uses the WT-capable send machinery").
+    const method = exitProbeMethod(paneId);
+    let sendResult: ToolResult;
     try {
-      await terminalSendHandler({
-        windowTitle: title, input: probe, method: "background", pressEnter: true,
+      sendResult = await terminalSendHandler({
+        windowTitle: title, input: probe, method, pressEnter: true,
         focusFirst: false, restoreFocus: false, preferClipboard: false, pasteKey: "auto",
         trackFocus: false, settleMs: 0, notifyDispatch: false,
       });
     } catch (e) {
       return { reason: `probe_error:${e instanceof Error ? e.message : String(e)}` };
     }
+    // `terminalSendHandler` returns a TYPED FAILURE (not a throw) when the channel rejects the probe (Codex
+    // PR3 R1 P1: the prior code ignored the return value). A silently-undelivered probe must be treated as a
+    // probe_error NOW, not polled to the full EXIT_PROBE_MS timeout — the outcome is the same fail-safe discard,
+    // but promptly and with the real cause, not a misleading "timeout".
+    if (!sendSucceeded(sendResult)) return { reason: "probe_error:send_rejected" };
     const deadline = Date.now() + EXIT_PROBE_MS;
     for (;;) {
       // RE-RESOLVE the title each read (Codex W-4b): the ran command may have changed the console title; the
@@ -450,6 +468,29 @@ export class KeyLockerWiring {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * The send channel the Mode-A exit probe must ride for a pane (S-pid E6 / Codex PR3 R1 P1): a WT pane
+ * uses `foreground_flash` (WT's XAML pipeline rejects background WM_CHAR, so a background probe is never
+ * delivered → the sentinel never writes → a WORKING one-shot credential is discarded); a classic console
+ * keeps `background` (byte-equivalent to the shipped probe — `foreground_flash` also resolves to no-steal
+ * wm_char there, but keeping `background` leaves the classic regression-guard path bit-identical). Exported
+ * as a pure function so the delivery-channel policy is unit-pinned without driving the impure loop. */
+export function exitProbeMethod(paneId: string): "background" | "foreground_flash" {
+  return parsePaneId(paneId)?.kind === "wt" ? "foreground_flash" : "background";
+}
+
+/** Did a `terminalSendHandler` ToolResult report success? The handler encodes its payload as JSON text in
+ *  `content[0]`; a typed failure carries `ok:false` (or is unparseable). Fail-closed: anything not a clean
+ *  `ok:true` is treated as NOT delivered (so a rejected probe short-circuits to a fail-safe discard rather
+ *  than polling to a misleading timeout — Codex PR3 R1 P1). Mirrors terminalRunHandler's `parseSendResult`. */
+function sendSucceeded(result: ToolResult): boolean {
+  try {
+    const block = result.content[0];
+    if (block?.type === "text") return (JSON.parse(block.text) as { ok?: boolean }).ok === true;
+  } catch { /* unparseable ⇒ treat as failure */ }
+  return false;
 }
 
 let wiringSingleton: KeyLockerWiring | null = null;

--- a/tests/unit/key-locker-anchoring.test.ts
+++ b/tests/unit/key-locker-anchoring.test.ts
@@ -29,7 +29,7 @@ vi.mock(import("../../src/tools/terminal.js"), async (importOriginal) => {
 
 import { KeyLockerManager } from "../../src/engine/key-locker/key-locker-manager.js";
 import type { PaneAnchor } from "../../src/engine/key-locker/inject-target.js";
-import { KeyLockerWiring } from "../../src/tools/key-locker-wiring.js";
+import { KeyLockerWiring, exitProbeMethod } from "../../src/tools/key-locker-wiring.js";
 import { maybeAdvisory } from "../../src/tools/_advisory.js";
 
 // wt panes have no window — their liveness is the shell's creation-time identity, faked via this map
@@ -243,6 +243,21 @@ describe("credentialNudge (Phase 3)", () => {
     const { wiring } = newWiring();
     const hint = nudge(wiring, { input: "C:\\Windows\\System32\\OpenSSH\\ssh.exe -p 2222 u@h", windowTitle: "cmd" });
     expect(hint).not.toBeNull();
+  });
+});
+
+// S-pid E6 / Codex PR3 R1 P1: the Mode-A exit probe's send channel must be WT-capable for a wt pane
+// (WT rejects background WM_CHAR ⇒ an undelivered probe would time out and DISCARD a working one-shot
+// credential in the DEFAULT flow). Pinned as a pure policy so the channel choice can't silently regress.
+describe("exitProbeMethod (S-pid E6 — WT probe channel)", () => {
+  it("a wt pane uses foreground_flash (WT-capable; background WM_CHAR is rejected by WT)", () => {
+    expect(exitProbeMethod("wt:31264:13322426700123")).toBe("foreground_flash");
+  });
+  it("a classic pane keeps background (byte-equivalent to the shipped probe — classic unchanged)", () => {
+    expect(exitProbeMethod("12345678")).toBe("background");
+  });
+  it("a malformed paneId defaults to background (never mis-routes to the flash path)", () => {
+    expect(exitProbeMethod("not-a-pane")).toBe("background");
   });
 });
 


### PR DESCRIPTION
## What & why

**Follow-up to #539 — a Codex-P1 fix that landed on the branch AFTER #539 was merged, so it is NOT in `main`.** #539 merged at commit `7e9f57e`; the fix commit `a12f5a6` was pushed afterward and was left behind. This PR carries it to `main` unchanged (cherry-pick).

### The bug (present in `main` right now)

Since #539, `key_locker({action:'launch_console'})` defaults to a Windows Terminal tab. But the Mode-A exit probe in `runToExit` (the completion detector for a ONE-SHOT credential command — `sudo <cmd>`, `git push`, `ssh host cmd`) was hardcoded to `method:"background"`, which Windows Terminal **rejects** (`wt_xaml_pipeline` — WT's XAML pipeline drops WM_CHAR). So in the now-default WT flow:

1. the secret is captured and filled correctly (the fill rides `AttachConsole`, pid-addressed — **unaffected**);
2. the exit probe is never delivered → the echo-immune sentinel never writes;
3. `runToExit` polls to its full timeout → `awaitLanded` returns not-accepted;
4. the capture loop **discards the just-captured, successfully-filled secret** (the D5 save-gate `finally` deletes it).

Net: a one-shot credential in the default WT flow is captured, filled, and then thrown away — the user is re-prompted next time. Interactive logins (`ssh user@host`, `sudo -i`) are unaffected (Mode-B is read-only, no send).

### The fix (gate E6 intent — "the Mode-A exit probe uses the WT-capable send machinery")

- `exitProbeMethod(paneId)` — a pure, exported, unit-pinned policy: a **wt** pane uses `foreground_flash` (resolves to `clipboard_flash` on the WT XAML window — a ~60ms focus flash of a **benign non-secret sentinel**; the secret never rides this path), a **classic** pane keeps `background` (resolves to no-steal `wm_char`; byte-equivalent to the shipped probe — the classic regression-guard path is bit-identical).
- `runToExit` now checks the `terminalSendHandler` return via `sendSucceeded()`: a typed send FAILURE (a `failWith`, not a throw — previously ignored) is treated as a prompt `probe_error` (fail-safe discard) instead of polling to the full `EXIT_PROBE_MS` timeout. Same fail-safe outcome, promptly and with the real cause.

## Review status (carried from #539)

Both reviewers verified this exact commit ON the #539 branch before it was orphaned:
- **Opus Round 2: GO** — foreground_flash confirmed the correct WT-capable channel (clipboard_flash for WT / no-steal wm_char for classic); classic byte-equivalent; no new disclosure path (the probe is `buildExitProbe`, a non-secret sentinel; the secret rides AttachConsole); `sendSucceeded` fail-closed. Two P3s, both gate-accepted (the ~60ms focus flash + the clipboard use are OQ-S-5, dogfood-confirmed).
- **Codex Round 1: P1** (this is the finding being fixed — Codex's API-contract axis caught the discard consequence that Opus had classed P3 "bounded timeout").

## Tests

`key-locker-anchoring` 23/23 (adds the `exitProbeMethod` pin: wt→foreground_flash, classic→background, malformed→background). Build green.

## Plan

`desktop-touch-mcp-internal@7a39bbc:docs/adr-014-v2-r3x-s-pid-gate.md` (E6, OQ-S-5 — updated to "resolved in La").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
