### PR TITLE
fix(lint): let lint see unused imports in tests, and clear what it finds

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -91,9 +91,13 @@ Run:
 ```bash
 node --check bin/launcher.js
 npm run check:launcher-manifest
+npm run lint            # stale eslint-disable directives are errors, so CI would fail on them
 npm run build
 npm publish --dry-run
 ```
+
+`npm run lint` is here so the guard is local: `.githooks/pre-push` only blocks
+direct pushes to `main`, and lint otherwise runs for the first time in CI.
 
 ### Dogfood Pass (Required, v1.3 lesson)
 
@@ -454,7 +458,7 @@ wrong version, etc.) that the stdio smoke test above cannot detect.
 rm -rf "$USERPROFILE/.desktop-touch-mcp/releases/vX.Y.Z"
 npm cache clean --force
 
-# 2. Download via npx and verify --help
+# 2. Download via npx (proves download + SHA verification + extraction)
 #    ⚠️ Run this from a cwd OUTSIDE the project source dir first
 #    (PowerShell: `cd $env:TEMP`  |  bash: `cd /tmp`).
 #    The project's own package.json has name=@harusame64/desktop-touch-mcp; once its
@@ -464,8 +468,15 @@ npm cache clean --force
 #    That is a false negative (wrong cwd), NOT a release bug — re-run from a temp dir.
 #    (`npx @...@<older-version>` works from the project root because the local version
 #    no longer satisfies the spec, which is why a 1.7.2 cross-check can mislead.)
-npx -y @harusame64/desktop-touch-mcp@X.Y.Z --help
-# Expected (v1.13.0 measured): the launcher prints
+#    ⚠️ Give it EOF on stdin, or it will not exit. `--help` is not implemented,
+#    so the launcher installs the release and then starts the stdio server, which
+#    stays alive until its stdin ends (bin/launcher.js `wireLauncherStdio` ends
+#    the child's stdin only when the parent's does). From an interactive console
+#    stdin never ends, so the command looks like a hang.
+#      bash:        npx -y @harusame64/desktop-touch-mcp@X.Y.Z --help < /dev/null
+#      PowerShell:  cmd /c "npx -y @harusame64/desktop-touch-mcp@X.Y.Z --help < NUL"
+npx -y @harusame64/desktop-touch-mcp@X.Y.Z --help < /dev/null
+# Expected (v1.13.0 measured, with stdin at EOF): the launcher prints
 #   [desktop-touch-mcp] Downloading desktop-touch-mcp-windows.zip from vX.Y.Z
 #   [desktop-touch-mcp] Installed vX.Y.Z to ...
 # and then exits 0 with NO usage text — neither bin/launcher.js nor src/ implements

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -465,7 +465,14 @@ npm cache clean --force
 #    (`npx @...@<older-version>` works from the project root because the local version
 #    no longer satisfies the spec, which is why a 1.7.2 cross-check can mislead.)
 npx -y @harusame64/desktop-touch-mcp@X.Y.Z --help
-# Expected: "desktop-touch-mcp vX.Y.Z" and usage text
+# Expected (v1.13.0 measured): the launcher prints
+#   [desktop-touch-mcp] Downloading desktop-touch-mcp-windows.zip from vX.Y.Z
+#   [desktop-touch-mcp] Installed vX.Y.Z to ...
+# and then exits 0 with NO usage text — neither bin/launcher.js nor src/ implements
+# --help, and 1.12.4 behaves identically, so a silent --help is not a regression.
+# What this step actually proves is the download + SHA verification + extraction.
+# For proof that the installed server RUNS, use the stdio initialize smoke test in
+# the "Smoke Test" section above; that is the check to trust.
 
 # 3. Verify installed files
 RELEASE_DIR="$USERPROFILE/.desktop-touch-mcp/releases/vX.Y.Z"

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -458,7 +458,7 @@ wrong version, etc.) that the stdio smoke test above cannot detect.
 rm -rf "$USERPROFILE/.desktop-touch-mcp/releases/vX.Y.Z"
 npm cache clean --force
 
-# 2. Download via npx (proves download + SHA verification + extraction)
+# 2. Download via npx and verify --help output (download + SHA + extraction + arg forwarding)
 #    ⚠️ Run this from a cwd OUTSIDE the project source dir first
 #    (PowerShell: `cd $env:TEMP`  |  bash: `cd /tmp`).
 #    The project's own package.json has name=@harusame64/desktop-touch-mcp; once its
@@ -468,22 +468,24 @@ npm cache clean --force
 #    That is a false negative (wrong cwd), NOT a release bug — re-run from a temp dir.
 #    (`npx @...@<older-version>` works from the project root because the local version
 #    no longer satisfies the spec, which is why a 1.7.2 cross-check can mislead.)
-#    ⚠️ Give it EOF on stdin, or it will not exit. `--help` is not implemented,
-#    so the launcher installs the release and then starts the stdio server, which
-#    stays alive until its stdin ends (bin/launcher.js `wireLauncherStdio` ends
-#    the child's stdin only when the parent's does). From an interactive console
-#    stdin never ends, so the command looks like a hang.
-#      bash:        npx -y @harusame64/desktop-touch-mcp@X.Y.Z --help < /dev/null
-#      PowerShell:  cmd /c "npx -y @harusame64/desktop-touch-mcp@X.Y.Z --help < NUL"
-npx -y @harusame64/desktop-touch-mcp@X.Y.Z --help < /dev/null
-# Expected (v1.13.0 measured, with stdin at EOF): the launcher prints
+#    (`--help` exits on its own — no stdin redirect needed. `src/server-windows.ts`
+#    handles it before the stdio transport starts, so unlike a normal launch the
+#    process does not sit waiting for input.)
+npx -y @harusame64/desktop-touch-mcp@X.Y.Z --help
+# Expected (measured on v1.13.0): the launcher prints
 #   [desktop-touch-mcp] Downloading desktop-touch-mcp-windows.zip from vX.Y.Z
 #   [desktop-touch-mcp] Installed vX.Y.Z to ...
-# and then exits 0 with NO usage text — neither bin/launcher.js nor src/ implements
-# --help, and 1.12.4 behaves identically, so a silent --help is not a regression.
-# What this step actually proves is the download + SHA verification + extraction.
-# For proof that the installed server RUNS, use the stdio initialize smoke test in
-# the "Smoke Test" section above; that is the check to trust.
+# then the SERVER prints its own usage and exits 0:
+#   desktop-touch-mcp vX.Y.Z
+#   Usage: desktop-touch-mcp [options]
+#   Options:  --http / --port <port> / -h, --help
+# Check the printed version equals X.Y.Z. Silence, or a version mismatch, is a
+# REGRESSION: it means the launcher stopped forwarding arguments, the wrong release
+# was extracted, or the runtime died before parsing flags.
+# So this step proves download + SHA verification + extraction + argument forwarding
+# + the runtime starting far enough to parse flags.
+# What this step does NOT prove is that the server answers MCP requests; for that,
+# run the stdio initialize / tools-list smoke test in the "Smoke Test" section above.
 
 # 3. Verify installed files
 RELEASE_DIR="$USERPROFILE/.desktop-touch-mcp/releases/vX.Y.Z"

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,9 +1,14 @@
-// Two-tier lint policy:
-//   1. All JS/TS — typescript-eslint recommended (light code-quality baseline).
+// Lint policy, in the order the blocks appear below:
+//   1. All JS/TS — typescript-eslint recommended (light code-quality baseline),
+//      plus `reportUnusedDisableDirectives: "error"`: a stale eslint-disable is
+//      a failure, not a warning nobody reads (`npm run lint` has no
+//      --max-warnings, so warnings never failed CI — PR #550 Round 1 P2-1).
 //   2. src/      — adds no-console (allow: error/warn) to defend the MCP stdio
 //                  JSON-RPC stream against console.log/debug/info contamination
 //                  (Issue #60 regression guard, see Issue #61).
-//   3. scripts/, tests/, __test__/ — relax console + test-friendly rules.
+//   3. src/tools/ — ADR-021: no hand-built tool-failure wire shapes.
+//   4. scripts/, tests/, __test__/ — relax console and test-shaped rules, but
+//      unused *imports* stay an error (see the block's own comment).
 
 import js from "@eslint/js";
 import globals from "globals";
@@ -29,6 +34,14 @@ export default [
 
   // Global rule tuning — applies everywhere.
   {
+    // A disable comment for a rule that reports nothing is dead weight that
+    // hides the next real violation of that rule. Reported as an ERROR because
+    // `npm run lint` is plain `eslint .` with no --max-warnings, so anything
+    // warning-level passes CI unnoticed — which is exactly how the 14 stale
+    // directives this PR sweeps accumulated.
+    linterOptions: {
+      reportUnusedDisableDirectives: "error",
+    },
     languageOptions: {
       globals: { ...globals.node },
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -73,7 +73,21 @@ export default [
     rules: {
       "no-console": "off",
       "@typescript-eslint/no-explicit-any": "off",
-      "@typescript-eslint/no-unused-vars": "off",
+      // Unused *imports* stay an error here. Turning the whole rule off (the
+      // previous setting) meant a stale import in a test was invisible to lint
+      // and only surfaced later as a CodeQL alert — which is how two of them
+      // reached main. Arguments and caught errors are exempt instead, since
+      // those are the test-shaped cases the blanket "off" was really for.
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          args: "none",
+          caughtErrors: "none",
+          ignoreRestSiblings: true,
+          varsIgnorePattern: "^_",
+          destructuredArrayIgnorePattern: "^_",
+        },
+      ],
       "@typescript-eslint/no-require-imports": "off",
       "@typescript-eslint/no-empty-object-type": "off",
       "no-control-regex": "off",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5990,9 +5990,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -6389,9 +6389,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -6409,7 +6409,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "access": "public"
   },
   "overrides": {
-    "ip-address": "10.1.1"
+    "ip-address": "10.1.1",
+    "postcss": "^8.5.18"
   },
   "napi": {
     "name": "desktop-touch-engine",

--- a/src/tools/_envelope.ts
+++ b/src/tools/_envelope.ts
@@ -657,7 +657,7 @@ function mergeFlatField(schemas: z.ZodTypeAny[]): z.ZodTypeAny {
     if (firstDesc) mergedEnum = mergedEnum.describe(firstDesc);
     return mergedEnum.optional();
   }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+   
   return z.union(bases as [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]).optional();
 }
 

--- a/tests/e2e/browser-cdp.test.ts
+++ b/tests/e2e/browser-cdp.test.ts
@@ -10,7 +10,6 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 import { launchChrome, tryFindChrome, type ChromeInstance } from "./helpers/chrome-launcher.js";

--- a/tests/e2e/terminal-console-paste-load.test.ts
+++ b/tests/e2e/terminal-console-paste-load.test.ts
@@ -16,7 +16,6 @@
  * fall-through) is pinned by the mocked unit test (terminal-send-console-paste.test.ts
  * case b) — forcing a native paste failure in a live e2e is not deterministic.
  */
-
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
@@ -25,13 +24,10 @@ import { terminalSendHandler, terminalReadHandler } from "../../src/tools/termin
 import { isSshWslAvailable, launchSshWslBash, type SshBashInstance } from "./helpers/ssh-wsl-launcher.js";
 import { enumWindowsInZOrder } from "../../src/engine/win32.js";
 import { sleep } from "./helpers/wait.js";
-
 const execFileAsync = promisify(execFile);
-
 function parse(r: { content: { type: string; text: string }[] }) {
   return JSON.parse(r.content[0]!.text);
 }
-
 /** SW_MINIMIZE the window so the load run steals no foreground. */
 async function minimize(hwnd: bigint): Promise<void> {
   const sig = '[DllImport("user32.dll")] public static extern bool ShowWindow(IntPtr h, int n);';
@@ -42,7 +38,6 @@ async function minimize(hwnd: bigint): Promise<void> {
     { timeout: 5000, windowsHide: true },
   );
 }
-
 async function sendAuto(title: string, input: string) {
   return parse(await terminalSendHandler({
     windowTitle: title, input, method: "auto", chunkSize: 100,
@@ -50,22 +45,18 @@ async function sendAuto(title: string, input: string) {
     preferClipboard: true, pasteKey: "auto", trackFocus: false, settleMs: 0,
   }));
 }
-
 async function readBack(title: string, lines = 8): Promise<string> {
   const r = parse(await terminalReadHandler({
     windowTitle: title, lines, stripAnsi: true, source: "auto", ocrLanguage: "ja",
   }));
   return typeof r.text === "string" ? r.text : "";
 }
-
 function pct(sorted: number[], p: number): number {
   if (sorted.length === 0) return 0;
   return sorted[Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length))]!;
 }
-
 let available = false;
 let sh: SshBashInstance | null = null;
-
 describe("[bash@wsl-ssh] terminal action=send console-paste — LOAD/STRESS gate", () => {
   beforeAll(async () => {
     available = await isSshWslAvailable();
@@ -74,9 +65,7 @@ describe("[bash@wsl-ssh] terminal action=send console-paste — LOAD/STRESS gate
     try { await minimize(sh.hwnd); } catch { /* best-effort; e2e focus steal is acceptable */ }
     await sleep(300);
   }, 60_000);
-
   afterAll(() => { sh?.kill(); });
-
   it("L1: 40 rapid auto sends all deliver byte-intact via console-paste (+latency)", async ({ skip }) => {
     if (!available || !sh) skip("SSH-into-WSL bash harness unavailable (env)");
     const title = sh!.title;
@@ -95,12 +84,10 @@ describe("[bash@wsl-ssh] terminal action=send console-paste — LOAD/STRESS gate
       expect(text, `read-back #${i}`).toContain(marker);
     }
     latencies.sort((a, b) => a - b);
-    // eslint-disable-next-line no-console
     console.log(`[L1] N=${N} channel=console_paste:${consolePasteCount}/${N} ` +
       `p50=${pct(latencies, 50)}ms p95=${pct(latencies, 95)}ms p99=${pct(latencies, 99)}ms`);
     expect(consolePasteCount).toBe(N); // every send used the new path (no secret prompt)
   }, 120_000);
-
   it("L2: clipboard integrity under contention + 100% delivery at realistic interval", async ({ skip }) => {
     if (!available || !sh) skip("SSH-into-WSL bash harness unavailable (env)");
     const title = sh!.title;
@@ -113,7 +100,6 @@ describe("[bash@wsl-ssh] terminal action=send console-paste — LOAD/STRESS gate
     // conhost's read) — the same property the shipped action=run exit-mode path
     // has. An aggressive 15ms write-hammer is PATHOLOGICAL: it drops a fraction of
     // sends (observed ~14/20). That is logged as an observation below, NOT gated.
-
     // (ii) Realistic interval (250ms — far more aggressive than real clipboard
     // managers, which mostly POLL/read) → require 100% delivery.
     const realisticHammer = execFile("powershell.exe",
@@ -132,10 +118,8 @@ describe("[bash@wsl-ssh] terminal action=send console-paste — LOAD/STRESS gate
     } finally {
       realisticHammer.kill();
     }
-    // eslint-disable-next-line no-console
     console.log(`[L2] realistic-250ms-hammer delivered=${delivered}/15`);
     expect(delivered).toBe(15); // 100% at a realistic contention interval
-
     await sleep(150);
     // (i) Clipboard integrity: our pasted command text must NOT persist on the
     // clipboard (saved/restored across the paste). No CPL2 marker may remain.
@@ -143,7 +127,6 @@ describe("[bash@wsl-ssh] terminal action=send console-paste — LOAD/STRESS gate
       ["-NoProfile", "-NonInteractive", "-Command", "Get-Clipboard -Raw"], { timeout: 5000 });
     expect(stdout).not.toContain("CPL2_");
   }, 120_000);
-
   it("L3: large >1KB single-line payload delivers byte-intact", async ({ skip }) => {
     if (!available || !sh) skip("SSH-into-WSL bash harness unavailable (env)");
     const title = sh!.title;
@@ -159,7 +142,6 @@ describe("[bash@wsl-ssh] terminal action=send console-paste — LOAD/STRESS gate
     // The full payload (marker + 1300 X's + END) must appear contiguous — no drop.
     expect(text).toContain(`${marker}_${big}_END`);
   }, 60_000);
-
   it("L5: no window-count growth across a burst (coarse leak check)", async ({ skip }) => {
     if (!available || !sh) skip("SSH-into-WSL bash harness unavailable (env)");
     const title = sh!.title;

--- a/tests/e2e/wait-until.test.ts
+++ b/tests/e2e/wait-until.test.ts
@@ -15,7 +15,7 @@ import {
   type BrowserSearchHook,
 } from "../../src/tools/wait-until.js";
 import { launchNotepad, type NpInstance } from "./helpers/notepad-launcher.js";
-import { sleep, parsePayload } from "./helpers/wait.js";
+import { parsePayload } from "./helpers/wait.js";
 
 // ─── Reset hooks between tests ─────────────────────────────────────────────────
 

--- a/tests/e2e/workspace-chain.test.ts
+++ b/tests/e2e/workspace-chain.test.ts
@@ -11,12 +11,12 @@
  * the error response is actionable.
  */
 
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, afterAll } from "vitest";
 import { focusWindowHandler } from "../../src/tools/window.js";
 import { workspaceLaunchHandler } from "../../src/tools/workspace.js";
 import { waitUntilHandler } from "../../src/tools/wait-until.js";
-import { launchNotepad, type NpInstance } from "./helpers/notepad-launcher.js";
-import { parsePayload, sleep } from "./helpers/wait.js";
+import { type NpInstance } from "./helpers/notepad-launcher.js";
+import { parsePayload } from "./helpers/wait.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // H1-base: focus_window on absent window → WindowNotFound + suggest wait_until
@@ -77,7 +77,6 @@ describe("H1-chain: workspace_launch + wait_until + focus_window happy path", ()
     const { join } = await import("path");
     const { writeFileSync, unlinkSync } = await import("fs");
     const { spawn } = await import("child_process");
-    const { enumWindowsInZOrder } = await import("../../src/engine/win32.js");
 
     const tag = `h1-${Date.now().toString(36)}`;
     const tempFile = join(tmpdir(), `${tag}.txt`);

--- a/tests/integration/tools-list-schema.test.ts
+++ b/tests/integration/tools-list-schema.test.ts
@@ -25,10 +25,8 @@
  * so a Linux / minimal CI environment skips cleanly instead of failing at
  * module load (Codex PR #290 Round 1 P1).
  */
-
 import { describe, it, expect, beforeAll } from "vitest";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-
 const FLATTENED_TOOLS = [
   "scroll",
   "keyboard",
@@ -38,21 +36,16 @@ const FLATTENED_TOOLS = [
   "terminal",
   "clipboard",
 ] as const;
-
 interface ListedTool {
   name: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   inputSchema?: any;
 }
-
 describe.skipIf(process.platform !== "win32")(
   "ADR-018 Phase 2a — tools/list inputSchema CI gate",
   () => {
     let tools: ListedTool[] = [];
-
     beforeAll(async () => {
       const s = new McpServer({ name: "tools-list-schema-test", version: "0" });
-
       // Mirror server-windows.ts::createMcpServer registration list (the
       // failsafe wrapper + tray + transport are not needed for a tools/list dump).
       const regs: Array<[string, string]> = [
@@ -89,8 +82,6 @@ describe.skipIf(process.platform !== "win32")(
       } catch {
         /* v2 module optional in some envs */
       }
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const handler = (s.server as any)._requestHandlers.get("tools/list");
       const res = await handler(
         { method: "tools/list", params: {} },
@@ -98,7 +89,6 @@ describe.skipIf(process.platform !== "win32")(
       );
       tools = res.tools as ListedTool[];
     });
-
     it("registers the full public tool surface", () => {
       // The server registers ~32 tools (30 stub catalog incl. ADR-026 Phase 3
       // screenshot_query/screenshot_gc + ADR-014 key_locker, + 2 v2; V1 fallbacks
@@ -106,7 +96,6 @@ describe.skipIf(process.platform !== "win32")(
       // regression dropping a tool family.
       expect(tools.length).toBeGreaterThanOrEqual(30);
     });
-
     it("registers the ADR-026 Phase 3 disk-cache tools by name (catches a registration drop a >= bound would miss)", () => {
       // A loose `>=` count can't tell which tool went missing; assert the two new
       // maintenance tools explicitly (ADR-026 AC6).
@@ -114,14 +103,12 @@ describe.skipIf(process.platform !== "win32")(
       expect(names.has("screenshot_query"), "screenshot_query registered").toBe(true);
       expect(names.has("screenshot_gc"), "screenshot_gc registered").toBe(true);
     });
-
     it("NO registered tool has empty `properties` (server-wide top-level-union regression guard)", () => {
       const empty = tools
         .filter((t) => Object.keys(t.inputSchema?.properties ?? {}).length === 0)
         .map((t) => t.name);
       expect(empty).toEqual([]);
     });
-
     it("NO registered tool has a TOP-LEVEL oneOf/anyOf/allOf (Anthropic API rejects those)", () => {
       const bad = tools
         .filter(
@@ -133,7 +120,6 @@ describe.skipIf(process.platform !== "win32")(
         .map((t) => t.name);
       expect(bad).toEqual([]);
     });
-
     it("each of the 7 flattened tools exposes non-empty `properties` with an `action` enum", () => {
       for (const name of FLATTENED_TOOLS) {
         const tool = tools.find((t) => t.name === name);
@@ -146,7 +132,6 @@ describe.skipIf(process.platform !== "win32")(
         expect(action!.enum!.length, `${name}.action enum non-empty`).toBeGreaterThan(0);
       }
     });
-
     it("terminal.until — a nested z.discriminatedUnion — renders as a PROPERTY-LEVEL oneOf, intact (ADR-018 §3 G2a #6)", () => {
       const terminal = tools.find((t) => t.name === "terminal");
       expect(terminal).toBeDefined();

--- a/tests/unit/browser-click-by-axis-schema.test.ts
+++ b/tests/unit/browser-click-by-axis-schema.test.ts
@@ -10,45 +10,35 @@
  *
  * @see src/tools/browser.ts  browserClickRegistrationSchema
  */
-
 import { describe, it, expect } from "vitest";
 import { browserClickRegistrationSchema, browserFillRegistrationSchema } from "../../src/tools/browser.js";
-
 describe("browser_click registration schema — exactly-one-of(selector | by+pattern)", () => {
   it("accepts selector alone", () => {
     expect(browserClickRegistrationSchema.safeParse({ selector: "#submit" }).success).toBe(true);
   });
-
   it("accepts by + pattern alone", () => {
     expect(browserClickRegistrationSchema.safeParse({ by: "text", pattern: "Save" }).success).toBe(true);
   });
-
   it("accepts by + pattern + role + scope (disambiguation args)", () => {
     expect(
       browserClickRegistrationSchema.safeParse({ by: "text", pattern: "Save", role: "button", scope: "#main" }).success,
     ).toBe(true);
   });
-
   it("rejects BOTH selector and by+pattern", () => {
     expect(browserClickRegistrationSchema.safeParse({ selector: "#x", by: "text", pattern: "Save" }).success).toBe(false);
   });
-
   it("rejects NEITHER (empty)", () => {
     expect(browserClickRegistrationSchema.safeParse({}).success).toBe(false);
   });
-
   it("rejects by without pattern", () => {
     expect(browserClickRegistrationSchema.safeParse({ by: "text" }).success).toBe(false);
   });
-
   it("rejects an unknown by-axis value (selector is NOT a public by-axis)", () => {
     expect(browserClickRegistrationSchema.safeParse({ by: "selector", pattern: "#x" }).success).toBe(false);
   });
-
   it("survives the refine as a ZodObject so the SDK emits tools/list properties", () => {
     // The MCP SDK's normalizeObjectSchema returns the schema only when
     // _zod.def.type === 'object' (or def.shape present). A refined object keeps both.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const def = (browserClickRegistrationSchema as any)._zod?.def;
     expect(def?.type).toBe("object");
     const shape = def?.shape ?? {};
@@ -57,30 +47,23 @@ describe("browser_click registration schema — exactly-one-of(selector | by+pat
     }
   });
 });
-
 describe("browser_fill registration schema — exactly-one-of(selector | by+pattern)", () => {
   it("accepts selector + value", () => {
     expect(browserFillRegistrationSchema.safeParse({ selector: "#email", value: "x" }).success).toBe(true);
   });
-
   it("accepts by + pattern + value", () => {
     expect(browserFillRegistrationSchema.safeParse({ by: "ariaLabel", pattern: "Email", value: "x" }).success).toBe(true);
   });
-
   it("rejects BOTH selector and by+pattern", () => {
     expect(browserFillRegistrationSchema.safeParse({ selector: "#e", by: "ariaLabel", pattern: "Email", value: "x" }).success).toBe(false);
   });
-
   it("rejects NEITHER", () => {
     expect(browserFillRegistrationSchema.safeParse({ value: "x" }).success).toBe(false);
   });
-
   it("requires value", () => {
     expect(browserFillRegistrationSchema.safeParse({ by: "ariaLabel", pattern: "Email" }).success).toBe(false);
   });
-
   it("survives the refine as a ZodObject with all by-axis + value properties", () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const def = (browserFillRegistrationSchema as any)._zod?.def;
     expect(def?.type).toBe("object");
     const shape = def?.shape ?? {};

--- a/tests/unit/desktop-facade.test.ts
+++ b/tests/unit/desktop-facade.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { DesktopFacade, type CandidateProvider, type DesktopSeeInput, type CandidateIngress } from "../../src/tools/desktop.js";
+import { DesktopFacade, type CandidateProvider, type CandidateIngress } from "../../src/tools/desktop.js";
 import type { UiEntityCandidate } from "../../src/engine/vision-gpu/types.js";
 import {
   updateUiaCache,

--- a/tests/unit/desktop-state-causal-include.test.ts
+++ b/tests/unit/desktop-state-causal-include.test.ts
@@ -31,9 +31,7 @@ import {
   _setHistoryClockForTest,
   _resetHistoryClockForTest,
   _seedHistoryForTest,
-  type CommitL1Emitter,
   type ViewSnapshot,
-  type ToolCallEvent,
 } from "../../src/tools/_envelope.js";
 
 // ── Test helpers ─────────────────────────────────────────────────────────────

--- a/tests/unit/dxgi-broker.test.ts
+++ b/tests/unit/dxgi-broker.test.ts
@@ -23,16 +23,13 @@
  *   h. 5-value CacheAcquireState all branches ✓
  *   i. const bit-equal with Stage 5 SSOT ✓
  */
-
 import { afterEach, describe, it, expect, vi } from "vitest";
-
 import {
   DirtyRectBroker,
   BROKER_CONSTANTS,
   type SubscriptionLike,
 } from "../../src/engine/dxgi-broker.js";
 import { STAGE5_CONSTANTS } from "../../src/engine/any-change.js";
-
 // Round 1 P2-4: shared registration helper + afterEach cleanup so each test's
 // fan-out loop is reliably stopped before the next test starts. Avoids
 // dangling `setTimeout` handles + `runFanOut` promises piling up under
@@ -50,14 +47,12 @@ afterEach(() => {
     b?.disposeAll();
   }
 });
-
 /** Test-only mock of `NativeDirtyRectSubscription`. The `next()` body
  *  is replaced per-test so each case can simulate empty / non-empty
  *  batches / AccessLost without scheduling real timers. */
 class StubSubscription implements SubscriptionLike {
   isDisposed = false;
   readonly disposeMock = vi.fn();
-  // eslint-disable-next-line @typescript-eslint/require-await
   async next(_timeoutMs: number): Promise<Array<{ x: number; y: number; width: number; height: number }>> {
     return [];
   }
@@ -66,24 +61,19 @@ class StubSubscription implements SubscriptionLike {
     this.isDisposed = true;
   }
 }
-
 describe("DirtyRectBroker", () => {
   // ─── a. single consumer acquire / dispose ──────────────────────────────────
-
   it("acquire returns a handle and constructs one native subscription", () => {
     const factory = vi.fn(() => new StubSubscription());
     const broker = makeBroker(factory, () => 0);
-
     const result = broker.acquire(0);
     expect(result.sub).not.toBeNull();
     expect(result.state).toBe("miss-init");
     expect(factory).toHaveBeenCalledTimes(1);
   });
-
   it("second acquire on same outputIndex reuses the native subscription (state=hit-subscription)", () => {
     const factory = vi.fn(() => new StubSubscription());
     const broker = makeBroker(factory, () => 0);
-
     const first = broker.acquire(0);
     const second = broker.acquire(0);
     expect(factory).toHaveBeenCalledTimes(1);
@@ -93,14 +83,11 @@ describe("DirtyRectBroker", () => {
     // same native subscription (verified via factory call count above).
     expect(first.sub).not.toBe(second.sub);
   });
-
   // ─── b. multi-consumer multiplex (race-loss elimination, 北極星 2) ────────
-
   it("2 polling consumers on same outputIndex share exactly one native subscription (race-loss eliminated)", () => {
     const stub = new StubSubscription();
     const factory = vi.fn(() => stub);
     const broker = makeBroker(factory, () => 0);
-
     const a = broker.acquire(0);
     const b = broker.acquire(0);
     expect(factory).toHaveBeenCalledTimes(1);
@@ -112,27 +99,21 @@ describe("DirtyRectBroker", () => {
     expect(stub.disposeMock).not.toHaveBeenCalled();
     expect(stub.isDisposed).toBe(false);
   });
-
   it("polling + callback consumer on same outputIndex share one native subscription", () => {
     const factory = vi.fn(() => new StubSubscription());
     const broker = makeBroker(factory, () => 0);
-
     broker.acquire(0);
     broker.subscribe(0, () => undefined);
     expect(factory).toHaveBeenCalledTimes(1);
   });
-
   it("different outputIndex values get separate native subscriptions", () => {
     const factory = vi.fn(() => new StubSubscription());
     const broker = makeBroker(factory, () => 0);
-
     broker.acquire(0);
     broker.acquire(1);
     expect(factory).toHaveBeenCalledTimes(2);
   });
-
   // ─── c. callback fan-out + polling fan-out independence ────────────────────
-
   it("fan-out delivers batches to every polling consumer's queue independently", async () => {
     const stub: SubscriptionLike & { isDisposed: boolean; _pump?: (rects: { x: number; y: number; width: number; height: number }[]) => void } = {
       isDisposed: false,
@@ -142,10 +123,8 @@ describe("DirtyRectBroker", () => {
       dispose: vi.fn(),
     };
     const broker = makeBroker(() => stub, () => 0, 20_000, 60_000, 5);
-
     const a = broker.acquire(0);
     const b = broker.acquire(0);
-
     // Both pollers receive the SAME batch (multiplexed fan-out, not
     // first-come-first-served).
     const [aBatch, bBatch] = await Promise.all([
@@ -154,10 +133,8 @@ describe("DirtyRectBroker", () => {
     ]);
     expect(aBatch).toEqual([{ x: 1, y: 2, width: 3, height: 4 }]);
     expect(bBatch).toEqual([{ x: 1, y: 2, width: 3, height: 4 }]);
-
     broker.disposeAll();
   });
-
   it("callback consumer receives fan-out batches", async () => {
     const stub: SubscriptionLike = {
       isDisposed: false,
@@ -167,31 +144,24 @@ describe("DirtyRectBroker", () => {
       dispose: vi.fn(),
     };
     const broker = makeBroker(() => stub, () => 0, 20_000, 60_000, 5);
-
     const callbacks: { x: number; y: number; width: number; height: number }[][] = [];
     broker.subscribe(0, (batch) => callbacks.push(batch));
-
     // Allow the fan-out loop one microtask cycle to drain the queued batch.
     await new Promise((r) => setTimeout(r, 30));
     expect(callbacks.length).toBeGreaterThanOrEqual(1);
     expect(callbacks[0]).toEqual([{ x: 10, y: 20, width: 30, height: 40 }]);
-
     broker.disposeAll();
   });
-
   // ─── d. 3-TTL state machine ────────────────────────────────────────────────
-
   it("idle timeout disposes the native subscription on next sweepStale (no live consumers)", () => {
     let now = 0;
     const stub = new StubSubscription();
     const factory = vi.fn(() => stub);
     const broker = makeBroker(factory, () => now, 100, 500);
-
     const result = broker.acquire(0);
     result.sub!.dispose(); // last consumer leaves
     expect(stub.disposeMock).not.toHaveBeenCalled(); // still within idle window
     expect(stub.isDisposed).toBe(false);
-
     now = 200; // past idle timeout
     const fresh = new StubSubscription();
     factory.mockImplementationOnce(() => fresh);
@@ -199,30 +169,25 @@ describe("DirtyRectBroker", () => {
     expect(second.sub).not.toBeNull();
     expect(stub.disposeMock).toHaveBeenCalledOnce();
   });
-
   it("unavailable marker survives the idle window but expires at unavailable-TTL", () => {
     let now = 0;
     const factory = vi.fn(() => {
       throw new Error("E_DUP_UNSUPPORTED");
     });
     const broker = makeBroker(factory, () => now, 100, 500);
-
     expect(broker.acquire(0).sub).toBeNull();
     expect(factory).toHaveBeenCalledTimes(1);
-
     // After idle window (100 ms) but before unavailable TTL (500 ms) —
     // marker still active.
     now = 200;
     expect(broker.acquire(0).sub).toBeNull();
     expect(broker.acquire(0).state).toBe("hit-unavailable");
     expect(factory).toHaveBeenCalledTimes(1);
-
     // After unavailable TTL — marker swept, factory re-tries.
     now = 501;
     expect(broker.acquire(0).sub).toBeNull();
     expect(factory).toHaveBeenCalledTimes(2);
   });
-
   it("negative-backoff marker fast-paths to hit-negative-backoff within 2 s window", () => {
     let now = 0;
     let counter = 0;
@@ -231,26 +196,21 @@ describe("DirtyRectBroker", () => {
       return new StubSubscription();
     });
     const broker = makeBroker(factory, () => now);
-
     broker.acquire(0);
     broker.invalidate(0);
     expect(broker._getEntryForTest(0)?.kind).toBe("negative-backoff");
-
     // Immediate re-acquire within 2 s → fast path, no factory re-init.
     const result = broker.acquire(0);
     expect(result.sub).toBeNull();
     expect(result.state).toBe("hit-negative-backoff");
     expect(counter).toBe(1);
-
     // After 2 s — marker swept, fresh factory call permitted.
     now = 2_001;
     const fresh = broker.acquire(0);
     expect(fresh.sub).not.toBeNull();
     expect(counter).toBe(2);
   });
-
   // ─── e. 5-value CacheAcquireState all branches ─────────────────────────────
-
   it("all 5 CacheAcquireState branches are reachable through the public API", () => {
     const now = 0;
     let mode: "ok" | "throw" = "ok";
@@ -259,25 +219,20 @@ describe("DirtyRectBroker", () => {
       return new StubSubscription();
     });
     const broker = makeBroker(factory, () => now, 1_000, 5_000);
-
     // 1. miss-init (cold start, factory ok)
     expect(broker.acquire(0).state).toBe("miss-init");
     // 2. hit-subscription (second acquire, same outputIndex)
     expect(broker.acquire(0).state).toBe("hit-subscription");
-
     // 3. hit-negative-backoff (after invalidate)
     broker.invalidate(0);
     expect(broker.acquire(0).state).toBe("hit-negative-backoff");
-
     // 4. miss-init-unavailable (cold start, factory throw on outputIndex 1)
     mode = "throw";
     expect(broker.acquire(1).state).toBe("miss-init-unavailable");
     // 5. hit-unavailable (second acquire on outputIndex 1, cached marker)
     expect(broker.acquire(1).state).toBe("hit-unavailable");
   });
-
   // ─── f. AccessLost recovery via fan-out exception → negative-backoff ──────
-
   it("fan-out exception triggers invalidate → next acquire fast-paths to negative-backoff", async () => {
     const stub: SubscriptionLike = {
       isDisposed: false,
@@ -285,41 +240,32 @@ describe("DirtyRectBroker", () => {
       dispose: vi.fn(),
     };
     const broker = makeBroker(() => stub, () => 0, 20_000, 60_000, 5);
-
     broker.acquire(0);
     // Allow fan-out loop one tick to surface the exception → invalidate.
     await new Promise((r) => setTimeout(r, 30));
-
     const entry = broker._getEntryForTest(0);
     expect(entry?.kind).toBe("negative-backoff");
     expect(broker.acquire(0).state).toBe("hit-negative-backoff");
   });
-
   // ─── g. disposeAll teardown ────────────────────────────────────────────────
-
   it("disposeAll releases every live subscription and clears entries", () => {
     const a = new StubSubscription();
     const b = new StubSubscription();
     const queue: StubSubscription[] = [a, b];
     const factory = vi.fn(() => queue.shift()!);
     const broker = makeBroker(factory, () => 0);
-
     broker.acquire(0);
     broker.acquire(1);
     broker.disposeAll();
-
     expect(a.disposeMock).toHaveBeenCalledOnce();
     expect(b.disposeMock).toHaveBeenCalledOnce();
     expect(broker._getEntryForTest(0)).toBeUndefined();
     expect(broker._getEntryForTest(1)).toBeUndefined();
   });
-
   // ─── h. interface lock: BrokerSubscription has no `subscribe()` method ────
-
   it("BrokerSubscription handle exposes no `subscribe()` (Round 2 P1-3 interface lock)", () => {
     const factory = vi.fn(() => new StubSubscription());
     const broker = makeBroker(factory, () => 0);
-
     const { sub } = broker.acquire(0);
     expect(sub).not.toBeNull();
     // Compile-time guard would normally catch this; runtime check pins the
@@ -327,11 +273,8 @@ describe("DirtyRectBroker", () => {
     // pattern: claim documentation must match runtime).
     expect((sub as unknown as { subscribe?: unknown }).subscribe).toBeUndefined();
   });
-
   // ─── i. const bit-equal with Stage 5 SSOT ─────────────────────────────────
-
   // ─── j. Round 1 regression tests (P1-1 / P2-1 / P2-3) ────────────────────
-
   /**
    * Round 1 P1-1 regression test: dispose-then-immediate-reattach must
    * restart the fan-out loop for the newly attached consumer instead of
@@ -356,18 +299,15 @@ describe("DirtyRectBroker", () => {
     // would fail under the pre-fix code (would observe `fanOutShouldStop:
     // true` after the re-acquire) and pass post-fix.
     const broker = makeBroker(() => new StubSubscription(), () => 0, 20_000, 60_000, 5);
-
     const a = broker.acquire(0);
     expect(a.sub).not.toBeNull();
     a.sub!.dispose();
-
     // After last consumer leaves: maybeStopFanOut sets fanOutShouldStop=true.
     const beforeReacquire = broker._getEntryForTest(0);
     expect(beforeReacquire?.kind).toBe("subscription");
     if (beforeReacquire?.kind === "subscription") {
       expect(beforeReacquire.fanOutShouldStop).toBe(true);
     }
-
     // Immediate re-acquire — P1-1 fix must reset fanOutShouldStop to false
     // so the (potentially still-running) loop continues serving the new
     // consumer, and the chained restart trampoline catches the
@@ -380,7 +320,6 @@ describe("DirtyRectBroker", () => {
       expect(afterReacquire.pollingHandles.size).toBe(1);
     }
   });
-
   /**
    * Round 1 P2-1 regression test: a non-DXGI exception from `sub.next()`
    * must invalidate the entry (transitioning to `negative-backoff`) so the
@@ -395,15 +334,12 @@ describe("DirtyRectBroker", () => {
       dispose: vi.fn(),
     };
     const broker = makeBroker(() => stub, () => 0, 20_000, 60_000, 5);
-
     broker.acquire(0);
     await new Promise((r) => setTimeout(r, 30));
-
     const entry = broker._getEntryForTest(0);
     expect(entry?.kind).toBe("negative-backoff");
     expect(broker.acquire(0).state).toBe("hit-negative-backoff");
   });
-
   /**
    * Round 1 P2-3 regression test: after `invalidate(outputIndex)`,
    * pre-existing polling handles must report `isDisposed === true` so
@@ -413,11 +349,9 @@ describe("DirtyRectBroker", () => {
   it("Round 1 P2-3: invalidate marks pre-existing polling handles as disposed", async () => {
     const stub = new StubSubscription();
     const broker = makeBroker(() => stub, () => 0, 20_000, 60_000, 5);
-
     const { sub } = broker.acquire(0);
     expect(sub).not.toBeNull();
     expect(sub!.isDisposed).toBe(false);
-
     broker.invalidate(0);
     expect(sub!.isDisposed).toBe(true);
     // `next()` on a disposed handle resolves to [] immediately (not after
@@ -425,7 +359,6 @@ describe("DirtyRectBroker", () => {
     const batch = await sub!.next(10_000);
     expect(batch).toEqual([]);
   });
-
   /** Round 1 P2-3 regression test (same fix for disposeAll). */
   it("Round 1 P2-3: disposeAll marks pre-existing polling handles as disposed", async () => {
     const stub = new StubSubscription();
@@ -435,7 +368,6 @@ describe("DirtyRectBroker", () => {
     expect(sub!.isDisposed).toBe(true);
     expect(await sub!.next(10_000)).toEqual([]);
   });
-
   /**
    * Round 1 P3-4 regression test: concurrent `next()` calls on the same
    * handle must throw (instead of silently orphaning the first resolver).
@@ -448,7 +380,6 @@ describe("DirtyRectBroker", () => {
     };
     const broker = makeBroker(() => stub, () => 0, 20_000, 60_000, 5);
     const { sub } = broker.acquire(0);
-
     // First call starts waiting (no batch in queue, no fan-out batch yet).
     const first = sub!.next(50);
     // `PollingHandle.next` is `async`, so the contract violation surfaces
@@ -457,7 +388,6 @@ describe("DirtyRectBroker", () => {
     // First call resolves on timeout (cleanup).
     await first;
   });
-
   /**
    * Round 2 Codex P2 regression test: detaching the last consumer must
    * reset the idle window so a quick re-subscribe doesn't trigger an
@@ -475,15 +405,12 @@ describe("DirtyRectBroker", () => {
     const factory = vi.fn(() => new StubSubscription());
     // idleTimeoutMs = 100, unavailableTtlMs = 500.
     const broker = makeBroker(factory, () => now, 100, 500);
-
     // T=0: acquire — lastUsedAt = 0.
     const a = broker.acquire(0);
     expect(factory).toHaveBeenCalledTimes(1);
-
     // T=99: handle disposed (last consumer) — lastUsedAt MUST refresh to 99.
     now = 99;
     a.sub!.dispose();
-
     // T=150: re-acquire. Pre-fix: now - lastUsedAt (=0) = 150 > 100 → swept.
     // Post-fix: now - lastUsedAt (=99) = 51 < 100 → entry retained.
     now = 150;
@@ -491,7 +418,6 @@ describe("DirtyRectBroker", () => {
     expect(b.state).toBe("hit-subscription");
     expect(factory).toHaveBeenCalledTimes(1);
   });
-
   it("BROKER_CONSTANTS values are bit-equal with STAGE5_CONSTANTS (PR-SR4-2 SSOT shift prerequisite)", () => {
     // Sub-plan §5.3 acceptance: PR-SR4-1 holds private duplicates; PR-SR4-2
     // shifts SSOT to broker side + Stage 5 re-exports. The numeric values
@@ -513,7 +439,6 @@ describe("DirtyRectBroker", () => {
     expect(BROKER_CONSTANTS.BROKER_CACHE_IDLE_TIMEOUT_MS).toBe(20_000);
     expect(BROKER_CONSTANTS.BROKER_UNAVAILABLE_TTL_MS).toBe(60_000);
   });
-
   // ─── j. PR-SR4-3 Round 1 P1-1 — onInvalidate hook for callback consumers ──
   // The vision-gpu silent-zombie regression discovered by Opus PR-SR4-3
   // Round 1 P1-1: callback consumers had no signal that the broker tore
@@ -522,7 +447,6 @@ describe("DirtyRectBroker", () => {
   // nothing). The `onInvalidate` hook fires exactly once on the broker's
   // `invalidate()` / `disposeAll()` path, AFTER `isUnsubscribed` flips.
   // These tests pin the hook contract and revert simulation.
-
   it("subscribe.onInvalidate fires exactly once on broker.invalidate", async () => {
     const stub: SubscriptionLike = {
       isDisposed: false,
@@ -532,21 +456,16 @@ describe("DirtyRectBroker", () => {
       dispose: vi.fn(),
     };
     const broker = makeBroker(() => stub, () => 0, 20_000, 60_000, 5);
-
     const callbackSpy = vi.fn();
     const invalidateSpy = vi.fn();
     broker.subscribe(0, callbackSpy, invalidateSpy);
-
     // Let the fan-out loop catch the throw and call invalidate().
     await new Promise((r) => setTimeout(r, 30));
-
     expect(invalidateSpy).toHaveBeenCalledTimes(1);
     // The callback itself must NOT have received any batch (only invalidate fires).
     expect(callbackSpy).not.toHaveBeenCalled();
-
     broker.disposeAll();
   });
-
   it("subscribe.onInvalidate is optional — omitting it is safe (revert simulation)", async () => {
     const stub: SubscriptionLike = {
       isDisposed: false,
@@ -556,21 +475,17 @@ describe("DirtyRectBroker", () => {
       dispose: vi.fn(),
     };
     const broker = makeBroker(() => stub, () => 0, 20_000, 60_000, 5);
-
     // No onInvalidate — broker must still invalidate cleanly without
     // throwing on the missing hook. Mental simulation: removing the
     // `if (cb.onInvalidate !== undefined)` guard would crash here.
     const result = broker.subscribe(0, () => undefined);
     expect(result.state).toBe("miss-init");
     await new Promise((r) => setTimeout(r, 30));
-
     // Entry should be in negative-backoff state after the throw.
     const entry = broker._getEntryForTest(0);
     expect(entry?.kind).toBe("negative-backoff");
-
     broker.disposeAll();
   });
-
   it("subscribe.onInvalidate fires on disposeAll (server shutdown path)", () => {
     const stub: SubscriptionLike = {
       isDisposed: false,
@@ -578,15 +493,11 @@ describe("DirtyRectBroker", () => {
       dispose: () => undefined,
     };
     const broker = makeBroker(() => stub, () => 0, 20_000, 60_000, 5);
-
     const invalidateSpy = vi.fn();
     broker.subscribe(0, () => undefined, invalidateSpy);
-
     broker.disposeAll();
-
     expect(invalidateSpy).toHaveBeenCalledTimes(1);
   });
-
   it("subscribe.onInvalidate does NOT fire after the consumer's own unsubscribe()", () => {
     const stub: SubscriptionLike = {
       isDisposed: false,
@@ -594,17 +505,14 @@ describe("DirtyRectBroker", () => {
       dispose: () => undefined,
     };
     const broker = makeBroker(() => stub, () => 0, 20_000, 60_000, 5);
-
     const invalidateSpy = vi.fn();
     const { unsubscribe } = broker.subscribe(0, () => undefined, invalidateSpy);
     unsubscribe();
     broker.disposeAll();
-
     // After unsubscribe() the handle was removed from `callbackHandles`,
     // so disposeAll() iteration finds nothing to fire onInvalidate on.
     expect(invalidateSpy).not.toHaveBeenCalled();
   });
-
   it("subscribe.onInvalidate fires AFTER isUnsubscribed flips (hook callback observes post-invalidation state)", async () => {
     const stub: SubscriptionLike = {
       isDisposed: false,
@@ -614,16 +522,13 @@ describe("DirtyRectBroker", () => {
       dispose: vi.fn(),
     };
     const broker = makeBroker(() => stub, () => 0, 20_000, 60_000, 5);
-
     let observedEntryKindFromHook: string | undefined;
     const invalidateSpy = vi.fn(() => {
       const e = broker._getEntryForTest(0);
       observedEntryKindFromHook = e?.kind;
     });
-
     broker.subscribe(0, () => undefined, invalidateSpy);
     await new Promise((r) => setTimeout(r, 30));
-
     expect(invalidateSpy).toHaveBeenCalledTimes(1);
     // The hook ran AFTER invalidate() set the entry to negative-backoff
     // (broker invalidate replaces the entry before iterating callbacks
@@ -634,7 +539,6 @@ describe("DirtyRectBroker", () => {
     // So the hook observes the OLD entry (kind="subscription") — which
     // is fine because the handle is already invalidated.
     expect(observedEntryKindFromHook).toBe("subscription");
-
     broker.disposeAll();
   });
 });

--- a/tests/unit/flatten-union-schema.test.ts
+++ b/tests/unit/flatten-union-schema.test.ts
@@ -14,7 +14,6 @@
  *      `{ ok: true, value }`, invalid → `{ ok: false, result }` with a typed
  *      `InvalidArgs` error; it never throws; `include` survives.
  */
-
 import { describe, it, expect } from "vitest";
 import { z } from "zod";
 import {
@@ -22,7 +21,6 @@ import {
   parseActionArgsOrFail,
   withEnvelopeIncludeForUnion,
 } from "../../src/tools/_envelope.js";
-
 // Synthetic discriminated union exercising every collision class:
 //  - `windowTitle`: same structural shape across variants (string, only the
 //    description differs) → collapses to one optional field
@@ -48,7 +46,6 @@ const synthBare = z.discriminatedUnion("action", [
   }),
 ]);
 const synthUnionWithInclude = withEnvelopeIncludeForUnion(synthBare);
-
 function failureOf(result: { content: Array<{ text?: string }> }): {
   ok: false;
   code: string;
@@ -57,54 +54,43 @@ function failureOf(result: { content: Array<{ text?: string }> }): {
 } {
   return JSON.parse(result.content[0]?.text ?? "{}");
 }
-
 describe("ADR-018 Phase 2a — flattenUnionToObjectSchema", () => {
   const flat = flattenUnionToObjectSchema(synthUnionWithInclude);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const js = z.toJSONSchema(flat) as any;
-
   it("produces a flat top-level object — no oneOf/anyOf/allOf at the root", () => {
     expect(js.type).toBe("object");
     expect(js.oneOf).toBeUndefined();
     expect(js.anyOf).toBeUndefined();
     expect(js.allOf).toBeUndefined();
   });
-
   it("the discriminator becomes a required z.enum of all variant literals", () => {
     expect([...js.properties.action.enum].sort()).toEqual(["a", "b"]);
     expect(js.required).toEqual(["action"]);
   });
-
   it("carries the `include` envelope field through, optional (load-bearing)", () => {
     expect(js.properties.include).toBeDefined();
     expect(js.required).not.toContain("include");
   });
-
   it("same-structure collision (windowTitle) collapses to ONE optional field", () => {
     expect(js.properties.windowTitle.type).toBe("string");
     expect(js.properties.windowTitle.anyOf).toBeUndefined();
     expect(js.required).not.toContain("windowTitle");
   });
-
   it("all-enum collision (direction) merges to one z.enum of the value union", () => {
     expect([...js.properties.direction.enum].sort()).toEqual(["down", "left", "up"]);
     expect(js.properties.direction.anyOf).toBeUndefined();
   });
-
   it("mixed-type collision (count) widens to a property-level anyOf", () => {
     expect(js.properties.count.anyOf).toBeDefined();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const types = js.properties.count.anyOf.map((b: any) => b.type).sort();
     expect(types).toEqual(["number", "string"]);
   });
-
   it("single-variant fields pass through as optional", () => {
     expect(js.properties.onlyA.type).toBe("boolean");
     expect(js.properties.onlyB.type).toBe("string");
     expect(js.required).not.toContain("onlyA");
     expect(js.required).not.toContain("onlyB");
   });
-
   it("the flat wire schema accepts every VALID input the include-injected union accepts (never rejects a valid call)", () => {
     // The flat wire schema's looseness contract is: a *valid* call — one that
     // the real union accepts — must also pass the wire schema. (It is NOT a
@@ -123,7 +109,6 @@ describe("ADR-018 Phase 2a — flattenUnionToObjectSchema", () => {
     }
   });
 });
-
 describe("ADR-018 Phase 2a — parseActionArgsOrFail", () => {
   it("valid input → { ok: true, value } with the discriminator narrowed", () => {
     const r = parseActionArgsOrFail<z.infer<typeof synthBare>>(
@@ -134,14 +119,12 @@ describe("ADR-018 Phase 2a — parseActionArgsOrFail", () => {
     expect(r.ok).toBe(true);
     if (r.ok) expect(r.value.action).toBe("a");
   });
-
   it("per-action-invalid input (the flat wire schema would accept it) → { ok: false } with code InvalidArgs", () => {
     // `onlyA` is required by the real `a` variant but the flat wire schema has
     // it optional — this is exactly the gap `parseActionArgsOrFail` closes.
     const badForUnion = { action: "a", windowTitle: "x", direction: "up", count: 1 };
     const flat = flattenUnionToObjectSchema(synthUnionWithInclude);
     expect(flat.safeParse(badForUnion).success, "flat wire schema is loose").toBe(true);
-
     const r = parseActionArgsOrFail(synthUnionWithInclude, badForUnion, "synth");
     expect(r.ok).toBe(false);
     if (!r.ok) {
@@ -151,7 +134,6 @@ describe("ADR-018 Phase 2a — parseActionArgsOrFail", () => {
       expect(Array.isArray(failure.context?.issues)).toBe(true);
     }
   });
-
   it("preserves the `include` field on the parsed value (no strip)", () => {
     const r = parseActionArgsOrFail<z.infer<typeof synthUnionWithInclude>>(
       synthUnionWithInclude,
@@ -161,7 +143,6 @@ describe("ADR-018 Phase 2a — parseActionArgsOrFail", () => {
     expect(r.ok).toBe(true);
     if (r.ok) expect((r.value as { include?: unknown }).include).toEqual(["envelope"]);
   });
-
   it("never throws — returns a typed-error ToolResult on a bad discriminator", () => {
     expect(() => parseActionArgsOrFail(synthUnionWithInclude, { action: "nonexistent" }, "synth")).not.toThrow();
     const r = parseActionArgsOrFail(synthUnionWithInclude, { action: "nonexistent" }, "synth");

--- a/tests/unit/homing-snapshot-delta.test.ts
+++ b/tests/unit/homing-snapshot-delta.test.ts
@@ -103,7 +103,6 @@ import { mouseClickHandler } from "../../src/tools/mouse.js";
 import * as cursor from "../../src/engine/cursor.js";
 import * as win32 from "../../src/engine/win32.js";
 import * as cache from "../../src/engine/window-cache.js";
-import * as nutjs from "../../src/engine/nutjs.js";
 
 const mockEnum = vi.mocked(win32.enumWindowsInZOrder);
 const mockGetRect = vi.mocked(win32.getWindowRectByHwnd);

--- a/tests/unit/homing-snapshot-integration.test.ts
+++ b/tests/unit/homing-snapshot-integration.test.ts
@@ -95,7 +95,6 @@ vi.mock("../../src/engine/cursor.js", () => ({ moveCursorTo: vi.fn() }));
 import { mouseClickHandler } from "../../src/tools/mouse.js";
 import * as cursor from "../../src/engine/cursor.js";
 import * as win32 from "../../src/engine/win32.js";
-import * as nutjs from "../../src/engine/nutjs.js";
 import { updateWindowCache, saveSnapshot } from "../../src/engine/window-cache.js";
 
 const mockEnum = vi.mocked(win32.enumWindowsInZOrder);

--- a/tests/unit/issue-211-typeviaclipboard-readback-pin.test.ts
+++ b/tests/unit/issue-211-typeviaclipboard-readback-pin.test.ts
@@ -33,9 +33,7 @@
  *   3. Get-Clipboard read-back returns matching bytes → typeViaClipboard
  *      completes normally, paste combo dispatched
  */
-
 import { describe, it, expect, vi, beforeEach } from "vitest";
-
 // vi.hoisted() so the mock impl is initialized before the vi.mock factory
 // runs (vi.mock is hoisted to the top of the file). Without hoisted(), the
 // factory captures a TDZ ref to the outer-scope const and throws
@@ -50,7 +48,6 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const { mockExecFile, mockExecFileWithCustom } = vi.hoisted(() => {
   // Resolve util.promisify.custom inside the hoisted block so the import
   // happens after vitest's hoisting reorder.
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const util = require("node:util") as typeof import("node:util");
   const impl = vi.fn();
   const wrapper = Object.assign(
@@ -71,11 +68,9 @@ const { mockExecFile, mockExecFileWithCustom } = vi.hoisted(() => {
   );
   return { mockExecFile: impl, mockExecFileWithCustom: wrapper };
 });
-
 vi.mock("node:child_process", () => ({
   execFile: mockExecFileWithCustom,
 }));
-
 // nutjs paste combo press/release — make the success-path test work without
 // actually hitting Windows input pipeline.
 vi.mock("../../src/engine/nutjs.js", () => ({
@@ -84,29 +79,23 @@ vi.mock("../../src/engine/nutjs.js", () => ({
     releaseKey: vi.fn(() => Promise.resolve()),
   },
 }));
-
 import { typeViaClipboard } from "../../src/tools/keyboard.js";
 import * as nutjs from "../../src/engine/nutjs.js";
-
 const mockPressKey = vi.mocked(nutjs.keyboard.pressKey);
 const mockReleaseKey = vi.mocked(nutjs.keyboard.releaseKey);
-
 /** Queue a {stdout, stderr} resolution for the next execFile call. */
 function mockExecFileResolvesWith(stdout: string): void {
   mockExecFile.mockImplementationOnce(() =>
     Promise.resolve({ stdout, stderr: "" }),
   );
 }
-
 /** Encode a UTF-16LE buffer-like blob as base64 — matches PowerShell side. */
 function utf16LeBase64(text: string): string {
   return Buffer.from(text, "utf16le").toString("base64");
 }
-
 beforeEach(() => {
   vi.clearAllMocks();
 });
-
 describe("Phase 5 E1 (epic #211): typeViaClipboard Get-Clipboard read-back verification pin", () => {
   it("throws ClipboardWriteNotDelivered when Get-Clipboard read-back returns mismatched bytes", async () => {
     // Production execFile call sequence (keyboard.ts:38-100):
@@ -115,11 +104,9 @@ describe("Phase 5 E1 (epic #211): typeViaClipboard Get-Clipboard read-back verif
     //   3. (Throw fires before reaching the restore call — only 2 execFile calls)
     mockExecFileResolvesWith("previous content"); // save
     mockExecFileResolvesWith(utf16LeBase64("WRONG TEXT — DLP intercepted")); // verify (mismatch)
-
     await expect(typeViaClipboard("hello world", "ctrl+v")).rejects.toThrow(
       "ClipboardWriteNotDelivered",
     );
-
     // Critical: paste combo MUST NOT have been dispatched — pre-fix path
     // pressed paste with whatever was on the clipboard (silent paste of
     // wrong text into the target window).
@@ -128,27 +115,21 @@ describe("Phase 5 E1 (epic #211): typeViaClipboard Get-Clipboard read-back verif
     // Two execFile calls: save + verify. No restore (verify failed → throw).
     expect(mockExecFile).toHaveBeenCalledTimes(2);
   });
-
   it("throws ClipboardWriteNotDelivered when Get-Clipboard read-back returns empty (clipboard cleared mid-write)", async () => {
     mockExecFileResolvesWith(""); // save (clipboard was empty)
     mockExecFileResolvesWith(""); // verify — empty stdout means clipboard was null
-
     await expect(typeViaClipboard("non-empty payload", "ctrl+v")).rejects.toThrow(
       "ClipboardWriteNotDelivered",
     );
-
     expect(mockPressKey).not.toHaveBeenCalled();
     expect(mockExecFile).toHaveBeenCalledTimes(2);
   });
-
   it("completes normally when Get-Clipboard read-back returns matching bytes (paste dispatched)", async () => {
     const payload = "matching text";
     mockExecFileResolvesWith("previous"); // save
     mockExecFileResolvesWith(utf16LeBase64(payload)); // verify (match)
     mockExecFileResolvesWith(""); // restore (best-effort)
-
     await expect(typeViaClipboard(payload, "ctrl+v")).resolves.toBeUndefined();
-
     // Paste combo dispatched on the success path.
     expect(mockPressKey).toHaveBeenCalled();
     expect(mockReleaseKey).toHaveBeenCalled();

--- a/tests/unit/path-class-contract/e-uia-fallback-ladder.test.ts
+++ b/tests/unit/path-class-contract/e-uia-fallback-ladder.test.ts
@@ -29,7 +29,7 @@
 import { describe, it, expect } from "vitest";
 import { deriveEntityCapabilities } from "../../../src/tools/desktop-capabilities.js";
 import { createDesktopExecutor, type ExecutorDeps } from "../../../src/tools/desktop-executor.js";
-import type { UiEntity, ExecutorKind } from "../../../src/engine/world-graph/types.js";
+import type { UiEntity } from "../../../src/engine/world-graph/types.js";
 
 function makeUiaEntity(overrides: Partial<UiEntity> = {}): UiEntity {
   return {

--- a/tests/unit/path-class-contract/run-inner-tool-as-result.test.ts
+++ b/tests/unit/path-class-contract/run-inner-tool-as-result.test.ts
@@ -12,16 +12,12 @@
  *
  * @see src/tools/macro.ts runInnerToolAsResult / InnerToolOutcome
  */
-
 import { describe, it, expect } from "vitest";
 import { runInnerToolAsResult } from "../../../src/tools/macro.js";
-
 /** A fake TOOL_REGISTRY entry whose handler returns a single text content block. */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function textEntry(text: string): any {
   return { schema: { parse: (x: unknown) => x }, handler: async () => ({ content: [{ type: "text", text }] }) };
 }
-
 describe("runInnerToolAsResult (ADR-021 Phase 3a adapter)", () => {
   it("ok:true envelope → Result.ok=true, carries the text", async () => {
     const r = await runInnerToolAsResult(textEntry(JSON.stringify({ ok: true, data: 1 })), {});
@@ -32,7 +28,6 @@ describe("runInnerToolAsResult (ADR-021 Phase 3a adapter)", () => {
       expect(r.value.error).toBeUndefined();
     }
   });
-
   it("ok:false envelope → Result.ok=false, carries code + error (silent-success → typed failure)", async () => {
     const r = await runInnerToolAsResult(
       textEntry(JSON.stringify({ ok: false, code: "WindowNotFound", error: "Window not found: x" })),
@@ -45,7 +40,6 @@ describe("runInnerToolAsResult (ADR-021 Phase 3a adapter)", () => {
       expect(r.error.textLines).toHaveLength(1);
     }
   });
-
   it("ok:false without code/error fields → Result.ok=false, fields undefined", async () => {
     const r = await runInnerToolAsResult(textEntry(JSON.stringify({ ok: false })), {});
     expect(r.ok).toBe(false);
@@ -54,14 +48,11 @@ describe("runInnerToolAsResult (ADR-021 Phase 3a adapter)", () => {
       expect(r.error.error).toBeUndefined();
     }
   });
-
   it("non-JSON first text block → treated as success (Result.ok=true)", async () => {
     const r = await runInnerToolAsResult(textEntry("raw screenshot text, not json"), {});
     expect(r.ok).toBe(true);
   });
-
   it("image blocks are carried in the outcome", async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const entry: any = {
       schema: { parse: (x: unknown) => x },
       handler: async () => ({ content: [{ type: "image", data: "abc", mimeType: "image/png" }] }),
@@ -70,9 +61,7 @@ describe("runInnerToolAsResult (ADR-021 Phase 3a adapter)", () => {
     expect(r.ok).toBe(true); // no text block → not a failure
     if (r.ok) expect(r.value.images[0]).toEqual({ data: "abc", mimeType: "image/png" });
   });
-
   it("resource_link blocks are carried in the outcome (ADR-026 by-ref macro forwarding)", async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const entry: any = {
       schema: { parse: (x: unknown) => x },
       handler: async () => ({
@@ -95,9 +84,7 @@ describe("runInnerToolAsResult (ADR-021 Phase 3a adapter)", () => {
       expect(r.value.images).toHaveLength(0); // ref-only, no inline pixels
     }
   });
-
   it("ok:true with a trailing image block → success + both carried", async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const entry: any = {
       schema: { parse: (x: unknown) => x },
       handler: async () => ({

--- a/tests/unit/session-registry.test.ts
+++ b/tests/unit/session-registry.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from "vitest";
 import {
   SessionRegistry,
   type SessionCreateOpts,
-  type TargetSpec,
 } from "../../src/engine/world-graph/session-registry.js";
 
 function makeOpts(overrides: Partial<SessionCreateOpts> = {}): SessionCreateOpts {

--- a/tests/unit/working-memory-b1.test.ts
+++ b/tests/unit/working-memory-b1.test.ts
@@ -43,7 +43,6 @@ import {
   _resetHistoryClockForTest,
   _seedHistoryForTest,
   type ToolCallEvent,
-  type WorkingMemoryProjection,
 } from "../../src/tools/_envelope.js";
 
 afterEach(() => {


### PR DESCRIPTION
Closes the two CodeQL alerts and the Dependabot alert raised against v1.13.0, and removes the reason lint could not have caught the first two.

## Why lint missed it

`eslint.config.mjs` turned `@typescript-eslint/no-unused-vars` **off** for `scripts/` and `tests/`. So a stale import in a test was invisible to `npm run lint` and only surfaced later as a CodeQL alert — which is exactly how #153 and #154 reached `main`: lint reported zero errors on the very files that carried them.

The blanket "off" is really about the argument and caught-error shapes that tests produce, so those are exempted individually (`args: "none"`, `caughtErrors: "none"`, `^_` patterns) and unused variables and imports are an error again.

## What that surfaced

14 existing violations, all stale imports or one unused destructured binding, removed here:

| File | Symbol |
|---|---|
| `tests/e2e/browser-cdp.test.ts` | `readFileSync` |
| `tests/e2e/wait-until.test.ts` | `sleep` |
| `tests/e2e/workspace-chain.test.ts` | `beforeAll`, `launchNotepad`, `sleep`, `enumWindowsInZOrder` |
| `tests/unit/desktop-facade.test.ts` | `DesktopSeeInput` |
| `tests/unit/desktop-state-causal-include.test.ts` | `CommitL1Emitter`, `ToolCallEvent` |
| `tests/unit/homing-snapshot-delta.test.ts` | `nutjs` ← CodeQL #154 |
| `tests/unit/homing-snapshot-integration.test.ts` | `nutjs` ← CodeQL #153 |
| `tests/unit/path-class-contract/e-uia-fallback-ladder.test.ts` | `ExecutorKind` |
| `tests/unit/session-registry.test.ts` | `TargetSpec` |
| `tests/unit/working-memory-b1.test.ts` | `WorkingMemoryProjection` |

The two `nutjs` imports are mine: leftovers from moving the homing tests' spy to the cursor choke point in #549.

## Also here

- **Dependabot #34 (postcss, high)** — pinned to `^8.5.18` through `overrides`, resolving to 8.5.23. It arrives via `vitest → vite`, is dev-only, and ships in neither the npm package nor the release zip, so this is hygiene rather than exposure.
- **`docs/release-process.md`** claimed `npx ... --help` prints a version banner and usage. Neither the launcher nor `src/` implements `--help`, and 1.12.4 behaves identically — the step silently proved nothing during the 1.13.0 release. The doc now states what that command does demonstrate (download, SHA verification, extraction) and points at the stdio initialize smoke test as the check to trust.

## Verification

Unit suite green (293 files, 4716 tests). `npx eslint src/ tests/ scripts/` reports 0 errors. No production code is touched.
