### PR TITLE
fix(deps): bump hono to 4.12.31 and fast-uri to 3.1.4 (Dependabot #29-33)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4871,9 +4871,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -5219,9 +5219,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.26",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
-      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Resolves 5 of the 6 open Dependabot alerts, all transitive via `@modelcontextprotocol/sdk`.

| Alert | Package | Fix | How |
|---|---|---|---|
| #29 #30 #31 | hono | 4.12.26 → **4.12.31** | within SDK's `^4.11.4` — lockfile bump |
| #32 #33 | fast-uri | 3.1.2 → **3.1.4** | within ajv's `^3.0.1` — lockfile bump |

**Not fixed here — #28 (`@hono/node-server` serve-static path traversal):** the fix (2.0.5) is a major bump the SDK does not yet allow (it pins `^1.19.9`). The vulnerable `serve-static` path is not exercised by the MCP JSON-RPC transport, so it is not exploitable in this server. Tracked upstream; recommend dismissing the alert with that rationale.

`package.json` unchanged (transitive bumps only). Build passes; CI runs the full suite. Ships to users with the next release (the runtime zip rebuilds from this lockfile at tag time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
