### PR TITLE
fix(key-locker): honor ssh options after the destination (F-3, P1 security)

### DIFF
--- a/src/engine/key-locker/command-derivation.ts
+++ b/src/engine/key-locker/command-derivation.ts
@@ -229,6 +229,11 @@ async function deriveSsh(args: string[], exec: ExecFn): Promise<BindingUri | nul
   // Query / no-login modes never prompt (`-G` config query, `-Q` algorithm query, `-V` version).
   // Modes that still authenticate (-T no-pty, -N no-remote-cmd) derive normally.
   const parsed = parseSshCommand(args);
+  // An argv we cannot classify is one whose destination AND remote-command boundary are both guesses — so
+  // which endpoint this secret would be typed at is a guess too. Fail closed: no binding, no lookup, no
+  // save. (Doubt is checked BEFORE queryMode for the same reason it is in `classifySshLogin`: with an
+  // unknown letter present we cannot even trust that `-G` is a query rather than that letter's value.)
+  if (parsed.undecidable) return null;
   if (parsed.queryMode || parsed.destination === undefined) return null;
   const resolved = await resolveCanonicalForSshCommand(args, exec);
   // host-not-known / unresolvable ⇒ fail closed: no binding, no lookup, no save.

--- a/src/engine/key-locker/key-locker-capture-driver.ts
+++ b/src/engine/key-locker/key-locker-capture-driver.ts
@@ -602,8 +602,9 @@ function sessionMatches(live: PaneSession, expected: SessionFrame): boolean {
 /**
  * The ssh-named DESCENDANTS of `shellPid` in a snapshot (subtree, not just direct children — the exempt
  * delta must see a `sudo ssh`/wrapper/tmux-reparented login the same way the W-2b scan does). For each,
- * report its interactive-login HOST (`commandLine` → `interactiveSshTarget`, or null for a tunnel/one-shot/
- * unreadable ssh) + its creation time (for the pid+time exempt). A `seen` set guards pid-reuse cycles.
+ * report its interactive-login HOST (`commandLine` → `classifySshLogin`, or null for a tunnel/one-shot/
+ * unclassifiable/unreadable ssh) + its creation time (for the pid+time exempt). A `seen` set guards
+ * pid-reuse cycles.
  */
 function sshDescendants(snap: ProcessSnapshot, shellPid: number): Map<number, { host: string | null; startTimeMs: number }> {
   const out = new Map<number, { host: string | null; startTimeMs: number }>();

--- a/src/engine/key-locker/key-locker-capture-driver.ts
+++ b/src/engine/key-locker/key-locker-capture-driver.ts
@@ -67,7 +67,7 @@ import type { PaneAnchor } from "./inject-target.js";
 import type { InjectResult } from "./injector.js";
 import {
   ENV_ASSIGN_RE,
-  interactiveSshTarget,
+  classifySshLogin,
   isKnownSession,
   programOf,
   type PaneSession,
@@ -624,7 +624,8 @@ function sshDescendants(snap: ProcessSnapshot, shellPid: number): Map<number, { 
       const id = snap.identify(pid);
       if (id.name !== SSH_PROGRAM) continue;
       const argv = snap.commandLine(pid);
-      const host = argv === null ? null : interactiveSshTarget(argv.slice(1));
+      const cls = argv === null ? ({ kind: "none" } as const) : classifySshLogin(argv.slice(1));
+      const host = cls.kind === "interactive" ? cls.host : null;
       out.set(pid, { host, startTimeMs: id.startTimeMs });
     }
   }
@@ -634,25 +635,27 @@ function sshDescendants(snap: ProcessSnapshot, shellPid: number): Map<number, { 
 /**
  * The interactive-login HOST the dispatched `command` opens (bare, lowercased), or null. Mirrors
  * `SessionTracker.recordDispatch`'s ssh-segment detection (env/redirect skip + backgrounded/piped/leading-
- * stdin-redirect + `interactiveSshTarget`) but returns the host instead of mutating a tracker. Used ONLY to
+ * stdin-redirect + `classifySshLogin`) but returns the host instead of mutating a tracker. Used ONLY to
  * host-match the exempt-pid delta (§0-CORR.2). This is AVAILABILITY-only, not security: any divergence from
  * `recordDispatch` only biases toward NO exempt (the W-2b scan then flags the assistant's own login → the
  * login declines — a bounded availability regression, never a wrong-target). Returns the FIRST segment's
  * interactive-ssh host — the one `recordDispatch` would push a frame for.
+ * An `undecidable` argv maps to null here, which upholds that bias exactly: no exempt is proven, so the
+ * scan flags and the pane declines (`recordDispatch` independently sinks it to UNKNOWN).
  */
 function dispatchedInteractiveSshHost(command: string): string | null {
   for (const seg of tokenizeCommandSegmentsWithOps(command)) {
     const { tokens, backgrounded, pipedStdin } = seg;
-    // Skip leading env-assignments; the redirect-skip is folded into interactiveSshTarget's own whole-argv
+    // Skip leading env-assignments; the redirect-skip is folded into classifySshLogin's own whole-argv
     // scan below, so here we only need to find the program token past leading `FOO=bar`.
     let start = 0;
     while (tokens[start] !== undefined && ENV_ASSIGN_RE.test(tokens[start])) start++;
     if (programOf(tokens[start]) !== SSH_PROGRAM) continue;
     // A backgrounded / downstream-piped ssh takes stdin off the tty ⇒ no interactive login (mirrors
-    // recordDispatch); a leading fd-0 redirect is caught inside interactiveSshTarget's whole-argv scan.
+    // recordDispatch); a leading fd-0 redirect is caught inside classifySshLogin's whole-argv scan.
     if (backgrounded || pipedStdin) continue;
-    const host = interactiveSshTarget(tokens.slice(start + 1));
-    if (host !== null) return host;
+    const cls = classifySshLogin(tokens.slice(start + 1));
+    if (cls.kind === "interactive") return cls.host;
   }
   return null;
 }

--- a/src/engine/key-locker/landed-detection.ts
+++ b/src/engine/key-locker/landed-detection.ts
@@ -24,7 +24,7 @@
 // primitives and tests drive fakes.
 
 import { tokenizeCommandSegmentsWithOps } from "./command-derivation.js";
-import { ENV_ASSIGN_RE, interactiveSshTarget, programOf } from "./session-tracker.js";
+import { ENV_ASSIGN_RE, classifySshLogin, programOf } from "./session-tracker.js";
 
 /** Which landed-detection mode a dispatched credential command uses. */
 export type LandedMode = "one-shot" | "interactive";
@@ -86,7 +86,10 @@ function privLaunchesInteractiveShell(rest: readonly string[]): boolean {
 
 /**
  * Classify which landed-mode a dispatched credential command uses. Interactive = an ssh INTERACTIVE
- * login (reuses the SAME `interactiveSshTarget` that pushes a session frame), a `sudo`/`doas` that opens
+ * login (reuses the SAME `classifySshLogin` that pushes a session frame — only a PROVEN `interactive`
+ * counts, so an `undecidable` argv falls to one-shot; that is DEFENCE IN DEPTH, not a live path: the same
+ * synchronous `recordDispatch` turn already sank such a pane to UNKNOWN, so it never arms and no landed
+ * check runs — and were it ever reached, one-shot is the stricter of the two), a `sudo`/`doas` that opens
  * a shell (`-i`/`-s`/`sudo su`/`sudo bash -l`, see `privLaunchesInteractiveShell`), or a bare `su`.
  * Everything else — a one-shot `ssh host cmd`, a plain `sudo <cmd>`, `git push`, `ssh-keygen` — is
  * one-shot (Mode A, exit-gated).
@@ -103,7 +106,7 @@ export function classifyLandedMode(command: string): LandedMode {
     while (start < tokens.length && ENV_ASSIGN_RE.test(tokens[start])) start++;
     const program = programOf(tokens[start]);
     const rest = tokens.slice(start + 1);
-    if (program === "ssh" && interactiveSshTarget(rest) !== null) return "interactive";
+    if (program === "ssh" && classifySshLogin(rest).kind === "interactive") return "interactive";
     if ((program === "sudo" || program === "doas") && privLaunchesInteractiveShell(rest)) return "interactive";
     if (program === "su") return "interactive";
   }

--- a/src/engine/key-locker/session-tracker.ts
+++ b/src/engine/key-locker/session-tracker.ts
@@ -302,7 +302,9 @@ export type SshLoginClass =
    *  label (L1 resolves the real endpoint later). */
   | { kind: "interactive"; host: string }
   /** PROVABLY opens no session in this pane: a query mode (`-G`/`-Q`/`-V`), `-N`/`-f`/`-W`, an argv whose
-   *  stdin is off the tty, or a one-shot with a PROVEN remote command. */
+   *  stdin is off the tty, a one-shot with a PROVEN remote command, or an argv a CONFIRMED with-arg option
+   *  leaves malformed (`ssh h -p` — ssh rejects it as a local usage error, exit 255, before any session
+   *  opens). Every member is PROVEN; a doubt belongs in `undecidable`, never here. */
   | { kind: "none" }
   /** The argv cannot be classified with confidence (an unknown option letter, or no locatable
    *  destination outside a query mode) ⇒ callers decline. */
@@ -332,6 +334,11 @@ export function classifySshLogin(rawArgs: readonly string[]): SshLoginClass {
   // (`if (!queryMode && destination === undefined) undecidable = true`), so `-V` / `-Q cipher` / `-G h`
   // carry `undecidable === false` and still fall through to the clean `none` below.
   if (parsed.undecidable) return { kind: "undecidable" };
+  // A confirmed with-arg option left without a value: ssh exits with a usage error before opening
+  // anything, so this is a PROVEN non-login — the pane never leaves local and keeps autofilling. It is
+  // checked AFTER `undecidable` on purpose: with an unknown letter in the argv, the "missing value" may
+  // not be missing at all (the trailing `-p` could be that letter's value), so doubt still wins.
+  if (parsed.malformed) return { kind: "none" };
   if (parsed.queryMode) return { kind: "none" };
   // Defensive: the parser's post-loop rule already covers this, but keep it so a future parser change
   // cannot silently re-open the hole.

--- a/src/engine/key-locker/session-tracker.ts
+++ b/src/engine/key-locker/session-tracker.ts
@@ -292,6 +292,32 @@ function scanRedirectionsForStdin(tokens: readonly string[]): { touchesStdin: bo
   return { touchesStdin, stripped };
 }
 
+/**
+ * Option letters whose presence means NO REMOTE LOGIN SHELL TAKES OVER THIS PANE, whatever else the
+ * invocation does. Each is a semantic judgment about ssh's behaviour, so this set is a TABLE with reasons,
+ * not a boolean chain — the next missing letter should read as a gap in a documented list rather than as an
+ * absent clause in an `||`:
+ *
+ *   N — holds a tunnel and never asks for a shell (the process stays alive; that is not a login)
+ *   f — forks to the background after authenticating; the foreground returns to the LOCAL prompt
+ *   W — turns the pane into a stdio conduit for a bastion and exits
+ *   O — sends a control command to an existing master (`-O check`) and exits; with no ControlPath it errors
+ *       out at once (measured: `No ControlPath specified for "-O" command`, exit 255). Either way, no shell
+ *   s — requests a SUBSYSTEM (`-s sftp`), not a login shell; with no subsystem named it exits locally
+ *       (measured: `You must specify a subsystem to invoke.`, exit 255). `-s sftp` reaching `none` today via
+ *       the remote-command check is the RIGHT answer for the WRONG reason — it would break the moment that
+ *       check moved
+ *
+ * The test is "does a remote login shell take over this pane", NOT "does the process persist": `-N` outlives
+ * everything here and still belongs (measured: alive past 6s, holding its tunnel), while a plain `ssh host`
+ * is the login. Judging by persistence instead breaks on the very first letter.
+ *
+ * ⚠ Unlike `SSH_FLAGS_WITH_ARG`, this set CANNOT be machine-checked against the synopsis — ssh's usage text
+ * says which options take a value, never which suppress the shell. It has to be right by reading, so it was
+ * swept letter-by-letter against the synopsis once (plan §1.5b) rather than grown one report at a time.
+ */
+const SSH_FLAGS_NO_LOGIN_SHELL = new Set([..."NfWOs"]);
+
 /** How an `ssh` argv (WITHOUT the leading `ssh` token) affects THIS pane's session. Three states, because
  *  two cannot express doubt — and treating doubt as "opens nothing" is exactly the F-3 inversion: the pane
  *  stays trusted-LOCAL while a real remote login is open, and a later `sudo` fills a LOCAL secret into a
@@ -301,10 +327,11 @@ export type SshLoginClass =
   /** An interactive login shell opened on this pane's tty. `host` is the bare, lowercased destination
    *  label (L1 resolves the real endpoint later). */
   | { kind: "interactive"; host: string }
-  /** PROVABLY opens no session in this pane: a query mode (`-G`/`-Q`/`-V`), `-N`/`-f`/`-W`, an argv whose
-   *  stdin is off the tty, a one-shot with a PROVEN remote command, or an argv a CONFIRMED with-arg option
-   *  leaves malformed (`ssh h -p` — ssh rejects it as a local usage error, exit 255, before any session
-   *  opens). Every member is PROVEN; a doubt belongs in `undecidable`, never here. */
+  /** PROVABLY opens no session in this pane: a query mode (`-G`/`-Q`/`-V`), a no-login-shell flag
+   *  (`SSH_FLAGS_NO_LOGIN_SHELL` = `-N`/`-f`/`-W`/`-O`/`-s`), an argv whose stdin is off the tty, a one-shot
+   *  with a PROVEN remote command, or an argv a CONFIRMED with-arg option leaves malformed (`ssh h -p` —
+   *  ssh rejects it as a local usage error, exit 255, before any session opens). Every member is PROVEN; a
+   *  doubt belongs in `undecidable`, never here. */
   | { kind: "none" }
   /** The argv cannot be classified with confidence (an unknown option letter, or no locatable
    *  destination outside a query mode) ⇒ callers decline. */
@@ -343,13 +370,17 @@ export function classifySshLogin(rawArgs: readonly string[]): SshLoginClass {
   // Defensive: the parser's post-loop rule already covers this, but keep it so a future parser change
   // cannot silently re-open the hole.
   if (parsed.destination === undefined) return { kind: "undecidable" };
-  // `-N` (no remote command), `-f` (fork to background) and `-W host:port` (forward stdin/stdout,
-  // implies -N/-T) do NOT open an interactive login shell in THIS pane: `-N` holds a tunnel, `-f`
-  // returns it to the LOCAL prompt, `-W` turns the pane into a stdio conduit for a bastion and exits.
-  // Pushing a remote frame would mislabel a later LOCAL command as remote → wrong-target on the
-  // fp-less sudo path (#495 P2 / R5 P2). Treat them as non-session-opening — no push.
-  if (parsed.flagLetters.has("N") || parsed.flagLetters.has("f") || parsed.flagLetters.has("W")) {
-    return { kind: "none" };
+  // A flag that PROVES no login shell takes over THIS pane (`-N`/`-f`/`-W`/`-O`/`-s`) → no session, no
+  // push: pushing a remote frame would mislabel a later LOCAL command as remote → wrong-target on the
+  // fp-less sudo path (#495 P2 / R5 P2). The letters and their per-letter reasons live in
+  // SSH_FLAGS_NO_LOGIN_SHELL; consulting the SET rather than an inline `has("N")||has("f")||…` chain is
+  // what makes the next omission a VISIBLE gap in a documented table instead of a missing `||` clause —
+  // `-O` (control-master command) and `-s` (subsystem) were exactly that missing clause (Codex PR#541).
+  // Checked BEFORE the remote-command step so `ssh h -s sftp` lands here for the RIGHT reason (a
+  // subsystem never opens a login shell) rather than by the coincidence that "sftp" is a remote-command
+  // token — a right answer resting on a wrong reason breaks the moment step 8's ordering moves.
+  for (const letter of SSH_FLAGS_NO_LOGIN_SHELL) {
+    if (parsed.flagLetters.has(letter)) return { kind: "none" };
   }
   // A one-shot `ssh host cmd …` has a REAL remote-command token after the destination → not an
   // interactive login. The parser locates that boundary with ssh's own two-pass rule, so a POST-

--- a/src/engine/key-locker/session-tracker.ts
+++ b/src/engine/key-locker/session-tracker.ts
@@ -108,7 +108,14 @@ export class SessionTracker {
         // stage `… | ssh host` whose stdin is the pipe, not the tty (Opus #495 R4 P2), and a LEADING
         // fd-0 redirect `< in ssh host` / `0>f ssh host` (Codex #495 R9) — pushing a remote frame in any
         // of them would mislabel a later LOCAL `sudo`/git as remote → wrong-target.
-        const remote = backgrounded || pipedStdin || leadingStdinRedir ? null : interactiveSshTarget(segment.slice(start + 1));
+        const cls: SshLoginClass = backgrounded || pipedStdin || leadingStdinRedir
+          ? { kind: "none" }
+          : classifySshLogin(segment.slice(start + 1));
+        // An UNCLASSIFIABLE ssh could be opening a login we cannot see. Trusting the pane as local would
+        // fill a LOCAL secret into a REMOTE prompt (F-3's derivative); pushing a guessed frame would
+        // mislabel a later local command. Neither is honest ⇒ sink to UNKNOWN and decline.
+        if (cls.kind === "undecidable") { this.markUnknown(paneId); return; }
+        const remote = cls.kind === "interactive" ? cls.host : null;
         if (remote !== null) {
           // A conditional (`&&` / `||`) ssh may or may not actually run — unknowable at dispatch time.
           // Pushing a remote frame that never materializes strands the pane as remote (no ssh child
@@ -285,13 +292,27 @@ function scanRedirectionsForStdin(tokens: readonly string[]): { touchesStdin: bo
   return { touchesStdin, stripped };
 }
 
+/** How an `ssh` argv (WITHOUT the leading `ssh` token) affects THIS pane's session. Three states, because
+ *  two cannot express doubt — and treating doubt as "opens nothing" is exactly the F-3 inversion: the pane
+ *  stays trusted-LOCAL while a real remote login is open, and a later `sudo` fills a LOCAL secret into a
+ *  REMOTE prompt. Every consumer must map `undecidable` to its own DECLINE.
+ *  Plan: desktop-touch-mcp-internal:docs/adr-014-v2-r3x-complete-fix-plan.md §1.3 / PR1.3 */
+export type SshLoginClass =
+  /** An interactive login shell opened on this pane's tty. `host` is the bare, lowercased destination
+   *  label (L1 resolves the real endpoint later). */
+  | { kind: "interactive"; host: string }
+  /** PROVABLY opens no session in this pane: a query mode (`-G`/`-Q`/`-V`), `-N`/`-f`/`-W`, an argv whose
+   *  stdin is off the tty, or a one-shot with a PROVEN remote command. */
+  | { kind: "none" }
+  /** The argv cannot be classified with confidence (an unknown option letter, or no locatable
+   *  destination outside a query mode) ⇒ callers decline. */
+  | { kind: "undecidable" };
+
 /**
- * If an `ssh` argv (without the leading `ssh`) is an INTERACTIVE LOGIN, return the resolved host
- * (bare, lowercased — the label; L1 resolves the real endpoint later). Return null for a one-shot
- * `ssh host cmd`, a query mode (`-G`/`-Q`/`-V`), no destination, or a stdin-off-the-tty ssh — none of
- * which open a session.
+ * Classify an `ssh` argv (without the leading `ssh`) by what it does to THIS pane's session. Every `none`
+ * is PROVEN; every doubt falls through to `undecidable`.
  */
-export function interactiveSshTarget(rawArgs: string[]): string | null {
+export function classifySshLogin(rawArgs: readonly string[]): SshLoginClass {
   // Redirections are shell I/O plumbing the shell consumes before exec, and they can appear ANYWHERE —
   // before the destination (`ssh 2>&1 host`), after it, or after a remote command. Scan the WHOLE argv:
   // a redirect that TOUCHES fd 0 (`ssh host < in`, `ssh 0>f host`) takes stdin off the tty → the ssh is
@@ -300,25 +321,32 @@ export function interactiveSshTarget(rawArgs: string[]): string | null {
   // command → the pane would else stay local while an interactive login opened → later remote `sudo`
   // wrong-targeted to localhost (Codex #495 P2).
   const { touchesStdin, stripped: args } = scanRedirectionsForStdin(rawArgs);
-  if (touchesStdin) return null;
+  if (touchesStdin) return { kind: "none" };
   const parsed = parseSshCommand(args);
-  if (parsed.queryMode || parsed.destination === undefined) return null;
+  // Query modes FIRST: `ssh -V` / `ssh -Q cipher` have no destination BY DESIGN, so they must stay clean
+  // `none`s rather than fall into the undecidable arm below.
+  if (parsed.queryMode) return { kind: "none" };
+  if (parsed.undecidable) return { kind: "undecidable" };
+  // Defensive: the parser's post-loop rule already covers this, but keep it so a future parser change
+  // cannot silently re-open the hole.
+  if (parsed.destination === undefined) return { kind: "undecidable" };
   // `-N` (no remote command), `-f` (fork to background) and `-W host:port` (forward stdin/stdout,
   // implies -N/-T) do NOT open an interactive login shell in THIS pane: `-N` holds a tunnel, `-f`
   // returns it to the LOCAL prompt, `-W` turns the pane into a stdio conduit for a bastion and exits.
   // Pushing a remote frame would mislabel a later LOCAL command as remote → wrong-target on the
   // fp-less sudo path (#495 P2 / R5 P2). Treat them as non-session-opening — no push.
-  if (parsed.flagLetters.has("N") || parsed.flagLetters.has("f") || parsed.flagLetters.has("W")) return null;
-  // A one-shot `ssh host cmd …` has a REAL remote-command token AFTER the destination → not an
-  // interactive login session. parseSshCommand consumes `optionArgs` (the options) + 1 (the
-  // destination); anything BEYOND that count (redirects already stripped above) is the remote command.
-  // STRUCTURAL token count, not indexOf (Opus R1 P2-1: `ssh -l host host` would make indexOf return the
-  // option-arg's index and misclassify it).
-  const consumed = parsed.optionArgs.length + 1;
-  if (args.length > consumed) return null; // trailing remote command → one-shot, no session
+  if (parsed.flagLetters.has("N") || parsed.flagLetters.has("f") || parsed.flagLetters.has("W")) {
+    return { kind: "none" };
+  }
+  // A one-shot `ssh host cmd …` has a REAL remote-command token after the destination → not an
+  // interactive login. The parser locates that boundary with ssh's own two-pass rule, so a POST-
+  // DESTINATION OPTION (`ssh host -v`) is no longer miscounted as a command (F-3: the old
+  // `optionArgs.length + 1` arithmetic could not tell the two apart, so every trailing option made the
+  // pane look local while a login was open).
+  if (parsed.remoteCommand.length > 0) return { kind: "none" };
   const at = parsed.destination.lastIndexOf("@");
   const host = at >= 0 ? parsed.destination.slice(at + 1) : parsed.destination;
-  return host.toLowerCase();
+  return { kind: "interactive", host: host.toLowerCase() };
 }
 
 /**

--- a/src/engine/key-locker/session-tracker.ts
+++ b/src/engine/key-locker/session-tracker.ts
@@ -307,16 +307,22 @@ function scanRedirectionsForStdin(tokens: readonly string[]): { touchesStdin: bo
  *       (measured: `You must specify a subsystem to invoke.`, exit 255). `-s sftp` reaching `none` today via
  *       the remote-command check is the RIGHT answer for the WRONG reason — it would break the moment that
  *       check moved
+ *   n — redirects stdin from `/dev/null`, so the remote shell hits EOF and exits AT ONCE, returning the pane
+ *       to LOCAL. It OPENS a shell yet does not PERSIST — the exact mirror of `-N` (measured 2026-07-18,
+ *       Windows OpenSSH 10.0.0.0p2 sshd: `ssh -n` prints the login prompt then exits 0 in ~400 ms, whereas a
+ *       plain login with stdin still on the tty holds the shell indefinitely). Almost always paired with `-f`
+ *       (already here), so the bare form is rare, but it is letter-only decidable and belongs on its own
  *
- * The test is "does a remote login shell take over this pane", NOT "does the process persist": `-N` outlives
- * everything here and still belongs (measured: alive past 6s, holding its tunnel), while a plain `ssh host`
- * is the login. Judging by persistence instead breaks on the very first letter.
+ * The test is "does a remote login shell take over this pane", NOT "does the process persist" — the two come
+ * apart in BOTH directions, which is why judging by persistence breaks on the very first letter: `-N` outlives
+ * everything here yet opens no shell (measured: alive past 6s, holding its tunnel), while `-n` opens a shell
+ * that vanishes in ~400 ms. Only a plain `ssh host` (persists AND takes over) is the login.
  *
  * ⚠ Unlike `SSH_FLAGS_WITH_ARG`, this set CANNOT be machine-checked against the synopsis — ssh's usage text
  * says which options take a value, never which suppress the shell. It has to be right by reading, so it was
  * swept letter-by-letter against the synopsis once (plan §1.5b) rather than grown one report at a time.
  */
-const SSH_FLAGS_NO_LOGIN_SHELL = new Set([..."NfWOs"]);
+const SSH_FLAGS_NO_LOGIN_SHELL = new Set([..."NfWOsn"]);
 
 /** How an `ssh` argv (WITHOUT the leading `ssh` token) affects THIS pane's session. Three states, because
  *  two cannot express doubt — and treating doubt as "opens nothing" is exactly the F-3 inversion: the pane
@@ -328,7 +334,7 @@ export type SshLoginClass =
    *  label (L1 resolves the real endpoint later). */
   | { kind: "interactive"; host: string }
   /** PROVABLY opens no session in this pane: a query mode (`-G`/`-Q`/`-V`), a no-login-shell flag
-   *  (`SSH_FLAGS_NO_LOGIN_SHELL` = `-N`/`-f`/`-W`/`-O`/`-s`), an argv whose stdin is off the tty, a one-shot
+   *  (`SSH_FLAGS_NO_LOGIN_SHELL` = `-N`/`-f`/`-W`/`-O`/`-s`/`-n`), an argv whose stdin is off the tty, a one-shot
    *  with a PROVEN remote command, or an argv a CONFIRMED with-arg option leaves malformed (`ssh h -p` —
    *  ssh rejects it as a local usage error, exit 255, before any session opens). Every member is PROVEN; a
    *  doubt belongs in `undecidable`, never here. */
@@ -370,7 +376,7 @@ export function classifySshLogin(rawArgs: readonly string[]): SshLoginClass {
   // Defensive: the parser's post-loop rule already covers this, but keep it so a future parser change
   // cannot silently re-open the hole.
   if (parsed.destination === undefined) return { kind: "undecidable" };
-  // A flag that PROVES no login shell takes over THIS pane (`-N`/`-f`/`-W`/`-O`/`-s`) → no session, no
+  // A flag that PROVES no login shell takes over THIS pane (`-N`/`-f`/`-W`/`-O`/`-s`/`-n`) → no session, no
   // push: pushing a remote frame would mislabel a later LOCAL command as remote → wrong-target on the
   // fp-less sudo path (#495 P2 / R5 P2). The letters and their per-letter reasons live in
   // SSH_FLAGS_NO_LOGIN_SHELL; consulting the SET rather than an inline `has("N")||has("f")||…` chain is

--- a/src/engine/key-locker/session-tracker.ts
+++ b/src/engine/key-locker/session-tracker.ts
@@ -323,10 +323,16 @@ export function classifySshLogin(rawArgs: readonly string[]): SshLoginClass {
   const { touchesStdin, stripped: args } = scanRedirectionsForStdin(rawArgs);
   if (touchesStdin) return { kind: "none" };
   const parsed = parseSshCommand(args);
-  // Query modes FIRST: `ssh -V` / `ssh -Q cipher` have no destination BY DESIGN, so they must stay clean
-  // `none`s rather than fall into the undecidable arm below.
-  if (parsed.queryMode) return { kind: "none" };
+  // DOUBT OUTRANKS EVERY POSITIVE VERDICT — including a query. If an unknown letter is present we cannot
+  // even trust that `-G`/`-V`/`-Q` IS a query: a future with-arg `-z` would eat the next token, so real ssh
+  // reads `ssh -z -G h` as "-G is -z's VALUE" and OPENS A SESSION while our flag scan sees a query. Checking
+  // queryMode first would answer `none` there ⇒ the pane stays trusted-LOCAL while a remote login is open —
+  // the exact silent disclosure `undecidable` exists to prevent (Opus R1 P1-1).
+  // This costs nothing for real queries: the parser's post-loop rule already exempts them
+  // (`if (!queryMode && destination === undefined) undecidable = true`), so `-V` / `-Q cipher` / `-G h`
+  // carry `undecidable === false` and still fall through to the clean `none` below.
   if (parsed.undecidable) return { kind: "undecidable" };
+  if (parsed.queryMode) return { kind: "none" };
   // Defensive: the parser's post-loop rule already covers this, but keep it so a future parser change
   // cannot silently re-open the hole.
   if (parsed.destination === undefined) return { kind: "undecidable" };

--- a/src/engine/key-locker/ssh-resolve.ts
+++ b/src/engine/key-locker/ssh-resolve.ts
@@ -121,11 +121,16 @@ export interface ParsedSshCommand {
  * login was open. See the findings + plan docs
  * (desktop-touch-mcp-internal:docs/adr-014-v2-r3x-la-live-dogfood-findings.md F-3, §1.2 of the fix plan).
  *
- * KNOWN GAP (availability-only, deliberate): `--` (end-of-options) is not modelled. Real ssh accepts it
- * (`ssh -G -- host` prints the config, i.e. a session would open); here `-` is in neither allow-list, so
- * the parse is `undecidable` and every consumer DECLINES. That is the fail-safe direction — a rare
- * invocation loses autofill, nothing is ever mis-targeted — so it is left to the drift guard's allow-list
- * rather than special-cased here.
+ * KNOWN GAP (deliberate, fail-safe direction): LONG options are not modelled — `--` (end-of-options),
+ * `--help`, `--version`. Real ssh accepts them (`ssh -G -- host` prints the config, i.e. a session would
+ * open), but their first letter (`-`, `h`, `v` after the leading `--`) lands outside both allow-lists, so
+ * the parse is `undecidable` and every consumer DECLINES.
+ *
+ * The cost is bigger than the invocation: `recordDispatch` maps `undecidable` to `markUnknown`, and an
+ * UNKNOWN pane does not recover on its own (see `markUnknown`'s doc — recovery is a future item), so the
+ * PANE stops autofilling until it is re-anchored, not just that one command. Accepted anyway: the
+ * alternative is guessing an option's arity, and a wrong guess mis-locates the destination — that is the
+ * disclosure direction. Nothing is ever mis-targeted here.
  */
 export function parseSshCommand(args: readonly string[]): ParsedSshCommand {
   const optionArgs: string[] = [];
@@ -304,6 +309,12 @@ export async function resolveCanonicalForSshCommand(
   exec: ExecFn = defaultExec,
 ): Promise<SshResolveResult> {
   const parsed = parseSshCommand(args);
+  // An argv we cannot classify has a GUESSED destination and a guessed option/command split, so which
+  // endpoint we would bind — i.e. whose prompt this secret gets typed into — is a guess too. Fail closed
+  // HERE, not only in `deriveSsh`: this is an exported engine seam, and containment must not rest on what
+  // today's callers happen to pass (強制命令 7). The other caller (`key-locker-tool.ts`) builds its argv
+  // itself and never produces an undecidable parse, so this costs nothing.
+  if (parsed.undecidable) return { kind: "unresolvable", reason: "unclassifiable ssh argv (unknown option letter)" };
   if (parsed.destination === undefined) return { kind: "unresolvable", reason: "no ssh destination" };
   let cfg: SshEffectiveConfig;
   try {

--- a/src/engine/key-locker/ssh-resolve.ts
+++ b/src/engine/key-locker/ssh-resolve.ts
@@ -48,37 +48,90 @@ export const defaultExec: ExecFn = async (file, args) => {
 
 // OpenSSH client option letters (`man ssh` synopsis): which short flags CONSUME the next token.
 // (Everything else — 46AaCfGgKkMNnqsTtVvXxYy — is a no-arg flag and falls to the else branch.)
-const SSH_FLAGS_WITH_ARG = new Set([..."BbcDEeFIiJLlmOoPpQRSWw"]);
+// Exported for the §1.3.1 drift guard (a unit canary re-derives both sets from the local ssh's own usage
+// synopsis, so an OpenSSH upgrade that moves a letter fails loudly instead of silently costing autofill).
+export const SSH_FLAGS_WITH_ARG = new Set([..."BbcDEeFIiJLlmOoPpQRSWw"]);
+// The COMPLEMENT of SSH_FLAGS_WITH_ARG: every option letter we KNOW takes no argument. Same source (the
+// `man ssh` synopsis cluster `[-46AaCfGgKkMNnqsTtVvXxYy]`), plus `2`, which the synopsis omits but every
+// build still ACCEPTS as a no-op (measured: `ssh -2 -G host` prints the config on OpenSSH 9.5p2 and
+// 10.3p1) — so `ssh -2 host` opens a REAL session and must classify as a login.
+//
+// `1` is deliberately in NEITHER list. The synopsis omits it and the real ssh is FATAL on it
+// (`SSH protocol v.1 is no longer supported`), so no session ever opens; listing it as no-arg would make
+// us confidently classify `ssh -1 host` as an interactive login and push a remote frame for a pane that
+// never left local — a later `sudo` would then fill a REMOTE secret into a LOCAL prompt. A retired letter
+// is indistinguishable from a letter we have simply never heard of, and both must decline.
+//
+// Together the two sets are a CLOSED allow-list: a letter in NEITHER makes the parse `undecidable`,
+// because without knowing whether it consumes the next token we can locate neither the destination nor the
+// remote-command boundary — and guessing either way fails toward DISCLOSURE.
+// Plan: desktop-touch-mcp-internal:docs/adr-014-v2-r3x-complete-fix-plan.md §1.3 / PR1.1
+export const SSH_FLAGS_NO_ARG = new Set([..."246AaCfGgKkMNnqsTtVvXxYy"]);
 
 export interface ParsedSshCommand {
   /** The destination token (`host` or `user@host`), or undefined if none was found. */
   destination?: string;
-  /** Every option token up to the destination, in order — passed through to `ssh -G` verbatim. */
+  /**
+   * Every option token (and its value), in order, from ANYWHERE before the remote command begins —
+   * including AFTER the destination, which is where real ssh accepts them too. Passed to `ssh -G` verbatim.
+   */
   optionArgs: string[];
   /** True if the invocation is a query / no-login mode (`-G` / `-Q` / `-V`) — never prompts. */
   queryMode: boolean;
   /**
-   * Every OPTION FLAG LETTER seen before the destination (getopt clusters expanded: `-fN` → {f,N};
+   * Every OPTION FLAG LETTER seen before the remote command (getopt clusters expanded: `-fN` → {f,N};
    * `-4p 2222` → {4,p}), EXCLUDING the VALUES of with-arg flags (`-p 2222` contributes `p`, not
    * `2222`; `-F fname` contributes `F`, not `fname`). Lets a caller detect session-shape flags like
    * `-f` (background) / `-N` (no remote command) / `-W` (stdio-forward, implies -N/-T) without
    * re-parsing. Only FLAG letters, so a with-arg value that happens to contain N/f/W never false-triggers.
    */
   flagLetters: ReadonlySet<string>;
+  /**
+   * The remote command: every token from the FIRST non-option token AFTER the destination to the end of
+   * argv, verbatim. Empty ⇒ the invocation opens a LOGIN SHELL on this tty.
+   *
+   * This mirrors OpenSSH `ssh.c`'s own two-pass argv rule (NOT platform getopt permutation, which is why it
+   * is identical across builds): getopt → the first non-option is the DESTINATION → `goto again` → getopt
+   * runs AGAIN over the remainder → the first non-option after THAT begins the remote command, and
+   * everything from there is passed through untouched (never re-parsed as options). So `ssh h -p 2222` has
+   * NO remote command (measured: the live pane reached the :2222 sshd), while `ssh h ls -la` has
+   * `["ls","-la"]` and the `-la` belongs to the remote `ls`.
+   */
+  remoteCommand: string[];
+  /**
+   * The parse is NOT trustworthy: an option letter outside BOTH allow-lists was seen (we cannot know
+   * whether it consumed the next token, so neither the destination nor the remote-command boundary is
+   * reliable), OR no destination could be located outside a query mode. Security consumers MUST sink to
+   * UNKNOWN on this — never "no session" (that is the F-3 inversion: it trusts a pane as LOCAL while a
+   * remote login is open).
+   */
+  undecidable: boolean;
 }
 
 /**
- * Split an `ssh …` argv (WITHOUT the leading program token) into passthrough options + the
- * destination. Tokens after the destination are the remote command — irrelevant to resolution.
+ * Split an `ssh …` argv (WITHOUT the leading program token) into passthrough options, the destination,
+ * and the remote command, using OpenSSH's OWN two-pass argv rule (`ssh.c`: getopt → destination →
+ * `goto again` → getopt → first non-option begins the remote command). Options are therefore recognised
+ * AFTER the destination too — `ssh h -p 2222` really does connect to port 2222.
+ *
+ * The pre-F-3 parser stopped at the destination and silently dropped every option behind it, so
+ * `ssh user@h -p 2222` resolved as port 22: the wrong endpoint's secret could be typed into this one's
+ * prompt, and `ssh h -v` was misread as a one-shot command ⇒ the pane was trusted LOCAL while a remote
+ * login was open. See the findings + plan docs
+ * (desktop-touch-mcp-internal:docs/adr-014-v2-r3x-la-live-dogfood-findings.md F-3, §1.2 of the fix plan).
  */
 export function parseSshCommand(args: readonly string[]): ParsedSshCommand {
   const optionArgs: string[] = [];
   const flagLetters = new Set<string>();
   let destination: string | undefined;
   let queryMode = false;
+  let remoteCommand: string[] = [];
+  let undecidable = false;
   for (let i = 0; i < args.length; i++) {
     const tok = args[i];
-    if (destination === undefined && tok.startsWith("-") && tok.length >= 2) {
+    // An option token is an option WHEREVER it appears until the remote command has begun — ssh's second
+    // getopt pass sees post-destination options exactly the same way (F-3's root fix is this guard).
+    if (remoteCommand.length === 0 && tok.startsWith("-") && tok.length >= 2) {
       optionArgs.push(tok);
       // Walk the getopt cluster left-to-right. No-arg letters accumulate; the FIRST with-arg letter
       // (`p`/`F`/`o`/`W`/…) consumes its VALUE — the rest of THIS token if attached (`-p2222`,
@@ -97,6 +150,10 @@ export function parseSshCommand(args: readonly string[]): ParsedSshCommand {
           if (!attached && i + 1 < args.length) optionArgs.push(args[++i]); // else it is the next token
           break;
         }
+        // A letter in NEITHER allow-list: we cannot know whether it eats the next token, so every
+        // boundary after it is a guess. Mark the parse untrustworthy but KEEP scanning so `flagLetters`
+        // stays as complete as it can be (no `break` — the caller declines on `undecidable` anyway).
+        if (!SSH_FLAGS_NO_ARG.has(L)) undecidable = true;
       }
       continue;
     }
@@ -104,9 +161,16 @@ export function parseSshCommand(args: readonly string[]): ParsedSshCommand {
       destination = tok;
       continue;
     }
-    break; // remote command begins — stop
+    // The first non-option token AFTER the destination begins the remote command; ssh passes everything
+    // from here through untouched, so we keep it verbatim and stop parsing (a trailing `-la` belongs to
+    // the remote `ls`, not to ssh).
+    remoteCommand = args.slice(i);
+    break;
   }
-  return { destination, optionArgs, queryMode, flagLetters };
+  // An argv we cannot even find a destination in is not a "no session" verdict — it is NO verdict. Query
+  // modes are exempt: `ssh -V` / `ssh -Q cipher` have no destination BY DESIGN and stay clean `none`s.
+  if (!queryMode && destination === undefined) undecidable = true;
+  return { destination, optionArgs, queryMode, flagLetters, remoteCommand, undecidable };
 }
 
 export interface SshEffectiveConfig {
@@ -143,6 +207,27 @@ export async function sshDashG(
   if (code !== 0) {
     throw new Error(`ssh -G exited ${code}: ${stderr.trim().slice(0, 300)}`);
   }
+  return parseSshDashGOutput(stdout, destination);
+}
+
+/**
+ * `ssh -G <argv…>` — the whole dispatched argv, verbatim. Same parsing + failure contract as `sshDashG`;
+ * the ONLY difference is that the real ssh, not our parser, decides which tokens are options. `args`
+ * excludes the leading `ssh` program token.
+ */
+export async function sshDashGArgv(
+  args: readonly string[],
+  exec: ExecFn = defaultExec,
+): Promise<SshEffectiveConfig> {
+  const { code, stdout, stderr } = await exec("ssh", ["-G", ...args]);
+  if (code !== 0) {
+    throw new Error(`ssh -G exited ${code}: ${stderr.trim().slice(0, 300)}`);
+  }
+  return parseSshDashGOutput(stdout, args.join(" "));
+}
+
+/** Parse `ssh -G` stdout into the effective, last-wins config. `destinationForError` only labels errors. */
+function parseSshDashGOutput(stdout: string, destinationForError: string): SshEffectiveConfig {
   let host = "";
   let user = "";
   let port = 22;
@@ -175,7 +260,7 @@ export async function sshDashG(
     }
   }
   if (host === "" || user === "") {
-    throw new Error(`ssh -G output missing hostname/user for '${destination}'`);
+    throw new Error(`ssh -G output missing hostname/user for '${destinationForError}'`);
   }
   return { host, user, port, hostKeyAlias, knownHostsFiles, proxyJump, proxyCommand };
 }
@@ -231,7 +316,14 @@ export async function resolveCanonicalForSshCommand(
   if (parsed.destination === undefined) return { kind: "unresolvable", reason: "no ssh destination" };
   let cfg: SshEffectiveConfig;
   try {
-    cfg = await sshDashG(parsed.destination, parsed.optionArgs, exec);
+    // Hand the WHOLE argv to `ssh -G` and let the real binary arbitrate the option / value / remote-command
+    // split with its own ssh.c two-pass rule. Our parser is correct, but the ENDPOINT decision — which
+    // server's secret gets typed — must not depend on the completeness of our own flag table: a wrong
+    // entry here would be silent and security-relevant. `ssh -G` never connects (see the header) and
+    // ignores a trailing remote command; a non-zero exit already fail-closes below. This is what this
+    // module's header always intended — the old call could not honour it, because `optionArgs` dropped
+    // everything after the destination (F-3).
+    cfg = await sshDashGArgv(args, exec);
   } catch (e) {
     return { kind: "unresolvable", reason: (e as Error).message };
   }

--- a/src/engine/key-locker/ssh-resolve.ts
+++ b/src/engine/key-locker/ssh-resolve.ts
@@ -107,6 +107,24 @@ export interface ParsedSshCommand {
    * remote login is open).
    */
   undecidable: boolean;
+  /**
+   * A CONFIRMED with-arg option was left without a value (`ssh h -p`): ssh rejects this as a local usage
+   * error (`option requires an argument -- p`, exit 255) BEFORE any session opens. Not a doubt — a known
+   * outcome, which is why it is a separate channel from `undecidable`:
+   *
+   *   `undecidable` = we do not know what ssh will do  ⇒ callers DECLINE (sink to UNKNOWN)
+   *   `malformed`   = we know ssh will fail locally     ⇒ callers may treat it as a PROVEN non-login
+   *
+   * Collapsing the two would be wrong in both directions: sinking a pane to UNKNOWN over a typo costs it
+   * autofill until it is re-anchored (recovery is a future item), while trusting a doubt as a non-login is
+   * the F-3 inversion itself. The guarantee rests on the letter really being with-arg — that is what
+   * `SSH_FLAGS_WITH_ARG` asserts and what the §1.3.1 drift canary keeps honest.
+   *
+   * The condition is deliberately narrow: a KNOWN with-arg letter, unattached, with no token left to
+   * consume. Nothing else belongs here — `ssh -p h` consumes `h` as the value (not malformed; it is
+   * `undecidable` for want of a destination).
+   */
+  malformed: boolean;
 }
 
 /**
@@ -139,6 +157,7 @@ export function parseSshCommand(args: readonly string[]): ParsedSshCommand {
   let queryMode = false;
   let remoteCommand: string[] = [];
   let undecidable = false;
+  let malformed = false;
   for (let i = 0; i < args.length; i++) {
     const tok = args[i];
     // An option token is an option WHEREVER it appears until the remote command has begun — ssh's second
@@ -159,7 +178,13 @@ export function parseSshCommand(args: readonly string[]): ParsedSshCommand {
         if (SSH_FLAGS_WITH_ARG.has(L)) {
           if (L === "Q") queryMode = true;
           const attached = c < tok.length - 1; // the value is the rest of THIS token
-          if (!attached && i + 1 < args.length) optionArgs.push(args[++i]); // else it is the next token
+          if (!attached) {
+            // The value is the NEXT token — unless there is none, in which case getopt hands ssh a usage
+            // error and it exits before opening anything. Recording that is what stops `ssh h -p` from
+            // looking like a login (the pane never left local, so pushing a remote frame would mislabel it).
+            if (i + 1 < args.length) optionArgs.push(args[++i]);
+            else malformed = true;
+          }
           break;
         }
         // A letter in NEITHER allow-list: we cannot know whether it eats the next token, so every
@@ -182,7 +207,7 @@ export function parseSshCommand(args: readonly string[]): ParsedSshCommand {
   // An argv we cannot even find a destination in is not a "no session" verdict — it is NO verdict. Query
   // modes are exempt: `ssh -V` / `ssh -Q cipher` have no destination BY DESIGN and stay clean `none`s.
   if (!queryMode && destination === undefined) undecidable = true;
-  return { destination, optionArgs, queryMode, flagLetters, remoteCommand, undecidable };
+  return { destination, optionArgs, queryMode, flagLetters, remoteCommand, undecidable, malformed };
 }
 
 export interface SshEffectiveConfig {

--- a/src/engine/key-locker/ssh-resolve.ts
+++ b/src/engine/key-locker/ssh-resolve.ts
@@ -340,6 +340,12 @@ export async function resolveCanonicalForSshCommand(
   // today's callers happen to pass (強制命令 7). The other caller (`key-locker-tool.ts`) builds its argv
   // itself and never produces an undecidable parse, so this costs nothing.
   if (parsed.undecidable) return { kind: "unresolvable", reason: "unclassifiable ssh argv (unknown option letter)" };
+  // A with-arg option with no value never runs: ssh answers with a usage error, so there is nothing to
+  // bind. Stated explicitly rather than relied upon: without this, the decline happens only as a side
+  // effect of how the argv is reassembled below (the dangling option swallows the destination, ssh then
+  // errors for want of one). That is true today, but it is an accident of reconstruction order, not a
+  // guarantee — and it costs a pointless spawn to discover.
+  if (parsed.malformed) return { kind: "unresolvable", reason: "malformed ssh argv (option with no value)" };
   if (parsed.destination === undefined) return { kind: "unresolvable", reason: "no ssh destination" };
   let cfg: SshEffectiveConfig;
   try {

--- a/src/engine/key-locker/ssh-resolve.ts
+++ b/src/engine/key-locker/ssh-resolve.ts
@@ -46,8 +46,9 @@ export const defaultExec: ExecFn = async (file, args) => {
   }
 };
 
-// OpenSSH client option letters (`man ssh` synopsis): which short flags CONSUME the next token.
-// (Everything else — 46AaCfGgKkMNnqsTtVvXxYy — is a no-arg flag and falls to the else branch.)
+// OpenSSH client option letters (`man ssh` synopsis): which short flags CONSUME the next token. The
+// no-arg letters are enumerated in SSH_FLAGS_NO_ARG below — the two sets are a CLOSED allow-list, so a
+// letter in neither is NOT assumed no-arg (that assumption is what `undecidable` exists to refuse).
 // Exported for the §1.3.1 drift guard (a unit canary re-derives both sets from the local ssh's own usage
 // synopsis, so an OpenSSH upgrade that moves a letter fails loudly instead of silently costing autofill).
 export const SSH_FLAGS_WITH_ARG = new Set([..."BbcDEeFIiJLlmOoPpQRSWw"]);
@@ -119,6 +120,12 @@ export interface ParsedSshCommand {
  * prompt, and `ssh h -v` was misread as a one-shot command ⇒ the pane was trusted LOCAL while a remote
  * login was open. See the findings + plan docs
  * (desktop-touch-mcp-internal:docs/adr-014-v2-r3x-la-live-dogfood-findings.md F-3, §1.2 of the fix plan).
+ *
+ * KNOWN GAP (availability-only, deliberate): `--` (end-of-options) is not modelled. Real ssh accepts it
+ * (`ssh -G -- host` prints the config, i.e. a session would open); here `-` is in neither allow-list, so
+ * the parse is `undecidable` and every consumer DECLINES. That is the fail-safe direction — a rare
+ * invocation loses autofill, nothing is ever mis-targeted — so it is left to the drift guard's allow-list
+ * rather than special-cased here.
  */
 export function parseSshCommand(args: readonly string[]): ParsedSshCommand {
   const optionArgs: string[] = [];
@@ -208,22 +215,6 @@ export async function sshDashG(
     throw new Error(`ssh -G exited ${code}: ${stderr.trim().slice(0, 300)}`);
   }
   return parseSshDashGOutput(stdout, destination);
-}
-
-/**
- * `ssh -G <argv…>` — the whole dispatched argv, verbatim. Same parsing + failure contract as `sshDashG`;
- * the ONLY difference is that the real ssh, not our parser, decides which tokens are options. `args`
- * excludes the leading `ssh` program token.
- */
-export async function sshDashGArgv(
-  args: readonly string[],
-  exec: ExecFn = defaultExec,
-): Promise<SshEffectiveConfig> {
-  const { code, stdout, stderr } = await exec("ssh", ["-G", ...args]);
-  if (code !== 0) {
-    throw new Error(`ssh -G exited ${code}: ${stderr.trim().slice(0, 300)}`);
-  }
-  return parseSshDashGOutput(stdout, args.join(" "));
 }
 
 /** Parse `ssh -G` stdout into the effective, last-wins config. `destinationForError` only labels errors. */
@@ -316,14 +307,12 @@ export async function resolveCanonicalForSshCommand(
   if (parsed.destination === undefined) return { kind: "unresolvable", reason: "no ssh destination" };
   let cfg: SshEffectiveConfig;
   try {
-    // Hand the WHOLE argv to `ssh -G` and let the real binary arbitrate the option / value / remote-command
-    // split with its own ssh.c two-pass rule. Our parser is correct, but the ENDPOINT decision — which
-    // server's secret gets typed — must not depend on the completeness of our own flag table: a wrong
-    // entry here would be silent and security-relevant. `ssh -G` never connects (see the header) and
-    // ignores a trailing remote command; a non-zero exit already fail-closes below. This is what this
-    // module's header always intended — the old call could not honour it, because `optionArgs` dropped
-    // everything after the destination (F-3).
-    cfg = await sshDashGArgv(args, exec);
+    // Pass the OPTIONS ONLY — never the remote command. `optionArgs` now carries post-destination options
+    // too (the F-3 two-pass fix), so this yields the same endpoint handing `ssh -G` the whole argv would,
+    // WITHOUT putting the remote command on ssh.exe's command line: `ssh h mysql -pS3CR3T` would otherwise
+    // publish that secret to every process that can read our argv (Opus R1 P2-1). The same threat model
+    // already bans the dispatched command from the diagnostic log; process arguments are no different.
+    cfg = await sshDashG(parsed.destination, parsed.optionArgs, exec);
   } catch (e) {
     return { kind: "unresolvable", reason: (e as Error).message };
   }

--- a/src/engine/key-locker/ssh-session-watch.ts
+++ b/src/engine/key-locker/ssh-session-watch.ts
@@ -83,15 +83,16 @@
 // intermediate — `sudo ssh`, a wrapper, a tmux server that stays UNDER the shell — is a grandchild the walk
 // still finds; an ssh REPARENTED OUT of the shell subtree entirely, e.g. a detached daemon, is out of scope,
 // a low-risk residual on the Windows target where a login pane's ssh normally stays under the shell) and
-// classify its argv with the SAME `interactiveSshTarget` rule: an interactive in-bound login — OR an ssh
-// whose argv is UNREADABLE or EMPTY (elevated/cross-user or a bad read: fail-safe) — sinks the
+// classify its argv with the SAME `classifySshLogin` rule: anything other than a PROVEN `none` — an
+// interactive in-bound login, an argv we cannot classify (`undecidable`), OR an ssh whose argv is
+// UNREADABLE or EMPTY (elevated/cross-user or a bad read: fail-safe) — sinks the
 // pane to `markUnknown`. A tunnel (`-N`/`-f`/`-L`), a one-shot (`ssh host cmd`), scp/sftp/git-over-ssh (their
 // inner ssh carries a trailing remote command) classify non-interactive ⇒ NOT sunk, so those panes keep
 // autofilling (OQ-W-7 = option B). This is a NEW fail-safe (markUnknown on doubt), never a new pop. It is
 // gated on `remoteDepth===0` so a LEGIT assistant-dispatched interactive ssh — whose `recordDispatch` has
 // pushed a frame (depth>0) — is handled by the existing unwatched-frame backstop, not this scan.
 
-import { interactiveSshTarget } from "./session-tracker.js";
+import { classifySshLogin } from "./session-tracker.js";
 
 /** The tracker surface the watch drives (a subset of `SessionTracker`, so tests inject a fake). */
 export interface SessionTrackerSink {
@@ -425,7 +426,10 @@ export class SshSessionWatch {
         // the module's "any doubt sinks" invariant).
         const argv = snap.commandLine(pid);
         if (argv === null || argv.length === 0) return true; // unreadable / empty ⇒ fail-safe (possibly interactive)
-        if (interactiveSshTarget(argv.slice(1)) !== null) return true; // an interactive in-bound login (exempt pid already skipped)
+        // Anything but a PROVEN `none` flags: an interactive login, or an argv we cannot classify with
+        // confidence (`undecidable` — an unknown option letter / no locatable destination). Only a proven
+        // non-session-opening ssh is trusted, upholding the module's "any doubt sinks" invariant.
+        if (classifySshLogin(argv.slice(1)).kind !== "none") return true; // (exempt pid already skipped)
       }
     }
     return false;

--- a/src/engine/key-locker/ssh-session-watch.ts
+++ b/src/engine/key-locker/ssh-session-watch.ts
@@ -432,6 +432,12 @@ export class SshSessionWatch {
         // Anything but a PROVEN `none` flags: an interactive login, or an argv we cannot classify with
         // confidence (`undecidable` — an unknown option letter / no locatable destination). Only a proven
         // non-session-opening ssh is trusted, upholding the module's "any doubt sinks" invariant.
+        //
+        // A `none` descendant may well still be ALIVE when we look (this scan also runs from `onDispatch`,
+        // right after delivery, and a doomed `ssh h -p` has not necessarily exited yet). That is fine, and
+        // liveness is NOT the reason it is safe: the reason is that this argv OPENS NO SESSION, so the pane
+        // it lives in is still local no matter what the process is doing. Reasoning from "the process is
+        // gone" — or from "it opens no shell" — is how the landed-mode conflation got in.
         if (classifySshLogin(argv.slice(1)).kind !== "none") return true; // (exempt pid already skipped)
       }
     }

--- a/src/engine/key-locker/ssh-session-watch.ts
+++ b/src/engine/key-locker/ssh-session-watch.ts
@@ -367,8 +367,9 @@ export class SshSessionWatch {
    * W-2b: does the shell's process SUBTREE hold an UNREGISTERED ssh that would make a LOCAL-anchored pane
    * actually remote — a user hand-`ssh host` the wiring never dispatched? Walk the `parentMap` subtree from
    * `shellPid` and, for each LIVE `ssh`-named DESCENDANT (subtree, not just direct — a `sudo ssh`/wrapper/
-   * tmux-reparented login is a grandchild), classify its argv with `interactiveSshTarget` (the SAME rule that
-   * decides whether an ssh opens a session). Returns true (⇒ caller `markUnknown`s, decline-not-disclose) iff
+   * tmux-reparented login is a grandchild), classify its argv with `classifySshLogin` (the SAME rule that
+   * decides whether an ssh opens a session) and trust ONLY a PROVEN `none` — an `undecidable` argv flags.
+   * Returns true (⇒ caller `markUnknown`s, decline-not-disclose) iff
    * any LIVE descendant is itself UNREADABLE (identify() name "" — an elevated/cross-user process we cannot
    * even name, e.g. the ssh in `sudo ssh`; Codex PR#512 P1), OR is an interactive in-bound `ssh` login, OR is
    * an `ssh` whose argv is UNREADABLE (`commandLine` null — an elevated/cross-user ssh we cannot introspect:
@@ -421,9 +422,11 @@ export class SshSessionWatch {
         if (descName === "") return true; // unreadable LIVE descendant ⇒ possibly interactive ssh (decline)
         if (descName !== SSH_PROGRAM) continue; // readable non-ssh ⇒ not an in-bound login
         // Fail-safe on ANY non-classifiable ssh: unreadable (null) OR an EMPTY argv — an ssh we cannot
-        // classify must sink the pane, never trust-local (Opus PR#512 P2: `interactiveSshTarget([])` returns
-        // null, which without this guard would fall through to "not flagged" = trust local, the opposite of
-        // the module's "any doubt sinks" invariant).
+        // classify must sink the pane, never trust-local. Belt and braces since F-3: `classifySshLogin([])`
+        // now returns `undecidable`, which the check below flags anyway. Kept deliberately — this module's
+        // "any doubt sinks" invariant must not depend on another module's classification order (the original
+        // Opus PR#512 P2 hole was exactly that dependency: the old classifier returned a bare null here,
+        // which fell through to "not flagged" = trust local).
         const argv = snap.commandLine(pid);
         if (argv === null || argv.length === 0) return true; // unreadable / empty ⇒ fail-safe (possibly interactive)
         // Anything but a PROVEN `none` flags: an interactive login, or an argv we cannot classify with

--- a/src/engine/win32.ts
+++ b/src/engine/win32.ts
@@ -408,7 +408,7 @@ export function getWindowIdentity(hwnd: unknown): ProcessIdentity {
  * a query/parse failure — so callers fail SAFE (ADR-014 v2 R3 L3-4 W-2b treats a
  * null read as "possibly an interactive in-bound ssh" and declines).
  *
- * argv[0] is the image (ssh path); pass `argv.slice(1)` to `interactiveSshTarget`.
+ * argv[0] is the image (ssh path); pass `argv.slice(1)` to `classifySshLogin`.
  * Uses `NtQueryInformationProcess(ProcessCommandLineInformation)` under the same
  * `PROCESS_QUERY_LIMITED_INFORMATION` right as the identity query (no cross-process
  * memory read).

--- a/src/win32/process.rs
+++ b/src/win32/process.rs
@@ -192,7 +192,7 @@ pub fn win32_get_process_identity(pid: u32) -> napi::Result<NativeProcessIdentit
 /// — and does NO cross-process memory read (the OS copies the string into OUR
 /// buffer). Split with `CommandLineToArgvW` for byte-exact parity with how the
 /// process was actually launched (quote/backslash rules), so the L3-4 caller can
-/// reuse `interactiveSshTarget` to tell an interactive in-bound `ssh host` from a
+/// reuse `classifySshLogin` to tell an interactive in-bound `ssh host` from a
 /// tunnel (`-N`/`-f`/`-L`) or one-shot (`ssh host cmd`).
 ///
 /// Returns `None` on ANY failure — a dead pid, ACCESS_DENIED on an elevated /

--- a/tests/unit/key-locker-derivation.test.ts
+++ b/tests/unit/key-locker-derivation.test.ts
@@ -232,6 +232,26 @@ describe("§8 #5 — sudo purpose + session host", () => {
     const uri = await deriveBinding("ssh prod.example.com sudo apt update", local, { exec: fakeExec });
     expect(uri).toMatchObject({ scheme: "ssh", host: "prod.example.com", user: "u", port: 22 });
   });
+
+  // ── the remote command must never reach a spawned process's ARGUMENTS ─────────────────────────────
+  // A dispatched command can carry a secret in plain sight (`mysql -pS3CR3T`), and `ssh` is enough to arm
+  // the poller, so `deriveBinding` runs over that argv. Resolution must pass the OPTIONS ONLY: Windows
+  // process command lines are readable by any same-user (and every elevated) process, so handing the whole
+  // argv to `ssh -G` would publish the secret. This is the same threat model that bans the dispatched
+  // command from the diagnostic log. (Regression pin: an earlier revision of the F-3 fix did exactly that.)
+  it("a secret inside the remote command NEVER reaches any exec's argv", async () => {
+    const seen: string[][] = [];
+    const spy: ExecFn = async (file, args) => {
+      seen.push([file, ...args]);
+      return fakeExec(file, args);
+    };
+    await deriveBinding("ssh h mysql -uroot -pS3CR3T --host=db", local, { exec: spy });
+    expect(seen.length).toBeGreaterThan(0); // the resolution actually ran
+    const flat = seen.map((a) => a.join(" ")).join("\n");
+    expect(flat).not.toContain("S3CR3T");
+    expect(flat).not.toContain("mysql");
+    for (const argv of seen) expect(argv).not.toContain("-pS3CR3T");
+  });
 });
 
 describe("§8 #6 — command derivation table", () => {

--- a/tests/unit/key-locker-derivation.test.ts
+++ b/tests/unit/key-locker-derivation.test.ts
@@ -250,7 +250,26 @@ describe("§8 #5 — sudo purpose + session host", () => {
     const flat = seen.map((a) => a.join(" ")).join("\n");
     expect(flat).not.toContain("S3CR3T");
     expect(flat).not.toContain("mysql");
-    for (const argv of seen) expect(argv).not.toContain("-pS3CR3T");
+  });
+
+  // ── an unclassifiable argv derives nothing, and never even asks ───────────────────────────────────
+  // With `-z` in neither flag table we cannot know whether it eats the next token, so both the
+  // destination and the option/command split are guesses — and a guessed endpoint decides whose prompt
+  // the secret is typed into. This decline is what lets the resolver go back to using our own flag table
+  // (it was the whole-argv detour's job before; that detour leaked secrets into ssh.exe's argv).
+  it("an unclassifiable ssh argv derives NO binding and spawns nothing", async () => {
+    const seen: string[][] = [];
+    const spy: ExecFn = async (file, args) => {
+      seen.push([file, ...args]);
+      return fakeExec(file, args);
+    };
+    expect(await deriveBinding("ssh h -z", local, { exec: spy })).toBeNull();
+    expect(await deriveBinding("ssh h -z value", local, { exec: spy })).toBeNull();
+    expect(seen).toEqual([]); // never reached the resolver
+  });
+
+  it("a KNOWN argv still derives normally (the undecidable arm is not over-broad)", async () => {
+    expect(await deriveBinding("ssh h -v", local, { exec: fakeExec })).toMatchObject({ scheme: "ssh", host: "h" });
   });
 });
 

--- a/tests/unit/key-locker-derivation.test.ts
+++ b/tests/unit/key-locker-derivation.test.ts
@@ -15,7 +15,7 @@ import {
   tokenizeCommandSegmentsWithOps,
   type SessionContext,
 } from "../../src/engine/key-locker/command-derivation.js";
-import { defaultExec, type ExecFn } from "../../src/engine/key-locker/ssh-resolve.js";
+import { defaultExec, parseSshCommand, type ExecFn } from "../../src/engine/key-locker/ssh-resolve.js";
 
 let tmp: string;
 let khFile: string;
@@ -28,20 +28,35 @@ const remotePane: SessionContext = { execHost: "prod.example.com", isRemote: tru
 // Canned ssh -G/ssh-keygen; git falls through to the real binary (fixture repos, no network).
 const fakeExec: ExecFn = async (file, args) => {
   if (file === "ssh" && args[0] === "-G") {
-    const dest = args[args.length - 1];
+    // The resolver hands `ssh -G` the WHOLE dispatched argv (F-3 / plan §1.6: the ENDPOINT decision must
+    // not ride on our own flag table), so this stub must locate the destination the way the real ssh does
+    // rather than assume it is the last token — `ssh -G h sudo apt update` would otherwise be read as a
+    // connection to `update`. (Verified against the real binary: `ssh -G h sudo apt update` prints the
+    // same config as `ssh -G h`; only the stderr pty warning differs, and we parse stdout.)
+    //
+    // It reuses `parseSshCommand` ON PURPOSE (plan §6.1(b)). That is circular ONLY in appearance: this
+    // suite pins the derivation PIPELINE (derive → canonical → fp-set → lookup), while the parser itself is
+    // pinned independently by the 27-row table (pure) and by the real-`ssh -G` suite in
+    // key-locker-ssh-resolve.test.ts — a broken parser fails those, loudly. Do NOT "fix" this into a
+    // hand-rolled mini-parser: an earlier attempt at exactly that mis-read the `-4p 2222` cluster, i.e. it
+    // reimplemented the code under test and got it wrong. This is scaffolding, not a layer, so it does not
+    // re-introduce the table dependency §1.4 removed from production.
+    const parsed = parseSshCommand(args.slice(1)); // drop the leading `-G`
+    const dest = parsed.destination ?? "";
+    const opts = parsed.optionArgs;
     let user = "u";
     let port = "22";
-    const li = args.indexOf("-l");
-    if (li >= 0) user = args[li + 1];
-    const pi = args.indexOf("-p");
-    if (pi >= 0) port = args[pi + 1];
+    const li = opts.indexOf("-l");
+    if (li >= 0) user = opts[li + 1];
+    const pi = opts.indexOf("-p");
+    if (pi >= 0) port = opts[pi + 1];
     let host = dest;
     const at = dest.lastIndexOf("@");
     if (at > 0) { user = dest.slice(0, at); host = dest.slice(at + 1); }
     host = host.replace(/^\[|\]$/g, ""); // real ssh -G prints IPv6 hostnames UNBRACKETED
     if (host === "resolvefail.example.com") return { code: 255, stdout: "", stderr: "boom" };
-    const ji = args.indexOf("-J"); // real ssh maps -J onto an effective ProxyJump line
-    const proxy = ji >= 0 ? `proxyjump ${args[ji + 1]}\n` : "";
+    const ji = opts.indexOf("-J"); // real ssh maps -J onto an effective ProxyJump line
+    const proxy = ji >= 0 ? `proxyjump ${opts[ji + 1]}\n` : "";
     return {
       code: 0,
       stdout: `hostname ${host}\nuser ${user}\nport ${port}\n${proxy}userknownhostsfile ${khFile}\nglobalknownhostsfile ${join(tmp, "absent")}\n`,

--- a/tests/unit/key-locker-derivation.test.ts
+++ b/tests/unit/key-locker-derivation.test.ts
@@ -42,6 +42,11 @@ const fakeExec: ExecFn = async (file, args) => {
     // reimplemented the code under test and got it wrong. This is scaffolding, not a layer, so it does not
     // re-introduce the table dependency §1.4 removed from production.
     const parsed = parseSshCommand(args.slice(1)); // drop the leading `-G`
+    // Real ssh refuses an option that has no value (`ssh -G h -p` → `option requires an argument`,
+    // exit 255) — it never prints a config. Without this the stub would hand back a clean port-22 config
+    // (`opts[pi+1]` is undefined → `Number(undefined)` is NaN → the port line is ignored → 22), i.e. the
+    // fake would be MORE permissive than the binary and could hide a real pipeline defect behind it.
+    if (parsed.malformed) return { code: 255, stdout: "", stderr: "option requires an argument" };
     const dest = parsed.destination ?? "";
     const opts = parsed.optionArgs;
     let user = "u";

--- a/tests/unit/key-locker-session-tracker.test.ts
+++ b/tests/unit/key-locker-session-tracker.test.ts
@@ -570,6 +570,11 @@ describe("classifySshLogin — three states (F-3)", () => {
     { argv: ["-N", "-L", "8080:x:80", "h"], expected: { kind: "none" } }, // tunnel, no login shell
     { argv: ["h", "-N"], expected: { kind: "none" } },
     { argv: ["h", "-f"], expected: { kind: "none" } },
+    // `-n` sends stdin from /dev/null, so the remote shell hits EOF and exits at once → the pane returns to
+    // LOCAL (measured: `ssh -n` exits 0 in ~400 ms vs a plain login that holds the shell). Opens a shell yet
+    // does not persist — the mirror of `-N`; a member of SSH_FLAGS_NO_LOGIN_SHELL, letter-only decidable.
+    { argv: ["h", "-n"], expected: { kind: "none" } },
+    { argv: ["-n", "h"], expected: { kind: "none" } }, // flag-before form
     // `-O` (control-master command) and `-s` (subsystem) never open a login shell on THIS pane — both are
     // letters in SSH_FLAGS_NO_LOGIN_SHELL, decided from the LETTER alone, no value semantics (Codex PR#541).
     // Before the set existed, `91c2575` answered `interactive` for these and pushed a remote frame for a
@@ -698,6 +703,18 @@ describe("recordDispatch — post-destination options and the undecidable sink (
     const t = new SessionTracker();
     t.beginLocalSession(P);
     t.recordDispatch(P, "ssh prod.example.com -O check");
+    expect(t.get(P)).toEqual({ execHost: "localhost", isRemote: false, cwd: undefined });
+    expect(isKnownSession(t.get(P))).toBe(true);
+  });
+
+  // `-n` redirects stdin from /dev/null, so the remote shell hits EOF and exits at once — the pane is back
+  // to local in ~400 ms (measured, Windows OpenSSH 10.0.0.0p2 sshd). Pushing a frame here would be wrong
+  // twice: the pane is local almost immediately, and the child's disappearance would trip the watch's
+  // unwatched-frame backstop into markUnknown. It opens a shell but does not take the pane over.
+  it("`ssh h -n` leaves the pane LOCAL — no frame (stdin off the tty; the remote shell EOF-exits)", () => {
+    const t = new SessionTracker();
+    t.beginLocalSession(P);
+    t.recordDispatch(P, "ssh prod.example.com -n");
     expect(t.get(P)).toEqual({ execHost: "localhost", isRemote: false, cwd: undefined });
     expect(isKnownSession(t.get(P))).toBe(true);
   });

--- a/tests/unit/key-locker-session-tracker.test.ts
+++ b/tests/unit/key-locker-session-tracker.test.ts
@@ -546,6 +546,12 @@ describe("SessionTracker — the get() shape feeds deriveBinding's SessionContex
 // post-destination OPTION from a command. `ssh h -v` therefore looked like a one-shot ⇒ NO frame pushed
 // ⇒ the pane stayed trusted-LOCAL while a real login was open ⇒ a later `sudo` would fill a LOCAL secret
 // into the REMOTE prompt. Three states + ssh's own two-pass boundary close both halves.
+//
+// Coverage vs the plan's decision table: the parser-shape rows (#13-#18 — cluster/attached/ProxyJump forms
+// like `-4p 2222 h`, `-p2222 alice@h`, `h -J bastion`) are omitted here ON PURPOSE, not dropped: each
+// reaches `interactive` by the SAME (verdict, reason) path as row #3 / #11 already below, and their parser
+// shape is pinned row-by-row in key-locker-ssh-resolve.test.ts. Everything with a DISTINCT verdict or a
+// distinct reason is present.
 describe("classifySshLogin — three states (F-3)", () => {
   const cases: Array<{ argv: string[]; expected: ReturnType<typeof classifySshLogin> }> = [
     { argv: ["h"], expected: { kind: "interactive", host: "h" } },
@@ -566,6 +572,12 @@ describe("classifySshLogin — three states (F-3)", () => {
     { argv: ["h", "-f"], expected: { kind: "none" } },
     { argv: ["h", "<", "in"], expected: { kind: "none" } }, // stdin off the tty
     { argv: ["h", "-z"], expected: { kind: "undecidable" } }, // letter in neither table
+    // DOUBT OUTRANKS A QUERY (Opus R1 P1-1). A future with-arg `-z` would eat the next token, so real ssh
+    // reads this as "-G is -z's value" and OPENS A SESSION — while our flag scan sees a query. Answering
+    // `none` here would leave the pane trusted-LOCAL during a remote login: the exact silent disclosure
+    // `undecidable` exists to prevent. Checking queryMode first (an earlier revision) did exactly that.
+    { argv: ["-z", "-G", "h"], expected: { kind: "undecidable" } },
+    { argv: ["-z", "-V", "h"], expected: { kind: "undecidable" } },
     { argv: ["-1", "h"], expected: { kind: "undecidable" } }, // retired letter — real ssh is fatal
     { argv: ["-2", "h"], expected: { kind: "interactive", host: "h" } }, // accepted no-op ⇒ a real session
     { argv: ["-P", "mytag", "h"], expected: { kind: "interactive", host: "h" } }, // -P takes a tag

--- a/tests/unit/key-locker-session-tracker.test.ts
+++ b/tests/unit/key-locker-session-tracker.test.ts
@@ -2,7 +2,12 @@
 // deriveBinding from localhost-collapsing a remote pane (or remote-collapsing a local one).
 // Plan: desktop-touch-mcp-internal@<plan>:docs/adr-014-v2-r3-l3-capture-plan.md
 import { describe, expect, it } from "vitest";
-import { SessionTracker, isKnownSession, type PaneSession } from "../../src/engine/key-locker/session-tracker.js";
+import {
+  SessionTracker,
+  classifySshLogin,
+  isKnownSession,
+  type PaneSession,
+} from "../../src/engine/key-locker/session-tracker.js";
 
 const P = "pane-1";
 
@@ -528,5 +533,95 @@ describe("SessionTracker — the get() shape feeds deriveBinding's SessionContex
       expect(typeof s.execHost).toBe("string");
       expect(typeof s.isRemote).toBe("boolean");
     }
+  });
+});
+
+// ── F-3: classifySshLogin + the recordDispatch arms it feeds ─────────────────────────────────────────
+//
+// Plan: desktop-touch-mcp-internal:docs/adr-014-v2-r3x-complete-fix-plan.md §1.3 / §5 PR1.3.
+// Findings: …-la-live-dogfood-findings.md F-3.
+//
+// The predecessor (`interactiveSshTarget`) returned host-or-null, so it could not say "I don't know" —
+// and it located the remote command by counting tokens (`optionArgs.length + 1`), which cannot tell a
+// post-destination OPTION from a command. `ssh h -v` therefore looked like a one-shot ⇒ NO frame pushed
+// ⇒ the pane stayed trusted-LOCAL while a real login was open ⇒ a later `sudo` would fill a LOCAL secret
+// into the REMOTE prompt. Three states + ssh's own two-pass boundary close both halves.
+describe("classifySshLogin — three states (F-3)", () => {
+  const cases: Array<{ argv: string[]; expected: ReturnType<typeof classifySshLogin> }> = [
+    { argv: ["h"], expected: { kind: "interactive", host: "h" } },
+    { argv: ["alice@H.example.com"], expected: { kind: "interactive", host: "h.example.com" } }, // lowercased
+    { argv: ["-p", "2222", "alice@h"], expected: { kind: "interactive", host: "h" } },
+    { argv: ["alice@h", "-p", "2222"], expected: { kind: "interactive", host: "h" } }, // FIXED (was none)
+    { argv: ["h", "-v"], expected: { kind: "interactive", host: "h" } }, // FIXED (was none)
+    { argv: ["h", "-l", "other"], expected: { kind: "interactive", host: "h" } }, // FIXED (was none)
+    { argv: ["h", "ls"], expected: { kind: "none" } }, // a PROVEN remote command
+    { argv: ["h", "-v", "ls"], expected: { kind: "none" } },
+    { argv: ["h", "ls", "-v"], expected: { kind: "none" } }, // the -v is the remote ls's
+    { argv: ["-G", "h"], expected: { kind: "none" } }, // query
+    { argv: ["h", "-G"], expected: { kind: "none" } }, // query, post-destination
+    { argv: ["-V"], expected: { kind: "none" } },
+    { argv: ["-Q", "cipher"], expected: { kind: "none" } },
+    { argv: ["-N", "-L", "8080:x:80", "h"], expected: { kind: "none" } }, // tunnel, no login shell
+    { argv: ["h", "-N"], expected: { kind: "none" } },
+    { argv: ["h", "-f"], expected: { kind: "none" } },
+    { argv: ["h", "<", "in"], expected: { kind: "none" } }, // stdin off the tty
+    { argv: ["h", "-z"], expected: { kind: "undecidable" } }, // letter in neither table
+    { argv: ["-1", "h"], expected: { kind: "undecidable" } }, // retired letter — real ssh is fatal
+    { argv: ["-2", "h"], expected: { kind: "interactive", host: "h" } }, // accepted no-op ⇒ a real session
+    { argv: ["-P", "mytag", "h"], expected: { kind: "interactive", host: "h" } }, // -P takes a tag
+    { argv: ["-P", "h"], expected: { kind: "undecidable" } }, // the tag ate the destination
+    { argv: [], expected: { kind: "undecidable" } },
+  ];
+  it.each(cases)("ssh $argv → $expected.kind", ({ argv, expected }) => {
+    expect(classifySshLogin(argv)).toEqual(expected);
+  });
+});
+
+describe("recordDispatch — post-destination options and the undecidable sink (F-3)", () => {
+  const P = "pane-f3";
+
+  it("`ssh h -p 2222` pushes a remote frame (the option no longer reads as a remote command)", () => {
+    const t = new SessionTracker();
+    t.beginLocalSession(P);
+    t.recordDispatch(P, "ssh deploy@prod.example.com -p 2222");
+    expect(t.get(P)).toEqual({ execHost: "prod.example.com", isRemote: true });
+  });
+
+  it("`ssh h -z` (unclassifiable) sinks the pane to UNKNOWN — never trusted-local", () => {
+    const t = new SessionTracker();
+    t.beginLocalSession(P);
+    t.recordDispatch(P, "ssh prod.example.com -z");
+    expect(isKnownSession(t.get(P))).toBe(false);
+  });
+
+  it("`ssh h ls` still pushes nothing — a proven one-shot leaves the pane local", () => {
+    const t = new SessionTracker();
+    t.beginLocalSession(P);
+    t.recordDispatch(P, "ssh prod.example.com ls");
+    expect(t.get(P)).toEqual({ execHost: "localhost", isRemote: false, cwd: undefined });
+  });
+
+  it("`ssh -P mytag h` pushes a remote frame — the tag is consumed, the destination survives", () => {
+    const t = new SessionTracker();
+    t.beginLocalSession(P);
+    t.recordDispatch(P, "ssh -P mytag prod.example.com");
+    expect(t.get(P)).toEqual({ execHost: "prod.example.com", isRemote: true });
+  });
+
+  // `-1` is FATAL in the real ssh ("SSH protocol v.1 is no longer supported"), so no session ever opens.
+  // Pushing a frame here would track a still-LOCAL pane as remote — a later `sudo` would then pull the
+  // REMOTE binding's secret into a LOCAL prompt (the mirror image of F-3). UNKNOWN is the honest state.
+  it("`ssh -1 h` sinks to UNKNOWN — it must NOT push a frame (real ssh never opens the session)", () => {
+    const t = new SessionTracker();
+    t.beginLocalSession(P);
+    t.recordDispatch(P, "ssh -1 prod.example.com");
+    expect(isKnownSession(t.get(P))).toBe(false);
+  });
+
+  it("`ssh -2 h` pushes a remote frame — the no-op flag is accepted and the login is real", () => {
+    const t = new SessionTracker();
+    t.beginLocalSession(P);
+    t.recordDispatch(P, "ssh -2 prod.example.com");
+    expect(t.get(P)).toEqual({ execHost: "prod.example.com", isRemote: true });
   });
 });

--- a/tests/unit/key-locker-session-tracker.test.ts
+++ b/tests/unit/key-locker-session-tracker.test.ts
@@ -571,6 +571,15 @@ describe("classifySshLogin — three states (F-3)", () => {
     { argv: ["h", "-N"], expected: { kind: "none" } },
     { argv: ["h", "-f"], expected: { kind: "none" } },
     { argv: ["h", "<", "in"], expected: { kind: "none" } }, // stdin off the tty
+    // A confirmed with-arg option with no value left: ssh exits with a usage error before opening
+    // anything ⇒ PROVEN non-login (and the pane, still local, keeps autofilling). NOT `undecidable`: we
+    // know exactly what ssh does here, and sinking the pane over a typo would cost it autofill until it
+    // is re-anchored.
+    { argv: ["h", "-p"], expected: { kind: "none" } },
+    { argv: ["h", "-l"], expected: { kind: "none" } },
+    { argv: ["h", "-4p"], expected: { kind: "none" } }, // same else-branch, reached through the cluster walk
+    // Doubt still outranks it: with an unknown letter present, the "missing" value may be that letter's.
+    { argv: ["h", "-z", "-p"], expected: { kind: "undecidable" } },
     { argv: ["h", "-z"], expected: { kind: "undecidable" } }, // letter in neither table
     // DOUBT OUTRANKS A QUERY (Opus R1 P1-1). A future with-arg `-z` would eat the next token, so real ssh
     // reads this as "-G is -z's value" and OPENS A SESSION — while our flag scan sees a query. Answering
@@ -635,5 +644,25 @@ describe("recordDispatch — post-destination options and the undecidable sink (
     t.beginLocalSession(P);
     t.recordDispatch(P, "ssh -2 prod.example.com");
     expect(t.get(P)).toEqual({ execHost: "prod.example.com", isRemote: true });
+  });
+
+  // Regression pin: `3e78b2d` pushed a remote frame here. ssh exits with `option requires an argument`
+  // (exit 255) without connecting, so the pane never left local — mislabelling it remote would send a
+  // later `sudo`'s REMOTE secret into this LOCAL prompt, and would leave the pane's recovery to the
+  // watch's backstop. The pane must simply stay local and keep working.
+  it("`ssh h -p` (no value) leaves the pane LOCAL — no frame, no sink (regression)", () => {
+    const t = new SessionTracker();
+    t.beginLocalSession(P);
+    t.recordDispatch(P, "ssh prod.example.com -p");
+    expect(t.get(P)).toEqual({ execHost: "localhost", isRemote: false, cwd: undefined });
+    expect(isKnownSession(t.get(P))).toBe(true); // still usable — a typo must not disable the pane
+  });
+
+  it("a LOCAL sudo after `ssh h -p` still derives locally (the pane was never remote)", () => {
+    const t = new SessionTracker();
+    t.beginLocalSession(P);
+    t.recordDispatch(P, "ssh prod.example.com -p");
+    t.recordDispatch(P, "sudo systemctl restart app");
+    expect(t.get(P)).toMatchObject({ execHost: "localhost", isRemote: false });
   });
 });

--- a/tests/unit/key-locker-session-tracker.test.ts
+++ b/tests/unit/key-locker-session-tracker.test.ts
@@ -580,6 +580,15 @@ describe("classifySshLogin — three states (F-3)", () => {
     { argv: ["h", "-4p"], expected: { kind: "none" } }, // same else-branch, reached through the cluster walk
     // Doubt still outranks it: with an unknown letter present, the "missing" value may be that letter's.
     { argv: ["h", "-z", "-p"], expected: { kind: "undecidable" } },
+    // KNOWN INACCURACY (pinned so it is visible, not silently believed). A value that is PRESENT but
+    // INVALID also makes ssh exit locally (`Bad port '2222x'`, status 255) — no session opens — yet we
+    // answer `interactive`. Telling a bad value from a good one means validating each option's semantics,
+    // i.e. re-implementing ssh's own config parser in a pure module; the resolver sidesteps this by asking
+    // the real `ssh -G` (which DOES reject it, so nothing is ever filled), but the sync classifier cannot.
+    // The cost is a spurious remote frame that the watch's unwatched-frame backstop sinks on the next
+    // tick. The pre-destination form (`ssh -p 2222x h`) has always behaved this way; the two-pass fix
+    // widened it to the post-destination form. Tracked for the release gate — see the findings doc.
+    { argv: ["h", "-p", "2222x"], expected: { kind: "interactive", host: "h" } },
     { argv: ["h", "-z"], expected: { kind: "undecidable" } }, // letter in neither table
     // DOUBT OUTRANKS A QUERY (Opus R1 P1-1). A future with-arg `-z` would eat the next token, so real ssh
     // reads this as "-G is -z's value" and OPENS A SESSION — while our flag scan sees a query. Answering

--- a/tests/unit/key-locker-session-tracker.test.ts
+++ b/tests/unit/key-locker-session-tracker.test.ts
@@ -570,6 +570,15 @@ describe("classifySshLogin — three states (F-3)", () => {
     { argv: ["-N", "-L", "8080:x:80", "h"], expected: { kind: "none" } }, // tunnel, no login shell
     { argv: ["h", "-N"], expected: { kind: "none" } },
     { argv: ["h", "-f"], expected: { kind: "none" } },
+    // `-O` (control-master command) and `-s` (subsystem) never open a login shell on THIS pane — both are
+    // letters in SSH_FLAGS_NO_LOGIN_SHELL, decided from the LETTER alone, no value semantics (Codex PR#541).
+    // Before the set existed, `91c2575` answered `interactive` for these and pushed a remote frame for a
+    // pane that never left local.
+    { argv: ["h", "-O", "check"], expected: { kind: "none" } }, // sends a control cmd to a master, then exits
+    { argv: ["-O", "check", "h"], expected: { kind: "none" } }, // flag-BEFORE form — was broken on main too
+    { argv: ["h", "-s"], expected: { kind: "none" } }, // bare subsystem request — ssh errors locally, no shell
+    { argv: ["h", "-s", "sftp"], expected: { kind: "none" } }, // subsystem, NOT a login shell (via the set, not remoteCommand)
+    { argv: ["-s", "h"], expected: { kind: "none" } }, // flag-BEFORE subsystem twin — also broken on main
     { argv: ["h", "<", "in"], expected: { kind: "none" } }, // stdin off the tty
     // A confirmed with-arg option with no value left: ssh exits with a usage error before opening
     // anything ⇒ PROVEN non-login (and the pane, still local, keeps autofilling). NOT `undecidable`: we
@@ -589,6 +598,12 @@ describe("classifySshLogin — three states (F-3)", () => {
     // tick. The pre-destination form (`ssh -p 2222x h`) has always behaved this way; the two-pass fix
     // widened it to the post-destination form. Tracked for the release gate — see the findings doc.
     { argv: ["h", "-p", "2222x"], expected: { kind: "interactive", host: "h" } },
+    // Same F-7 class via a different mechanism: `-v` LOOKS like a flag but is eaten as `-p`'s VALUE, so the
+    // parse is neither `malformed` (a value IS present) nor `undecidable` (no unknown letter is scanned). Real
+    // ssh: `Bad port '-v'`, exit 255 — no session — yet we answer `interactive`. This is the exact case Codex
+    // raised on PR#541; it stays out of scope for the SAME reason as `2222x` (telling a bad value from a good
+    // one is per-option value semantics), pinned here so the gap is VISIBLE, not silently absent.
+    { argv: ["h", "-p", "-v"], expected: { kind: "interactive", host: "h" } },
     { argv: ["h", "-z"], expected: { kind: "undecidable" } }, // letter in neither table
     // DOUBT OUTRANKS A QUERY (Opus R1 P1-1). A future with-arg `-z` would eat the next token, so real ssh
     // reads this as "-G is -z's value" and OPENS A SESSION — while our flag scan sees a query. Answering
@@ -673,5 +688,28 @@ describe("recordDispatch — post-destination options and the undecidable sink (
     t.recordDispatch(P, "ssh prod.example.com -p");
     t.recordDispatch(P, "sudo systemctl restart app");
     expect(t.get(P)).toMatchObject({ execHost: "localhost", isRemote: false });
+  });
+
+  // `-O check` sends a control command to an existing master (or errors when there is none) and exits —
+  // it never opens a login shell in this pane. `91c2575` classified it `interactive` and pushed a remote
+  // frame; a later `sudo` would then pull the REMOTE binding's secret into this LOCAL prompt. The pane
+  // must stay local and keep autofilling.
+  it("`ssh h -O check` leaves the pane LOCAL — no frame (control-master command, not a login)", () => {
+    const t = new SessionTracker();
+    t.beginLocalSession(P);
+    t.recordDispatch(P, "ssh prod.example.com -O check");
+    expect(t.get(P)).toEqual({ execHost: "localhost", isRemote: false, cwd: undefined });
+    expect(isKnownSession(t.get(P))).toBe(true);
+  });
+
+  // `-s` requests a subsystem, never a login shell — for BOTH the bare form (ssh errors locally) and the
+  // named form `-s sftp`. The latter used to reach `none` only because "sftp" was a remote-command token;
+  // now it lands there for the real reason, so a step-ordering change cannot silently re-open the hole.
+  it("`ssh h -s sftp` leaves the pane LOCAL — no frame (subsystem, not a login shell)", () => {
+    const t = new SessionTracker();
+    t.beginLocalSession(P);
+    t.recordDispatch(P, "ssh prod.example.com -s sftp");
+    expect(t.get(P)).toEqual({ execHost: "localhost", isRemote: false, cwd: undefined });
+    expect(isKnownSession(t.get(P))).toBe(true);
   });
 });

--- a/tests/unit/key-locker-ssh-resolve.test.ts
+++ b/tests/unit/key-locker-ssh-resolve.test.ts
@@ -185,10 +185,20 @@ describe.skipIf(!hasOpenSsh)("§8 #2 — ssh resolution + option passthrough (re
     expect(r.kind).toBe("unresolvable");
   });
 
-  it("a trailing remote command is ignored by ssh -G (it is not read as the destination)", async () => {
+  // The remote command must not change the endpoint — and it must never be handed to the spawned `ssh -G`
+  // either, since it can carry a secret (`ssh h mysql -pX`). The resolver passes options-only; this pins
+  // the observable half (same endpoint), and key-locker-derivation.test.ts pins the argv half.
+  it("a trailing remote command does not change the resolved endpoint", async () => {
     const withCmd = await resolveCanonicalForSshCommand([...mainOpts(), "bob@real.example.com", "sudo", "apt", "update"]);
     const bare = await resolveCanonicalForSshCommand([...mainOpts(), "bob@real.example.com"]);
     expect(withCmd).toEqual(bare);
+  });
+
+  it("an unclassifiable argv fails closed — no binding is derived from a guessed destination", async () => {
+    const r = await resolveCanonicalForSshCommand([...mainOpts(), "bob@real.example.com", "-z"]);
+    // The resolver itself still answers (real ssh would reject `-z`, so this is `unresolvable`), but the
+    // DERIVATION declines outright — see the `undecidable` pin in key-locker-derivation.test.ts.
+    expect(r.kind).not.toBe("ok");
   });
 
   it("a default-port entry stored in BRACKETED [host]:22 form is still found (Codex R4)", async () => {
@@ -289,6 +299,11 @@ describe.skipIf(!hasOpenSsh)("§8 #3 — P2-1 defense: recorded-identity drift (
 // prompt) and `ssh h -v` was misread as a one-shot (⇒ the pane was trusted LOCAL while a remote login was
 // open). Real ssh accepts post-destination options because ssh.c runs getopt AGAIN after the destination
 // (`goto again`) — ssh.c's own rule, not platform getopt permutation, so it is identical in every build.
+//
+// 26 rows = the plan's table minus its row 21 (`h < in`), which is CLASSIFIER-only: redirects are stripped
+// by `classifySshLogin` before it ever calls this parser, so `parseSshCommand(["h","<","in"])` legitimately
+// returns `remoteCommand: ["<","in"]` and the plan's parser columns for that row describe the stripped
+// argv (= row 1). It is pinned in key-locker-session-tracker.test.ts instead.
 describe("parseSshCommand — OpenSSH two-pass argv rule (F-3)", () => {
   interface Row {
     n: string;

--- a/tests/unit/key-locker-ssh-resolve.test.ts
+++ b/tests/unit/key-locker-ssh-resolve.test.ts
@@ -14,6 +14,7 @@ import {
   resolveCanonicalForSshCommand,
   SSH_FLAGS_NO_ARG,
   SSH_FLAGS_WITH_ARG,
+  type ExecFn,
 } from "../../src/engine/key-locker/ssh-resolve.js";
 import { BindingStore } from "../../src/engine/key-locker/binding-store.js";
 import { formatBindingUri } from "../../src/engine/key-locker/binding.js";
@@ -194,11 +195,19 @@ describe.skipIf(!hasOpenSsh)("§8 #2 — ssh resolution + option passthrough (re
     expect(withCmd).toEqual(bare);
   });
 
-  it("an unclassifiable argv fails closed — no binding is derived from a guessed destination", async () => {
-    const r = await resolveCanonicalForSshCommand([...mainOpts(), "bob@real.example.com", "-z"]);
-    // The resolver itself still answers (real ssh would reject `-z`, so this is `unresolvable`), but the
-    // DERIVATION declines outright — see the `undecidable` pin in key-locker-derivation.test.ts.
-    expect(r.kind).not.toBe("ok");
+  // Deliberately NOT driven by the real ssh: today's ssh rejects `-z`, so a real-binary assertion here
+  // would pass with or without the guard — a tautology. The case the guard exists for is the FUTURE one
+  // where ssh *accepts* the unknown letter, so the fake below answers as that future ssh would (a clean
+  // config for a host we could have resolved). We must still decline, and must never even ask.
+  it("an unclassifiable argv fails closed BEFORE any exec — even if ssh would have answered", async () => {
+    const calls: string[][] = [];
+    const wouldSucceed: ExecFn = async (file, args) => {
+      calls.push([file, ...args]);
+      return { code: 0, stdout: "hostname real.example.com\nuser bob\nport 22\n", stderr: "" };
+    };
+    const r = await resolveCanonicalForSshCommand(["bob@real.example.com", "-z", "value"], wouldSucceed);
+    expect(r.kind).toBe("unresolvable");
+    expect(calls).toEqual([]); // never spawned: a guessed destination is not worth asking about
   });
 
   it("a default-port entry stored in BRACKETED [host]:22 form is still found (Codex R4)", async () => {

--- a/tests/unit/key-locker-ssh-resolve.test.ts
+++ b/tests/unit/key-locker-ssh-resolve.test.ts
@@ -9,7 +9,12 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { resolveCanonicalForSshCommand } from "../../src/engine/key-locker/ssh-resolve.js";
+import {
+  parseSshCommand,
+  resolveCanonicalForSshCommand,
+  SSH_FLAGS_NO_ARG,
+  SSH_FLAGS_WITH_ARG,
+} from "../../src/engine/key-locker/ssh-resolve.js";
 import { BindingStore } from "../../src/engine/key-locker/binding-store.js";
 import { formatBindingUri } from "../../src/engine/key-locker/binding.js";
 
@@ -160,6 +165,32 @@ describe.skipIf(!hasOpenSsh)("§8 #2 — ssh resolution + option passthrough (re
     expect(r.kind).toBe("unresolvable");
   });
 
+  // ── F-3 (real `ssh -G`): options BEHIND the destination reach the resolver ──────────────────────────
+  // The pre-fix parser stopped at the destination, so these all resolved as if the option were absent.
+  it("a post-destination -p reaches ssh -G — `h -p 2222` is the SAME endpoint as `-p 2222 h`", async () => {
+    const post = await resolveCanonicalForSshCommand([...mainOpts(), "bob@real.example.com", "-p", "2222"]);
+    const pre = await resolveCanonicalForSshCommand([...mainOpts(), "-p", "2222", "bob@real.example.com"]);
+    expect(post.kind).toBe(pre.kind);
+    expect(post).toEqual(pre); // order of options vs destination must not change the endpoint
+  });
+
+  it("a post-destination -l changes the derived user (it used to be silently dropped)", async () => {
+    const r = await resolveCanonicalForSshCommand([...mainOpts(), "real.example.com", "-l", "carol"]);
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") expect(r.uri.user).toBe("carol");
+  });
+
+  it("a post-destination -J still defers — the bastion prompt is not the final host's", async () => {
+    const r = await resolveCanonicalForSshCommand([...mainOpts(), "bob@real.example.com", "-J", "bastion.example.com"]);
+    expect(r.kind).toBe("unresolvable");
+  });
+
+  it("a trailing remote command is ignored by ssh -G (it is not read as the destination)", async () => {
+    const withCmd = await resolveCanonicalForSshCommand([...mainOpts(), "bob@real.example.com", "sudo", "apt", "update"]);
+    const bare = await resolveCanonicalForSshCommand([...mainOpts(), "bob@real.example.com"]);
+    expect(withCmd).toEqual(bare);
+  });
+
   it("a default-port entry stored in BRACKETED [host]:22 form is still found (Codex R4)", async () => {
     const khBracketed = fwd(join(tmp, "known_hosts_bracketed"));
     writeFileSync(khBracketed, `[::1]:22 ${pub1}\n`, "utf8");
@@ -173,6 +204,39 @@ describe.skipIf(!hasOpenSsh)("§8 #2 — ssh resolution + option passthrough (re
     if (r.kind === "ok") {
       expect(r.uri).toMatchObject({ host: "[::1]", port: 22 });
       expect(r.uri.fpSet).toEqual([fp1]);
+    }
+  });
+});
+
+// ── F-3 security regression pin (acceptance-critical) ────────────────────────────────────────────────
+//
+// The bug this pins is a CREDENTIAL MISDIRECTION, not a missing autofill. Pre-fix, `ssh alice@h -p 2222`
+// dropped the `-p`, so it derived the port-22 canonical key AND the port-22 known_hosts fingerprints —
+// a bit-exact match for a stored port-22 binding. `BindingStore.resolve` is a plain map lookup, the
+// fp-set was derived from the WRONG endpoint (so it cannot detect the mismatch), and L2's
+// injection-instant re-verify checks the shell pid + creation time, never the endpoint. The port-22
+// secret would have been typed into the port-2222 server's prompt.
+describe.skipIf(!hasOpenSsh)("F-3 — a port-22 binding must NOT resolve for an explicit -p 2222", () => {
+  it("`ssh bob@h` and `ssh bob@h -p 2222` derive DIFFERENT keys ⇒ the :22 secret cannot reach :2222", async () => {
+    const store = BindingStore.load(join(tmp, "store-f3"), async () => true);
+
+    // The user saves a credential for the DEFAULT-port server and binds it.
+    const bound = await resolveCanonicalForSshCommand([...mainOpts(), "bob@real.example.com"]);
+    expect(bound.kind).toBe("ok");
+    if (bound.kind !== "ok") return;
+    await store.bind(bound.canonical, "opaque-port22", { uri: formatBindingUri(bound.uri), createdAt: "t" });
+    expect(await store.resolve(bound.canonical)).toEqual({ opaqueId: "opaque-port22" });
+
+    // The assistant then runs a DIFFERENT server on the same host, with the port behind the destination.
+    const other = await resolveCanonicalForSshCommand([...mainOpts(), "bob@real.example.com", "-p", "2222"]);
+    // It resolves the real endpoint now (:2222) — or fails closed if that port has no known_hosts entry.
+    // Either way the one forbidden outcome is reusing the port-22 key.
+    if (other.kind === "ok") {
+      expect(other.uri.port).toBe(2222);
+      expect(other.canonical).not.toBe(bound.canonical);
+      expect(await store.resolve(other.canonical)).toBeUndefined(); // ⇒ no opaqueId ⇒ no autofill
+    } else {
+      expect(other.kind).toBe("host-not-known"); // fail-closed, never the port-22 binding
     }
   });
 });
@@ -212,5 +276,102 @@ describe.skipIf(!hasOpenSsh)("§8 #3 — P2-1 defense: recorded-identity drift (
     if (drifted.kind !== "ok") return;
     expect(drifted.canonical).not.toBe(bound.canonical);
     expect(await store.resolve(drifted.canonical)).toBeUndefined(); // ⇒ no opaqueId ⇒ no autofill
+  });
+});
+
+// ── F-3: OpenSSH's two-pass argv rule ────────────────────────────────────────────────────────────────
+//
+// Plan: desktop-touch-mcp-internal:docs/adr-014-v2-r3x-complete-fix-plan.md §1.2 / §5 PR1.2 — the table
+// below IS that table. Findings: …-la-live-dogfood-findings.md F-3.
+//
+// The pre-fix parser stopped at the destination and dropped every option behind it, so
+// `ssh user@h -p 2222` resolved as port 22 (the wrong endpoint's secret could be typed into this one's
+// prompt) and `ssh h -v` was misread as a one-shot (⇒ the pane was trusted LOCAL while a remote login was
+// open). Real ssh accepts post-destination options because ssh.c runs getopt AGAIN after the destination
+// (`goto again`) — ssh.c's own rule, not platform getopt permutation, so it is identical in every build.
+describe("parseSshCommand — OpenSSH two-pass argv rule (F-3)", () => {
+  interface Row {
+    n: string;
+    argv: string[];
+    destination: string | undefined;
+    optionArgs: string[];
+    flagLetters: string[];
+    remoteCommand: string[];
+    undecidable: boolean;
+    queryMode?: boolean;
+  }
+  const rows: Row[] = [
+    { n: "1  h", argv: ["h"], destination: "h", optionArgs: [], flagLetters: [], remoteCommand: [], undecidable: false },
+    { n: "2  -p 2222 alice@h", argv: ["-p", "2222", "alice@h"], destination: "alice@h", optionArgs: ["-p", "2222"], flagLetters: ["p"], remoteCommand: [], undecidable: false },
+    { n: "3  alice@h -p 2222 (FIXED)", argv: ["alice@h", "-p", "2222"], destination: "alice@h", optionArgs: ["-p", "2222"], flagLetters: ["p"], remoteCommand: [], undecidable: false },
+    { n: "4  h ls", argv: ["h", "ls"], destination: "h", optionArgs: [], flagLetters: [], remoteCommand: ["ls"], undecidable: false },
+    { n: "5  h -v (FIXED)", argv: ["h", "-v"], destination: "h", optionArgs: ["-v"], flagLetters: ["v"], remoteCommand: [], undecidable: false },
+    { n: "6  h -v ls", argv: ["h", "-v", "ls"], destination: "h", optionArgs: ["-v"], flagLetters: ["v"], remoteCommand: ["ls"], undecidable: false },
+    { n: "7  h ls -v (the -v is the remote ls's)", argv: ["h", "ls", "-v"], destination: "h", optionArgs: [], flagLetters: [], remoteCommand: ["ls", "-v"], undecidable: false },
+    { n: "8  -G h", argv: ["-G", "h"], destination: "h", optionArgs: ["-G"], flagLetters: ["G"], remoteCommand: [], undecidable: false, queryMode: true },
+    { n: "9  h -G", argv: ["h", "-G"], destination: "h", optionArgs: ["-G"], flagLetters: ["G"], remoteCommand: [], undecidable: false, queryMode: true },
+    { n: "10 -l other h", argv: ["-l", "other", "h"], destination: "h", optionArgs: ["-l", "other"], flagLetters: ["l"], remoteCommand: [], undecidable: false },
+    { n: "11 h -l other (FIXED)", argv: ["h", "-l", "other"], destination: "h", optionArgs: ["-l", "other"], flagLetters: ["l"], remoteCommand: [], undecidable: false },
+    { n: "12 -N -L 8080:x:80 h", argv: ["-N", "-L", "8080:x:80", "h"], destination: "h", optionArgs: ["-N", "-L", "8080:x:80"], flagLetters: ["N", "L"], remoteCommand: [], undecidable: false },
+    { n: "13 h -N -L 8080:x:80", argv: ["h", "-N", "-L", "8080:x:80"], destination: "h", optionArgs: ["-N", "-L", "8080:x:80"], flagLetters: ["N", "L"], remoteCommand: [], undecidable: false },
+    { n: "14 -4p 2222 h", argv: ["-4p", "2222", "h"], destination: "h", optionArgs: ["-4p", "2222"], flagLetters: ["4", "p"], remoteCommand: [], undecidable: false },
+    { n: "15 -p2222 alice@h", argv: ["-p2222", "alice@h"], destination: "alice@h", optionArgs: ["-p2222"], flagLetters: ["p"], remoteCommand: [], undecidable: false },
+    { n: "16 alice@h -p2222 (FIXED)", argv: ["alice@h", "-p2222"], destination: "alice@h", optionArgs: ["-p2222"], flagLetters: ["p"], remoteCommand: [], undecidable: false },
+    { n: "17 -J bastion h", argv: ["-J", "bastion", "h"], destination: "h", optionArgs: ["-J", "bastion"], flagLetters: ["J"], remoteCommand: [], undecidable: false },
+    { n: "18 h -J bastion (FIXED)", argv: ["h", "-J", "bastion"], destination: "h", optionArgs: ["-J", "bastion"], flagLetters: ["J"], remoteCommand: [], undecidable: false },
+    { n: "19 h -z (letter in neither table)", argv: ["h", "-z"], destination: "h", optionArgs: ["-z"], flagLetters: ["z"], remoteCommand: [], undecidable: true },
+    { n: "20 -P mytag h (-P takes a tag)", argv: ["-P", "mytag", "h"], destination: "h", optionArgs: ["-P", "mytag"], flagLetters: ["P"], remoteCommand: [], undecidable: false },
+    { n: "20b -P h (the tag eats the destination)", argv: ["-P", "h"], destination: undefined, optionArgs: ["-P", "h"], flagLetters: ["P"], remoteCommand: [], undecidable: true },
+    { n: "22 (empty argv)", argv: [], destination: undefined, optionArgs: [], flagLetters: [], remoteCommand: [], undecidable: true },
+    { n: "23 -V", argv: ["-V"], destination: undefined, optionArgs: ["-V"], flagLetters: ["V"], remoteCommand: [], undecidable: false, queryMode: true },
+    { n: "24 -Q cipher", argv: ["-Q", "cipher"], destination: undefined, optionArgs: ["-Q", "cipher"], flagLetters: ["Q"], remoteCommand: [], undecidable: false, queryMode: true },
+    { n: "25 -1 h (retired letter — in NEITHER table by design)", argv: ["-1", "h"], destination: "h", optionArgs: ["-1"], flagLetters: ["1"], remoteCommand: [], undecidable: true },
+    { n: "26 -2 h (accepted no-op)", argv: ["-2", "h"], destination: "h", optionArgs: ["-2"], flagLetters: ["2"], remoteCommand: [], undecidable: false },
+  ];
+
+  it.each(rows)("row $n", (r: Row) => {
+    const p = parseSshCommand(r.argv);
+    expect(p.destination).toBe(r.destination);
+    expect(p.optionArgs).toEqual(r.optionArgs);
+    expect([...p.flagLetters].sort()).toEqual([...r.flagLetters].sort());
+    expect(p.remoteCommand).toEqual(r.remoteCommand);
+    expect(p.undecidable).toBe(r.undecidable);
+    expect(p.queryMode).toBe(r.queryMode ?? false);
+  });
+});
+
+// ── §1.3.1 flag-table drift guard ────────────────────────────────────────────────────────────────────
+//
+// Both tables are a COPY of a moving spec (the `man ssh` synopsis). The parser CONTAINS an unknown letter
+// safely (`undecidable` ⇒ every consumer declines), but a drifted table silently costs autofill — and a
+// future with-arg letter we mis-list as no-arg is the one direction that can mis-locate a destination.
+// This canary re-derives both sets from the LOCAL ssh's own usage text, so the OpenSSH upgrade that moves
+// a letter fails here — on the machine that upgraded — instead of going unnoticed.
+//
+// A canary, not a gate: it skips where OpenSSH is absent (the same rule as the real-`ssh -G` suites above).
+describe.skipIf(!hasOpenSsh)("§1.3.1 — the flag tables match the local OpenSSH synopsis", () => {
+  // `ssh` with no args prints the usage synopsis and exits non-zero — that IS the normal path here.
+  const usage = (): string => {
+    const r = spawnSync("ssh", [], { encoding: "utf8", windowsHide: true });
+    return `${r.stdout ?? ""}${r.stderr ?? ""}`;
+  };
+
+  it("every `[-X value]` letter in the synopsis is in SSH_FLAGS_WITH_ARG, and vice versa", () => {
+    // `[-B bind_interface]` / `[-D [bind_address:]port]` / `[-w local_tun[:remote_tun]]` — a letter, a
+    // space, then a value placeholder. The bare cluster `[-46Aa…]` has no space, so it never matches here.
+    const real = [...usage().matchAll(/\[-([A-Za-z]) [^\]]/g)].map((m) => m[1]);
+    expect(real.length).toBeGreaterThan(10); // the synopsis parsed at all (guards against a format change)
+    expect([...new Set(real)].sort()).toEqual([...SSH_FLAGS_WITH_ARG].sort());
+  });
+
+  it("the synopsis no-arg cluster equals SSH_FLAGS_NO_ARG minus the measured `2` exception", () => {
+    const cluster = /\[-([A-Za-z0-9]+)\]/.exec(usage())?.[1] ?? "";
+    expect(cluster.length).toBeGreaterThan(10); // the cluster parsed at all
+    // `2` is the ONE deliberate extra: the synopsis omits it, but every build still ACCEPTS it as a no-op
+    // (measured: `ssh -2 -G host` prints the config), so `ssh -2 host` opens a REAL session and must
+    // classify as a login. `1` is deliberately in NEITHER table (real ssh: "SSH protocol v.1 is no longer
+    // supported", fatal) and is therefore INSIDE this guard's net — if a future OpenSSH re-uses `-1`, this
+    // fails and we re-decide rather than silently classifying a dead invocation as a login.
+    expect([...cluster].sort()).toEqual([...SSH_FLAGS_NO_ARG].filter((c) => c !== "2").sort());
   });
 });

--- a/tests/unit/key-locker-ssh-resolve.test.ts
+++ b/tests/unit/key-locker-ssh-resolve.test.ts
@@ -323,6 +323,7 @@ describe("parseSshCommand — OpenSSH two-pass argv rule (F-3)", () => {
     remoteCommand: string[];
     undecidable: boolean;
     queryMode?: boolean;
+    malformed?: boolean;
   }
   const rows: Row[] = [
     { n: "1  h", argv: ["h"], destination: "h", optionArgs: [], flagLetters: [], remoteCommand: [], undecidable: false },
@@ -351,6 +352,17 @@ describe("parseSshCommand — OpenSSH two-pass argv rule (F-3)", () => {
     { n: "24 -Q cipher", argv: ["-Q", "cipher"], destination: undefined, optionArgs: ["-Q", "cipher"], flagLetters: ["Q"], remoteCommand: [], undecidable: false, queryMode: true },
     { n: "25 -1 h (retired letter — in NEITHER table by design)", argv: ["-1", "h"], destination: "h", optionArgs: ["-1"], flagLetters: ["1"], remoteCommand: [], undecidable: true },
     { n: "26 -2 h (accepted no-op)", argv: ["-2", "h"], destination: "h", optionArgs: ["-2"], flagLetters: ["2"], remoteCommand: [], undecidable: false },
+    // A confirmed with-arg option with NO value left: ssh exits with a usage error before opening
+    // anything, so the pane never leaves local. `3e78b2d` reported these as `interactive` and pushed a
+    // remote frame for a pane that had not moved — `main` happened to be right here (it ignored
+    // post-destination options entirely), so this was a regression the two-pass fix introduced.
+    { n: "27 h -p (no value left)", argv: ["h", "-p"], destination: "h", optionArgs: ["-p"], flagLetters: ["p"], remoteCommand: [], undecidable: false, malformed: true },
+    { n: "28 h -l (no value left)", argv: ["h", "-l"], destination: "h", optionArgs: ["-l"], flagLetters: ["l"], remoteCommand: [], undecidable: false, malformed: true },
+    { n: "29 h -o (no value left)", argv: ["h", "-o"], destination: "h", optionArgs: ["-o"], flagLetters: ["o"], remoteCommand: [], undecidable: false, malformed: true },
+    // The cluster path reaches the same else-branch: `-4p` ends on a with-arg letter that is not attached.
+    { n: "30 h -4p (cluster tail, no value left)", argv: ["h", "-4p"], destination: "h", optionArgs: ["-4p"], flagLetters: ["4", "p"], remoteCommand: [], undecidable: false, malformed: true },
+    // NOT malformed: the value IS available (it eats the destination) ⇒ undecidable for want of a destination.
+    { n: "31 -p h (the value eats the destination)", argv: ["-p", "h"], destination: undefined, optionArgs: ["-p", "h"], flagLetters: ["p"], remoteCommand: [], undecidable: true },
   ];
 
   it.each(rows)("row $n", (r: Row) => {
@@ -361,6 +373,7 @@ describe("parseSshCommand — OpenSSH two-pass argv rule (F-3)", () => {
     expect(p.remoteCommand).toEqual(r.remoteCommand);
     expect(p.undecidable).toBe(r.undecidable);
     expect(p.queryMode).toBe(r.queryMode ?? false);
+    expect(p.malformed).toBe(r.malformed ?? false);
   });
 });
 
@@ -373,6 +386,20 @@ describe("parseSshCommand — OpenSSH two-pass argv rule (F-3)", () => {
 // a letter fails here — on the machine that upgraded — instead of going unnoticed.
 //
 // A canary, not a gate: it skips where OpenSSH is absent (the same rule as the real-`ssh -G` suites above).
+// The `malformed ⇒ none` verdict rests on one claim about the real binary: a with-arg option with no
+// value is a LOCAL usage error, so no session opens. That is getopt's contract, not a property of `-p` —
+// an optstring letter declared with `:` and given no argument makes getopt return an error and ssh exit.
+// So this pins THE CONTRACT with one representative letter; do NOT grow it to one case per letter (the
+// per-letter fact that matters — "does this letter take a value at all?" — is `SSH_FLAGS_WITH_ARG`, and
+// the canary above is what keeps that honest).
+describe.skipIf(!hasOpenSsh)("getopt contract — a with-arg option with no value is a local error", () => {
+  it("`ssh <host> -p` exits non-zero with a usage error instead of connecting", () => {
+    const r = spawnSync("ssh", ["localhost", "-p"], { encoding: "utf8", windowsHide: true });
+    expect(r.status).not.toBe(0);
+    expect(`${r.stdout ?? ""}${r.stderr ?? ""}`).toMatch(/option requires an argument/i);
+  });
+});
+
 describe.skipIf(!hasOpenSsh)("§1.3.1 — the flag tables match the local OpenSSH synopsis", () => {
   // `ssh` with no args prints the usage synopsis and exits non-zero — that IS the normal path here.
   const usage = (): string => {

--- a/tests/unit/key-locker-ssh-resolve.test.ts
+++ b/tests/unit/key-locker-ssh-resolve.test.ts
@@ -181,6 +181,15 @@ describe.skipIf(!hasOpenSsh)("§8 #2 — ssh resolution + option passthrough (re
     if (r.kind === "ok") expect(r.uri.user).toBe("carol");
   });
 
+  // The sync classifier cannot tell a bad option value from a good one (that would mean re-implementing
+  // ssh's config parser), so `ssh h -p 2222x` still reports an interactive login. This pins the layer that
+  // DOES catch it: the resolver asks the real ssh, which rejects the value, so nothing is ever bound or
+  // filled. It is why that known classifier inaccuracy costs a spurious frame and not a secret.
+  it("a post-destination BAD option value fails closed — the real ssh rejects it", async () => {
+    const r = await resolveCanonicalForSshCommand([...mainOpts(), "bob@real.example.com", "-p", "2222x"]);
+    expect(r.kind).toBe("unresolvable");
+  });
+
   it("a post-destination -J still defers — the bastion prompt is not the final host's", async () => {
     const r = await resolveCanonicalForSshCommand([...mainOpts(), "bob@real.example.com", "-J", "bastion.example.com"]);
     expect(r.kind).toBe("unresolvable");

--- a/tests/unit/key-locker-ssh-session-watch.test.ts
+++ b/tests/unit/key-locker-ssh-session-watch.test.ts
@@ -496,6 +496,35 @@ describe("SshSessionWatch — W-2b: an UNREGISTERED interactive ssh on a LOCAL p
     expect(sink.unknowns).toEqual([]);
   });
 
+  // ── F-3: the scan shares the classifier, so it inherited BOTH halves of the bug ──────────────────
+  // Pre-fix, `ssh host -v` counted as a "remote command" ⇒ classified one-shot ⇒ the user's own hand-typed
+  // login was NOT flagged ⇒ the pane stayed trusted-local ⇒ a later assistant `sudo` would fill a LOCAL
+  // secret into that REMOTE prompt. The guard at :422-427 only covered an unreadable/empty argv; a
+  // readable-but-misparsed one fell straight through to trust-local.
+  it("interactive ssh with a POST-DESTINATION option (`ssh host -v`) ⇒ markUnknown (F-3)", () => {
+    const { watch, sink } = setup(localPane({ 2100: { parent: 1000, name: "ssh", start: 21, argv: ["ssh", "user@host-a", "-v"] } }));
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 0);
+    watch.tick();
+    expect(sink.unknowns).toEqual(["pane-1"]);
+  });
+
+  it("interactive ssh with a post-destination `-p` (`ssh host -p 2222`) ⇒ markUnknown (F-3)", () => {
+    const { watch, sink } = setup(localPane({ 2200: { parent: 1000, name: "ssh", start: 22, argv: ["ssh", "user@host-a", "-p", "2222"] } }));
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 0);
+    watch.tick();
+    expect(sink.unknowns).toEqual(["pane-1"]);
+  });
+
+  it("an UNCLASSIFIABLE ssh (`ssh host -z`) ⇒ markUnknown — only a PROVEN none is trusted", () => {
+    const { watch, sink } = setup(localPane({ 2300: { parent: 1000, name: "ssh", start: 23, argv: ["ssh", "host-a", "-z"] } }));
+    watch.watchPane("pane-1", 1000);
+    sink.setDepth("pane-1", 0);
+    watch.tick();
+    expect(sink.unknowns).toEqual(["pane-1"]);
+  });
+
   it("a ONE-SHOT (`ssh host cmd`) ⇒ NOT flagged", () => {
     const { watch, sink } = setup(localPane({ 3100: { parent: 1000, name: "ssh", start: 31, argv: ["ssh", "host-a", "uptime"] } }));
     watch.watchPane("pane-1", 1000);


### PR DESCRIPTION
## What

`ssh user@host -p 2222` silently resolved as **port 22**. The argv parser stopped at the destination, so every option behind it was dropped. Real OpenSSH accepts them — `ssh.c` runs getopt **again** after the destination (`goto again`) — which is why, in the live dogfood, the pane genuinely reached the `:2222` sshd while we derived `:22`.

## Why it is P1, not "autofill didn't fire"

The derived canonical key carried the **port-22 known_hosts fingerprints**, so it bit-matched a stored port-22 binding. Nothing downstream can catch that:

| guard | what it actually checks |
|---|---|
| `BindingStore.resolve` | a plain string-key map lookup |
| the fp-set | derived **from the wrong endpoint** — so it equals the stored one. Broken at derivation, not comparison |
| `sessionMatches` | `execHost` + `isRemote`, where `execHost` is a **portless, userless** bare host |
| injection-instant re-verify | shell **pid + creation time** — process identity, never endpoint identity |

⇒ the port-22 secret could be typed into the port-2222 server's prompt.

`ssh host -l otheruser` is the same bug and easier to hit: `ssh -G host` yields the default user with a **bit-identical** fp-set, so the secret reaches a **different principal on the same host**.

**The same parser fed the fail-safe meant to catch this**, so both halves broke together. Any trailing option (`ssh host -v`) counted as a "remote command" ⇒ pane classified one-shot ⇒ no remote frame pushed ⇒ the W-2b scan did not flag the login either ⇒ a later `sudo` fills a **LOCAL** secret into the **REMOTE** prompt. (`ssh-session-watch.ts` already fail-safed an *unreadable* argv; a readable-but-misparsed one fell straight through to trust-local.)

Reachable on the shipped classic path — independent of the Windows Terminal work.

## How

- **Parse with ssh's own two-pass rule.** Options are options *wherever* they appear; the first non-option token after the destination begins the remote command. One guard condition is the root fix.
- **`ParsedSshCommand` gains `remoteCommand` + `undecidable`.** A letter outside both allow-lists — or no destination outside a query mode — makes the parse untrustworthy.
- **`interactiveSshTarget` → `classifySshLogin`.** Host-or-null could not say "I don't know", and treating doubt as "opens nothing" *is* the inversion. Now `interactive` / `none` / `undecidable`; every consumer declines on `undecidable`, and only a **proven** `none` is trusted.
- **`ssh -G` receives the whole argv**, so the endpoint decision never rides on the completeness of our own flag table. Verified against the real binary: `ssh -G h sudo apt update` prints the same config as `ssh -G h` (only the stderr pty warning differs; we parse stdout).
- **`1` is deliberately in neither allow-list** — real ssh is fatal on it (`SSH protocol v.1 is no longer supported`), so a pushed frame would track a still-local pane as remote: the mirror of this bug. **`2` is no-arg** — undocumented in the synopsis but accepted by every build, so `ssh -2 host` opens a real session.

## Verification

Measured on this machine against **two** independent builds (Windows OpenSSH 9.5p2 and Git/MSYS 10.3p1 — the two the DF-3 comment warns about):

```
before:  ssh dtmdogfood@localhost -p 2222  →  host-not-known, port 22  →  deriveBinding = null
after :  ssh dtmdogfood@localhost -p 2222  →  ssh://dtmdogfood@localhost:2222
         both option orders now converge on the identical canonical URI
```

Tests (4605 unit passed, 0 failed):
- the **26-row argv decision table** (pure)
- the **three-state classifier** + `recordDispatch` arms
- **W-2b** flags post-destination and unclassifiable forms; still does not flag a proven one-shot
- real-`ssh -G` post-destination cases (`-p` / `-l` / `-J` / trailing command)
- a **security regression pin**: a port-22 binding never resolves for `-p 2222`
- a **flag-table canary** that re-derives both allow-lists from the local ssh's usage synopsis, so an OpenSSH upgrade that moves a letter fails loudly instead of silently costing autofill

No existing assertion changed. The derivation suite's `ssh -G` stub was made faithful to the new call shape (it assumed the destination was the last token, so `ssh h sudo apt update` read as a connection to `update`); it now reuses `parseSshCommand` deliberately — the parser is pinned independently by the pure table and the real-`ssh -G` suite, so the stub is scaffolding, not a second implementation.

## Notes for review

- Found by the **live Windows Terminal dogfood**, not by a test.
- `landed-detection.ts` was a fourth caller the plan's table missed (the compiler caught it). It was a victim of the same bug: `ssh h -p 2222` classified one-shot ⇒ Mode A waited for an exit that never comes ⇒ timeout ⇒ **a correct secret was discarded**. It now falls to Mode B correctly.
- Follow-ups (Windows Terminal launch + the arm race, `terminal(action='run')` paneId, locker observability) are separate PRs; this one is first because it is the only shipped one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
