### PR TITLE
fix(deps): bump js-yaml to 4.3.0 (Dependabot #26, CVE-2026-59869)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1691,9 +1691,9 @@
       }
     },
     "node_modules/@napi-rs/cli": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/@napi-rs/cli/-/cli-3.7.3.tgz",
-      "integrity": "sha512-iu5BOoYjYVixp5jwE7JniHvg72XuKWXUfXteu+6Gt/XY4/mslsS+Qbipleg1+3CAUGHkWc+ebaMJj7Pc93BXSQ==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/cli/-/cli-3.7.4.tgz",
+      "integrity": "sha512-idELIUceJ9zPgx/shcMt1fSSsteFG68v56RIXi4qUm7OYuJOt7CoMj2KnHVmbOqXgUHWQU1lCULrtQdZDG4F5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5476,9 +5476,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## What

Bumps the dev-only transitive dependency `js-yaml` from **4.2.0 → 4.3.0** and `@napi-rs/cli` from 3.7.3 → 3.7.4 (which pulls the patched js-yaml).

## Why

Dependabot alert #26 — **GHSA-52cp-r559-cp3m / CVE-2026-59869** (High, 7.5).
`js-yaml` can consume O(N²) CPU parsing a document whose size grows only linearly, via chained merge-keys (`<<:`). Fixed in 4.3.0 by capping merged keys per parse.

## Impact / risk

- **Dev / build-time only.** `js-yaml` is reached solely through `@napi-rs/cli` build tooling. It is **not** shipped in the npm launcher package nor in the GitHub Release runtime zip, so no end-user runtime is exposed.
- Change is lock-only, minimal (2 packages), `^4.2.0` already permits 4.3.0.

## Verification

- `npm run build` (tsc) passes
- `node --check bin/launcher.js` passes
- `npm ls js-yaml` → `js-yaml@4.3.0`

Remaining `npm audit` findings (`brace-expansion`, `body-parser`, `file-type`/jimp via `@nut-tree-fork/nut-js`) are separate alerts and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
